### PR TITLE
Fix high-severity correctness bugs (scoring, jobs, route error handling)

### DIFF
--- a/modules/retrieve-games.js
+++ b/modules/retrieve-games.js
@@ -1,4 +1,5 @@
 const { internalFetch } = require('./internal-api');
+const { withRetry } = require('./retry');
 // Configure API key authorization: ApiKeyAuth
 const CFBD_API_KEY = process.env.CFBD_API_KEY;
 var cfb = require('cfb.js');
@@ -7,6 +8,20 @@ var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
 ApiKeyAuth.apiKey = CFBD_API_KEY;
 
 var gamesApi = new cfb.GamesApi();
+
+// Dedupes games by id. Two teams in the same league can play each other, so the
+// same game gets collected twice; [...new Set(objects)] does NOT dedupe those
+// because each API result is a distinct object reference.
+function dedupeGamesById(games) {
+    var seen = new Set();
+    return games.filter(function (game) {
+        if (seen.has(game.id)) {
+            return false;
+        }
+        seen.add(game.id);
+        return true;
+    });
+}
 
 module.exports = {
 
@@ -35,7 +50,6 @@ module.exports = {
 
     retrieveGames: async (teams, week) => {
         var allGameData = [];
-        var uniqueGames;
         var year = process.env.YEAR;
         var opts = {
             'week': week,
@@ -46,18 +60,19 @@ module.exports = {
         for (const team of teams) {
             opts.team = team;
 
-            var response = await gamesApi.getGames(year, opts);
-            var gameData = await response;
-
-            for (let x = 0; x < gameData.length; x++) {
-                allGameData.push(gameData[x]);
+            try {
+                var gameData = await withRetry(() => gamesApi.getGames(year, opts), { label: `getGames(${team})` });
+                for (let x = 0; x < gameData.length; x++) {
+                    allGameData.push(gameData[x]);
+                }
+            } catch (err) {
+                console.log(`❌ Skipping team ${team} after repeated getGames failures: ${err.message || err}`);
             }
         }
 
-        uniqueGames = [...new Set(allGameData)];
-        return uniqueGames;
+        return dedupeGamesById(allGameData);
     },
-    
+
     massRetrieveGames: async (week, seasonType) => {
 
         const response = await internalFetch(`${process.env.URL}/games/week/mass-create`, {
@@ -88,7 +103,6 @@ module.exports = {
 
     retrievePostseasonGames: async (teams, week) => {
         var allGameData = [];
-        var uniqueGames;
         var year = process.env.YEAR;
         var opts = {
             'week': week,
@@ -99,16 +113,17 @@ module.exports = {
         for (const team of teams) {
             opts.team = team;
 
-            var response = await gamesApi.getGames(year, opts);
-            var gameData = await response;
-
-            for (let x = 0; x < gameData.length; x++) {
-                allGameData.push(gameData[x]);
+            try {
+                var gameData = await withRetry(() => gamesApi.getGames(year, opts), { label: `getGames(${team})` });
+                for (let x = 0; x < gameData.length; x++) {
+                    allGameData.push(gameData[x]);
+                }
+            } catch (err) {
+                console.log(`❌ Skipping team ${team} after repeated getGames failures: ${err.message || err}`);
             }
         }
 
-        uniqueGames = [...new Set(allGameData)];
-        return uniqueGames;
+        return dedupeGamesById(allGameData);
     },
 
     retrieveGameBySeasonWeekTeam: async (season, week, team) => {

--- a/modules/retry.js
+++ b/modules/retry.js
@@ -1,0 +1,20 @@
+// Retries an async function with linear backoff. Used to make flaky external
+// API calls (CollegeFootballData) resilient to transient failures / 429s
+// instead of letting a single hiccup take down an entire job run.
+async function withRetry(fn, { retries = 3, baseDelayMs = 1000, label = 'operation' } = {}) {
+    let lastErr;
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            console.log(`⚠️  ${label} failed (attempt ${attempt}/${retries}): ${err.message || err}`);
+            if (attempt < retries) {
+                await new Promise(resolve => setTimeout(resolve, baseDelayMs * attempt));
+            }
+        }
+    }
+    throw lastErr;
+}
+
+module.exports = { withRetry };

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -23,15 +23,18 @@ module.exports= {
 
         for (const user of userData) {
             function score(item){
-                return item.score;
+                return typeof item.score === 'number' ? item.score : 0;
               }
-              
+
               function sum(prev, next){
                 return prev + next;
               }
-              
-              
-            var totalScore = user.seasons[0].weeklyScore.map(score).reduce(sum);
+
+            // Seed reduce with 0 so users with no weekly scores yet (new users
+            // / start of season) return 0 instead of throwing "Reduce of empty
+            // array with no initial value" and aborting the whole loop.
+            var weeklyScore = user.seasons[0].weeklyScore || [];
+            var totalScore = weeklyScore.map(score).reduce(sum, 0);
             updateUserCumulativeScore(user._id, totalScore);
         }
     },
@@ -110,7 +113,9 @@ module.exports= {
                 user.seasons[0].weeklyScore.splice(spliceIndex, 1, scoreObject);
                 await updateUser(user._id, user.seasons[0].weeklyScore);
             } else if (user.seasons[0].weeklyScore.length == 0){
-                await updateUser(user._id, scoreObject);
+                // First score of the season: weeklyScore is an array field, so
+                // wrap the object rather than storing a bare object.
+                await updateUser(user._id, [scoreObject]);
             } else {
                 user.seasons[0].weeklyScore.push(scoreObject);
                 await updateUser(user._id, user.seasons[0].weeklyScore);

--- a/modules/team-scoring.js
+++ b/modules/team-scoring.js
@@ -1,30 +1,37 @@
 const { internalFetch } = require('./internal-api');
 module.exports = {
     updateAllTeamScores: async function() {
-        await internalFetch(`${process.env.URL}/teams`, {
+        const teamsResponse = await internalFetch(`${process.env.URL}/teams`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json'
             }
-        }).then(res => res.json()).then(data => {
-            console.log("Number of teams: " + data.length)
-            data.forEach(async (team) => {
-                var response = await internalFetch(`${process.env.URL}/calculate-team-score/${process.env.YEAR}/${team.id}/${team.school}`, {
+        });
+        const teams = await teamsResponse.json();
+        console.log("Number of teams: " + teams.length);
+
+        // Sequential + awaited: forEach(async) fired ~130 requests at once and
+        // returned before any completed, so the caller (the jobs) resolved
+        // before scores were actually written, and rejections went unhandled.
+        for (const team of teams) {
+            try {
+                const response = await internalFetch(`${process.env.URL}/calculate-team-score/${process.env.YEAR}/${team.id}/${team.school}`, {
                     method: 'GET',
                     headers: {
                     'Accept': 'application/json'
                     }
                 });
 
-                response.json().then(data => {
-                    if (response.status == 200) {
-                        console.log("✅ Score successfully calculated for " + data.school);
-                    } else {
-                        console.log("❌ Team score could not be calculated for " + data.school + " | " + response.status);
-                    }
-                });
-            })
-        });
+                const data = await response.json();
+                if (response.status == 200) {
+                    console.log("✅ Score successfully calculated for " + data.school);
+                } else {
+                    console.log("❌ Team score could not be calculated for " + team.school + " | " + response.status);
+                }
+            } catch (err) {
+                console.log(`❌ Error calculating score for team ${team.school}: ${err.message || err}`);
+            }
+        }
     }
 };

--- a/routes/rankings.js
+++ b/routes/rankings.js
@@ -72,31 +72,31 @@ router.get('/:season/', async (req, res) => {
 // Retrieving new rankings and saving to database || By Year & Week & Season Type
 router.post('/retrieveRankings', async (req, res) => {
     try {
-        var opts = { 
+        var opts = {
         'week': req.body.week,
         'seasonType': req.body.seasonType
         };
 
-        rankingsApi.getRankings(req.body.season, opts).then(async function(data) {
-            console.log('Rankings API called successfully. Returned data: ', data);
+        // Awaited (not .then with a broken err/error handler) so a rejected
+        // API call or a failed save is caught by this try/catch instead of
+        // becoming an unhandled promise rejection with no response sent.
+        const data = await rankingsApi.getRankings(req.body.season, opts);
+        console.log('Rankings API called successfully.');
 
-            const ranking = new Ranking({
-                season: req.body.season,
-                seasonType: req.body.seasonType,
-                week: req.body.week,
-                polls: data[0].polls
-            });
-
-            const newRanking = await ranking.save();
-
-            console.log("New Ranking Record", newRanking);
-
-            res.status(201).json(newRanking);
-        }, function(error) {
-            res.status(400).json({message: err.message});
+        const ranking = new Ranking({
+            season: req.body.season,
+            seasonType: req.body.seasonType,
+            week: req.body.week,
+            polls: data[0].polls
         });
+
+        const newRanking = await ranking.save();
+        console.log("New Ranking Record", newRanking);
+
+        res.status(201).json(newRanking);
     } catch (err) {
-        res.status(500).json({message: err.message});
+        console.log("Error retrieving rankings:", err.message);
+        res.status(400).json({message: err.message});
     }
 });
 

--- a/routes/recruiting.js
+++ b/routes/recruiting.js
@@ -57,45 +57,28 @@ router.post('/new/:year', async (req, res) => {
     var allNewRankings = [];
 
     try {
-        var opts = { 
+        var opts = {
         'year': req.body.season,
         };
 
-        recruitingApi.getRecruitingTeams(opts).then(async function(data) {
+        // Awaited (not .then with a broken err/error handler) so a rejected
+        // API call or failed insert is caught here instead of becoming an
+        // unhandled rejection with no response sent.
+        const data = await recruitingApi.getRecruitingTeams(opts);
 
-            const recruitingRanking = new Recruiting({
-                season: req.body.season,
-                seasonType: req.body.seasonType,
-                week: req.body.week,
-                polls: data[0].polls
-            });
+        for (const ranking of data) {
+            var alreadyExists = await Recruiting.find({ year: ranking.year, team: ranking.team });
+            if (alreadyExists.length == 0) {
+                allNewRankings.push(new Recruiting(ranking));
+            }
+        }
 
-            for (const ranking of data) {
-                var alreadyExists = await Recruiting.find({ year: ranking.year, team: ranking.team });
-                ranking.year = ranking.year;
-                ranking.rank = ranking.rank;
-                ranking.team = ranking.team;
-                ranking.points = ranking.points;
-        
-                if (alreadyExists.length == 0) {
-                    const newRanking = new Recruiting(ranking);
-                    allNewRankings.push(newRanking);
-                }
-            }
-                
-            try {
-                console.log("all new rankings length", allNewRankings.length);
-                const newRankings = await Recruiting.insertMany(allNewRankings);
-                return res.status(201).json(newRankings);
-            } catch (err) {
-                console.log("Error saving recruiting rankings: ", err.message)
-                res.status(400).json({message: err.message});
-            }
-        }, function(error) {
-            res.status(400).json({message: err.message});
-        });
+        console.log("all new rankings length", allNewRankings.length);
+        const newRankings = await Recruiting.insertMany(allNewRankings);
+        return res.status(201).json(newRankings);
     } catch (err) {
-        res.status(500).json({message: err.message});
+        console.log("Error saving recruiting rankings:", err.message);
+        res.status(400).json({message: err.message});
     }
 });
 

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -189,23 +189,29 @@ router.post('/:season/expectedWins', async (req, res) => {
     }
     var updatedTeams = [];
 
-    for (teamJson of teamJsonData) {
+    for (const teamJson of teamJsonData) {
 
         var team = await getTeamByName(teamJson.team);
+        if (team == null) {
+            console.log(`Skipping unknown team: ${teamJson.team}`);
+            continue;
+        }
 
         var index = team.seasons.findIndex(x => x.season == req.params.season);
 
         if (index > -1) {
             if (teamJson.expectedWins != null) {
                 team.seasons[index].expectedWins = teamJson.expectedWins;
-            } 
+            }
         }
 
         try {
             const updatedTeam = await team.save();
             updatedTeams.push(updatedTeam);
         } catch (err) {
-            res.status(400).json({message: err.message});
+            // Log and keep going; sending a response here would collide with
+            // the res.status(200) after the loop ("headers already sent").
+            console.log(`Error saving expected wins for ${teamJson.team}: ${err.message}`);
         }
     }
 
@@ -308,16 +314,14 @@ async function getTeam(req, res, next) {
 }
 
 async function getTeamByName(teamName) {
-    let team;
+    // Returns the matching team, or null if not found / on error. This is a
+    // plain helper (no res in scope), so the caller decides how to respond.
     try {
-        team = await Team.findOne( { $or: [{"school": teamName}, {"alternateNames": teamName}]});
-        if (team == null) {
-            return res.status(404).json({message: 'Cannot find expected team ' + teamName});
-        }
+        return await Team.findOne( { $or: [{"school": teamName}, {"alternateNames": teamName}]});
     } catch (err) {
-        return res.status(500).json({message: err.message});
+        console.log(`Error looking up team ${teamName}: ${err.message}`);
+        return null;
     }
-    return team;
 }
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -21,6 +21,23 @@ function safeJson(obj) {
     });
 }
 
+// Builds the view's user context from the OIDC user, tolerating accounts that
+// are missing user_metadata / roles / metadata. Previously these were accessed
+// unguarded (e.g. user_metadata.roles.length), so any such account threw a
+// TypeError and got a 500 on every page.
+function buildUserContext(oidcUser) {
+    const meta = (oidcUser && oidcUser.user_metadata) || {};
+    const roles = meta.roles || [];
+    const innerMeta = meta.metadata || {};
+    return {
+        firstName: oidcUser && oidcUser.name,
+        role: roles.length > 0 ? roles[0] : '',
+        userId: innerMeta.userId,
+        league: innerMeta.league || '',
+        isMaintenance: false
+    };
+}
+
 // Routing
 const path = require('path')
 
@@ -66,12 +83,7 @@ db.on('open', () => console.log('Connected to Database'));
 // req.isAuthenticated is provided from the auth router
 app.get('/', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
 
         const userState = safeJson(req.oidc.user);
 
@@ -87,12 +99,7 @@ app.get('/valentine', (req, res) => {
 
 app.get('/standings', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
         res.render('standings', {user, userState});
@@ -103,15 +110,10 @@ app.get('/standings', (req, res) => {
 
 app.get('/rules', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
-        res.render('scoringRules' + req.oidc.user.user_metadata.metadata.league, {user, userState});
+        res.render('scoringRules' + user.league, {user, userState});
     } else {
         res.redirect("/login");
     }
@@ -119,13 +121,8 @@ app.get('/rules', (req, res) => {
 
 app.get('/draft-room', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false,
-            isDraft: false
-        };
+        const user = buildUserContext(req.oidc.user);
+        user.isDraft = false;
         const userState = safeJson(req.oidc.user);
 
         res.render('draftRoom', {user, userState});
@@ -136,12 +133,7 @@ app.get('/draft-room', (req, res) => {
 
 app.get('/admin', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
         res.render('admin', {user, userState});
@@ -152,12 +144,7 @@ app.get('/admin', (req, res) => {
 
 app.get('/index', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
         res.render('standings', {user, userState});
@@ -168,12 +155,7 @@ app.get('/index', (req, res) => {
 
 app.get('/userHome', async function(req, res) {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
         res.render('userHome', {user, userState});
@@ -184,12 +166,7 @@ app.get('/userHome', async function(req, res) {
 
 app.get('/team', async function(req, res) {
     if (req.oidc.isAuthenticated()) {
-        const user = {
-            firstName: req.oidc.user.name,
-            role: req.oidc.user.user_metadata.roles.length > 0 ? req.oidc.user.user_metadata.roles[0] : '',
-            userId: req.oidc.user.user_metadata.metadata.userId,
-            isMaintenance: false
-        };
+        const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
         res.render('team', {user, userState});

--- a/update-daily-scores-job.js
+++ b/update-daily-scores-job.js
@@ -1,4 +1,5 @@
 const { internalFetch } = require('./modules/internal-api');
+const { withRetry } = require('./modules/retry');
 if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config()
 }
@@ -19,7 +20,7 @@ const bettingModule = require('./modules/betting.js');
 async function updateScores () {
 
     var gamesApi = new cfb.GamesApi();
-    var calendar = await gamesApi.getCalendar(process.env.YEAR);
+    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
     var weekNumber = 1;
     var isPostseason = false;
 
@@ -41,6 +42,7 @@ async function updateScores () {
                 break;
             } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
                 weekNumber = (calendarWeek.week - 1);
+                break;
             }
         }
     }
@@ -237,16 +239,27 @@ if ((todayDate.getHours() == 23)) {
     console.log(dayText);
     console.log("Current Date", todayDate.toLocaleString());
     
-    updateScores();
-
-    transporter.sendMail(mailOptions, function(error, info){
-        if (error) {
-            console.log(error);
-        } else {
-            console.log('Email sent: ' + info.response);
+    // Await the update so the email reflects the real outcome, and don't
+    // swallow failures: previously updateScores() was fire-and-forget, so the
+    // "Update Complete" email was sent before scores finished (and any error
+    // was an unhandled rejection with a green email still going out).
+    (async () => {
+        try {
+            await updateScores();
+        } catch (err) {
+            console.error("❌ Daily score update failed:", err);
+            mailOptions.subject = 'Campus Clash | Daily Update FAILED';
+            mailOptions.html = `<p>The daily score update failed at ${todayDate.toLocaleString()}.</p><pre>${(err && err.stack) ? err.stack : err}</pre>`;
         }
-    });
-    
+
+        try {
+            const info = await transporter.sendMail(mailOptions);
+            console.log('Email sent: ' + info.response);
+        } catch (mailErr) {
+            console.log(mailErr);
+        }
+    })();
+
 } else {
     dayText = "Time is not 11PM, so no updates run.";
     console.log(dayText);

--- a/update-saturday-scores-job.js
+++ b/update-saturday-scores-job.js
@@ -1,4 +1,5 @@
 const { internalFetch } = require('./modules/internal-api');
+const { withRetry } = require('./modules/retry');
 if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config()
 }
@@ -18,7 +19,7 @@ const recordsModule = require('./modules/records.js');
 async function updateScores () {
 
     var gamesApi = new cfb.GamesApi();
-    var calendar = await gamesApi.getCalendar(process.env.YEAR);
+    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
     var weekNumber = 1;
     var isPostseason = false;
 
@@ -40,6 +41,7 @@ async function updateScores () {
                 break;
             } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
                 weekNumber = (calendarWeek.week - 1);
+                break;
             }
         }
     }
@@ -234,16 +236,25 @@ if ((todayDate.getDay() == 6) && ((todayDate.getHours() == 15) || (todayDate.get
     console.log(dayText);
     console.log("Current Date", todayDate.toLocaleString());
     
-    updateScores();
-
-    transporter.sendMail(mailOptions, function(error, info){
-        if (error) {
-            console.log(error);
-        } else {
-            console.log('Email sent: ' + info.response);
+    // Await the update so the email reflects the real outcome, and don't
+    // swallow failures (see comment in update-daily-scores-job.js).
+    (async () => {
+        try {
+            await updateScores();
+        } catch (err) {
+            console.error("❌ Saturday score update failed:", err);
+            mailOptions.subject = 'Campus Clash | Saturday Update FAILED';
+            mailOptions.html = `<p>The Saturday score update failed at ${todayDate.toLocaleString()}.</p><pre>${(err && err.stack) ? err.stack : err}</pre>`;
         }
-    });
-    
+
+        try {
+            const info = await transporter.sendMail(mailOptions);
+            console.log('Email sent: ' + info.response);
+        } catch (mailErr) {
+            console.log(mailErr);
+        }
+    })();
+
 } else {
     dayText = "Today is not Saturday, so games & scores are NOT being updated.";
     console.log(dayText);

--- a/update-sunday-scores-job.js
+++ b/update-sunday-scores-job.js
@@ -1,4 +1,5 @@
 const { internalFetch } = require('./modules/internal-api');
+const { withRetry } = require('./modules/retry');
 if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config()
 }
@@ -18,7 +19,7 @@ const recordsModule = require('./modules/records.js');
 async function updateScores () {
 
     var gamesApi = new cfb.GamesApi();
-    var calendar = await gamesApi.getCalendar(process.env.YEAR);
+    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
     var weekNumber = 1;
     var isPostseason = false;
 
@@ -40,6 +41,7 @@ async function updateScores () {
                 break;
             } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
                 weekNumber = (calendarWeek.week - 1);
+                break;
             }
         }
     }
@@ -235,15 +237,24 @@ if (todayDate.getDay() == 0) {
     console.log(dayText);
     console.log("Current Date", todayDate.toLocaleString());
 
-    updateScores();
+    // Await the update so the email reflects the real outcome, and don't
+    // swallow failures (see comment in update-daily-scores-job.js).
+    (async () => {
+        try {
+            await updateScores();
+        } catch (err) {
+            console.error("❌ Sunday score update failed:", err);
+            mailOptions.subject = 'Campus Clash | Sunday Update FAILED';
+            mailOptions.html = `<p>The Sunday score update failed at ${todayDate.toLocaleString()}.</p><pre>${(err && err.stack) ? err.stack : err}</pre>`;
+        }
 
-    transporter.sendMail(mailOptions, function(error, info){
-      if (error) {
-        console.log(error);
-      } else {
-        console.log('Email sent: ' + info.response);
-      }
-    });
+        try {
+            const info = await transporter.sendMail(mailOptions);
+            console.log('Email sent: ' + info.response);
+        } catch (mailErr) {
+            console.log(mailErr);
+        }
+    })();
   }
 } else {
     dayText = "Today is not Sunday, so games & scores are NOT being updated.";


### PR DESCRIPTION
Fixes the nine **High-severity** correctness bugs from the codebase review. Follows up #170 (critical issues). No auth/deploy surface changes — no new env vars required.

## What's fixed

| # | Bug | Fix |
|---|-----|-----|
| 1 | `user_metadata` access crashed every page for accounts missing that claim (500 lockout) | Safe `buildUserContext()` helper with optional chaining; also collapses the 8× duplicated block |
| 2 | Jobs emailed "Update Complete" *before* scores ran (fire-and-forget) and swallowed errors | `await updateScores()` in try/catch; email now reports **FAILED** with the error on failure |
| 3 | Missing `break` → wrong week scored between game windows | Added `break` to the week-detection loop in all 3 scores jobs |
| 4 | `reduce()` with no seed crashed cumulative scoring for users with no weekly scores | Seed `reduce(sum, 0)` + coerce non-numeric scores |
| 5 | First week's score stored as a bare object, not an array | Store `[scoreObject]` to match the schema |
| 6 | Broken error handlers: `getTeamByName` used out-of-scope `res`; `rankings.js`/`recruiting.js` used `err` where param was `error` | Refactored to `await` + `try/catch`; also fixed a double-response in the expectedWins loop and removed dead code |
| 7 | No error handling/retry on CFBD calls — one hiccup killed the whole job | `withRetry()` (linear backoff) around `getCalendar`/`getGames`; a persistently failing team is skipped with a log |
| 8 | `team-scoring.js` `forEach(async)` fired ~130 concurrent requests and returned before any finished | Sequential `for...of` with `await` + per-team error handling |
| 9 | `[...new Set(objects)]` didn't dedupe games → games saved twice | `dedupeGamesById()` keyed on `game.id` |

Adds `modules/retry.js`.

## Verification
- All changed files pass `node --check`.
- **17 targeted checks pass**: `dedupeGamesById`, the `reduce` fix (empty + missing-score), `buildUserContext` (missing/null metadata), and `withRetry` (succeeds after transient failures).
- Server boots; `GET /users` still returns **401** unauthenticated (auth from #170 intact).
- Existing Jest suite unchanged at its pre-existing baseline (3 pass / 18 fail — those 18 were already failing on `main` before #170, unrelated to these changes).

## Not included (by design)
- The 18 failing legacy tests and their coverage gaps — worth a dedicated pass; several of these fixes (#4, #5, #3, #9) would each be nicely pinned by a unit test.
- Medium/Low findings (NoSQL operator validation, admin role check, DST offset, client-side fetch error handling, hygiene) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)