### PR TITLE
Live, interactive draft board (Sleeper/ESPN-style)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "fantasy-cfb",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["server.js"],
+      "port": 3000
+    }
+  ]
+}

--- a/models/draft.js
+++ b/models/draft.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose');
+
+// A single pick in a draft. team is stored as the full team object (Mixed) so
+// that when the draft completes we can write it straight onto each user's
+// season.teams, matching how the existing manual draft persists teams.
+const draftPickSchema = new mongoose.Schema({
+    round: { type: Number, required: true },
+    overall: { type: Number, required: true },   // 1-based overall pick number
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    team: { type: mongoose.Schema.Types.Mixed, required: true },
+    pickedAt: { type: Date },
+    pickedByCommissioner: { type: Boolean, default: false }
+}, { _id: false });
+
+const draftSchema = new mongoose.Schema({
+    league: { type: String, required: true },
+    season: { type: Number, required: true },
+
+    // pending: configured but no time set | scheduled: has a start time
+    // active: draft is live | complete: all picks made & persisted to users
+    status: {
+        type: String,
+        enum: ['pending', 'scheduled', 'active', 'complete'],
+        default: 'pending'
+    },
+
+    // --- commissioner-configured settings ---
+    scheduledAt: { type: Date },
+    autoOpen: { type: Boolean, default: false },
+    snake: { type: Boolean, default: true },
+    totalRounds: { type: Number, default: 10 },
+    orderMethod: {
+        type: String,
+        enum: ['standings', 'random', 'manual'],
+        default: 'standings'
+    },
+    // participant user ids, in pick order (slot 1 first)
+    draftOrder: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+
+    // --- live draft state ---
+    picks: { type: [draftPickSchema], default: [] },
+    currentOverall: { type: Number, default: 1 },  // next overall pick to be made
+
+    createdAt: { type: Date, default: Date.now },
+    updatedAt: { type: Date, default: Date.now }
+});
+
+// One draft per league per season.
+draftSchema.index({ league: 1, season: 1 }, { unique: true });
+
+module.exports = mongoose.model('Draft', draftSchema);

--- a/modules/draft-engine.js
+++ b/modules/draft-engine.js
@@ -1,0 +1,49 @@
+// Pure snake-draft math and validation helpers. No I/O — easy to unit test.
+
+// For a 1-based overall pick number, return which round it's in, the 0-based
+// position within that round, and the 0-based slot into draftOrder (reversed on
+// even rounds when snake is on).
+function slotForOverall(overall, numPlayers, snake) {
+    const round = Math.floor((overall - 1) / numPlayers) + 1;   // 1-based
+    const pickInRound = (overall - 1) % numPlayers;             // 0-based
+    let slotIndex = pickInRound;
+    if (snake && round % 2 === 0) {
+        slotIndex = numPlayers - 1 - pickInRound;               // reverse even rounds
+    }
+    return { round, pickInRound, slotIndex };
+}
+
+function totalPicks(draft) {
+    return draft.totalRounds * draft.draftOrder.length;
+}
+
+function isComplete(draft) {
+    return draft.currentOverall > totalPicks(draft);
+}
+
+// Who is on the clock right now, or null if the draft is complete / empty.
+function whoseTurn(draft) {
+    const numPlayers = draft.draftOrder.length;
+    if (numPlayers === 0 || isComplete(draft)) {
+        return null;
+    }
+    const { round, slotIndex } = slotForOverall(draft.currentOverall, numPlayers, draft.snake);
+    return {
+        userId: String(draft.draftOrder[slotIndex]),
+        overall: draft.currentOverall,
+        round
+    };
+}
+
+// Full pick-by-pick order of userIds (useful for rendering the board upcoming).
+function pickOrder(draft) {
+    const order = [];
+    const numPlayers = draft.draftOrder.length;
+    for (let overall = 1; overall <= totalPicks(draft); overall++) {
+        const { round, slotIndex } = slotForOverall(overall, numPlayers, draft.snake);
+        order.push({ overall, round, userId: String(draft.draftOrder[slotIndex]) });
+    }
+    return order;
+}
+
+module.exports = { slotForOverall, totalPicks, isComplete, whoseTurn, pickOrder };

--- a/modules/draft-socket.js
+++ b/modules/draft-socket.js
@@ -21,6 +21,7 @@ function publicState(draft) {
         status: d.status,
         snake: d.snake,
         totalRounds: d.totalRounds,
+        scheduledAt: d.scheduledAt,
         draftOrder: (d.draftOrder || []).map(String),
         picks: d.picks || [],
         currentOverall: d.currentOverall,
@@ -76,6 +77,27 @@ module.exports = function registerDraftSockets(io) {
                 socket.data.season = season;
                 socket.join(roomKey(league, season));
                 socket.emit('draft-state', publicState(draft));
+            } catch (err) {
+                socket.emit('draft-error', { message: err.message });
+            }
+        });
+
+        socket.on('start-draft', async ({ league, season }) => {
+            try {
+                if (!isCommissioner(socket.user)) {
+                    return socket.emit('draft-error', { message: 'Only the commissioner can start the draft' });
+                }
+                const draft = await Draft.findOne({ league, season });
+                if (!draft) return socket.emit('draft-error', { message: 'No draft configured' });
+                if (draft.status === 'complete') return socket.emit('draft-error', { message: 'Draft is already complete' });
+                if (!Array.isArray(draft.draftOrder) || draft.draftOrder.length < 2) {
+                    return socket.emit('draft-error', { message: 'Draft needs at least 2 participants' });
+                }
+                draft.status = 'active';
+                if (!draft.currentOverall || draft.currentOverall < 1) draft.currentOverall = 1;
+                draft.updatedAt = new Date();
+                await draft.save();
+                io.to(roomKey(league, season)).emit('draft-state', publicState(draft));
             } catch (err) {
                 socket.emit('draft-error', { message: err.message });
             }

--- a/modules/draft-socket.js
+++ b/modules/draft-socket.js
@@ -103,6 +103,31 @@ module.exports = function registerDraftSockets(io) {
             }
         });
 
+        socket.on('undo-pick', async ({ league, season }) => {
+            try {
+                if (!isCommissioner(socket.user)) {
+                    return socket.emit('draft-error', { message: 'Only the commissioner can undo a pick' });
+                }
+                const draft = await Draft.findOne({ league, season });
+                if (!draft) return socket.emit('draft-error', { message: 'No draft configured' });
+                if (draft.status !== 'active') return socket.emit('draft-error', { message: 'Can only undo during an active draft' });
+                if (!draft.picks.length) return socket.emit('draft-error', { message: 'No picks to undo' });
+
+                // Atomic: remove the last pick and step the clock back, guarded on
+                // currentOverall so it can't race with an in-flight pick.
+                const updated = await Draft.findOneAndUpdate(
+                    { _id: draft._id, status: 'active', currentOverall: draft.currentOverall },
+                    { $pop: { picks: 1 }, $inc: { currentOverall: -1 }, $set: { updatedAt: new Date() } },
+                    { new: true }
+                );
+                if (!updated) return socket.emit('draft-error', { message: 'Undo failed — try again' });
+
+                io.to(roomKey(league, season)).emit('draft-state', publicState(updated));
+            } catch (err) {
+                socket.emit('draft-error', { message: err.message });
+            }
+        });
+
         socket.on('make-pick', async ({ league, season, team, forUserId }) => {
             try {
                 const draft = await Draft.findOne({ league, season });

--- a/modules/draft-socket.js
+++ b/modules/draft-socket.js
@@ -1,0 +1,150 @@
+const Draft = require('../models/draft');
+const engine = require('./draft-engine');
+const draftToken = require('./draft-token');
+const { internalFetch } = require('./internal-api');
+
+function roomKey(league, season) {
+    return `draft:${league}:${season}`;
+}
+
+function isCommissioner(user) {
+    return user && (user.role === 'Admin' || user.role === 'League Manager');
+}
+
+// The shape broadcast to clients — the draft plus a derived "on the clock".
+function publicState(draft) {
+    const d = draft.toObject ? draft.toObject() : draft;
+    return {
+        _id: d._id,
+        league: d.league,
+        season: d.season,
+        status: d.status,
+        snake: d.snake,
+        totalRounds: d.totalRounds,
+        draftOrder: (d.draftOrder || []).map(String),
+        picks: d.picks || [],
+        currentOverall: d.currentOverall,
+        onTheClock: engine.whoseTurn(d)
+    };
+}
+
+// On completion, write each member's drafted teams onto their season, reusing
+// the existing PATCH /users/draft/:id endpoint (server-to-server, token auth).
+async function persistTeamsToUsers(draft) {
+    const teamsByUser = {};
+    for (const pick of draft.picks) {
+        const uid = String(pick.userId);
+        if (!teamsByUser[uid]) teamsByUser[uid] = [];
+        const team = pick.team || {};
+        // CFBD team.location uses `id`; the user schema expects `venue_id`.
+        if (team.location && team.location.id != null && team.location.venue_id == null) {
+            team.location.venue_id = team.location.id;
+            delete team.location.id;
+        }
+        teamsByUser[uid].push(team);
+    }
+
+    for (const userId of Object.keys(teamsByUser)) {
+        await internalFetch(`${process.env.URL}/users/draft/${userId}`, {
+            method: 'PATCH',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ season: draft.season, teams: teamsByUser[userId] })
+        });
+    }
+}
+
+module.exports = function registerDraftSockets(io) {
+    // Authenticate every socket from the handshake token.
+    io.use((socket, next) => {
+        const token = socket.handshake.auth && socket.handshake.auth.token;
+        const payload = draftToken.verify(token, process.env.AUTH_SECRET);
+        if (!payload || !payload.userId) {
+            return next(new Error('unauthorized'));
+        }
+        socket.user = payload; // { userId, role, name }
+        next();
+    });
+
+    io.on('connection', (socket) => {
+        socket.on('join-draft', async ({ league, season }) => {
+            try {
+                const draft = await Draft.findOne({ league, season });
+                if (!draft) {
+                    return socket.emit('draft-error', { message: 'No draft configured' });
+                }
+                socket.data.league = league;
+                socket.data.season = season;
+                socket.join(roomKey(league, season));
+                socket.emit('draft-state', publicState(draft));
+            } catch (err) {
+                socket.emit('draft-error', { message: err.message });
+            }
+        });
+
+        socket.on('make-pick', async ({ league, season, team, forUserId }) => {
+            try {
+                const draft = await Draft.findOne({ league, season });
+                if (!draft) return socket.emit('draft-error', { message: 'No draft configured' });
+                if (draft.status !== 'active') return socket.emit('draft-error', { message: 'Draft is not active' });
+                if (!team || team.id == null) return socket.emit('draft-error', { message: 'Invalid team' });
+
+                const turn = engine.whoseTurn(draft);
+                if (!turn) return socket.emit('draft-error', { message: 'Draft is complete' });
+
+                const commish = isCommissioner(socket.user);
+                // A member may only pick on their own turn; a commissioner may
+                // pick for whoever is on the clock (absent member).
+                if (String(socket.user.userId) !== turn.userId && !commish) {
+                    return socket.emit('draft-error', { message: "It's not your turn" });
+                }
+
+                const pick = {
+                    round: turn.round,
+                    overall: turn.overall,
+                    userId: turn.userId,
+                    team,
+                    pickedAt: new Date(),
+                    pickedByCommissioner: String(socket.user.userId) !== turn.userId
+                };
+
+                // Atomic apply: only if the turn hasn't advanced and the team
+                // isn't already taken. Prevents double-picks / races.
+                const updated = await Draft.findOneAndUpdate(
+                    {
+                        _id: draft._id,
+                        status: 'active',
+                        currentOverall: turn.overall,
+                        'picks.team.id': { $ne: team.id }
+                    },
+                    { $push: { picks: pick }, $inc: { currentOverall: 1 }, $set: { updatedAt: new Date() } },
+                    { new: true }
+                );
+
+                if (!updated) {
+                    return socket.emit('draft-error', { message: 'Pick no longer valid (turn advanced or team already taken)' });
+                }
+
+                let finalDraft = updated;
+                if (engine.isComplete(updated)) {
+                    finalDraft = await Draft.findByIdAndUpdate(
+                        updated._id,
+                        { $set: { status: 'complete', updatedAt: new Date() } },
+                        { new: true }
+                    );
+                }
+
+                io.to(roomKey(league, season)).emit('pick-made', { pick, state: publicState(finalDraft) });
+
+                if (finalDraft.status === 'complete') {
+                    await persistTeamsToUsers(finalDraft);
+                    io.to(roomKey(league, season)).emit('draft-complete', publicState(finalDraft));
+                }
+            } catch (err) {
+                socket.emit('draft-error', { message: err.message });
+            }
+        });
+    });
+};
+
+module.exports.roomKey = roomKey;
+module.exports.publicState = publicState;

--- a/modules/draft-token.js
+++ b/modules/draft-token.js
@@ -1,0 +1,37 @@
+const crypto = require('crypto');
+
+// Small self-contained signed token (HMAC-SHA256) used to authenticate socket
+// connections. The browser gets one from GET /draft-token (which requires an
+// Auth0 session), then passes it in the socket handshake. This avoids threading
+// the express-openid-connect session through Socket.IO while still giving the
+// socket server a trustworthy identity. Signed with AUTH_SECRET.
+
+function sign(payload, secret, ttlMs = 6 * 60 * 60 * 1000) {
+    const body = { ...payload, exp: Date.now() + ttlMs };
+    const data = Buffer.from(JSON.stringify(body)).toString('base64url');
+    const sig = crypto.createHmac('sha256', secret).update(data).digest('base64url');
+    return `${data}.${sig}`;
+}
+
+function verify(token, secret) {
+    if (!token || typeof token !== 'string') return null;
+    const parts = token.split('.');
+    if (parts.length !== 2) return null;
+    const [data, sig] = parts;
+
+    const expected = crypto.createHmac('sha256', secret).update(data).digest('base64url');
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+    let body;
+    try {
+        body = JSON.parse(Buffer.from(data, 'base64url').toString());
+    } catch (e) {
+        return null;
+    }
+    if (!body.exp || Date.now() > body.exp) return null;
+    return body;
+}
+
+module.exports = { sign, verify };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,14 @@
         "mongoose": "^7.4.2",
         "node-schedule": "^2.1.1",
         "nodemailer": "^7.0.5",
+        "socket.io": "^4.8.3",
         "toastify-js": "^1.12.0"
       },
       "devDependencies": {
         "dotenv": "^16.5.0",
         "jest": "^29.7.0",
-        "nodemon": "^3.0.1"
+        "nodemon": "^3.0.1",
+        "socket.io-client": "^4.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1396,6 +1398,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -1457,6 +1465,15 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1536,6 +1553,15 @@
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -1846,6 +1872,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/base64url": {
       "version": "3.0.1",
@@ -2285,6 +2320,23 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2580,6 +2632,107 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5630,6 +5783,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
@@ -6342,6 +6504,157 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -6870,6 +7183,36 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "mongoose": "^7.4.2",
     "node-schedule": "^2.1.1",
     "nodemailer": "^7.0.5",
+    "socket.io": "^4.8.3",
     "toastify-js": "^1.12.0"
   },
   "devDependencies": {
     "dotenv": "^16.5.0",
     "jest": "^29.7.0",
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "socket.io-client": "^4.8.3"
   }
 }

--- a/public/admin.css
+++ b/public/admin.css
@@ -183,3 +183,102 @@
         height: 35px !important;
     }
 }
+/* ---------- Draft Configuration panel ---------- */
+.draft-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+    color: #F4F6FB;
+}
+
+.draft-config-form .draft-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.draft-config-form label {
+    font-size: 0.9em;
+}
+
+.draft-config-form select,
+.draft-config-form input[type="datetime-local"],
+.draft-config-form input[type="number"] {
+    color: #F4F6FB;
+    background-color: #101322;
+    border: 1px solid #2A2E42;
+    border-radius: 4px;
+    padding: 6px;
+}
+
+.draft-status-row {
+    font-size: 0.95em;
+}
+
+.draft-status-badge {
+    text-transform: capitalize;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background-color: #2A2E42;
+}
+
+.draft-status-badge.status-active { background-color: #71d28d; color: #101322; }
+.draft-status-badge.status-complete { background-color: #64b5f6; color: #101322; }
+.draft-status-badge.status-scheduled { background-color: #ed5858; color: #fff; }
+
+.draft-order-header {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.draft-order-buttons {
+    display: flex;
+    gap: 6px;
+}
+
+.draft-order-buttons button {
+    font-size: 0.8em;
+    padding: 4px 8px;
+}
+
+.draft-order-list {
+    list-style: decimal inside;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.draft-order-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background-color: #101322;
+    border: 1px solid #2A2E42;
+    border-radius: 4px;
+    padding: 6px 8px;
+}
+
+.draft-order-name {
+    flex: 1;
+}
+
+.draft-order-move button {
+    padding: 2px 6px;
+    font-size: 0.75em;
+    margin-left: 2px;
+}
+
+.draft-config-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 6px;
+}
+
+.draft-config-actions button[draft-reset-btn] {
+    background-color: #ed5858;
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -971,3 +971,254 @@ function setNavbarUserId() {
         setTimeout(setNavbarUserId, 500);
     }
 }
+
+/////////////////////////////////////////////////////
+//////////////////// Draft Config ///////////////////
+/////////////////////////////////////////////////////
+
+var draftMembers = [];    // member objects in current display order
+var currentDraft = null;  // loaded Draft doc for the selected league+season
+
+function getDraftLeagueCode() {
+    var code = (userState.user_metadata.metadata.league == 'gg' ? 'graham-league' : 'claunts-league');
+    if (userState.user_metadata.roles?.at(-1) == 'Admin') {
+        var stored = window.localStorage.getItem("leagueCode");
+        if (stored && stored != "undefined") code = stored;
+    }
+    return code;
+}
+
+function getSelectedDraftSeason() {
+    return parseInt(document.querySelector('[draft-season]').value, 10);
+}
+
+function populateDraftSeasonOptions() {
+    var sel = document.querySelector('[draft-season]');
+    if (!sel) return;
+    var currentYear = new Date().getFullYear();
+    var str = '';
+    for (var y = currentYear + 1; y >= currentYear - 3; y--) {
+        str += `<option value="${y}">${y}</option>`;
+    }
+    sel.innerHTML = str;
+    sel.value = currentYear;
+}
+
+async function displayDraftConfigContainer() {
+    var container = document.querySelector('[draft-config-container]');
+    if (container.style.display == 'flex' || container.style.display == '') {
+        container.style.display = 'none';
+    } else {
+        container.style.display = 'flex';
+        await loadDraftConfig();
+    }
+}
+
+async function loadDraftConfig() {
+    var leagueCode = getDraftLeagueCode();
+    var season = getSelectedDraftSeason();
+
+    // All league members (full seasons, so we can order by prior standings).
+    var membersResp = await fetch(`/users/league/${leagueCode}/all`, { headers: { 'Accept': 'application/json' } });
+    var members = await membersResp.json();
+
+    // Existing draft config for this league+season (null if none yet).
+    var draftResp = await fetch(`/draft/${leagueCode}/${season}`, { headers: { 'Accept': 'application/json' } });
+    currentDraft = await draftResp.json();
+
+    var byId = {};
+    members.forEach(m => { byId[String(m._id)] = m; });
+
+    var orderedIds = [];
+    var participantIds = new Set();
+
+    if (currentDraft && Array.isArray(currentDraft.draftOrder) && currentDraft.draftOrder.length) {
+        orderedIds = currentDraft.draftOrder.map(String);
+        orderedIds.forEach(id => participantIds.add(id));
+    } else {
+        // Default: everyone, ordered by reverse standings.
+        members = sortByStandings(members, season);
+        orderedIds = members.map(m => String(m._id));
+        orderedIds.forEach(id => participantIds.add(id));
+    }
+
+    draftMembers = [];
+    orderedIds.forEach(id => { if (byId[id]) draftMembers.push(byId[id]); });
+    // Include any members not already in the saved order (e.g. newly added).
+    members.forEach(m => {
+        if (!orderedIds.includes(String(m._id))) {
+            draftMembers.push(m);
+            participantIds.add(String(m._id));
+        }
+    });
+
+    renderDraftOrderList(participantIds);
+    populateDraftFormFields();
+}
+
+function sortByStandings(members, season) {
+    return members.slice().sort((a, b) => {
+        var aScore = (a.seasons.find(s => s.season == (season - 1))?.cumulativeScore) ?? 100000;
+        var bScore = (b.seasons.find(s => s.season == (season - 1))?.cumulativeScore) ?? 100000;
+        return aScore - bScore; // worst record picks first
+    });
+}
+
+function getCurrentParticipantIds() {
+    var set = new Set();
+    document.querySelectorAll('[draft-order-list] .draft-order-item').forEach(li => {
+        var cb = li.querySelector('.draft-participant');
+        if (cb && cb.checked) set.add(li.getAttribute('data-user-id'));
+    });
+    return set;
+}
+
+function renderDraftOrderList(participantIds) {
+    var list = document.querySelector('[draft-order-list]');
+    if (!list) return;
+    var str = '';
+    draftMembers.forEach(m => {
+        var id = String(m._id);
+        var checked = participantIds.has(id) ? 'checked' : '';
+        str += `<li class="draft-order-item" data-user-id="${id}">
+            <input type="checkbox" class="draft-participant" ${checked}>
+            <span class="draft-order-name">${m.firstName} ${m.lastName}</span>
+            <span class="draft-order-move">
+              <button type="button" title="Move up" onclick="moveDraftMember('${id}', -1)">&#9650;</button>
+              <button type="button" title="Move down" onclick="moveDraftMember('${id}', 1)">&#9660;</button>
+            </span>
+        </li>`;
+    });
+    list.innerHTML = str;
+}
+
+function moveDraftMember(id, dir) {
+    var participants = getCurrentParticipantIds();
+    var idx = draftMembers.findIndex(m => String(m._id) === id);
+    var swap = idx + dir;
+    if (idx < 0 || swap < 0 || swap >= draftMembers.length) return;
+    var tmp = draftMembers[idx];
+    draftMembers[idx] = draftMembers[swap];
+    draftMembers[swap] = tmp;
+    renderDraftOrderList(participants);
+}
+
+function autoOrderStandings() {
+    var participants = getCurrentParticipantIds();
+    draftMembers = sortByStandings(draftMembers, getSelectedDraftSeason());
+    renderDraftOrderList(participants);
+}
+
+function randomizeOrder() {
+    var participants = getCurrentParticipantIds();
+    for (var i = draftMembers.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        var t = draftMembers[i];
+        draftMembers[i] = draftMembers[j];
+        draftMembers[j] = t;
+    }
+    renderDraftOrderList(participants);
+}
+
+function isoToLocalInput(iso) {
+    var d = new Date(iso);
+    var pad = n => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function localInputToIso(val) {
+    if (!val) return null;
+    return new Date(val).toISOString();
+}
+
+function populateDraftFormFields() {
+    var status = currentDraft ? currentDraft.status : 'not configured';
+    var statusEl = document.querySelector('[draft-status]');
+    statusEl.textContent = status;
+    statusEl.className = 'draft-status-badge status-' + status.replace(/\s/g, '-');
+
+    document.querySelector('[draft-rounds]').value = (currentDraft && currentDraft.totalRounds) || 10;
+    document.querySelector('[draft-type]').value = (currentDraft && currentDraft.snake === false) ? 'linear' : 'snake';
+    document.querySelector('[draft-autoopen]').checked = (currentDraft && currentDraft.autoOpen) || false;
+    document.querySelector('[draft-datetime]').value =
+        (currentDraft && currentDraft.scheduledAt) ? isoToLocalInput(currentDraft.scheduledAt) : '';
+
+    var resetBtn = document.querySelector('[draft-reset-btn]');
+    resetBtn.style.display = (currentDraft && currentDraft._id) ? 'inline-block' : 'none';
+
+    // Lock settings once the draft is live/finished (but keep season + reset usable).
+    var locked = currentDraft && (currentDraft.status === 'active' || currentDraft.status === 'complete');
+    document.querySelectorAll('#draft-config-form input, #draft-config-form select, #draft-config-form button')
+        .forEach(el => { el.disabled = !!locked; });
+    document.querySelector('[draft-season]').disabled = false;
+    if (resetBtn) resetBtn.disabled = false;
+}
+
+async function resetDraft() {
+    if (!currentDraft || !currentDraft._id) return;
+    const response = await fetch(`/draft/${currentDraft._id}/reset`, {
+        method: 'POST',
+        headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+    });
+    response.json().then(data => {
+        if (response.status == 200) {
+            currentDraft = data;
+            populateDraftFormFields();
+            successToast.options.text = "Draft reset";
+            successToast.showToast();
+        } else {
+            failToast.options.text = "Draft could not be reset";
+            failToast.showToast();
+        }
+    });
+}
+
+const draftConfigForm = document.getElementById('draft-config-form');
+if (draftConfigForm) {
+    draftConfigForm.addEventListener('submit', async function(event) {
+        event.preventDefault();
+
+        var participants = getCurrentParticipantIds();
+        var draftOrder = draftMembers.map(m => String(m._id)).filter(id => participants.has(id));
+
+        if (draftOrder.length < 2) {
+            failToast.options.text = "Select at least 2 participants for the draft";
+            failToast.showToast();
+            return;
+        }
+
+        var body = {
+            league: getDraftLeagueCode(),
+            season: getSelectedDraftSeason(),
+            scheduledAt: localInputToIso(document.querySelector('[draft-datetime]').value),
+            autoOpen: document.querySelector('[draft-autoopen]').checked,
+            snake: document.querySelector('[draft-type]').value === 'snake',
+            totalRounds: parseInt(document.querySelector('[draft-rounds]').value, 10) || 10,
+            orderMethod: 'manual',
+            draftOrder: draftOrder
+        };
+
+        const response = await fetch('/draft', {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+
+        response.json().then(data => {
+            if (response.status == 200) {
+                currentDraft = data;
+                populateDraftFormFields();
+                successToast.options.text = "Draft settings saved";
+                successToast.showToast();
+            } else {
+                failToast.options.text = (data.message || "Draft settings could not be saved");
+                failToast.showToast();
+            }
+        });
+    });
+}
+
+if (document.querySelector('[draft-season]')) {
+    populateDraftSeasonOptions();
+    document.querySelector('[draft-season]').addEventListener('change', loadDraftConfig);
+}

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -216,85 +216,145 @@
 .draft-status-panel {
     text-align: center;
     color: #F4F6FB;
-    padding: 12px;
-    font-size: 1.1em;
+    padding: 18px 12px 4px;
+    font-size: 1.05em;
 }
 
 .draft-countdown {
-    font-size: 1.4em;
+    font-size: 1.6em;
     font-weight: 700;
     color: #64b5f6;
-    margin-bottom: 10px;
+    margin-bottom: 12px;
+    letter-spacing: 0.5px;
 }
 
 .draft-live-label {
-    font-size: 1.3em;
+    font-size: 1.35em;
     font-weight: 700;
+    margin: 0;
 }
 
 .draft-start-btn {
     background-color: #71d28d;
     color: #101322;
     border: none;
-    border-radius: 6px;
-    padding: 10px 22px;
+    border-radius: 8px;
+    padding: 11px 26px;
     font-weight: 700;
+    font-size: 1em;
     cursor: pointer;
+    transition: background-color 0.2s;
 }
-
 .draft-start-btn:hover { background-color: #5bbf79; }
 
+/* Board sits in a centered card that uses the width without stretching thin */
 .draft-board-wrap {
-    padding: 0 12px 16px;
+    max-width: 1200px;
+    margin: 8px auto 24px;
+    padding: 0 16px;
 }
 
+/* On the clock: a prominent banner bar */
 .on-the-clock {
     text-align: center;
     color: #F4F6FB;
-    font-size: 1.15em;
-    padding: 10px;
+    font-size: 1.1em;
+    padding: 12px 16px;
+    margin-bottom: 14px;
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 10px;
 }
-
 .on-the-clock .you-are-up {
     color: #71d28d;
-    font-weight: 700;
+    font-weight: 800;
+    font-size: 1.05em;
 }
 
+#draft-board {
+    margin: 0;
+    border-radius: 12px;
+    overflow: auto;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+    border: 1px solid #2A2E42;
+}
+
+/* Reset the inherited old-board padding/backgrounds */
+#draft-table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+    background: #131725;
+}
+#draft-board-head th:first-child,
+.draft-board-name { width: 150px; }
+#draft-table th,
+#draft-table td {
+    padding: 8px 6px;
+    text-align: center;
+    border-bottom: 1px solid #232838;
+}
+#draft-table td:not(:first-child) { background-color: transparent; }
+
+#draft-board-head th {
+    background: #0f1220;
+    color: #9aa4bf;
+    font-size: 0.85em;
+    font-weight: 700;
+    padding: 10px 6px;
+    position: sticky;
+    top: 0;
+}
+#draft-board-head th:first-child { text-align: left; padding-left: 16px; }
+
+/* Sticky player-name column + zebra striping for readability */
 .draft-board-name {
-    text-align: left;
+    text-align: left !important;
     white-space: nowrap;
     font-weight: 600;
     color: #F4F6FB;
+    position: sticky;
+    left: 0;
+    background: #161b2b;
+    padding-left: 16px !important;
+    min-width: 120px;
 }
+#draft-board-body tr:nth-child(even) td { background-color: #10131f; }
+#draft-board-body tr:nth-child(even) .draft-board-name { background-color: #141827; }
 
+.draft-board-cell {
+    width: 9%;
+    height: 52px;
+}
 .draft-board-cell img {
-    width: 34px;
-    height: 34px;
+    width: 42px;
+    height: 42px;
     object-fit: contain;
     vertical-align: middle;
 }
 
+/* Current pick: filled highlight instead of a floaty thin outline */
 .on-clock-cell {
-    outline: 2px solid #ed5858;
-    outline-offset: -2px;
+    background-color: rgba(237, 88, 88, 0.18) !important;
+    box-shadow: inset 0 0 0 2px #ed5858;
+    border-radius: 4px;
 }
 
+/* Draft action buttons in the team list */
 .draft-pick-btn {
     background-color: #71d28d;
     color: #101322;
     border: none;
-    border-radius: 5px;
-    padding: 5px 12px;
-    font-weight: 600;
+    border-radius: 6px;
+    padding: 6px 16px;
+    font-weight: 700;
     cursor: pointer;
+    transition: background-color 0.2s;
 }
-
+.draft-pick-btn:hover:not(:disabled) { background-color: #5bbf79; }
 .draft-pick-btn:disabled {
-    background-color: #3a3f52;
-    color: #888;
+    background-color: #2a2f42;
+    color: #6b7280;
     cursor: not-allowed;
 }
-
-[user-table-body] tr.drafted {
-    opacity: 0.4;
-}
+[user-table-body] tr.drafted { opacity: 0.35; }

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -212,3 +212,89 @@
         padding: 2em 1em 1em;
     }
 }
+/* ---------- Live draft board ---------- */
+.draft-status-panel {
+    text-align: center;
+    color: #F4F6FB;
+    padding: 12px;
+    font-size: 1.1em;
+}
+
+.draft-countdown {
+    font-size: 1.4em;
+    font-weight: 700;
+    color: #64b5f6;
+    margin-bottom: 10px;
+}
+
+.draft-live-label {
+    font-size: 1.3em;
+    font-weight: 700;
+}
+
+.draft-start-btn {
+    background-color: #71d28d;
+    color: #101322;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 22px;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.draft-start-btn:hover { background-color: #5bbf79; }
+
+.draft-board-wrap {
+    padding: 0 12px 16px;
+}
+
+.on-the-clock {
+    text-align: center;
+    color: #F4F6FB;
+    font-size: 1.15em;
+    padding: 10px;
+}
+
+.on-the-clock .you-are-up {
+    color: #71d28d;
+    font-weight: 700;
+}
+
+.draft-board-name {
+    text-align: left;
+    white-space: nowrap;
+    font-weight: 600;
+    color: #F4F6FB;
+}
+
+.draft-board-cell img {
+    width: 34px;
+    height: 34px;
+    object-fit: contain;
+    vertical-align: middle;
+}
+
+.on-clock-cell {
+    outline: 2px solid #ed5858;
+    outline-offset: -2px;
+}
+
+.draft-pick-btn {
+    background-color: #71d28d;
+    color: #101322;
+    border: none;
+    border-radius: 5px;
+    padding: 5px 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.draft-pick-btn:disabled {
+    background-color: #3a3f52;
+    color: #888;
+    cursor: not-allowed;
+}
+
+[user-table-body] tr.drafted {
+    opacity: 0.4;
+}

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -400,3 +400,46 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
 .xwins-fill { height: 100%; background: #71d28d; }
 
 .drafted-chip { background: #2a2f42; color: #6b7280; border-radius: 6px; padding: 4px 12px; font-size: 0.85em; }
+
+/* ---------- Commissioner undo ---------- */
+.draft-undo-btn {
+    background: transparent;
+    color: #ed8a8a;
+    border: 1px solid #ed5858;
+    border-radius: 8px;
+    padding: 8px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 8px;
+    transition: background-color 0.2s, color 0.2s;
+}
+.draft-undo-btn:hover { background: #ed5858; color: #fff; }
+
+/* ---------- Mobile pass ---------- */
+@media only screen and (max-width: 768px) {
+    .draft-status-panel { font-size: 0.95em; padding: 12px 10px 4px; }
+    .draft-countdown { font-size: 1.2em; }
+    .draft-live-label { font-size: 1.1em; }
+
+    .draft-board-wrap { padding: 0 8px; margin: 6px auto 16px; }
+    .on-the-clock { font-size: 0.95em; padding: 10px; }
+
+    #draft-table th, #draft-table td { padding: 5px 3px; }
+    .draft-board-cell { height: 40px; }
+    .draft-board-cell img { width: 30px; height: 30px; }
+    #draft-board-head th:first-child, .draft-board-name { width: 92px; min-width: 92px; padding-left: 10px !important; }
+    #draft-board-head th:first-child { padding-left: 10px; }
+
+    .content.pool { padding: 0 8px; }
+    .pool-controls { gap: 8px; }
+    .pool-controls input[type="text"] { flex: 1 1 100%; }
+    .pool-controls select { flex: 1 1 auto; }
+    .pool-spacer { display: none; }
+    .pool-count { flex: 1 1 100%; text-align: left; }
+
+    .pool-table thead th, .pool-table tbody td { padding: 6px 8px; font-size: 0.82em; }
+    .pool-table thead th:first-child, .pool-table tbody td:first-child { width: 130px; }
+    .team-cell { gap: 6px; }
+    .team-cell img { width: 20px; height: 20px; }
+    .xwins-bar { width: 44px; }
+}

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -358,3 +358,45 @@
     cursor: not-allowed;
 }
 [user-table-body] tr.drafted { opacity: 0.35; }
+
+/* ---------- Team pool (draft aid) ---------- */
+.content.pool { max-width: 1100px; margin: 8px auto 40px; padding: 0 16px; display: block; }
+.pool-title { color: #F4F6FB; margin: 0 0 12px; }
+.pool-controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 12px; }
+.pool-controls input[type="text"], .pool-controls select {
+    background: #101322; color: #F4F6FB; border: 1px solid #2A2E42;
+    border-radius: 6px; padding: 8px 10px; font-size: 0.95em;
+}
+.pool-spacer { flex: 1; }
+.pool-count { color: #9aa4bf; font-size: 0.9em; }
+.pool-toggle { display: flex; align-items: center; gap: 6px; color: #9aa4bf; font-size: 0.9em; cursor: pointer; }
+
+.pool-table-wrap { overflow-x: auto; border: 1px solid #2A2E42; border-radius: 10px; }
+table.pool-table { width: 100%; border-collapse: collapse; background: #131725; }
+.pool-table thead th {
+    position: sticky; top: 0; background: #0f1220; color: #9aa4bf;
+    font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.5px;
+    padding: 10px 12px; text-align: left; cursor: pointer; user-select: none; white-space: nowrap;
+}
+.pool-table thead th.num { text-align: right; }
+.pool-table thead th .arrow { color: #4b5573; margin-left: 4px; font-size: 0.9em; }
+.pool-table thead th.sorted .arrow { color: #64b5f6; }
+.pool-table thead th:first-child, .pool-table tbody td:first-child { width: 210px; }
+.pool-table tbody td { padding: 7px 12px; border-top: 1px solid #1e2333; font-size: 0.92em; color: #F4F6FB; text-align: left; }
+.pool-table tbody td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.pool-table tbody tr:hover { background: #171c2c; }
+
+.team-cell { display: flex; align-items: center; gap: 9px; font-weight: 600; white-space: nowrap; }
+.team-cell img { width: 26px; height: 26px; object-fit: contain; }
+
+.rank-badge { display: inline-block; min-width: 26px; text-align: center; padding: 2px 7px;
+    border-radius: 10px; font-weight: 700; font-size: 0.85em; background: #263043; color: #9aa4bf; }
+.rank-badge.top25 { background: #1f3a5c; color: #8fc3ff; }
+.rank-badge.top10 { background: #eab308; color: #101322; }
+.muted { color: #5b6480; }
+
+.xwins-wrap { display: flex; align-items: center; gap: 8px; justify-content: flex-end; }
+.xwins-bar { width: 70px; height: 6px; background: #232838; border-radius: 3px; overflow: hidden; }
+.xwins-fill { height: 100%; background: #71d28d; }
+
+.drafted-chip { background: #2a2f42; color: #6b7280; border-radius: 6px; padding: 4px 12px; font-size: 0.85em; }

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -1,5 +1,6 @@
 // Live draft room. Connects to the Socket.IO draft engine, renders the board
-// in real time, and lets whoever is on the clock draft a team.
+// in real time, and lets whoever is on the clock draft a team. The team pool
+// below the board is a sortable/filterable draft aid.
 
 var socket;
 var draft = null;            // latest draft state from the server (or null)
@@ -14,6 +15,10 @@ var season = new Date().getFullYear();
 var isMobile = false;
 var countdownTimer;
 
+var pool = [];               // enriched team rows for the pool table
+var poolSort = { key: 'xwins', dir: -1 };
+var xwMin = 0, xwMax = 0;
+
 window.onload = async function () {
     detectMobile();
     initNavbarToggle();
@@ -21,7 +26,6 @@ window.onload = async function () {
     setUserContext();
     await getMembers();
     await getTeams();
-    setDynamicYearHeaders();
     setNavbarUserId();
     connectSocket();
 };
@@ -60,68 +64,132 @@ async function getMembers() {
     data.forEach(m => { membersById[String(m._id)] = m; });
 }
 
+async function getRecruitingRankings() {
+    const res = await fetch(`/recruiting/${new Date().getFullYear()}`, { headers: { 'Accept': 'application/json' } });
+    return res.json().catch(() => []);
+}
+
 async function getTeams() {
     const res = await fetch('/teams', { headers: { 'Accept': 'application/json' } });
     const data = await res.json();
     teamList = data;
     data.forEach(t => { teamsById[String(t.id)] = t; });
-    await displayTeams(data);
+
+    const recruiting = await getRecruitingRankings();
+    buildPool(data, recruiting);
+    populateConfFilter();
+    renderPool();
 }
 
-function setDynamicYearHeaders() {
-    var rr = document.querySelector('[recruiting-ranking]');
-    var ew = document.querySelector('[expected-wins]');
-    if (rr) rr.innerHTML = `${new Date().getFullYear()} Recruiting`;
-    if (ew) ew.innerHTML = `${new Date().getFullYear()} xWins`;
-}
-
-async function getRecruitingRankings() {
-    const res = await fetch(`/recruiting/${new Date().getFullYear()}`, { headers: { 'Accept': 'application/json' } });
-    return res.json();
-}
-
-async function displayTeams(data) {
-    var recruitingRankings = await getRecruitingRankings();
-    const body = document.querySelector('[user-table-body]');
-    var str = '';
-
-    data.sort((a, b) => scoreForTeam(b) - scoreForTeam(a));
-
-    data.forEach(team => {
-        var conference = '-';
-        var cumulScore = '-';
-        var expectedWins = 0;
-        if (team.seasons.length > 0) {
-            var season = team.seasons.find(s => s.season == (new Date().getFullYear() - 1));
-            var currentSeason = team.seasons.find(s => s.season == (new Date().getFullYear()));
-            conference = team.seasons.at(-1).conference;
-            if (season != null) cumulScore = (leagueVersion == 'V1') ? season.cumulativeScoreV1 : season.cumulativeScoreV2;
-            expectedWins = currentSeason != null ? currentSeason.expectedWins : 0;
+function buildPool(teams, recruiting) {
+    var yr = new Date().getFullYear();
+    pool = teams.map(t => {
+        var conf = '-', score = null, xwins = 0;
+        if (t.seasons && t.seasons.length) {
+            var prev = t.seasons.find(s => s.season == (yr - 1));
+            var cur = t.seasons.find(s => s.season == yr);
+            conf = t.seasons.at(-1).conference;
+            if (prev) score = (leagueVersion == 'V1') ? prev.cumulativeScoreV1 : prev.cumulativeScoreV2;
+            if (cur) xwins = cur.expectedWins || 0;
         }
-
-        var teamRecruiting = { rank: '-' };
-        if (recruitingRankings.length > 0) {
-            teamRecruiting = recruitingRankings.filter(o => (o.team == team.school || team.alternateNames.includes(o.team)))[0] || { rank: '-' };
+        var rank = null;
+        if (recruiting && recruiting.length) {
+            var r = recruiting.filter(o => o.team == t.school || (t.alternateNames || []).includes(o.team))[0];
+            if (r) rank = r.rank;
         }
-
-        str += `<tr data-team-id="${team.id}">`;
-        str += `<td style="text-align: left;"><img src="${team.logos.at(-1)}" alt="${team.mascot}">${team.school}</td>`;
-        str += `<td>${conference}</td>`;
-        str += `<td>${teamRecruiting.rank}</td>`;
-        str += `<td>${cumulScore}</td>`;
-        str += `<td>O/U ${expectedWins}</td>`;
-        str += `<td><button type="button" class="draft-pick-btn" id="draft-btn-${team.id}" onclick="makePick(${team.id})" disabled>Draft</button></td>`;
-        str += '</tr>';
+        return { id: t.id, name: t.school, logo: (t.logos || []).at(-1), conf, score, xwins, rank };
     });
-
-    body.innerHTML = str;
+    var xw = pool.map(p => p.xwins).filter(v => v > 0);
+    xwMin = xw.length ? Math.min(...xw) : 0;
+    xwMax = xw.length ? Math.max(...xw) : 0;
 }
 
-function scoreForTeam(team) {
-    if (!team.seasons || team.seasons.length === 0) return 0;
-    var s = team.seasons.find(x => x.season == (new Date().getFullYear() - 1));
-    if (s == null) return 0;
-    return (leagueVersion == 'V1' ? s.cumulativeScoreV1 : s.cumulativeScoreV2) || 0;
+function barWidth(x) {
+    if (!x || x <= 0) return 0;
+    if (xwMax === xwMin) return 100;
+    return 15 + ((x - xwMin) / (xwMax - xwMin)) * 85;
+}
+
+function populateConfFilter() {
+    var sel = document.getElementById('poolConf');
+    if (!sel) return;
+    [...new Set(pool.map(p => p.conf))].filter(c => c && c !== '-').sort().forEach(c => {
+        var o = document.createElement('option');
+        o.value = c; o.textContent = c;
+        sel.appendChild(o);
+    });
+}
+
+function sortVal(p, k) {
+    if (k === 'name') return p.name.toLowerCase();
+    if (k === 'conf') return (p.conf || '').toLowerCase();
+    if (k === 'rank') return p.rank == null ? 999 : p.rank;
+    if (k === 'score') return p.score == null ? -1 : p.score;
+    if (k === 'xwins') return p.xwins == null ? -1 : p.xwins;
+    return 0;
+}
+
+function sortPool(key) {
+    if (poolSort.key === key) {
+        poolSort.dir *= -1;
+    } else {
+        poolSort.key = key;
+        // Names/conference/recruiting read best ascending; stats descending.
+        poolSort.dir = (key === 'name' || key === 'conf' || key === 'rank') ? 1 : -1;
+    }
+    renderPool();
+}
+
+function renderPool() {
+    var body = document.querySelector('[user-table-body]');
+    if (!body) return;
+
+    var draftedIds = new Set((draft && draft.picks ? draft.picks : []).map(p => String(p.team.id)));
+    var oc = (draft && draft.onTheClock) || {};
+    var canAct = draft && draft.status === 'active' && (String(oc.userId) === String(myUserId) || isCommish);
+
+    var q = (document.getElementById('poolSearch').value || '').toLowerCase();
+    var cf = document.getElementById('poolConf').value;
+    var showD = document.getElementById('showDrafted').checked;
+
+    var rows = pool.filter(p => {
+        var drafted = draftedIds.has(String(p.id));
+        if (drafted && !showD) return false;
+        if (cf && p.conf !== cf) return false;
+        if (q && !(p.name.toLowerCase().includes(q) || (p.conf || '').toLowerCase().includes(q))) return false;
+        return true;
+    });
+    var k = poolSort.key, dir = poolSort.dir;
+    rows.sort((a, b) => { var av = sortVal(a, k), bv = sortVal(b, k); return (av < bv ? -1 : av > bv ? 1 : 0) * dir; });
+
+    var cols = [['name', 'Team'], ['conf', 'Conference'], ['rank', 'Recruiting'], ['score', 'Last Season'], ['xwins', 'xWins'], ['draft', '']];
+    document.getElementById('pool-head').innerHTML = cols.map(([key, label]) => {
+        var numCls = (key === 'rank' || key === 'score' || key === 'xwins') ? 'num' : '';
+        var sorted = key === poolSort.key;
+        var arrow = key === 'draft' ? '' : `<span class="arrow">${sorted ? (poolSort.dir < 0 ? '▼' : '▲') : '↕'}</span>`;
+        var onclick = key === 'draft' ? '' : `onclick="sortPool('${key}')"`;
+        return `<th class="${numCls} ${sorted ? 'sorted' : ''}" ${onclick}>${label}${arrow}</th>`;
+    }).join('');
+
+    body.innerHTML = rows.map(p => {
+        var drafted = draftedIds.has(String(p.id));
+        var badge = p.rank == null ? '<span class="muted">—</span>' : `<span class="rank-badge ${p.rank <= 10 ? 'top10' : p.rank <= 25 ? 'top25' : ''}">#${p.rank}</span>`;
+        var bw = barWidth(p.xwins);
+        var action = drafted
+            ? '<span class="drafted-chip">Drafted</span>'
+            : `<button class="draft-pick-btn" onclick="makePick(${p.id})" ${canAct ? '' : 'disabled'}>Draft</button>`;
+        return `<tr class="${drafted ? 'drafted' : ''}">
+            <td><span class="team-cell"><img src="${p.logo}" alt="${p.name}">${p.name}</span></td>
+            <td>${p.conf}</td>
+            <td class="num">${badge}</td>
+            <td class="num">${p.score == null ? '-' : p.score}</td>
+            <td class="num"><span class="xwins-wrap">${p.xwins || '-'}<span class="xwins-bar"><span class="xwins-fill" style="width:${bw}%"></span></span></span></td>
+            <td class="num">${action}</td>
+        </tr>`;
+    }).join('');
+
+    var avail = pool.filter(p => !draftedIds.has(String(p.id))).length;
+    document.getElementById('poolCount').textContent = `${rows.length} shown · ${avail} available`;
 }
 
 /////////////////////////////////////////////////////
@@ -194,7 +262,7 @@ function renderAll() {
     renderStatus();
     renderBoard();
     renderOnTheClock();
-    updateAvailability();
+    renderPool();
 }
 
 function renderStatus() {
@@ -283,43 +351,9 @@ function renderOnTheClock() {
     }
 }
 
-function updateAvailability() {
-    var draftedIds = new Set((draft && draft.picks ? draft.picks : []).map(p => String(p.team.id)));
-    var oc = (draft && draft.onTheClock) || {};
-    var myTurn = draft && draft.status === 'active' && String(oc.userId) === String(myUserId);
-    var canAct = draft && draft.status === 'active' && (myTurn || isCommish);
-
-    document.querySelectorAll('[user-table-body] tr').forEach(row => {
-        var teamId = row.getAttribute('data-team-id');
-        var btn = row.querySelector('.draft-pick-btn');
-        var drafted = draftedIds.has(String(teamId));
-        row.classList.toggle('drafted', drafted);
-        if (!btn) return;
-        if (drafted) {
-            btn.disabled = true;
-            btn.textContent = 'Drafted';
-        } else {
-            btn.textContent = 'Draft';
-            btn.disabled = !canAct;
-        }
-    });
-}
-
 /////////////////////////////////////////////////////
 //////////////////// Helpers /////////////////////////
 /////////////////////////////////////////////////////
-
-const _filterFunction = () => {
-    const filterColumns = [0, 1];
-    const trs = document.querySelectorAll(`.fl-table tr:not(.headerRow)`);
-    const filter = document.querySelector('#myInput').value.replace(/\s/g, "");
-    const regex = new RegExp(escape(filter), 'i');
-    const isFoundInTds = td => regex.test(td.innerHTML.replace(/\s/g, ""));
-    const isFound = arr => arr.some(isFoundInTds);
-    trs.forEach(({ style, children }) => {
-        style.display = isFound(filterColumns.map(c => children[c])) ? '' : 'none';
-    });
-};
 
 function setNavbarUserId() {
     var userId = (userState.user_metadata.metadata && userState.user_metadata.metadata.userId) || window.localStorage.getItem('userId');

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -1,615 +1,354 @@
-var leagueVersion;
-var isMobile;
-var teamOptionList;
+// Live draft room. Connects to the Socket.IO draft engine, renders the board
+// in real time, and lets whoever is on the clock draft a team.
+
+var socket;
+var draft = null;            // latest draft state from the server (or null)
 var teamList = [];
-var users = [];
-var currentTeamIndex = 0;
-var currentRound = 1;
-var draftDirection = 1;
-const totalRounds = 10;
-const userTeams = [];
+var teamsById = {};
+var membersById = {};        // userId -> { firstName, lastName }
+var myUserId;
+var isCommish = false;
+var leagueCode;
+var leagueVersion = 'V2';
+var season = new Date().getFullYear();
+var isMobile = false;
+var countdownTimer;
 
-window.onload = async function() {
+window.onload = async function () {
     detectMobile();
-
-    function initNavbarToggle() {
-        const toggleButton = document.querySelector('.toggle-button');
-        const navbarLinks = document.querySelector('.navbar-links');
-
-        if (toggleButton && navbarLinks) {
-            toggleButton.addEventListener('click', () => {
-                navbarLinks.classList.toggle('active');
-            });
-            console.log("✅ Navbar toggle initialized");
-        } else {
-            // Retry after 500ms if elements aren't in the DOM yet
-            console.log("⏳ Navbar elements not found, retrying...");
-            setTimeout(initNavbarToggle, 500);
-        }
-    }
-
     initNavbarToggle();
 
-    await getUserProfile();
+    setUserContext();
+    await getMembers();
     await getTeams();
     setDynamicYearHeaders();
+    setNavbarUserId();
+    connectSocket();
 };
 
-$('#myModal').on('shown.bs.modal', function () {
-    $('#myInput').trigger('focus')
-})
-
 function detectMobile() {
-    if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/.test(navigator.userAgent)){
-        // true for mobile device
-        isMobile = true;
-    } else{
-        // false for not mobile device
-        isMobile = false;
+    isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/.test(navigator.userAgent);
+}
+
+function initNavbarToggle() {
+    const toggleButton = document.querySelector('.toggle-button');
+    const navbarLinks = document.querySelector('.navbar-links');
+    if (toggleButton && navbarLinks) {
+        toggleButton.addEventListener('click', () => navbarLinks.classList.toggle('active'));
+    } else {
+        setTimeout(initNavbarToggle, 500);
     }
 }
 
-async function getUserProfile() {
-    const response = await fetch(`/profile`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
+function setUserContext() {
+    var meta = (userState && userState.user_metadata) || {};
+    var roles = meta.roles || [];
+    myUserId = meta.metadata && meta.metadata.userId;
+    isCommish = roles.includes('Admin') || roles.includes('League Manager');
 
-    response.json().then(async data => {
-        console.log("user metadata", data)
-
-        // Only set leagueCode from metaData if it's not already stored
-        if (!window.localStorage.getItem("leagueCode") && data?.user_metadata?.metadata?.league) {
-            var newLeagueCode = (data.user_metadata.metadata.league == 'gg' ? 'graham-league' : 'claunts-league');
-            window.localStorage.setItem("leagueCode", newLeagueCode);
-        }
-
-        if (userState.user_metadata.roles?.at(-1) == 'Admin') { 
-            const leagueCode = window.localStorage.getItem("leagueCode");
-
-            if (leagueCode && (leagueCode != "undefined")) {
-                const currentSelectedLeague = window.sessionStorage.getItem("league");
-                if (currentSelectedLeague) {
-                    $("#dropdownMenuButton").text(currentSelectedLeague);
-                }
-            }
-        }
-        
-        getUsers();
-    });
-}
-
-async function getUsers() {
-    var leagueCode = (userState.user_metadata.metadata.league == 'gg' ? 'graham-league' : 'claunts-league');
-    const response = await fetch(`/users/league/${leagueCode}/all`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
-
-    response.json().then(async data => {
-        if (!isMobile) displayUsers(data);
-        setNavbarUserId();
-    });
-}
-
-function displayUsers(data) {
-    if (document.querySelector('[draft-table-body]')) {
-        const draftTableBody = document.querySelector('[draft-table-body]');
-        var str = '';
-
-        if ((data[0].seasons.at(-1).draftPosition != null) && (data[0].seasons.at(-1).draftPosition != '')) {
-            data.sort((a, b) => {
-                return (a.seasons.at(-1).draftPosition) - (b.seasons.at(-1).draftPosition);
-            });
-        } else {
-            data.sort((a, b) => {
-                return (a.seasons.at(-2)?.cumulativeScore || 1000) - (b.seasons.at(-2)?.cumulativeScore || 1000);
-            });
-        }
-
-        users = data;
-
-        data.forEach( (user, index) => {
-            userTeams.push(user.firstName);
-
-            str += '<tr>';
-            str += `<td>${user.firstName} ${user.lastName.substring(0,1)}.</td>`;
-
-            for(var i = 1; i < 11; i++) {
-                str += `<td id="${user._id}-round${i}"></td>`;
-            }
-
-            str += '</tr>';
-        });
-
-        draftTableBody.innerHTML = str;
-
-        document.querySelectorAll('td[id*="-round"]').forEach(cell => {
-            cell.addEventListener('click', function() {
-                const currentTeamName = cell.children[0].alt;
-        
-                $('#changeTeamModal p:first').text(`Which team do you want to select instead of ${currentTeamName}?`);
-        
-                $('#changeTeamModal').attr("cell-id", cell.id);
-                $('#changeTeamModal').attr("previous-school", currentTeamName);
-                $('#changeTeamModal').attr("previous-value", cell.children[0].title);
-                $('#changeTeamModal').modal('show');
-            });
-        });
-
-        $(`*[id*=${users[currentTeamIndex]._id}]:visible`).each(function() {
-            $(this).css('background-color', '#ed5858');
-        });
-
-        // Initialize the current user and round display
-        document.getElementById('current-team').textContent = `Current Team: ${userTeams[currentTeamIndex].charAt(0).toUpperCase() + userTeams[currentTeamIndex].slice(1)}`;
-        document.getElementById('current-round').textContent = `Round ${currentRound}`;
-
-        var previous;
-
-        $("select").on('focus', function() {
-            previous = this.value;
-
-        }).on("change", function(){
-            $('#team-form button').attr('disabled', false);
-
-            if (previous != "") {
-                $("select").find("option[value=" + previous + "]").show();
-            }
-            
-            $("select").not(this).find("option[value=" + $(this).val() + "]").hide();
-        });
+    leagueCode = (meta.metadata && meta.metadata.league == 'gg') ? 'graham-league' : 'claunts-league';
+    if (roles.at(-1) == 'Admin') {
+        var stored = window.localStorage.getItem('leagueCode');
+        if (stored && stored != 'undefined') leagueCode = stored;
     }
+    leagueVersion = (leagueCode == 'claunts-league') ? 'V1' : 'V2';
+}
+
+async function getMembers() {
+    const res = await fetch(`/users/league/${leagueCode}/all`, { headers: { 'Accept': 'application/json' } });
+    const data = await res.json();
+    data.forEach(m => { membersById[String(m._id)] = m; });
 }
 
 async function getTeams() {
-    fetch("/teams", {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    }).then(res => res.json()).then(data => {
-        setTeamOptions(data);
-        displayTeams(data);
-    });
-}
-
-function setTeamOptions(data) {
-    teamOptionList = document.querySelectorAll('[team-options]');
+    const res = await fetch('/teams', { headers: { 'Accept': 'application/json' } });
+    const data = await res.json();
     teamList = data;
-    var str = '<option value="" disabled selected>Select A Team</option>';
-    
-    data.sort((a, b) => {
-        return a.school.localeCompare(b.school)
-    });
-
-    data.forEach( team => {
-        str += '<option value="';
-        str += team.id;
-        str += '">' + team.school;
-        str += '</option>';
-    });
-
-    teamOptionList.forEach(selector => {
-        selector.innerHTML = str;
-    });
-
-    _multiplyNode(document.querySelector('.draft-team-container'), 1, true);
+    data.forEach(t => { teamsById[String(t.id)] = t; });
+    await displayTeams(data);
 }
 
 function setDynamicYearHeaders() {
-    document.querySelector('[recruiting-ranking]').innerHTML = `${new Date().getFullYear()} Recruiting`;
-    document.querySelector('[expected-wins]').innerHTML = `${new Date().getFullYear()} xWins`;
+    var rr = document.querySelector('[recruiting-ranking]');
+    var ew = document.querySelector('[expected-wins]');
+    if (rr) rr.innerHTML = `${new Date().getFullYear()} Recruiting`;
+    if (ew) ew.innerHTML = `${new Date().getFullYear()} xWins`;
 }
 
 async function getRecruitingRankings() {
-    var response = await fetch(`/recruiting/${new Date().getFullYear()}`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
-
-    var recruitingRankings = await response.json();
-
-    return recruitingRankings;
+    const res = await fetch(`/recruiting/${new Date().getFullYear()}`, { headers: { 'Accept': 'application/json' } });
+    return res.json();
 }
 
 async function displayTeams(data) {
     var recruitingRankings = await getRecruitingRankings();
-
-    const userTableBody = document.querySelector('[user-table-body]');
+    const body = document.querySelector('[user-table-body]');
     var str = '';
 
-    data.sort((a, b) => {
-        var aScore = 0;
-        var bScore = 0;
+    data.sort((a, b) => scoreForTeam(b) - scoreForTeam(a));
 
-        if (a.seasons.length > 0) {
-            var aSeason = a.seasons.find((season) => season.season == (new Date().getFullYear() - 1));
-
-            if (leagueVersion == "V1") {
-                aScore = aSeason != null ? aSeason.cumulativeScoreV1 : 0;
-            } else {
-                aScore = aSeason != null ? aSeason.cumulativeScoreV2 : 0;
-            }
-        }
-
-        if (b.seasons.length > 0) {
-            var bSeason = b.seasons.find((season) => season.season == (new Date().getFullYear() - 1));
-
-            if (leagueVersion == "V1") {
-                bScore = bSeason != null ? bSeason.cumulativeScoreV1 : 0;
-            } else {
-                bScore = bSeason != null ? bSeason.cumulativeScoreV2 : 0;
-            }
-        }
-        
-        return bScore - aScore;
-    });
-
-    data.forEach( (team, index) => {
-        var conference = "-";
-        var cumulScoreV1 = 0;
-        var cumulScoreV2 = 0;
+    data.forEach(team => {
+        var conference = '-';
+        var cumulScore = '-';
         var expectedWins = 0;
-
         if (team.seasons.length > 0) {
-            var season = team.seasons.find((season) => season.season == (new Date().getFullYear() - 1));
-            var currentSeason = team.seasons.find((season) => season.season == (new Date().getFullYear()));
+            var season = team.seasons.find(s => s.season == (new Date().getFullYear() - 1));
+            var currentSeason = team.seasons.find(s => s.season == (new Date().getFullYear()));
             conference = team.seasons.at(-1).conference;
-            cumulScoreV1 = season != null ? season.cumulativeScoreV1 : "-";
-            cumulScoreV2 = season != null ? season.cumulativeScoreV2 : "-";
+            if (season != null) cumulScore = (leagueVersion == 'V1') ? season.cumulativeScoreV1 : season.cumulativeScoreV2;
             expectedWins = currentSeason != null ? currentSeason.expectedWins : 0;
         }
 
-        str += '<tr><td style="text-align: left;">';
-        refLink = `/team?team=${team.id}`;
-
-        str += '<a href="' + refLink + '"><img src="' + team.logos.at(-1) + '" alt="' + team.mascot + '">'
-        str += team.school;
-        str += '</td>';
-
-        str += '<td>' + conference + '</td>';
-
-        var teamRecruiting;
-
+        var teamRecruiting = { rank: '-' };
         if (recruitingRankings.length > 0) {
-            teamRecruiting = recruitingRankings.filter(obj => {
-                return (obj.team == team.school || team.alternateNames.includes(obj.team))
-            })[0];
-        } else {
-            teamRecruiting = {
-                rank: "-"
-            }
+            teamRecruiting = recruitingRankings.filter(o => (o.team == team.school || team.alternateNames.includes(o.team)))[0] || { rank: '-' };
         }
 
-        if (teamRecruiting == null) {
-            console.log("team", team)
-        }
-
-        str += '<td>' + teamRecruiting.rank + '</td>';
-
-        if (leagueVersion == "V1") {
-            str += '<td>' + cumulScoreV1 + '</td>';
-        } else {
-            str += '<td>' + cumulScoreV2 + '</td>';
-        }
-
-        str += '<td>O/U ' + expectedWins + '</td>'
-        
+        str += `<tr data-team-id="${team.id}">`;
+        str += `<td style="text-align: left;"><img src="${team.logos.at(-1)}" alt="${team.mascot}">${team.school}</td>`;
+        str += `<td>${conference}</td>`;
+        str += `<td>${teamRecruiting.rank}</td>`;
+        str += `<td>${cumulScore}</td>`;
+        str += `<td>O/U ${expectedWins}</td>`;
+        str += `<td><button type="button" class="draft-pick-btn" id="draft-btn-${team.id}" onclick="makePick(${team.id})" disabled>Draft</button></td>`;
         str += '</tr>';
     });
 
-    userTableBody.innerHTML = str;
+    body.innerHTML = str;
 }
 
-async function submitDraft() {
+function scoreForTeam(team) {
+    if (!team.seasons || team.seasons.length === 0) return 0;
+    var s = team.seasons.find(x => x.season == (new Date().getFullYear() - 1));
+    if (s == null) return 0;
+    return (leagueVersion == 'V1' ? s.cumulativeScoreV1 : s.cumulativeScoreV2) || 0;
+}
 
-    var userBodies = [];
+/////////////////////////////////////////////////////
+//////////////////// Live Socket /////////////////////
+/////////////////////////////////////////////////////
 
-    users.forEach(
-        user => {
-            var userId = user._id;
-            var userTeamSelections = $(`*[id*=${user._id}]`).toArray();
+async function connectSocket() {
+    try {
+        const res = await fetch('/draft-token', { headers: { 'Accept': 'application/json' } });
+        const { token } = await res.json();
+        socket = io({ auth: { token } });
 
-            const teamDocuments = [];
-            userTeamSelections.forEach(
-                team => {
-                    var teamId = team.children[0].getAttribute("title");
-                    var teamObj = teamList.find((element) => element.id == teamId);
-                    teamObj.location.venue_id = teamObj.location.id;
-                    delete teamObj.location.id;
-                    teamDocuments.push(teamObj);
-                }
-            );
-
-            var userBody = {
-                "userId": userId,
-                "teams": teamDocuments
-            };
-
-            userBodies.push(userBody);
-        }
-    );
-    console.log("userBodies", userBodies)
-
-    var isSuccess = [];
-
-    for (let user of userBodies) {
-        var userUpdated = await updateUser(user.userId, user.teams);
-        isSuccess.push(userUpdated);
-    }
-
-    if (isSuccess.includes(false)) {
-        failToast.options.text = "Some users could not be updated for the new season";
+        socket.on('connect', () => socket.emit('join-draft', { league: leagueCode, season }));
+        socket.on('draft-state', onDraftState);
+        socket.on('pick-made', onPickMade);
+        socket.on('draft-complete', onDraftComplete);
+        socket.on('draft-error', (e) => {
+            if (e && /no draft/i.test(e.message || '')) {
+                draft = null;
+                renderAll();
+            } else {
+                failToast.options.text = (e && e.message) || 'Draft error';
+                failToast.showToast();
+            }
+        });
+    } catch (err) {
+        failToast.options.text = 'Could not connect to the draft';
         failToast.showToast();
-    } else {
-        successToast.options.text = "Draft submitted successfully";
-        successToast.showToast();
-        startConfetti();
-        $('#submit-draft button').attr('disabled', true)
     }
 }
 
-async function updateUser(userId, teams) {
-    
-    var requestBody = `{
-        "season": ${new Date().getFullYear()},
-        "teams": ${JSON.stringify(teams)}
-        }`;
+function onDraftState(state) {
+    draft = state;
+    renderAll();
+}
 
-    const response = await fetch(`/users/draft/` + userId, {
-        method: 'PATCH',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        },
-        body: requestBody,
+function onPickMade({ pick, state }) {
+    draft = state;
+    renderAll();
+    var member = membersById[String(pick.userId)];
+    var name = member ? `${member.firstName} ${member.lastName.substring(0, 1)}.` : 'Someone';
+    successToast.options.text = `${name} drafted ${pick.team.school}`;
+    successToast.showToast();
+}
+
+function onDraftComplete(state) {
+    draft = state;
+    renderAll();
+    if (typeof startConfetti === 'function') startConfetti();
+    successToast.options.text = 'Draft complete!';
+    successToast.showToast();
+}
+
+function makePick(teamId) {
+    var team = teamsById[String(teamId)];
+    if (!team || !socket) return;
+    document.querySelectorAll('.draft-pick-btn').forEach(b => b.disabled = true);
+    socket.emit('make-pick', { league: leagueCode, season, team });
+}
+
+function startDraft() {
+    if (socket) socket.emit('start-draft', { league: leagueCode, season });
+}
+
+/////////////////////////////////////////////////////
+/////////////////////// Render ///////////////////////
+/////////////////////////////////////////////////////
+
+function renderAll() {
+    renderStatus();
+    renderBoard();
+    renderOnTheClock();
+    updateAvailability();
+}
+
+function renderStatus() {
+    var el = document.getElementById('draft-status');
+    if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
+
+    if (!draft) {
+        el.innerHTML = `<p>No draft is scheduled for ${season} yet.</p>`;
+        return;
+    }
+
+    var startBtn = isCommish ? `<button type="button" class="draft-start-btn" onclick="startDraft()">Start Draft</button>` : '';
+
+    if (draft.status === 'pending') {
+        el.innerHTML = `<p>Draft is set up but not scheduled.</p>${startBtn}`;
+    } else if (draft.status === 'scheduled') {
+        el.innerHTML = `<div class="draft-countdown" id="countdown"></div>${startBtn}`;
+        updateCountdown();
+        countdownTimer = setInterval(updateCountdown, 1000);
+    } else if (draft.status === 'active') {
+        el.innerHTML = `<p class="draft-live-label">🟢 Draft in progress</p>`;
+    } else if (draft.status === 'complete') {
+        el.innerHTML = `<p class="draft-live-label">🎉 Draft complete!</p>`;
+    }
+}
+
+function updateCountdown() {
+    var el = document.getElementById('countdown');
+    if (!el || !draft || !draft.scheduledAt) { if (el) el.textContent = 'Draft scheduled'; return; }
+    var diff = new Date(draft.scheduledAt).getTime() - Date.now();
+    if (diff <= 0) { el.textContent = 'Draft starting soon…'; return; }
+    var d = Math.floor(diff / 86400000);
+    var h = Math.floor((diff % 86400000) / 3600000);
+    var m = Math.floor((diff % 3600000) / 60000);
+    var s = Math.floor((diff % 60000) / 1000);
+    el.textContent = `Draft starts in ${d}d ${h}h ${m}m ${s}s`;
+}
+
+function renderBoard() {
+    var wrap = document.getElementById('draft-board-wrap');
+    if (!draft || (draft.status !== 'active' && draft.status !== 'complete')) {
+        wrap.style.display = 'none';
+        return;
+    }
+    wrap.style.display = 'block';
+
+    var head = document.getElementById('draft-board-head');
+    var body = document.getElementById('draft-board-body');
+
+    var headStr = '<th>Player</th>';
+    for (var r = 1; r <= draft.totalRounds; r++) headStr += `<th>${r}</th>`;
+    head.innerHTML = headStr;
+
+    var onClock = draft.onTheClock || {};
+    var bodyStr = '';
+    draft.draftOrder.forEach(userId => {
+        var member = membersById[String(userId)];
+        var name = member ? `${member.firstName} ${member.lastName.substring(0, 1)}.` : '—';
+        bodyStr += '<tr>';
+        bodyStr += `<td class="draft-board-name">${name}</td>`;
+        for (var round = 1; round <= draft.totalRounds; round++) {
+            var pick = draft.picks.find(p => String(p.userId) === String(userId) && p.round === round);
+            var isClock = onClock.userId === String(userId) && onClock.round === round;
+            var cls = isClock ? 'draft-board-cell on-clock-cell' : 'draft-board-cell';
+            if (pick) {
+                bodyStr += `<td class="${cls}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${pick.team.school}" title="${pick.team.school}"></td>`;
+            } else {
+                bodyStr += `<td class="${cls}"></td>`;
+            }
+        }
+        bodyStr += '</tr>';
     });
-        
-    var updateSuccessful = response.json().then(data => {
-        if (response.status == 200) {
-            return true;
+    body.innerHTML = bodyStr;
+}
+
+function renderOnTheClock() {
+    var el = document.getElementById('on-the-clock');
+    if (!draft || draft.status !== 'active' || !draft.onTheClock) { el.innerHTML = ''; return; }
+    var oc = draft.onTheClock;
+    var member = membersById[String(oc.userId)];
+    var name = member ? `${member.firstName} ${member.lastName}` : 'Unknown';
+    if (String(oc.userId) === String(myUserId)) {
+        el.innerHTML = `<span class="you-are-up">🟢 You're on the clock! — Round ${oc.round}, Pick #${oc.overall}</span>`;
+    } else {
+        el.innerHTML = `<span>On the clock: <strong>${name}</strong> — Round ${oc.round}, Pick #${oc.overall}</span>`;
+    }
+}
+
+function updateAvailability() {
+    var draftedIds = new Set((draft && draft.picks ? draft.picks : []).map(p => String(p.team.id)));
+    var oc = (draft && draft.onTheClock) || {};
+    var myTurn = draft && draft.status === 'active' && String(oc.userId) === String(myUserId);
+    var canAct = draft && draft.status === 'active' && (myTurn || isCommish);
+
+    document.querySelectorAll('[user-table-body] tr').forEach(row => {
+        var teamId = row.getAttribute('data-team-id');
+        var btn = row.querySelector('.draft-pick-btn');
+        var drafted = draftedIds.has(String(teamId));
+        row.classList.toggle('drafted', drafted);
+        if (!btn) return;
+        if (drafted) {
+            btn.disabled = true;
+            btn.textContent = 'Drafted';
         } else {
-            return false;
+            btn.textContent = 'Draft';
+            btn.disabled = !canAct;
         }
-    });
-
-    return updateSuccessful;
-}
-
-function updateDraftOrder() {
-
-    if ((currentTeamIndex == (userTeams.length - 1)) && (draftDirection == 1)){
-        draftDirection = -1;
-        currentRound++;
-    } else if ((currentTeamIndex == 0) && (draftDirection == -1)) {
-        draftDirection = 1;
-        currentRound++;
-    } else if (draftDirection === 1) {
-        currentTeamIndex++;
-    } else {
-        currentTeamIndex--;
-    }
-
-    if (currentRound > 10) {
-        $("#submit-draft").removeAttr("hidden");
-        $('#team').attr('disabled', true)
-        $('#team-form button').attr('disabled', true)
-
-        document.getElementById('team-form').removeEventListener('submit', this);
-    } else {
-        document.getElementById('current-team').textContent = `Current Team: ${userTeams[currentTeamIndex].charAt(0).toUpperCase() + userTeams[currentTeamIndex].slice(1)}`;
-        document.getElementById('current-round').textContent = `Round ${currentRound}`;
-        $(`*[id*=${users[currentTeamIndex]._id}]:visible`).each(function() {
-            $(this).css('background-color', '#ed5858');
-        });
-    }
-}
-
-function confirmNewTeam(){
-    
-    const newTeamValue = $('#changeTeamModal select').val();
-
-    $('#changeTeamModal').modal('hide');
-    var teamObject = teamList.filter(obj => {
-        return obj.id == newTeamValue
-    })[0];
-
-    if (newTeamValue) {
-        const currentTeamName = $('#changeTeamModal').attr("previous-school");
-        const currentTeamValue = $('#changeTeamModal').attr("previous-value");
-        const teamIndex = userTeams.findIndex(team => team === currentTeamName);
-        const cellId = $('#changeTeamModal').attr("cell-id");
-        const newCell = document.getElementById(cellId); // Use original cell ID to retrieve newCell
-
-        if (newCell) {
-            const img = document.createElement('img');
-            img.src = teamObject.logos.at(-1);
-            img.alt = teamObject.school;
-            img.title = teamObject.id;
-            newCell.innerHTML = '';
-            newCell.appendChild(img);
-            userTeams[teamIndex] = newTeamValue;
-
-            $("select").find("option[value=" + currentTeamValue + "]").show();
-            $('#changeTeamModal select').val('');
-        }
-    }
-}
-
-function closeChangeTeamModal() {
-    $('#changeTeamModal').modal('hide');
-    $('#changeTeamModal select').val('');
-    $('#changeTeamModal .btn-primary').prop('disabled', true);
-}
-
-//Event Listener for Add Team Event
-if (document.getElementById('team-form')) {
-    document.getElementById('team-form').addEventListener('submit', function(event) {
-        event.preventDefault();
-
-        $('#team-form button').attr('disabled', true);
-
-        $(`*[id*=${users[currentTeamIndex]._id}]:visible`).each(function() {
-            $(this).css('background-color', '#2A2E42');
-        });
-
-        const teamName = document.getElementById('team').value;
-        const team = users[currentTeamIndex]._id;
-        const round = `round${currentRound}`;
-
-        var teamObject = teamList.filter(obj => {
-            return obj.id == teamName
-        })[0];
-        
-        const cellId = `${team}-${round}`;
-        const cell = document.getElementById(cellId);
-        
-        if (cell) {
-            const img = document.createElement('img');
-            img.src = teamObject.logos.at(-1);
-            img.alt = teamObject.school;
-            img.title = teamObject.id
-            cell.innerHTML = '';
-            cell.appendChild(img);
-            document.getElementById('team-form').reset();
-            updateDraftOrder();
-
-        } else {
-            alert('Error: Invalid team or round selection');
-        }
-        $("select").find("option[value=" + teamName + "]").hide();
-    });
-}
-
-// Event listener for team logo click
-if (document.querySelectorAll('td[id*="-round"]')) {
-    document.querySelectorAll('td[id*="-round"]').forEach(cell => {
-        cell.addEventListener('click', function() {
-            const currentTeamName = cell.children[0].alt;
-
-            $('#changeTeamModal p:first').text(`Which team do you want to select instead of ${currentTeamName}?`);
-            $('#changeTeamModal').attr("cell-id", cell.id);
-            $('#changeTeamModal').attr("previous-school", currentTeamName);
-            $('#changeTeamModal').attr("previous-value", cell.children[0].title);
-            $('#changeTeamModal').modal('show');
-        });
     });
 }
 
 /////////////////////////////////////////////////////
-//////////////////Helper Functions///////////////////
+//////////////////// Helpers /////////////////////////
 /////////////////////////////////////////////////////
-
-function _multiplyNode(node, count, deep) {
-    for (var i = 0, copy; i < count - 1; i++) {
-        copy = node.cloneNode(deep);
-        node.parentNode.insertBefore(copy, node);
-    }
-}
 
 const _filterFunction = () => {
-    const columns = [
-      { name: 'Team', index: 0, isFilter: true },
-      { name: 'Conference', index: 1, isFilter: true }
-    ]
-    const filterColumns = columns.filter(c => c.isFilter).map(c => c.index)
-    const trs = document.querySelectorAll(`.fl-table tr:not(.headerRow)`)
+    const filterColumns = [0, 1];
+    const trs = document.querySelectorAll(`.fl-table tr:not(.headerRow)`);
     const filter = document.querySelector('#myInput').value.replace(/\s/g, "");
-    const regex = new RegExp(escape(filter), 'i')
-    const isFoundInTds = td => regex.test(td.innerHTML.replace(/\s/g, ""))
-    const isFound = childrenArr => childrenArr.some(isFoundInTds)
-    const setTrStyleDisplay = ({ style, children }) => {
-      style.display = isFound([
-        ...filterColumns.map(c => children[c]) // <-- filter Columns
-      ]) ? '' : 'none'
-    }
-    
-    trs.forEach(setTrStyleDisplay)
+    const regex = new RegExp(escape(filter), 'i');
+    const isFoundInTds = td => regex.test(td.innerHTML.replace(/\s/g, ""));
+    const isFound = arr => arr.some(isFoundInTds);
+    trs.forEach(({ style, children }) => {
+        style.display = isFound(filterColumns.map(c => children[c])) ? '' : 'none';
+    });
 };
 
-var successToast = Toastify({
-    text: "",
-    duration: 4000,
-    close: true,
-    gravity: "top", // `top` or `bottom`
-    position: "left", // `left`, `center` or `right`
-    stopOnFocus: true, // Prevents dismissing of toast on hover
-    style: {
-      background: "#71d28d",
-      color: "#222"
-    },
-    offset: {
-        y: '40px' // vertical axis - can be a number or a string indicating unity. eg: '2em'
-    },
-});
-
-var failToast = Toastify({
-    text: "",
-    duration: 3000,
-    close: true,
-    gravity: "top", // `top` or `bottom`
-    position: "left", // `left`, `center` or `right`
-    stopOnFocus: true, // Prevents dismissing of toast on hover
-    style: {
-      background: "#d27171",
-      color: "#222"
-    },
-    offset: {
-        y: '40px' // vertical axis - can be a number or a string indicating unity. eg: '2em'
-    },
-});
-
-if ($("[league-selector]")) {
-    setTimeout(() => {
-        $("[league-selector] a").click(function(){
-            $(this).parents(".dropdown").find('.btn').html($(this).text());
-            $(this).parents(".dropdown").find('.btn').val($(this).attr('value'));
-            var selectedLeague = $("#dropdownMenuButton").text();
-            var selectedLeagueCode = $("#dropdownMenuButton").val();
-            window.sessionStorage.setItem("league", selectedLeague);
-            window.localStorage.setItem("leagueCode", selectedLeagueCode);
-            window.location.reload();
-        });
-    }, "200");
-}
-
 function setNavbarUserId() {
-    var userId = userState.user_metadata.metadata.userId || null;
-
-    if (userId == null) {
-        userId = window.localStorage.getItem("userId");
-    }
-
-    const toggleButton = document.querySelector('.toggle-button');
-    const navbarLinks = document.querySelector('.navbar-links');
+    var userId = (userState.user_metadata.metadata && userState.user_metadata.metadata.userId) || window.localStorage.getItem('userId');
     const myLink = document.querySelector('[user-home]');
-
-    if (toggleButton && navbarLinks && myLink) {
+    if (myLink) {
         myLink.href = `/userHome?user=${userId}`;
-        console.log("✅ user profile link initialized");
     } else {
-        // Retry after 500ms if elements aren't in the DOM yet
-        console.log("⏳ Navbar elements not found, retrying...");
         setTimeout(setNavbarUserId, 500);
     }
 }
 
-$(document).ready(function() {
-    $('#changeTeamModal .btn-primary').prop('disabled', true);
-        $('#changeTeamModal select').change(function() {
-            if($(this).val() != '') {
-                $('#changeTeamModal .btn-primary').prop('disabled', false);
-            }
-    });
+var successToast = Toastify({
+    text: "", duration: 4000, close: true, gravity: "top", position: "left", stopOnFocus: true,
+    style: { background: "#71d28d", color: "#222" }, offset: { y: '40px' }
 });
+
+var failToast = Toastify({
+    text: "", duration: 3000, close: true, gravity: "top", position: "left", stopOnFocus: true,
+    style: { background: "#d27171", color: "#222" }, offset: { y: '40px' }
+});
+
+if ($("[league-selector]")) {
+    setTimeout(() => {
+        $("[league-selector] a").click(function () {
+            $(this).parents(".dropdown").find('.btn').html($(this).text());
+            $(this).parents(".dropdown").find('.btn').val($(this).attr('value'));
+            window.sessionStorage.setItem("league", $("#dropdownMenuButton").text());
+            window.localStorage.setItem("leagueCode", $("#dropdownMenuButton").val());
+            window.location.reload();
+        });
+    }, 200);
+}

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -202,7 +202,19 @@ async function connectSocket() {
         const { token } = await res.json();
         socket = io({ auth: { token } });
 
+        // Fires on the initial connect AND every reconnect, so a dropped
+        // connection auto-rejoins and re-syncs the latest state.
         socket.on('connect', () => socket.emit('join-draft', { league: leagueCode, season }));
+        socket.on('disconnect', (reason) => {
+            if (reason !== 'io client disconnect') {
+                failToast.options.text = 'Connection lost — reconnecting…';
+                failToast.showToast();
+            }
+        });
+        socket.io.on('reconnect', () => {
+            successToast.options.text = 'Reconnected';
+            successToast.showToast();
+        });
         socket.on('draft-state', onDraftState);
         socket.on('pick-made', onPickMade);
         socket.on('draft-complete', onDraftComplete);
@@ -254,6 +266,10 @@ function startDraft() {
     if (socket) socket.emit('start-draft', { league: leagueCode, season });
 }
 
+function undoPick() {
+    if (socket) socket.emit('undo-pick', { league: leagueCode, season });
+}
+
 /////////////////////////////////////////////////////
 /////////////////////// Render ///////////////////////
 /////////////////////////////////////////////////////
@@ -283,7 +299,9 @@ function renderStatus() {
         updateCountdown();
         countdownTimer = setInterval(updateCountdown, 1000);
     } else if (draft.status === 'active') {
-        el.innerHTML = `<p class="draft-live-label">🟢 Draft in progress</p>`;
+        var undoBtn = (isCommish && draft.picks && draft.picks.length)
+            ? `<button type="button" class="draft-undo-btn" onclick="undoPick()">&#8617; Undo last pick</button>` : '';
+        el.innerHTML = `<p class="draft-live-label">🟢 Draft in progress</p>${undoBtn}`;
     } else if (draft.status === 'complete') {
         el.innerHTML = `<p class="draft-live-label">🎉 Draft complete!</p>`;
     }

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const router = express.Router();
+const Draft = require('../models/draft');
+
+// Get the draft for a league + season (returns null if none configured yet).
+router.get('/:league/:season', async (req, res) => {
+    try {
+        const draft = await Draft.findOne({ league: req.params.league, season: req.params.season });
+        res.json(draft);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Create or update a draft's configuration (upsert on league+season).
+// Settings are locked once the draft is active or complete.
+router.post('/', async (req, res) => {
+    try {
+        const { league, season } = req.body;
+        if (!league || season == null) {
+            return res.status(400).json({ message: 'league and season are required' });
+        }
+
+        const existing = await Draft.findOne({ league, season });
+        if (existing && (existing.status === 'active' || existing.status === 'complete')) {
+            return res.status(409).json({ message: `Draft is ${existing.status}; settings are locked` });
+        }
+
+        const update = {
+            league,
+            season,
+            scheduledAt: req.body.scheduledAt || null,
+            autoOpen: !!req.body.autoOpen,
+            snake: req.body.snake !== false,
+            totalRounds: req.body.totalRounds || 10,
+            orderMethod: req.body.orderMethod || 'manual',
+            draftOrder: Array.isArray(req.body.draftOrder) ? req.body.draftOrder : [],
+            status: req.body.scheduledAt ? 'scheduled' : 'pending',
+            updatedAt: new Date()
+        };
+
+        const draft = await Draft.findOneAndUpdate(
+            { league, season },
+            { $set: update, $setOnInsert: { picks: [], currentOverall: 1 } },
+            { new: true, upsert: true, setDefaultsOnInsert: true }
+        );
+
+        res.status(200).json(draft);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+// Reset a draft: clear picks and return it to pending. Used to re-run a draft
+// or wipe a mistaken start.
+router.post('/:id/reset', async (req, res) => {
+    try {
+        const draft = await Draft.findByIdAndUpdate(
+            req.params.id,
+            { $set: { status: 'pending', picks: [], currentOverall: 1, updatedAt: new Date() } },
+            { new: true }
+        );
+        if (draft == null) {
+            return res.status(404).json({ message: 'Draft not found' });
+        }
+        res.json(draft);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -51,6 +51,32 @@ router.post('/', async (req, res) => {
     }
 });
 
+// Start a draft: flip it to active so picks can be made. Requires a configured
+// order of at least 2 participants.
+router.post('/:id/start', async (req, res) => {
+    try {
+        const draft = await Draft.findById(req.params.id);
+        if (draft == null) {
+            return res.status(404).json({ message: 'Draft not found' });
+        }
+        if (draft.status === 'complete') {
+            return res.status(409).json({ message: 'Draft is already complete' });
+        }
+        if (!Array.isArray(draft.draftOrder) || draft.draftOrder.length < 2) {
+            return res.status(400).json({ message: 'Draft needs at least 2 participants' });
+        }
+        draft.status = 'active';
+        if (!draft.currentOverall || draft.currentOverall < 1) {
+            draft.currentOverall = 1;
+        }
+        draft.updatedAt = new Date();
+        await draft.save();
+        res.json(draft);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
 // Reset a draft: clear picks and return it to pending. Used to re-run a draft
 // or wipe a mistaken start.
 router.post('/:id/reset', async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -203,6 +203,9 @@ app.use('/records', requireAuthOrToken, recordRouter);
 const bettingRouter = require('./routes/betting');
 app.use('/betting', requireAuthOrToken, bettingRouter);
 
+const draftRouter = require('./routes/draft');
+app.use('/draft', requireAuthOrToken, draftRouter);
+
 app.get('/calculate-team-score/:season/:teamId/:teamName', requireAuthOrToken, async (req, res) => {
     var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);
 

--- a/server.js
+++ b/server.js
@@ -4,11 +4,15 @@ if (process.env.NODE_ENV !== 'production') {
 
 const express = require('express');
 const app = express();
+const http = require('http');
+const { Server } = require('socket.io');
 const retrieveGamesModule = require('./modules/retrieve-games.js');
 const scoringModule = require('./modules/scoring.js');
 const schedule = require('node-schedule');
 const { auth } = require('express-openid-connect');
 const requireAuthOrToken = require('./modules/require-auth');
+const draftToken = require('./modules/draft-token');
+const registerDraftSockets = require('./modules/draft-socket');
 
 // Serializes an object to JSON that is safe to embed inside an inline <script>
 // tag. Escapes the characters that could break out of the script context
@@ -57,6 +61,17 @@ const { requiresAuth } = require('express-openid-connect');
 
 app.get('/profile', requiresAuth(), (req, res) => {
   res.send(JSON.stringify(req.oidc.user));
+});
+
+// Mint a short-lived signed token the browser uses to authenticate its draft
+// socket connection. Requires a real Auth0 session so the identity is trusted.
+app.get('/draft-token', requiresAuth(), (req, res) => {
+  const ctx = buildUserContext(req.oidc.user);
+  const token = draftToken.sign(
+    { userId: ctx.userId, role: ctx.role, name: ctx.firstName },
+    process.env.AUTH_SECRET
+  );
+  res.json({ token });
 });
 
 // register the given template engine 
@@ -216,6 +231,11 @@ app.get('/calculate-team-score/:season/:teamId/:teamName', requireAuthOrToken, a
     }
 });
 
-app.listen(process.env.PORT || 3000, () =>{
+// Wrap Express in an HTTP server so Socket.IO (live draft) can share the port.
+const server = http.createServer(app);
+const io = new Server(server);
+registerDraftSockets(io);
+
+server.listen(process.env.PORT || 3000, () =>{
     console.log('Server Started');
 });

--- a/tests/DraftEngine.spec.js
+++ b/tests/DraftEngine.spec.js
@@ -1,0 +1,38 @@
+const engine = require('../modules/draft-engine');
+
+describe('draft engine (snake logic)', () => {
+    const snake = { draftOrder: ['A', 'B', 'C'], totalRounds: 4, snake: true, currentOverall: 1 };
+
+    it('computes total picks', () => {
+        expect(engine.totalPicks(snake)).toBe(12);
+    });
+
+    it('produces a correct snake pick order', () => {
+        const order = engine.pickOrder(snake).map(p => p.userId);
+        expect(order).toEqual(['A', 'B', 'C', 'C', 'B', 'A', 'A', 'B', 'C', 'C', 'B', 'A']);
+    });
+
+    it('reverses direction on even rounds', () => {
+        expect(engine.whoseTurn({ ...snake, currentOverall: 1 }).userId).toBe('A'); // R1 first
+        expect(engine.whoseTurn({ ...snake, currentOverall: 3 }).userId).toBe('C'); // R1 last
+        expect(engine.whoseTurn({ ...snake, currentOverall: 4 }).userId).toBe('C'); // R2 first (reversed)
+        expect(engine.whoseTurn({ ...snake, currentOverall: 6 }).userId).toBe('A'); // R2 last
+    });
+
+    it('reports the correct round number', () => {
+        expect(engine.whoseTurn({ ...snake, currentOverall: 1 }).round).toBe(1);
+        expect(engine.whoseTurn({ ...snake, currentOverall: 4 }).round).toBe(2);
+        expect(engine.whoseTurn({ ...snake, currentOverall: 7 }).round).toBe(3);
+    });
+
+    it('returns null / complete once all picks are made', () => {
+        expect(engine.whoseTurn({ ...snake, currentOverall: 13 })).toBeNull();
+        expect(engine.isComplete({ ...snake, currentOverall: 13 })).toBe(true);
+        expect(engine.isComplete({ ...snake, currentOverall: 12 })).toBe(false);
+    });
+
+    it('supports straight (non-snake) drafts', () => {
+        const linear = { draftOrder: ['A', 'B', 'C'], totalRounds: 2, snake: false, currentOverall: 1 };
+        expect(engine.pickOrder(linear).map(p => p.userId)).toEqual(['A', 'B', 'C', 'A', 'B', 'C']);
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -47,6 +47,56 @@
     <div class="admin-functions">
         <div class="function-container">
             <div class="button-container">
+                <button onclick="displayDraftConfigContainer()">
+                    <i class="fa-solid fa-list-ol" style="padding-right: 5px;"></i>
+                    Configure Draft
+                </button>
+            </div>
+            <div class="sub-container" draft-config-container style="display: none">
+                <form id="draft-config-form" class="draft-config-form">
+                    <div class="draft-status-row">
+                        Status: <span draft-status class="draft-status-badge">—</span>
+                    </div>
+                    <div class="draft-field">
+                        <label>Season</label>
+                        <select draft-season></select>
+                    </div>
+                    <div class="draft-field">
+                        <label>Draft date &amp; time</label>
+                        <input type="datetime-local" draft-datetime>
+                    </div>
+                    <div class="draft-field">
+                        <label>Rounds</label>
+                        <input type="number" draft-rounds min="1" max="20" value="10">
+                    </div>
+                    <div class="draft-field">
+                        <label>Type</label>
+                        <select draft-type>
+                            <option value="snake">Snake</option>
+                            <option value="linear">Linear</option>
+                        </select>
+                    </div>
+                    <div class="draft-field">
+                        <label><input type="checkbox" draft-autoopen> Auto-open room at scheduled time</label>
+                    </div>
+                    <div class="draft-order-header">
+                        <label>Draft order</label>
+                        <div class="draft-order-buttons">
+                            <button type="button" onclick="autoOrderStandings()">Auto (reverse standings)</button>
+                            <button type="button" onclick="randomizeOrder()">Randomize</button>
+                        </div>
+                    </div>
+                    <ol draft-order-list class="draft-order-list"></ol>
+                    <div class="draft-config-actions">
+                        <button type="submit">Save Draft Settings</button>
+                        <button type="button" draft-reset-btn onclick="resetDraft()" style="display:none;">Reset Draft</button>
+                    </div>
+                </form>
+                <hr>
+            </div>
+        </div>
+        <div class="function-container">
+            <div class="button-container">
                 <button onclick="displayCreateUserContainer()">
                     <i class="fa-solid fa-user-plus" style="padding-right: 5px;"></i>
                     Add a Player

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -12,7 +12,6 @@
     <script src="confetti.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script defer src="draftRoom.js"></script>
-    <script src="sorttable.js"></script>
     <title>Campus Clash</title>
     <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
@@ -50,27 +49,19 @@
         </div>
     </div>
 
-    <div class="content">
-        <input
-            type="text"
-            id="myInput"
-            onkeyup="_filterFunction()"
-            placeholder="Team or Conference"
-            title="Type in a team name or conference">
-        <div class="team-list-container" team-list-container>
-            <table class="fl-table sortable">
-                <thead>
-                <tr class="headerRow">
-                    <th class="sticky-header team-header" style="cursor: pointer;">Team</th>
-                    <th class="sticky-header team-header" style="cursor: pointer;">Conference</th>
-                    <th class="sticky-header team-header sorttable_numeric" recruiting-ranking style="cursor: pointer;"></th>
-                    <th class="sticky-header team-header sorttable_numeric" style="cursor: pointer;">Previous Season Score</th>
-                    <th class="sticky-header team-header sorttable_numeric" expected-wins style="cursor: pointer;">xWins</th>
-                    <th class="sticky-header team-header sorttable_nosort">Draft</th>
-                </tr>
-                </thead>
-                <tbody user-table-body>
-                <tbody>
+    <div class="content pool">
+        <h2 class="pool-title">Available Teams</h2>
+        <div class="pool-controls">
+            <input type="text" id="poolSearch" placeholder="Search team…" oninput="renderPool()">
+            <select id="poolConf" onchange="renderPool()"><option value="">All conferences</option></select>
+            <label class="pool-toggle"><input type="checkbox" id="showDrafted" onchange="renderPool()"> Show drafted</label>
+            <span class="pool-spacer"></span>
+            <span class="pool-count" id="poolCount"></span>
+        </div>
+        <div class="pool-table-wrap">
+            <table class="pool-table">
+                <thead><tr id="pool-head"></tr></thead>
+                <tbody user-table-body></tbody>
             </table>
         </div>
     </div>

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -10,16 +10,15 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <script src="confetti.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
     <script defer src="draftRoom.js"></script>
     <script src="sorttable.js"></script>
     <title>Campus Clash</title>
     <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 </head>
 <body>
     <%- include('partials/navbar') %>
@@ -34,95 +33,31 @@
             Draft Room
         </div>
     </div>
-    <% if (user && (user.role == "Admin" || user.role == "League Manager") && user.isDraft) { %>
-    <div draft-board class="temp-draft-table">
+
+    <!-- Live draft status: countdown before the draft, controls, completion -->
+    <div id="draft-status" class="draft-status-panel"></div>
+
+    <!-- Live draft board (members x rounds), shown once active -->
+    <div id="draft-board-wrap" class="draft-board-wrap" style="display:none;">
+        <div id="on-the-clock" class="on-the-clock"></div>
         <div id="draft-board" style="overflow-x: auto;">
-    
             <table id="draft-table">
                 <thead>
-                    <tr>
-                        <th>Teams</th>
-                        <th>1</th>
-                        <th>2</th>
-                        <th>3</th>
-                        <th>4</th>
-                        <th>5</th>
-                        <th>6</th>
-                        <th>7</th>
-                        <th>8</th>
-                        <th>9</th>
-                        <th>10</th>
-                    </tr>
+                    <tr id="draft-board-head"></tr>
                 </thead>
-                <tbody draft-table-body>
-                </tbody>
+                <tbody id="draft-board-body"></tbody>
             </table>
         </div>
-    
-        <div id="add-team">
-        <form id="team-form">
-            <select id="team" team-options name="team">
-            </select>
-            <button type="submit" disabled="disabled">Add Team</button>
-        </form>
-        <p id="current-team"></p>
-        <p id="current-round"></p>
-        </div>
     </div>
-    <div id="submit-draft" class="submit-draft-container" hidden>
-        <button type="button" data-toggle="modal" data-target="#exampleModal">Submit Draft</button>
-    </div>
-    <!-- Modal -->
-    <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel">Draft Confirmation</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-            </div>
-            <div class="modal-body">
-                Are you ready to lock in this year's draft?
-            </div>
-            <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitDraft()">&#128548;</button>
-            </div>
-        </div>
-        </div>
-    </div>
-    <!-- Change Team Modal -->
-    <div class="modal fade" id="changeTeamModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel">Team Selection Change</h5>
-            <button type="button" class="close" onclick="closeChangeTeamModal()" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-            </div>
-            <div class="modal-body">
-                <p></p>
-                <select team-options></select>
-            </div>
-            <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" onclick="closeChangeTeamModal()">Close</button>
-            <button type="button" class="btn btn-primary" onclick="confirmNewTeam()">Confirm</button>
-            </div>
-        </div>
-        </div>
-    </div>
-    <% } %>
+
     <div class="content">
-        <input 
-            type="text" 
-            id="myInput" 
-            onkeyup="_filterFunction()" 
-            placeholder="Team or Conference" 
+        <input
+            type="text"
+            id="myInput"
+            onkeyup="_filterFunction()"
+            placeholder="Team or Conference"
             title="Type in a team name or conference">
         <div class="team-list-container" team-list-container>
-            
             <table class="fl-table sortable">
                 <thead>
                 <tr class="headerRow">
@@ -131,6 +66,7 @@
                     <th class="sticky-header team-header sorttable_numeric" recruiting-ranking style="cursor: pointer;"></th>
                     <th class="sticky-header team-header sorttable_numeric" style="cursor: pointer;">Previous Season Score</th>
                     <th class="sticky-header team-header sorttable_numeric" expected-wins style="cursor: pointer;">xWins</th>
+                    <th class="sticky-header team-header sorttable_nosort">Draft</th>
                 </tr>
                 </thead>
                 <tbody user-table-body>


### PR DESCRIPTION
Replaces the manual, screen-shared draft with a real-time draft board every league member joins from their own device. Built in six steps; **37 tests passing**.

## What it does
- **Configure Draft (admin panel):** commissioner sets date/time, rounds, snake/linear, participants, and pick order (auto reverse-standings / randomize / manual reorder). Saved as a `Draft` document.
- **Live board:** every member sees picks land in real time, an "on the clock" indicator (highlighted when it's *you*), a pre-draft countdown, and confetti on completion.
- **Server-authoritative snake engine:** turn order enforced by identity (you can't pick out of turn); atomic pick application prevents races/double-picks; on completion each member's teams are persisted via the existing `/users/draft/:id` flow.
- **Team pool as a draft aid:** sortable columns (defaults to xWins), recruiting badges (top-10/top-25), functional xWins bars, drafted-hidden toggle with a live count, conference filter + search.
- **Commissioner controls:** Start, pick-for-the-member-on-the-clock, and Undo last pick.
- **Reconnect handling** (auto-rejoin + status feedback) and a **mobile pass**.

## Architecture
- `models/draft.js` — draft config + live state (one per league+season)
- `routes/draft.js` — config CRUD + start/reset (behind `requireAuthOrToken`)
- `modules/draft-engine.js` — pure snake math (unit-tested)
- `modules/draft-token.js` — HMAC-signed token so sockets carry a trusted identity without threading the Auth0 session through Socket.IO (`GET /draft-token` mints it)
- `modules/draft-socket.js` — Socket.IO auth + `join` / `make-pick` / `start-draft` / `undo-pick`, broadcasts, completion→persist
- `server.js` — wraps Express in an `http.Server` so Socket.IO shares the port
- Client: `views/draftRoom.ejs`, `public/draftRoom.js`, `public/draftRoom.css` (also bumped this page's jQuery 1.11.3 → 3.6.0 and dropped sorttable.js)

## New dependency
- `socket.io` (runtime); `socket.io-client` (dev, for tests)

## Testing
- **6 jest tests** for the snake engine (`tests/DraftEngine.spec.js`); 37 total in CI.
- Socket **integration tests** (isolated temp users, auto-cleaned): auth incl. bad-token rejection, out-of-turn rejection, correct snake ordering, completion + team persistence, `start-draft` (commissioner-gated) broadcast, and `undo-pick`.
- Board / pool / mobile verified visually via static mocks against the real CSS.

## ⚠️ Before/at deploy
- Socket auth is signed with **`AUTH_SECRET`** (already set) — no new env var.
- Socket.IO works on Heroku; a single web dyno is simplest (sticky sessions needed only if scaled to multiple dynos).
- **xWins data:** 2026 expected-wins are all 0 in the DB, so that column/sort/bars will be flat until 2026 data is loaded (`json/expectedWins{year}.json` + admin "Refresh Expected Wins").

🤖 Generated with [Claude Code](https://claude.com/claude-code)