### PR TITLE
Low-priority cleanup: fetch-failure surfacing, rankings param, log noise

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -228,7 +228,6 @@ async function getUserProfile() {
     });
 
     response.json().then(async data => {
-        console.log("user metadata", data)
         userMetadata = data;
 
         // Only set leagueCode from metaData if it's not already stored
@@ -261,10 +260,8 @@ window.onload = async function() {
             toggleButton.addEventListener('click', () => {
                 navbarLinks.classList.toggle('active');
             });
-            console.log("✅ Navbar toggle initialized");
         } else {
             // Retry after 500ms if elements aren't in the DOM yet
-            console.log("⏳ Navbar elements not found, retrying...");
             setTimeout(initNavbarToggle, 500);
         }
     }
@@ -924,7 +921,6 @@ function displayApiCallsContainer() {
 }
 
 function block_screen() {
-    console.log("running block screen")
     $('<div id="screenBlock"></div>').appendTo('body');
     $('#screenBlock').css( { opacity: 0, width: $(document).width(), height: $(document).height() } );
     $('#screenBlock').addClass('blockDiv');
@@ -964,10 +960,8 @@ function setNavbarUserId() {
 
     if (toggleButton && navbarLinks && myLink) {
         myLink.href = `/userHome?user=${userId}`;
-        console.log("✅ user profile link initialized");
     } else {
         // Retry after 500ms if elements aren't in the DOM yet
-        console.log("⏳ Navbar elements not found, retrying...");
         setTimeout(setNavbarUserId, 500);
     }
 }

--- a/public/scoringRules.js
+++ b/public/scoringRules.js
@@ -9,10 +9,8 @@ window.onload = async function () {
             toggleButton.addEventListener('click', () => {
                 navbarLinks.classList.toggle('active');
             });
-            console.log("✅ Navbar toggle initialized");
         } else {
             // Retry after 500ms if elements aren't in the DOM yet
-            console.log("⏳ Navbar elements not found, retrying...");
             setTimeout(initNavbarToggle, 500);
         }
     }
@@ -29,7 +27,6 @@ window.onload = async function () {
     });
 
     response.json().then(async data => {
-        console.log("user metadata", data)
 
         // Only set leagueCode from metaData if it's not already stored
         if (!window.localStorage.getItem("leagueCode") && data?.user_metadata?.metadata?.league) {
@@ -78,10 +75,8 @@ function setNavbarUserId() {
 
     if (toggleButton && navbarLinks && myLink) {
         myLink.href = `/userHome?user=${userId}`;
-        console.log("✅ user profile link initialized");
     } else {
         // Retry after 500ms if elements aren't in the DOM yet
-        console.log("⏳ Navbar elements not found, retrying...");
         setTimeout(setNavbarUserId, 500);
     }
 }

--- a/public/standings.js
+++ b/public/standings.js
@@ -37,10 +37,8 @@ window.onload = async function() {
             toggleButton.addEventListener('click', () => {
                 navbarLinks.classList.toggle('active');
             });
-            console.log("✅ Navbar toggle initialized");
         } else {
             // Retry after 500ms if elements aren't in the DOM yet
-            console.log("⏳ Navbar elements not found, retrying...");
             setTimeout(initNavbarToggle, 500);
         }
     }
@@ -57,7 +55,6 @@ window.onload = async function() {
     });
 
     response.json().then(async data => {
-        console.log("user metadata", data)
         userMetadata = data;
 
         weekCode = window.localStorage.getItem("weekCode");
@@ -1049,10 +1046,8 @@ function setNavbarUserId(metaData, usersData) {
 
     if (toggleButton && navbarLinks && myLink) {
         myLink.href = `/userHome?user=${userId}`;
-        console.log("✅ user profile link initialized");
     } else {
         // Retry after 500ms if elements aren't in the DOM yet
-        console.log("⏳ Navbar elements not found, retrying...");
         setTimeout(setNavbarUserId, 500);
     }
 }

--- a/public/team.js
+++ b/public/team.js
@@ -8,7 +8,6 @@ async function getUserProfile() {
     });
 
     response.json().then(async data => {
-        console.log("user metadata", data)
 
         // Only set leagueCode from metaData if it's not already stored
         if (!window.localStorage.getItem("leagueCode") && data?.user_metadata?.metadata?.league) {
@@ -38,10 +37,8 @@ window.onload = function() {
             toggleButton.addEventListener('click', () => {
                 navbarLinks.classList.toggle('active');
             });
-            console.log("✅ Navbar toggle initialized");
         } else {
             // Retry after 500ms if elements aren't in the DOM yet
-            console.log("⏳ Navbar elements not found, retrying...");
             setTimeout(initNavbarToggle, 500);
         }
     }
@@ -654,10 +651,8 @@ function setNavbarUserId() {
 
     if (toggleButton && navbarLinks && myLink) {
         myLink.href = `/userHome?user=${userId}`;
-        console.log("✅ user profile link initialized");
     } else {
         // Retry after 500ms if elements aren't in the DOM yet
-        console.log("⏳ Navbar elements not found, retrying...");
         setTimeout(setNavbarUserId, 500);
     }
 }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -34,7 +34,6 @@ async function getUserProfile() {
     });
 
     response.json().then(async data => {
-        console.log("user metadata", data)
 
         weekCode = window.localStorage.getItem("weekCode");
         const currentSelectedWeek = window.localStorage.getItem("week");
@@ -72,10 +71,8 @@ window.onload = function() {
             toggleButton.addEventListener('click', () => {
                 navbarLinks.classList.toggle('active');
             });
-            console.log("✅ Navbar toggle initialized");
         } else {
             // Retry after 500ms if elements aren't in the DOM yet
-            console.log("⏳ Navbar elements not found, retrying...");
             setTimeout(initNavbarToggle, 500);
         }
     }
@@ -114,7 +111,6 @@ async function getUser() {
     });
 
     response.json().then(async data => {
-        console.log("userData",data);
         userData = data[0];
         changeHeader(data[0]);
         displayTeams(data[0]);
@@ -727,10 +723,8 @@ function setNavbarUserId() {
 
     if (toggleButton && navbarLinks && myLink) {
         myLink.href = `/userHome?user=${userId}`;
-        console.log("✅ user profile link initialized");
     } else {
         // Retry after 500ms if elements aren't in the DOM yet
-        console.log("⏳ Navbar elements not found, retrying...");
         setTimeout(setNavbarUserId, 500);
     }
 }

--- a/routes/rankings.js
+++ b/routes/rankings.js
@@ -40,7 +40,7 @@ router.get('/:week/:seasonType', async (req, res) => {
 // Getting One By Year & Week & Season Type
 router.get('/:season/:week/:seasonType', async (req, res) => {
     try {
-        const ranking = await Ranking.findOne({season: req.params.season, week: req.params.week, seasonType: "regular"});
+        const ranking = await Ranking.findOne({season: req.params.season, week: req.params.week, seasonType: req.params.seasonType});
 
         if (JSON.stringify(ranking) == "null") {
             res.status(400).json({message: `No rankings found for season ${req.params.season} & week ${req.params.week} & seasonType ${req.params.seasonType}`});

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -12,6 +12,25 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
     <!-- Bootstrap JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js" integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Surface otherwise-silent failures (e.g. a failed fetch) instead of leaving the UI quietly broken -->
+    <script>
+        (function () {
+            var lastShown = 0;
+            window.addEventListener('unhandledrejection', function (event) {
+                console.error('Unhandled promise rejection:', event.reason);
+                var now = Date.now();
+                if (now - lastShown < 5000) return; // throttle so one outage isn't a toast storm
+                lastShown = now;
+                if (window.Toastify) {
+                    window.Toastify({
+                        text: 'Something went wrong loading data. Please try refreshing.',
+                        duration: 4000, close: true, gravity: 'top', position: 'left',
+                        style: { background: '#d27171', color: '#222' }, offset: { y: '40px' }
+                    }).showToast();
+                }
+            });
+        })();
+    </script>
 </head>
 <nav id="navbar" class="navbar">
     <div class="brand-title" style="display: flex; flex-flow: column;">


### PR DESCRIPTION
The final low-priority items from the codebase review.

## 1. Surface silent fetch failures
The client had no error handling around `fetch` calls, so a network failure/timeout left the UI quietly broken with only an unhandled rejection. Added a global `unhandledrejection` handler in the shared **navbar partial** (so it applies to every page) that logs the error and shows a throttled error toast. This surfaces failures without needing to retrofit every call site.

## 2. Honor the `:seasonType` param in the rankings route
`GET /rankings/:season/:week/:seasonType` hardcoded `seasonType: 'regular'`, ignoring the path segment (its own error message already referenced the param). Scoring is unaffected — it always requests `'regular'`, even for postseason — so honoring the param just makes the job/admin "do these rankings already exist?" checks accurate. Verified `regular` vs `postseason` now return distinct records.

## 3. Drop debug console noise
Removed debug-only `console.log`s from the client (full `user_metadata`/`userData` object dumps and navbar-init chatter); kept `console.error` and functional logs.

## Testing
- Rankings route verified via curl (regular vs postseason distinct); all views still render with the handler present; edited client files syntax-checked; jest **37/37**.

This clears the remaining medium/low findings from the original review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)