### PR TITLE
Configurable scoring (Phase 2): configurable structure (Option A)

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -8,6 +8,11 @@ const scoringConfigSchema = new mongoose.Schema({
     league: { type: String, required: true, unique: true },
     model: { type: String, enum: ['claunts', 'graham'], required: true },
     values: { type: mongoose.Schema.Types.Mixed, default: {} },
+    // Phase 2 structure overrides: how regular-win rules combine
+    // ('first' = priority, 'sum' = additive) and which postseason event
+    // conditions are switched off (by condition key).
+    combineMode: { type: String, enum: ['first', 'sum'] },
+    disabled: { type: [String], default: [] },
     updatedAt: { type: Date, default: Date.now }
 });
 

--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -1,7 +1,17 @@
-// Single source of truth for the two leagues' scoring models: default point
-// values (matching the historical hardcoded engine exactly) plus ordered field
-// metadata that drives BOTH the admin "Configure Scoring" form and the rules
-// page — so the page can never drift from the engine.
+// Single source of truth for the two leagues' scoring models.
+//
+// Phase 1 made point VALUES configurable. Phase 2 makes the STRUCTURE
+// configurable within a fixed vocabulary (see scoring-detectors.js): a
+// commissioner can edit each rule's points, enable/disable postseason events,
+// and flip the regular-win combine mode ('first' = priority, 'sum' = additive).
+//
+// A model's STRUCTURE (which conditions exist, their order, additive flags, the
+// default combine mode) is code-owned. The commissioner's overrides are just:
+// point `values`, a `combineMode`, and a `disabled` list of postseason
+// condition keys. resolveConfig() merges overrides onto the model defaults so a
+// partial/absent config always yields a valid, fully-populated config.
+
+// --- default point values (match the historical hardcoded engine exactly) ---
 
 const CLAUNTS_DEFAULTS = {
     nonConfWinUnranked: 1,
@@ -31,39 +41,62 @@ const GRAHAM_DEFAULTS = {
     nationalChampionship: 10
 };
 
-// Ordered fields for UI + rules page. `additive: true` marks a Graham bonus
-// that stacks on top of the base win (rendered with a "+").
-const CLAUNTS_FIELDS = [
-    { key: 'nonConfWinUnranked', label: 'Non-conference win vs. unranked opponent' },
-    { key: 'nonConfWinRanked', label: 'Non-conference win vs. ranked opponent' },
-    { key: 'confWin', label: 'Conference win' },
-    { key: 'confChampionship', label: 'Conference championship win' },
-    { key: 'bowlAppearance', label: 'Non-playoff bowl appearance' },
-    { key: 'bowlWin', label: 'Non-playoff bowl win' },
-    { key: 'cfpAppearance', label: 'CFP appearance' },
-    { key: 'cfpQuarterfinal', label: 'CFP Quarterfinal appearance' },
-    { key: 'cfpSemifinal', label: 'CFP Semifinal appearance' },
-    { key: 'nationalChampionship', label: 'National Championship appearance' }
-];
+// --- structural definitions ---------------------------------------------
+//
+// regularWin: ordered rules combined per `combineMode`. Under 'first' the first
+//   matching rule's points win (Claunts: a conference win scores 2 even vs a
+//   ranked team). Under 'sum' the points of every matching rule are added
+//   (Graham: base + conference + ranked + upset bonuses stack).
+// postseason: ordered independent events. The engine walks them in order and a
+//   non-`additive` match stops evaluation — this reproduces the old elif
+//   precedence (e.g. a Rose Bowl quarterfinal scores the CFP value, not a bowl
+//   appearance). `additive: true` rules add their points and keep going.
+//
+// `condition` is the detector key (scoring-detectors.js CONDITIONS); `pointsKey`
+// indexes the point value; `label` drives the admin form and rules page.
 
-const GRAHAM_FIELDS = [
-    { key: 'baseWin', label: 'Non-con win vs. unranked opponent' },
-    { key: 'confBonus', label: 'Conference win vs. unranked opponent', additive: true },
-    { key: 'rankedTop25Bonus', label: 'Win vs. opponent ranked #11–25', additive: true },
-    { key: 'rankedTop10Bonus', label: 'Win vs. opponent ranked #1–10', additive: true },
-    { key: 'nonP5UpsetBonus', label: 'Non P5 team beats a P5 team', additive: true },
-    { key: 'confChampionship', label: 'Conference championship win' },
-    { key: 'bowlWin', label: 'Non-playoff bowl win' },
-    { key: 'cfpFirstRound', label: 'CFP First Round appearance' },
-    { key: 'cfpQuarterfinal', label: 'CFP Quarterfinal appearance' },
-    { key: 'cfpQuarterfinalTop4Bonus', label: 'CFP Quarterfinal — top-4 seed bye bonus' },
-    { key: 'cfpSemifinal', label: 'CFP Semifinal appearance' },
-    { key: 'nationalChampionship', label: 'National Championship win' }
-];
+const STRUCTURES = {
+    claunts: {
+        combineMode: 'first',
+        regularWin: [
+            { condition: 'conferenceWin', pointsKey: 'confWin', label: 'Conference win' },
+            { condition: 'nonConfRankedWin', pointsKey: 'nonConfWinRanked', label: 'Non-conference win vs. ranked opponent' },
+            { condition: 'baseWin', pointsKey: 'nonConfWinUnranked', label: 'Non-conference win vs. unranked opponent' }
+        ],
+        postseason: [
+            { condition: 'cfpQuarterfinal', pointsKey: 'cfpQuarterfinal', label: 'CFP Quarterfinal appearance' },
+            { condition: 'cfpSemifinal', pointsKey: 'cfpSemifinal', label: 'CFP Semifinal appearance' },
+            { condition: 'nationalChampionship', pointsKey: 'nationalChampionship', label: 'National Championship appearance' },
+            { condition: 'cfpFirstRoundLoss', pointsKey: 'cfpAppearance', label: 'CFP appearance (first-round exit)' },
+            { condition: 'bowlAppearance', pointsKey: 'bowlAppearance', label: 'Non-playoff bowl appearance', additive: true },
+            { condition: 'bowlWin', pointsKey: 'bowlWin', label: 'Non-playoff bowl win' },
+            { condition: 'confChampionship', pointsKey: 'confChampionship', label: 'Conference championship win' }
+        ]
+    },
+    graham: {
+        combineMode: 'sum',
+        regularWin: [
+            { condition: 'baseWin', pointsKey: 'baseWin', label: 'Non-con win vs. unranked opponent' },
+            { condition: 'confBonus', pointsKey: 'confBonus', label: 'Conference win vs. unranked opponent', additive: true },
+            { condition: 'rankedTop25Bonus', pointsKey: 'rankedTop25Bonus', label: 'Win vs. opponent ranked #11–25', additive: true },
+            { condition: 'rankedTop10Bonus', pointsKey: 'rankedTop10Bonus', label: 'Win vs. opponent ranked #1–10', additive: true },
+            { condition: 'nonP5UpsetBonus', pointsKey: 'nonP5UpsetBonus', label: 'Non P5 team beats a P5 team', additive: true }
+        ],
+        postseason: [
+            { condition: 'cfpFirstRound', pointsKey: 'cfpFirstRound', label: 'CFP First Round appearance' },
+            { condition: 'cfpQuarterfinalTop4Bonus', pointsKey: 'cfpQuarterfinalTop4Bonus', label: 'CFP Quarterfinal — top-4 seed bye bonus', additive: true },
+            { condition: 'cfpQuarterfinal', pointsKey: 'cfpQuarterfinal', label: 'CFP Quarterfinal appearance' },
+            { condition: 'cfpSemifinal', pointsKey: 'cfpSemifinal', label: 'CFP Semifinal appearance' },
+            { condition: 'nationalChampionshipWin', pointsKey: 'nationalChampionship', label: 'National Championship win' },
+            { condition: 'bowlWin', pointsKey: 'bowlWin', label: 'Non-playoff bowl win' },
+            { condition: 'confChampionship', pointsKey: 'confChampionship', label: 'Conference championship win' }
+        ]
+    }
+};
 
 const MODELS = {
-    claunts: { defaults: CLAUNTS_DEFAULTS, fields: CLAUNTS_FIELDS },
-    graham: { defaults: GRAHAM_DEFAULTS, fields: GRAHAM_FIELDS }
+    claunts: { defaults: CLAUNTS_DEFAULTS, structure: STRUCTURES.claunts },
+    graham: { defaults: GRAHAM_DEFAULTS, structure: STRUCTURES.graham }
 };
 
 // Claunts = V1 engine, Graham = V2 engine. Unknown leagues default to Claunts.
@@ -71,18 +104,42 @@ function modelForLeague(league) {
     return league === 'graham-league' ? 'graham' : 'claunts';
 }
 
-// Returns { model, values } for a league, merging any provided overrides over
-// the model defaults (so a partial/absent config still yields valid values).
+// Flat, ordered field metadata for the admin form + rules page. Regular-win
+// fields carry group 'regular'; postseason fields group 'postseason' and are
+// toggleable (enable/disable). `enabled` reflects the resolved `disabled` set.
+function fieldsForModel(model, disabled) {
+    const structure = (MODELS[model] || MODELS.claunts).structure;
+    const off = new Set(disabled || []);
+    const regular = structure.regularWin.map(r => ({
+        key: r.pointsKey, condition: r.condition, label: r.label,
+        additive: !!r.additive, group: 'regular', toggleable: false, enabled: true
+    }));
+    const post = structure.postseason.map(r => ({
+        key: r.pointsKey, condition: r.condition, label: r.label,
+        additive: !!r.additive, group: 'postseason', toggleable: true, enabled: !off.has(r.condition)
+    }));
+    return regular.concat(post);
+}
+
+// Returns a fully-resolved config for a league:
+//   { model, combineMode, values, disabled }
+// merging any provided overrides over the model defaults.
 function resolveConfig(league, overrides) {
-    const model = (overrides && overrides.model) || modelForLeague(league);
-    const base = MODELS[model] ? MODELS[model].defaults : CLAUNTS_DEFAULTS;
+    const model = (overrides && overrides.model && MODELS[overrides.model]) ? overrides.model : modelForLeague(league);
+    const modelDef = MODELS[model] || MODELS.claunts;
+    const combineMode = (overrides && (overrides.combineMode === 'sum' || overrides.combineMode === 'first'))
+        ? overrides.combineMode
+        : modelDef.structure.combineMode;
+    const disabled = (overrides && Array.isArray(overrides.disabled)) ? overrides.disabled.slice() : [];
     return {
         model,
-        values: Object.assign({}, base, (overrides && overrides.values) || {})
+        combineMode,
+        values: Object.assign({}, modelDef.defaults, (overrides && overrides.values) || {}),
+        disabled
     };
 }
 
 module.exports = {
-    CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, CLAUNTS_FIELDS, GRAHAM_FIELDS,
-    MODELS, modelForLeague, resolveConfig
+    CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, STRUCTURES, MODELS,
+    modelForLeague, fieldsForModel, resolveConfig
 };

--- a/modules/scoring-detectors.js
+++ b/modules/scoring-detectors.js
@@ -1,0 +1,142 @@
+// Fixed vocabulary of scoring "condition detectors" plus the low-level game
+// predicates they build on. These encode WHAT a game/team situation is; the
+// point VALUES and which conditions are scored live in the per-league config
+// (see scoring-defaults.js) and are applied by the engine in scoring.js.
+//
+// Commissioners can change point values, toggle postseason events, and flip the
+// regular-win combine mode — but they do NOT invent new conditions. This module
+// is that closed vocabulary. The predicate bodies are lifted verbatim from the
+// pre-Phase-2 engine so behavior is byte-for-byte identical.
+
+// --- low-level game predicates -------------------------------------------
+
+function isConference(game) {
+    if ((game.homeConference == "FBS Independents") || (game.awayConference == "FBS Independents")) {
+        return false;
+    } else {
+        return game.conferenceGame;
+    }
+}
+
+// Finds the relevant poll (CFP committee if present, else AP Top 25). Returns
+// null if rankings weren't loaded for the week or neither poll is present, so
+// callers degrade gracefully instead of throwing.
+function findPoll(rankings) {
+    if (!rankings || !Array.isArray(rankings.polls)) return null;
+    var poll = rankings.polls.find(x => x.poll === 'Playoff Committee Rankings')
+        || rankings.polls.find(x => x.poll === 'AP Top 25');
+    if (!poll || !Array.isArray(poll.ranks)) return null;
+    return poll;
+}
+
+// 0 = unranked, 1 = ranked #11-25, 2 = ranked #1-10.
+function rankValue(team, rankings) {
+    var poll = findPoll(rankings);
+    if (!poll) return 0;
+    var entry = poll.ranks.find(y => y.school === team);
+    if (!entry) return 0;
+    return entry.rank <= 10 ? 2 : 1;
+}
+
+function isPowerFiveUpset(teamConf, oppConf) {
+    var powerFive = ["ACC", "Big 12", "Big Ten", "SEC"];
+    return (!powerFive.includes(teamConf)) && (powerFive.includes(oppConf));
+}
+
+function notesIncludes(game, text) {
+    return !!game.notes && game.notes.toLowerCase().includes(text);
+}
+
+function isConferenceChampion(game) {
+    return notesIncludes(game, "championship") && (game.seasonType == "regular");
+}
+
+function isBowlGame(game) {
+    return notesIncludes(game, "bowl") && !notesIncludes(game, "playoff") && (game.seasonType == "postseason");
+}
+
+function isFirstRound(game) {
+    return notesIncludes(game, "first round") && (game.seasonType == "postseason");
+}
+
+function isQuarterFinalist(game) {
+    return notesIncludes(game, "quarterfinal") && (game.seasonType == "postseason");
+}
+
+function isSemiFinalist(game) {
+    return notesIncludes(game, "semifinal") && (game.seasonType == "postseason");
+}
+
+function isFinalist(game) {
+    return notesIncludes(game, "national championship") && (game.seasonType == "postseason");
+}
+
+function isTop4Seed(game, teamId) {
+    return isQuarterFinalist(game) && (game.homeId == teamId);
+}
+
+// --- context ------------------------------------------------------------
+
+// Normalizes one (team, game, rankings) into the fields every condition needs.
+// team may not appear in the game (defensive): won/opponent stay false/empty and
+// only appearance-based bracket conditions can fire, matching the old code which
+// awarded bracket points regardless of which side the team was on.
+function buildContext(team, game, rankings) {
+    var isHome = game.homeId == team;
+    var isAway = game.awayId == team;
+    var won = isHome ? (game.homePoints > game.awayPoints)
+        : isAway ? (game.awayPoints > game.homePoints) : false;
+    var opponent = isHome ? game.awayTeam : (isAway ? game.homeTeam : null);
+    var teamConf = isHome ? game.homeConference : (isAway ? game.awayConference : null);
+    var oppConf = isHome ? game.awayConference : (isAway ? game.homeConference : null);
+    return {
+        game: game,
+        team: team,
+        isRegular: game.seasonType == "regular",
+        won: won,
+        opponent: opponent,
+        rankVal: rankValue(opponent, rankings),
+        isConference: isConference(game),
+        isPowerFiveUpset: isPowerFiveUpset(teamConf, oppConf)
+    };
+}
+
+// --- condition vocabulary -----------------------------------------------
+// Each entry maps a condition key -> predicate(ctx). Regular-win conditions are
+// gated to won && regular so bracket/bowl games that fall through score 0.
+
+const CONDITIONS = {
+    // Regular-season / non-bracket win conditions.
+    baseWin: (ctx) => ctx.won && ctx.isRegular && !isConferenceChampion(ctx.game),
+    conferenceWin: (ctx) => ctx.won && ctx.isRegular && ctx.isConference && !isConferenceChampion(ctx.game),
+    confBonus: (ctx) => ctx.won && ctx.isRegular && ctx.isConference && !isConferenceChampion(ctx.game),
+    nonConfRankedWin: (ctx) => ctx.won && ctx.isRegular && !ctx.isConference && ctx.rankVal > 0 && !isConferenceChampion(ctx.game),
+    rankedTop25Bonus: (ctx) => ctx.won && ctx.isRegular && ctx.rankVal === 1 && !isConferenceChampion(ctx.game),
+    rankedTop10Bonus: (ctx) => ctx.won && ctx.isRegular && ctx.rankVal === 2 && !isConferenceChampion(ctx.game),
+    nonP5UpsetBonus: (ctx) => ctx.won && ctx.isRegular && ctx.isPowerFiveUpset && !isConferenceChampion(ctx.game),
+
+    // Conference championship (regular-season titled game), win only.
+    confChampionship: (ctx) => ctx.won && isConferenceChampion(ctx.game),
+
+    // Bowls (non-playoff postseason).
+    bowlAppearance: (ctx) => isBowlGame(ctx.game),
+    bowlWin: (ctx) => ctx.won && isBowlGame(ctx.game),
+
+    // CFP bracket. Appearance conditions fire win or lose; *Loss/*Win are gated.
+    cfpFirstRound: (ctx) => isFirstRound(ctx.game),
+    cfpFirstRoundLoss: (ctx) => isFirstRound(ctx.game) && !ctx.won,
+    cfpQuarterfinal: (ctx) => isQuarterFinalist(ctx.game),
+    cfpQuarterfinalTop4Bonus: (ctx) => isTop4Seed(ctx.game, ctx.team),
+    cfpSemifinal: (ctx) => isSemiFinalist(ctx.game),
+    nationalChampionship: (ctx) => isFinalist(ctx.game),           // appearance (Claunts)
+    nationalChampionshipWin: (ctx) => ctx.won && isFinalist(ctx.game) // win only (Graham)
+};
+
+module.exports = {
+    CONDITIONS,
+    buildContext,
+    // exported for reuse/tests:
+    isConference, findPoll, rankValue, isPowerFiveUpset,
+    isConferenceChampion, isBowlGame, isFirstRound,
+    isQuarterFinalist, isSemiFinalist, isFinalist, isTop4Seed
+};

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -1,5 +1,6 @@
 const { internalFetch } = require('./internal-api');
-const { CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, resolveConfig } = require('./scoring-defaults');
+const { resolveConfig, MODELS } = require('./scoring-defaults');
+const { CONDITIONS, buildContext } = require('./scoring-detectors');
 // Configure API key authorization: ApiKeyAuth
 const CFBD_API_KEY = process.env.CFBD_API_KEY;
 var cfb = require('cfb.js');
@@ -76,10 +77,13 @@ module.exports= {
                     for (const game of response) {
                         var teamScore = 0;
 
+                        // Pass the full resolved config (model + combineMode +
+                        // values + disabled) so commissioner structure changes
+                        // are honored, not just point values.
                         if (cfg.model == "claunts") {
-                            teamScore = await module.exports.calculateScoreV1(team.id, game, week, process.env.YEAR, cfg.values);
+                            teamScore = await module.exports.calculateScoreV1(team.id, game, week, process.env.YEAR, cfg);
                         } else if (cfg.model == "graham") {
-                            teamScore = await module.exports.calculateScoreV2(team.id, game, week, process.env.YEAR, cfg.values);
+                            teamScore = await module.exports.calculateScoreV2(team.id, game, week, process.env.YEAR, cfg);
                         }
 
                         score += teamScore;
@@ -157,8 +161,8 @@ module.exports= {
                 var gameScoreV1 = 0;
                 var gameScoreV2 = 0;
 
-                gameScoreV1 = await module.exports.calculateScoreV1(teamId, game, game.week, season, clauntsCfg.values);
-                gameScoreV2 = await module.exports.calculateScoreV2(teamId, game, game.week, season, grahamCfg.values);
+                gameScoreV1 = await module.exports.calculateScoreV1(teamId, game, game.week, season, clauntsCfg);
+                gameScoreV2 = await module.exports.calculateScoreV2(teamId, game, game.week, season, grahamCfg);
 
                 cumulativeScoreV1 += gameScoreV1;
                 cumulativeScoreV2 += gameScoreV2;
@@ -191,47 +195,18 @@ module.exports= {
         }
     },
 
-    //Scoring for Claunts League. cfg holds this league's point values.
-    calculateScoreV1: async function (team, data, week, season = process.env.YEAR, cfg = CLAUNTS_DEFAULTS) {
-        var game = data;
-        var score = 0;
-        var rankings = await getRankingsForGame(game, week, season);
-
-        if (isQuarterFinalist(game)) {
-            score += cfg.cfpQuarterfinal;
-        } else if (isSemiFinalist(game)) {
-            score += cfg.cfpSemifinal;
-        } else if (isFinalist(game)) {
-            score += cfg.nationalChampionship;
-        } else if (game.homeId == team) {
-            score += scoreV1RegularOrBowl(game, game.homePoints > game.awayPoints, game.awayTeam, rankings, cfg);
-        } else if (game.awayId == team) {
-            score += scoreV1RegularOrBowl(game, game.awayPoints > game.homePoints, game.homeTeam, rankings, cfg);
-        }
-
-        return score;
+    // Scoring for the Claunts league (claunts model). `cfg` may be a flat point-
+    // values object (back-compat with callers/tests that only tune values) or a
+    // fully-resolved config { model, combineMode, values, disabled }.
+    calculateScoreV1: async function (team, data, week, season = process.env.YEAR, cfg = MODELS.claunts.defaults) {
+        var rankings = await getRankingsForGame(data, week, season);
+        return evaluate('claunts', team, data, rankings, normalizeCfg('claunts', cfg));
     },
 
-    //Scoring for Graham League. cfg holds this league's point values.
-    calculateScoreV2: async function (team, data, week, season = process.env.YEAR, cfg = GRAHAM_DEFAULTS) {
-        var game = data;
-        var score = 0;
-        var rankings = await getRankingsForGame(game, week, season);
-
-        if (isFirstRound(game)) {
-            score += cfg.cfpFirstRound;
-        } else if (isQuarterFinalist(game)) {
-            if (isTop4Seed(game, team)) score += cfg.cfpQuarterfinalTop4Bonus;
-            score += cfg.cfpQuarterfinal;
-        } else if (isSemiFinalist(game)) {
-            score += cfg.cfpSemifinal;
-        } else if (game.homeId == team) {
-            score += scoreV2RegularOrBowl(game, game.homePoints > game.awayPoints, game.awayTeam, game.homeConference, game.awayConference, rankings, cfg);
-        } else if (game.awayId == team) {
-            score += scoreV2RegularOrBowl(game, game.awayPoints > game.homePoints, game.homeTeam, game.awayConference, game.homeConference, rankings, cfg);
-        }
-
-        return score;
+    // Scoring for the Graham league (graham model). See calculateScoreV1 re: cfg.
+    calculateScoreV2: async function (team, data, week, season = process.env.YEAR, cfg = MODELS.graham.defaults) {
+        var rankings = await getRankingsForGame(data, week, season);
+        return evaluate('graham', team, data, rankings, normalizeCfg('graham', cfg));
     },
 
     updateTeamScores: async function (teamId, scoreUpdate) {
@@ -364,192 +339,66 @@ async function getRankingsForGame(game, week, season) {
     return response.json();
 }
 
-// Claunts (V1) regular-season / bowl scoring for one team in a game.
-function scoreV1RegularOrBowl(game, won, opponent, rankings, cfg) {
+// --- unified scoring engine ---------------------------------------------
+
+// Coerces the `cfg` arg accepted by calculateScoreV1/V2 into the shape the
+// engine needs: { combineMode, values, disabled }. A fully-resolved config
+// (from resolveConfig / getScoringConfig) is passed through; a bare point-values
+// object is wrapped, letting the model's default combine mode apply and leaving
+// all postseason events enabled.
+function normalizeCfg(model, cfg) {
+    if (cfg && typeof cfg === 'object' && cfg.values && typeof cfg.values === 'object') {
+        return { combineMode: cfg.combineMode, values: cfg.values, disabled: cfg.disabled || [] };
+    }
+    return { combineMode: undefined, values: cfg || {}, disabled: [] };
+}
+
+function pointsOf(values, key) {
+    var v = values[key];
+    return typeof v === 'number' ? v : 0;
+}
+
+// The single data-driven engine both leagues run through. `model` selects the
+// code-owned structure (rule lists + default combine mode); `cfg` supplies the
+// commissioner's point values, combine-mode override, and disabled postseason
+// events. See modules/scoring-defaults.js for the structure and the exact
+// precedence rationale.
+function evaluate(model, team, game, rankings, cfg) {
+    var structure = (MODELS[model] || MODELS.claunts).structure;
+    var values = cfg.values || {};
+    var disabled = new Set(cfg.disabled || []);
+    var combineMode = (cfg.combineMode === 'sum' || cfg.combineMode === 'first')
+        ? cfg.combineMode : structure.combineMode;
+    var ctx = buildContext(team, game, rankings);
+
+    // 1. Postseason events, in order. Each enabled matching rule adds its
+    //    points; a non-additive match stops evaluation. This first-match-stop
+    //    reproduces the old elif precedence (bracket rounds short-circuit the
+    //    bowl/regular paths, so a CFP game at a bowl venue never double-counts).
     var score = 0;
-    var isBowlTeam = isBowlParticipant(game);
-    if (isBowlTeam) score += cfg.bowlAppearance;
-    if (won) {
-        if (isFinalist(game)) {
-            score += cfg.nationalChampionship;
-        } else if (isBowlWin(game)) {
-            score += cfg.bowlWin;
-        } else if (isConferenceChampion(game)) {
-            score += cfg.confChampionship;
-        } else if (!isBowlTeam && !isFirstRound(game)) {
-            score += cfg.nonConfWinUnranked;
-            // Conference win is fixed (ranked or not); a non-conference win over
-            // a ranked opponent scores more.
-            if (isConference(game)) {
-                score = cfg.confWin;
-            } else if (isRankedV1(opponent, rankings)) {
-                score = cfg.nonConfWinRanked;
-            }
+    var matchedPost = false;
+    for (var i = 0; i < structure.postseason.length; i++) {
+        var pr = structure.postseason[i];
+        if (disabled.has(pr.condition)) continue;
+        var pd = CONDITIONS[pr.condition];
+        if (pd && pd(ctx)) {
+            score += pointsOf(values, pr.pointsKey);
+            matchedPost = true;
+            if (!pr.additive) break;
         }
-    } else if (isFirstRound(game)) {
-        score += cfg.cfpAppearance;
+    }
+    if (matchedPost) return score;
+
+    // 2. Regular-win group (only if no postseason event matched). Combine mode
+    //    'sum' adds every matching rule (Graham); 'first' takes the first match
+    //    in priority order (Claunts).
+    for (var j = 0; j < structure.regularWin.length; j++) {
+        var rr = structure.regularWin[j];
+        var rd = CONDITIONS[rr.condition];
+        if (rd && rd(ctx)) {
+            score += pointsOf(values, rr.pointsKey);
+            if (combineMode !== 'sum') break;
+        }
     }
     return score;
-}
-
-// Graham (V2) regular-season / bowl scoring for one team in a game (additive).
-function scoreV2RegularOrBowl(game, won, opponent, teamConf, oppConf, rankings, cfg) {
-    if (!won) return 0;
-    if (isFinalist(game)) return cfg.nationalChampionship;
-    if (isBowlWin(game)) return cfg.bowlWin;
-    if (isConferenceChampion(game)) return cfg.confChampionship;
-
-    var score = cfg.baseWin;
-    if (isConference(game)) score += cfg.confBonus;
-    var rankVal = isRanked(opponent, rankings);   // 0 unranked, 1 = #11-25, 2 = #1-10
-    if (rankVal === 2) score += cfg.rankedTop10Bonus;
-    else if (rankVal === 1) score += cfg.rankedTop25Bonus;
-    if (isPowerFive(teamConf, oppConf)) score += cfg.nonP5UpsetBonus;
-    return score;
-}
-
-function isConference(game) {
-    if ((game.homeConference == "FBS Independents") || (game.awayConference == "FBS Independents")) {
-        return false;
-    } else {
-        return game.conferenceGame;
-    }
-}
-
-// Finds the relevant poll (CFP committee if present, else AP Top 25). Returns
-// null if rankings weren't loaded for the week or neither poll is present, so
-// callers degrade gracefully instead of throwing.
-function findPoll(rankings) {
-    if (!rankings || !Array.isArray(rankings.polls)) return null;
-    var poll = rankings.polls.find(x => x.poll === 'Playoff Committee Rankings')
-        || rankings.polls.find(x => x.poll === 'AP Top 25');
-    if (!poll || !Array.isArray(poll.ranks)) return null;
-    return poll;
-}
-
-function isRankedV1(team, rankings) {
-    var poll = findPoll(rankings);
-    if (!poll) return false;
-    return poll.ranks.some(y => y.school === team);
-}
-
-function isRanked(team, rankings) {
-    var poll = findPoll(rankings);
-    if (!poll) return 0;
-    var entry = poll.ranks.find(y => y.school === team);
-    if (!entry) return 0;
-    return entry.rank <= 10 ? 2 : 1;   // #1-10 -> 2, #11-25 -> 1
-}
-
-function isPowerFive(teamConf, oppConf) {
-    var powerFive = new Array("ACC", "Big 12", "Big Ten", "SEC");
-
-    if ((!powerFive.includes(teamConf)) && (powerFive.includes(oppConf))) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-function isConferenceChampion(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("championship") && (game.seasonType == "regular")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
-}
-
-function isBowlWin(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("bowl") && !game.notes.toLowerCase().includes("playoff") && (game.seasonType == "postseason")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
-}
-
-function isBowlParticipant(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("bowl") && !game.notes.toLowerCase().includes("playoff") && (game.seasonType == "postseason")) {
-            return true;
-        } else {
-            return false;
-        }
-    } else {
-        return false;
-    }
-}
-
-function isFirstRound(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("first round") && (game.seasonType == "postseason")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
-}
-
-function isTop4Seed(game, teamId) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("quarterfinal") && (game.seasonType == "postseason") && (game.homeId == teamId)) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
-}
-
-function isQuarterFinalist(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("quarterfinal") && (game.seasonType == "postseason")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
-}
-
-function isSemiFinalist(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("semifinal") && (game.seasonType == "postseason")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
-}
-
-function isFinalist(game) {
-    if (game.notes) {
-        if (game.notes.toLowerCase().includes("national championship") && (game.seasonType == "postseason")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-     else {
-        return false;
-    }
 }

--- a/public/admin.css
+++ b/public/admin.css
@@ -216,6 +216,21 @@
     font-size: 0.95em;
 }
 
+/* Postseason event rows carry an enable/disable checkbox; dim disabled ones. */
+.scoring-field label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.scoring-field .scoring-toggle {
+    flex: 0 0 auto;
+}
+
+.scoring-disabled {
+    opacity: 0.45;
+}
+
 .draft-status-badge {
     text-transform: capitalize;
     font-weight: 600;

--- a/public/admin.js
+++ b/public/admin.js
@@ -1235,21 +1235,46 @@ async function displayScoringConfigContainer() {
 async function loadScoringConfig() {
     var leagueCode = getDraftLeagueCode();
     var res = await fetch(`/scoring-config/${leagueCode}`, { headers: { 'Accept': 'application/json' } });
-    scoringConfigData = await res.json();   // { league, model, values, fields }
+    scoringConfigData = await res.json();   // { league, model, combineMode, values, disabled, fields }
     document.querySelector('[scoring-config-model]').textContent =
         (leagueCode === 'graham-league' ? 'Graham' : 'Claunts') + ' — ' + scoringConfigData.model + ' model';
+    var mode = document.querySelector('[scoring-config-combine-mode]');
+    if (mode) mode.value = scoringConfigData.combineMode || 'first';
+    document.querySelector('[scoring-config-note]').style.display = 'none';
     renderScoringFields();
 }
 
+// Renders the value inputs grouped by regular vs postseason. Postseason events
+// get an enable/disable checkbox (Option A: commissioners tune points + toggle
+// events + flip combine mode; they do not add/reorder rules or pick conditions).
 function renderScoringFields() {
     var wrap = document.querySelector('[scoring-config-fields]');
     var vals = scoringConfigData.values || {};
-    wrap.innerHTML = (scoringConfigData.fields || []).map(function (f) {
-        return `<div class="draft-field">
-            <label>${f.additive ? '+ ' : ''}${f.label}</label>
+    var fields = scoringConfigData.fields || [];
+
+    function fieldRow(f) {
+        var toggle = f.toggleable
+            ? `<input type="checkbox" class="scoring-toggle" data-condition="${f.condition}" ${f.enabled ? 'checked' : ''} title="Enable this event">`
+            : '';
+        return `<div class="draft-field scoring-field${f.enabled ? '' : ' scoring-disabled'}" data-condition="${f.condition}">
+            <label>${toggle}${f.additive ? '+ ' : ''}${f.label}</label>
             <input type="number" step="1" min="0" data-key="${f.key}" value="${vals[f.key]}">
         </div>`;
-    }).join('');
+    }
+
+    var regular = fields.filter(function (f) { return f.group === 'regular'; });
+    var post = fields.filter(function (f) { return f.group === 'postseason'; });
+    wrap.innerHTML =
+        '<div class="draft-status-row">Regular season</div>' + regular.map(fieldRow).join('') +
+        '<div class="draft-status-row">Postseason</div>' + post.map(fieldRow).join('');
+
+    // Grey out a postseason row when its event is disabled.
+    wrap.querySelectorAll('.scoring-toggle').forEach(function (cb) {
+        cb.addEventListener('change', function () {
+            var row = wrap.querySelector('.scoring-field[data-condition="' + cb.getAttribute('data-condition') + '"]');
+            if (row) row.classList.toggle('scoring-disabled', !cb.checked);
+        });
+    });
 }
 
 async function saveScoringConfig() {
@@ -1258,19 +1283,32 @@ async function saveScoringConfig() {
     document.querySelectorAll('[scoring-config-fields] input[data-key]').forEach(function (inp) {
         values[inp.getAttribute('data-key')] = parseFloat(inp.value);
     });
+    var disabled = [];
+    document.querySelectorAll('[scoring-config-fields] .scoring-toggle').forEach(function (cb) {
+        if (!cb.checked) disabled.push(cb.getAttribute('data-condition'));
+    });
+    var modeEl = document.querySelector('[scoring-config-combine-mode]');
+    var combineMode = modeEl ? modeEl.value : undefined;
+
     var res = await fetch('/scoring-config', {
         method: 'POST',
         headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-        body: JSON.stringify({ league: leagueCode, model: scoringConfigData.model, values: values })
+        body: JSON.stringify({
+            league: leagueCode, model: scoringConfigData.model,
+            values: values, combineMode: combineMode, disabled: disabled
+        })
     });
     var data = await res.json();
     if (res.status === 200) {
         scoringConfigData = data;
+        var modeReload = document.querySelector('[scoring-config-combine-mode]');
+        if (modeReload) modeReload.value = scoringConfigData.combineMode || 'first';
         renderScoringFields();
-        successToast.options.text = 'Scoring values saved';
+        document.querySelector('[scoring-config-note]').style.display = 'block';
+        successToast.options.text = 'Scoring config saved';
         successToast.showToast();
     } else {
-        failToast.options.text = (data.message || 'Could not save scoring values');
+        failToast.options.text = (data.message || 'Could not save scoring config');
         failToast.showToast();
     }
 }

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -1,37 +1,55 @@
 const express = require('express');
 const router = express.Router();
 const ScoringConfig = require('../models/scoringConfig');
-const { resolveConfig, MODELS } = require('../modules/scoring-defaults');
+const { resolveConfig, fieldsForModel } = require('../modules/scoring-defaults');
+
+// Attaches the ordered field metadata (for the admin form + rules page) to a
+// resolved config. `fields` reflect the resolved `disabled` set via each
+// field's `enabled` flag.
+function withFields(cfg) {
+    return Object.assign({}, cfg, { fields: fieldsForModel(cfg.model, cfg.disabled) });
+}
 
 // Resolved config (defaults-merged) for a league — always returns usable
-// values, even if the commissioner hasn't saved a config yet. Includes the
-// ordered field metadata so the admin UI can build the form.
+// values, combine mode, disabled events, and field metadata, even if the
+// commissioner hasn't saved a config yet.
 router.get('/:league', async (req, res) => {
     try {
         const doc = await ScoringConfig.findOne({ league: req.params.league });
-        const overrides = doc ? { model: doc.model, values: doc.values } : null;
-        const cfg = resolveConfig(req.params.league, overrides);
-        res.json(Object.assign({}, cfg, { fields: MODELS[cfg.model].fields }));
+        const overrides = doc
+            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled }
+            : null;
+        res.json(withFields(resolveConfig(req.params.league, overrides)));
     } catch (err) {
         res.status(500).json({ message: err.message });
     }
 });
 
-// Upsert a league's scoring values (commissioner-gated via the mutation gate).
+// Upsert a league's scoring config (commissioner-gated via the mutation gate).
+// Accepts point `values`, a `combineMode` override, and a `disabled` list of
+// postseason condition keys.
 router.post('/', async (req, res) => {
     try {
-        const { league, model, values } = req.body;
+        const { league, model, values, combineMode, disabled } = req.body;
         if (!league) {
             return res.status(400).json({ message: 'league is required' });
         }
-        const resolved = resolveConfig(league, { model, values });
+        const resolved = resolveConfig(league, { model, values, combineMode, disabled });
         const doc = await ScoringConfig.findOneAndUpdate(
             { league },
-            { $set: { league, model: resolved.model, values: resolved.values, updatedAt: new Date() } },
+            { $set: {
+                league,
+                model: resolved.model,
+                values: resolved.values,
+                combineMode: resolved.combineMode,
+                disabled: resolved.disabled,
+                updatedAt: new Date()
+            } },
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
-        const cfg = resolveConfig(league, { model: doc.model, values: doc.values });
-        res.json(Object.assign({}, cfg, { fields: MODELS[cfg.model].fields }));
+        res.json(withFields(resolveConfig(league, {
+            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled
+        })));
     } catch (err) {
         res.status(400).json({ message: err.message });
     }

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const { auth } = require('express-openid-connect');
 const requireAuthOrToken = require('./modules/require-auth');
 const requireCommissioner = require('./modules/require-commissioner');
 const ScoringConfig = require('./models/scoringConfig');
-const { resolveConfig, MODELS } = require('./modules/scoring-defaults');
+const { resolveConfig, fieldsForModel } = require('./modules/scoring-defaults');
 const draftToken = require('./modules/draft-token');
 const registerDraftSockets = require('./modules/draft-socket');
 
@@ -137,11 +137,13 @@ app.get('/rules', async (req, res) => {
         let cfg;
         try {
             const doc = await ScoringConfig.findOne({ league: leagueCode });
-            cfg = resolveConfig(leagueCode, doc ? { model: doc.model, values: doc.values } : null);
+            cfg = resolveConfig(leagueCode, doc
+                ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled }
+                : null);
         } catch (err) {
             cfg = resolveConfig(leagueCode, null);
         }
-        const fields = MODELS[cfg.model].fields;
+        const fields = fieldsForModel(cfg.model, cfg.disabled);
 
         res.render('scoringRules', { user, userState, cfg, fields });
     } else {

--- a/tests/ScoringParity.spec.js
+++ b/tests/ScoringParity.spec.js
@@ -1,0 +1,106 @@
+// Parity proof for the Phase-2 unified engine: for the DEFAULT (unchanged)
+// configuration, the new data-driven engine must score every game identically
+// to the frozen pre-Phase-2 engine (tests/legacyScoring.reference.js).
+//
+// We generate a large matrix of synthetic games covering every scoring
+// condition crossed with win/loss, home/away, ranking tier, conference vs
+// non-conference, and P5/non-P5 matchups, then assert engine == oracle for both
+// models on every case.
+
+const engine = require('../modules/scoring');
+const legacy = require('./legacyScoring.reference');
+const { CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS } = require('../modules/scoring-defaults');
+
+// The new engine fetches rankings via global.fetch; the oracle takes them
+// directly. Feed both the same rankings for each case.
+function mockRankings(ranks) {
+    global.fetch = jest.fn(() => Promise.resolve({
+        json: () => Promise.resolve({ polls: [{ poll: 'AP Top 25', ranks }] })
+    }));
+    return { polls: [{ poll: 'AP Top 25', ranks }] };
+}
+afterEach(() => { jest.restoreAllMocks(); });
+
+// --- matrix generation ---------------------------------------------------
+
+const CONFERENCES = ['SEC', 'ACC', 'Big Ten', 'Big 12', 'Sun Belt', 'Mid-American', 'FBS Independents'];
+const RANK_TIERS = [
+    { label: 'unranked', ranks: [] },
+    { label: 'top25', ranks: [{ school: 'Opp', rank: 18 }] },
+    { label: 'top10', ranks: [{ school: 'Opp', rank: 4 }] }
+];
+const NOTES = [
+    { label: 'plain', notes: null, seasonType: 'regular' },
+    { label: 'confChamp', notes: 'SEC Championship', seasonType: 'regular' },
+    { label: 'bowl', notes: 'Famous Toastery Bowl', seasonType: 'postseason' },
+    { label: 'roseBowlName', notes: 'Rose Bowl Game', seasonType: 'postseason' },
+    { label: 'firstRound', notes: 'CFP First Round', seasonType: 'postseason' },
+    { label: 'quarterfinal', notes: 'CFP Quarterfinal at the Rose Bowl Game', seasonType: 'postseason' },
+    { label: 'semifinal', notes: 'CFP Semifinal at the Rose Bowl Game Pres. by Prudential', seasonType: 'postseason' },
+    { label: 'natlChamp', notes: 'CFP National Championship Pres. by AT&T', seasonType: 'postseason' },
+    { label: 'confGameFlag', notes: null, seasonType: 'regular' }
+];
+
+// Builds every game/team permutation of the matrix.
+function* cases() {
+    for (const note of NOTES) {
+        for (const homeConf of CONFERENCES) {
+            for (const awayConf of CONFERENCES) {
+                for (const confGame of [true, false]) {
+                    for (const homeWins of [true, false]) {
+                        for (const tier of RANK_TIERS) {
+                            for (const scoreTeam of ['home', 'away']) {
+                                const game = {
+                                    seasonType: note.seasonType,
+                                    notes: note.notes,
+                                    conferenceGame: confGame,
+                                    homeId: 1, awayId: 2,
+                                    homeTeam: 'MyTeam', awayTeam: 'Opp',
+                                    homePoints: homeWins ? 31 : 17,
+                                    awayPoints: homeWins ? 17 : 31,
+                                    homeConference: homeConf, awayConference: awayConf
+                                };
+                                const teamId = scoreTeam === 'home' ? 1 : 2;
+                                yield { game, teamId, ranks: tier.ranks };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+describe('Phase 2 parity: unified engine == frozen legacy engine (default config)', () => {
+    it('Claunts (V1) matches across the full synthetic matrix', async () => {
+        let checked = 0, mismatches = [];
+        for (const c of cases()) {
+            const rankings = mockRankings(c.ranks);
+            const got = await engine.calculateScoreV1(c.teamId, c.game, 5, 2025, CLAUNTS_DEFAULTS);
+            const want = legacy.calculateScoreV1(c.teamId, c.game, rankings, CLAUNTS_DEFAULTS);
+            if (got !== want) mismatches.push({ ...c, got, want });
+            checked++;
+        }
+        if (mismatches.length) {
+            throw new Error(`${mismatches.length}/${checked} V1 mismatches, e.g. ` +
+                JSON.stringify(mismatches[0], null, 2));
+        }
+        expect(checked).toBeGreaterThan(1000);
+    });
+
+    it('Graham (V2) matches across the full synthetic matrix', async () => {
+        let checked = 0, mismatches = [];
+        for (const c of cases()) {
+            const rankings = mockRankings(c.ranks);
+            const got = await engine.calculateScoreV2(c.teamId, c.game, 5, 2025, GRAHAM_DEFAULTS);
+            const want = legacy.calculateScoreV2(c.teamId, c.game, rankings, GRAHAM_DEFAULTS);
+            if (got !== want) mismatches.push({ ...c, got, want });
+            checked++;
+        }
+        if (mismatches.length) {
+            throw new Error(`${mismatches.length}/${checked} V2 mismatches, e.g. ` +
+                JSON.stringify(mismatches[0], null, 2));
+        }
+        expect(checked).toBeGreaterThan(1000);
+    });
+});

--- a/tests/ScoringStructure.spec.js
+++ b/tests/ScoringStructure.spec.js
@@ -1,0 +1,88 @@
+// Phase 2 behavior: the engine honors structural overrides in a resolved
+// config — a flipped combine mode and disabled postseason events.
+
+const scoring = require('../modules/scoring');
+const { resolveConfig, fieldsForModel } = require('../modules/scoring-defaults');
+
+function mockRankings(ranks) {
+    global.fetch = jest.fn(() => Promise.resolve({
+        json: () => Promise.resolve({ polls: [{ poll: 'AP Top 25', ranks }] })
+    }));
+}
+afterEach(() => { jest.restoreAllMocks(); });
+
+function homeWin({ conf = false, homeConf = 'SEC', awayConf = 'ACC', notes = null, seasonType = 'regular' } = {}) {
+    return {
+        seasonType, notes, conferenceGame: conf,
+        homeId: 1, awayId: 2, homeTeam: 'MyTeam', awayTeam: 'Opp',
+        homePoints: 30, awayPoints: 20, homeConference: homeConf, awayConference: awayConf
+    };
+}
+const quarterfinal = {
+    seasonType: 'postseason', notes: 'CFP Quarterfinal at the Rose Bowl Game',
+    homeId: 1, awayId: 2, homeTeam: 'A', awayTeam: 'B', homePoints: 30, awayPoints: 20
+};
+const bowl = {
+    seasonType: 'postseason', notes: 'Famous Toastery Bowl',
+    homeId: 1, awayId: 2, homeTeam: 'A', awayTeam: 'B', homePoints: 30, awayPoints: 20
+};
+
+describe('combine mode override', () => {
+    it("Claunts flipped to 'sum' stacks conference + ranked instead of first-match", async () => {
+        mockRankings([{ school: 'Opp', rank: 5 }]);
+        // Default (first): conference win vs ranked = 2. Flipped to sum:
+        // conferenceWin(2) + baseWin(1) both match => 3 (nonConfRankedWin needs
+        // a non-conference game, so it does not apply here).
+        const cfg = resolveConfig('claunts-league', { combineMode: 'sum' });
+        expect(cfg.combineMode).toBe('sum');
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: true, awayConf: 'SEC' }), 5, 2025, cfg)).toBe(3);
+    });
+
+    it("Graham forced to 'first' takes only the base win, not additive bonuses", async () => {
+        mockRankings([{ school: 'Opp', rank: 5 }]);
+        // Default (sum): base 1 + top10 2 = 3. Forced 'first': just base 1.
+        const cfg = resolveConfig('graham-league', { combineMode: 'first' });
+        expect(await scoring.calculateScoreV2(1, homeWin(), 5, 2025, cfg)).toBe(1);
+    });
+});
+
+describe('disabled postseason events', () => {
+    it('disabling bowlWin (Claunts) leaves only the bowl appearance points', async () => {
+        mockRankings([]);
+        // Default: appearance 4 + win 5 = 9. Disable bowlWin -> 4.
+        const cfg = resolveConfig('claunts-league', { disabled: ['bowlWin'] });
+        expect(await scoring.calculateScoreV1(1, bowl, 1, 2025, cfg)).toBe(4);
+    });
+
+    it('disabling the top-4 bye bonus (Graham) drops QF from 12 to 6', async () => {
+        mockRankings([]);
+        // Home team (id 1) is the top-4 seed. Default QF = 6 + 6 bye = 12.
+        const cfg = resolveConfig('graham-league', { disabled: ['cfpQuarterfinalTop4Bonus'] });
+        expect(await scoring.calculateScoreV2(1, quarterfinal, 1, 2025, cfg)).toBe(6);
+    });
+
+    it('disabling the entire bowl set (Claunts) makes a bowl win score 0', async () => {
+        mockRankings([]);
+        const cfg = resolveConfig('claunts-league', { disabled: ['bowlAppearance', 'bowlWin'] });
+        expect(await scoring.calculateScoreV1(1, bowl, 1, 2025, cfg)).toBe(0);
+    });
+});
+
+describe('fieldsForModel', () => {
+    it('marks postseason fields toggleable and reflects disabled state', () => {
+        const fields = fieldsForModel('claunts', ['bowlWin']);
+        const bowlWin = fields.find(f => f.condition === 'bowlWin');
+        const confWin = fields.find(f => f.condition === 'conferenceWin');
+        expect(bowlWin).toMatchObject({ group: 'postseason', toggleable: true, enabled: false });
+        expect(confWin).toMatchObject({ group: 'regular', toggleable: false, enabled: true });
+    });
+
+    it('every field key resolves to a default point value', () => {
+        for (const model of ['claunts', 'graham']) {
+            const cfg = resolveConfig(model === 'graham' ? 'graham-league' : 'claunts-league', null);
+            for (const f of fieldsForModel(model, [])) {
+                expect(typeof cfg.values[f.key]).toBe('number');
+            }
+        }
+    });
+});

--- a/tests/legacyScoring.reference.js
+++ b/tests/legacyScoring.reference.js
@@ -1,0 +1,186 @@
+// FROZEN reference copy of the pre-Phase-2 scoring engine (calculateScoreV1 /
+// calculateScoreV2 and their helpers), lifted verbatim from modules/scoring.js
+// as of the "Configurable scoring (Phase 1)" merge. This is the oracle the
+// parity test compares the new unified engine against — it must NOT be changed
+// when the engine is refactored, or the parity guarantee is meaningless.
+//
+// The only edits vs. the original: point values are inlined via the passed
+// `cfg` (defaulting to the model defaults) exactly as the Phase-1 engine did,
+// and rankings are supplied directly rather than fetched (the test provides
+// them) so this file has no I/O.
+
+const { CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS } = require('../modules/scoring-defaults');
+
+// --- public entry points (frozen) ---------------------------------------
+
+function calculateScoreV1(team, game, rankings, cfg = CLAUNTS_DEFAULTS) {
+    var score = 0;
+    if (isQuarterFinalist(game)) {
+        score += cfg.cfpQuarterfinal;
+    } else if (isSemiFinalist(game)) {
+        score += cfg.cfpSemifinal;
+    } else if (isFinalist(game)) {
+        score += cfg.nationalChampionship;
+    } else if (game.homeId == team) {
+        score += scoreV1RegularOrBowl(game, game.homePoints > game.awayPoints, game.awayTeam, rankings, cfg);
+    } else if (game.awayId == team) {
+        score += scoreV1RegularOrBowl(game, game.awayPoints > game.homePoints, game.homeTeam, rankings, cfg);
+    }
+    return score;
+}
+
+function calculateScoreV2(team, game, rankings, cfg = GRAHAM_DEFAULTS) {
+    var score = 0;
+    if (isFirstRound(game)) {
+        score += cfg.cfpFirstRound;
+    } else if (isQuarterFinalist(game)) {
+        if (isTop4Seed(game, team)) score += cfg.cfpQuarterfinalTop4Bonus;
+        score += cfg.cfpQuarterfinal;
+    } else if (isSemiFinalist(game)) {
+        score += cfg.cfpSemifinal;
+    } else if (game.homeId == team) {
+        score += scoreV2RegularOrBowl(game, game.homePoints > game.awayPoints, game.awayTeam, game.homeConference, game.awayConference, rankings, cfg);
+    } else if (game.awayId == team) {
+        score += scoreV2RegularOrBowl(game, game.awayPoints > game.homePoints, game.homeTeam, game.awayConference, game.homeConference, rankings, cfg);
+    }
+    return score;
+}
+
+// --- helpers (frozen) ----------------------------------------------------
+
+function scoreV1RegularOrBowl(game, won, opponent, rankings, cfg) {
+    var score = 0;
+    var isBowlTeam = isBowlParticipant(game);
+    if (isBowlTeam) score += cfg.bowlAppearance;
+    if (won) {
+        if (isFinalist(game)) {
+            score += cfg.nationalChampionship;
+        } else if (isBowlWin(game)) {
+            score += cfg.bowlWin;
+        } else if (isConferenceChampion(game)) {
+            score += cfg.confChampionship;
+        } else if (!isBowlTeam && !isFirstRound(game)) {
+            score += cfg.nonConfWinUnranked;
+            if (isConference(game)) {
+                score = cfg.confWin;
+            } else if (isRankedV1(opponent, rankings)) {
+                score = cfg.nonConfWinRanked;
+            }
+        }
+    } else if (isFirstRound(game)) {
+        score += cfg.cfpAppearance;
+    }
+    return score;
+}
+
+function scoreV2RegularOrBowl(game, won, opponent, teamConf, oppConf, rankings, cfg) {
+    if (!won) return 0;
+    if (isFinalist(game)) return cfg.nationalChampionship;
+    if (isBowlWin(game)) return cfg.bowlWin;
+    if (isConferenceChampion(game)) return cfg.confChampionship;
+
+    var score = cfg.baseWin;
+    if (isConference(game)) score += cfg.confBonus;
+    var rankVal = isRanked(opponent, rankings);
+    if (rankVal === 2) score += cfg.rankedTop10Bonus;
+    else if (rankVal === 1) score += cfg.rankedTop25Bonus;
+    if (isPowerFive(teamConf, oppConf)) score += cfg.nonP5UpsetBonus;
+    return score;
+}
+
+function isConference(game) {
+    if ((game.homeConference == "FBS Independents") || (game.awayConference == "FBS Independents")) {
+        return false;
+    } else {
+        return game.conferenceGame;
+    }
+}
+
+function findPoll(rankings) {
+    if (!rankings || !Array.isArray(rankings.polls)) return null;
+    var poll = rankings.polls.find(x => x.poll === 'Playoff Committee Rankings')
+        || rankings.polls.find(x => x.poll === 'AP Top 25');
+    if (!poll || !Array.isArray(poll.ranks)) return null;
+    return poll;
+}
+
+function isRankedV1(team, rankings) {
+    var poll = findPoll(rankings);
+    if (!poll) return false;
+    return poll.ranks.some(y => y.school === team);
+}
+
+function isRanked(team, rankings) {
+    var poll = findPoll(rankings);
+    if (!poll) return 0;
+    var entry = poll.ranks.find(y => y.school === team);
+    if (!entry) return 0;
+    return entry.rank <= 10 ? 2 : 1;
+}
+
+function isPowerFive(teamConf, oppConf) {
+    var powerFive = new Array("ACC", "Big 12", "Big Ten", "SEC");
+    if ((!powerFive.includes(teamConf)) && (powerFive.includes(oppConf))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+function isConferenceChampion(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("championship") && (game.seasonType == "regular");
+    }
+    return false;
+}
+
+function isBowlWin(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("bowl") && !game.notes.toLowerCase().includes("playoff") && (game.seasonType == "postseason");
+    }
+    return false;
+}
+
+function isBowlParticipant(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("bowl") && !game.notes.toLowerCase().includes("playoff") && (game.seasonType == "postseason");
+    }
+    return false;
+}
+
+function isFirstRound(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("first round") && (game.seasonType == "postseason");
+    }
+    return false;
+}
+
+function isTop4Seed(game, teamId) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("quarterfinal") && (game.seasonType == "postseason") && (game.homeId == teamId);
+    }
+    return false;
+}
+
+function isQuarterFinalist(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("quarterfinal") && (game.seasonType == "postseason");
+    }
+    return false;
+}
+
+function isSemiFinalist(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("semifinal") && (game.seasonType == "postseason");
+    }
+    return false;
+}
+
+function isFinalist(game) {
+    if (game.notes) {
+        return game.notes.toLowerCase().includes("national championship") && (game.seasonType == "postseason");
+    }
+    return false;
+}
+
+module.exports = { calculateScoreV1, calculateScoreV2 };

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -105,10 +105,20 @@
             <div class="sub-container" scoring-config-container style="display: none">
                 <form id="scoring-config-form" class="draft-config-form">
                     <div class="draft-status-row">League: <span scoring-config-model></span></div>
+                    <div class="draft-field">
+                        <label>Regular-season combine mode</label>
+                        <select scoring-config-combine-mode>
+                            <option value="first">First match wins (priority)</option>
+                            <option value="sum">Sum all bonuses (additive)</option>
+                        </select>
+                    </div>
                     <div scoring-config-fields></div>
                     <div class="draft-config-actions">
-                        <button type="submit">Save Scoring Values</button>
+                        <button type="submit">Save Scoring Config</button>
                     </div>
+                    <p scoring-config-note class="draft-status-row" style="display:none">
+                        Saved. Run a full-season rescore to apply structural changes to existing scores.
+                    </p>
                 </form>
                 <hr>
             </div>

--- a/views/scoringRules.ejs
+++ b/views/scoringRules.ejs
@@ -38,9 +38,27 @@
     </section>
 
     <section class="rules-section">
-      <h2 class="rule-header">🏈 Scoring System</h2>
+      <h2 class="rule-header">🏈 Regular Season Scoring</h2>
+      <p class="scoring-mode">
+        <% if (cfg.combineMode === 'sum') { %>
+          Bonuses <strong>stack</strong> — a win earns the base points plus every bonus that applies.
+        <% } else { %>
+          A win scores the <strong>single highest-priority</strong> rule that applies (bonuses do not stack).
+        <% } %>
+      </p>
       <ul class="scoring-list">
-        <% fields.forEach(function(f){ var v = cfg.values[f.key]; %>
+        <% fields.filter(function(f){ return f.group === 'regular' && f.enabled; }).forEach(function(f){ var v = cfg.values[f.key]; %>
+          <li>
+            <% if (f.additive) { %><i class="fas fa-plus"></i><% } %><%= v %> <%= v === 1 ? 'pt' : 'pts' %> — <%= f.label %>
+          </li>
+        <% }); %>
+      </ul>
+    </section>
+
+    <section class="rules-section">
+      <h2 class="rule-header">🏆 Postseason Scoring</h2>
+      <ul class="scoring-list">
+        <% fields.filter(function(f){ return f.group === 'postseason' && f.enabled; }).forEach(function(f){ var v = cfg.values[f.key]; %>
           <li>
             <% if (f.additive) { %><i class="fas fa-plus"></i><% } %><%= v %> <%= v === 1 ? 'pt' : 'pts' %> — <%= f.label %>
           </li>


### PR DESCRIPTION
## Summary

Phase 2 of configurable scoring. Phase 1 (#178) made per-league point **values** configurable; this makes the scoring **structure** configurable within a fixed vocabulary (Option A, as agreed):

- **Unified engine.** `calculateScoreV1`/`calculateScoreV2` are now thin wrappers over one data-driven engine in [`modules/scoring.js`](modules/scoring.js). Detectors moved to [`modules/scoring-detectors.js`](modules/scoring-detectors.js) **unchanged**.
- **Regular-win combine mode** per league: `'first'` (priority — Claunts, a conf win = 2 even vs a ranked team) or `'sum'` (additive — Graham, base + bonuses stack).
- **Postseason events** are an ordered set with per-event enable/disable. A non-additive match short-circuits, reproducing the old `elif` precedence — so a CFP game at a bowl venue never double-counts appearance/bowl points.
- Commissioners edit points, toggle postseason events, and flip the combine mode. They do **not** invent/reorder conditions (that's Option B, out of scope).

## Modeling facts preserved
- Claunts conf win = 2 even vs ranked (first-match, not highest).
- Claunts bowls additive (4 appearance + 5 win = 9) even though regular wins are `'first'`.
- Graham QF top-4-seed bye bonus (+6 → 12) intact.
- Graham natl-champ = **win only**; Claunts natl-champ = **appearance** (distinct conditions).

## Parity proof
- Frozen verbatim copy of the pre-Phase-2 engine in [`tests/legacyScoring.reference.js`](tests/legacyScoring.reference.js) is the oracle.
- [`tests/ScoringParity.spec.js`](tests/ScoringParity.spec.js) asserts the new engine == oracle across a **~10,500-case synthetic matrix per model** (every condition × win/loss × home/away × rank tier × conf/non-conf × P5 combos) for the default config.
- All existing 50 tests stay green (untouched). [`tests/ScoringStructure.spec.js`](tests/ScoringStructure.spec.js) covers combine-mode flips and disabled events. **59 tests total.**

## Config / API / job safety
- `scoringConfig` model gains optional `combineMode` + `disabled[]`. `resolveConfig` returns `{model, combineMode, values, disabled}`.
- `GET/POST /scoring-config` handle the new fields (verified via curl round-trip on the test DB).
- Engine still loads config via `internalFetch` → `/scoring-config` in job processes (no Mongoose in `scoring.js`).

## UI
- Admin "Configure Scoring": value inputs grouped regular/postseason, enable/disable checkboxes for postseason events, a combine-mode selector, and a "rescore to apply" note.
- Rules page regenerates from config (grouped, shows combine mode, hides disabled events). Verified via static render for Claunts default, Graham default, and a modified Claunts (sum + bowl-win disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)