### PR TITLE
Fix: mass-create games crashes the server on empty/bad week

### DIFF
--- a/modules/retrieve-games.js
+++ b/modules/retrieve-games.js
@@ -23,6 +23,28 @@ function dedupeGamesById(games) {
     });
 }
 
+// Guards for the /games/week/mass-create route. Kept pure (no req/res/DB) so
+// they can be unit-tested. Return an error message to send as a 400, or null
+// when the request is good to process.
+
+// A missing week/seasonType (e.g. the admin dropdown left unselected) must be
+// rejected BEFORE calling CFBD: an empty week makes CFBD return a 400 JSON
+// object instead of an array, and iterating that object throws "not iterable"
+// — an unhandled rejection that crashes the Node process.
+function massCreateInputError(week, seasonType) {
+    if (!week || !seasonType) return 'week and seasonType are required';
+    return null;
+}
+
+// Even with valid inputs the CFBD call can fail (rate limit, bad params, etc.),
+// returning a non-OK status and a JSON object rather than a games array.
+function gamesResponseError(responseOk, status, gameData) {
+    if (!responseOk || !Array.isArray(gameData)) {
+        return (gameData && gameData.message) ? gameData.message : `CFBD request failed (${status})`;
+    }
+    return null;
+}
+
 module.exports = {
 
     retrieveTeams: async () => {
@@ -175,5 +197,7 @@ module.exports = {
     },
 
     // Exported for testing.
-    dedupeGamesById: dedupeGamesById
+    dedupeGamesById: dedupeGamesById,
+    massCreateInputError: massCreateInputError,
+    gamesResponseError: gamesResponseError
 };

--- a/routes/games.js
+++ b/routes/games.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const Game = require('../models/game');
+const { massCreateInputError, gamesResponseError } = require('../modules/retrieve-games');
 
 // Configure API key authorization: ApiKeyAuth
 const CFBD_API_KEY = process.env.CFBD_API_KEY;
@@ -122,6 +123,15 @@ router.post('/week/mass-create', async (req, res) => {
         'division': 'fbs'
     };
 
+    // Reject a missing week/seasonType before hitting CFBD: an empty week makes
+    // CFBD return a 400 JSON object instead of an array, and iterating that
+    // object below throws "not iterable" — an unhandled rejection in this async
+    // handler, which crashes the Node process.
+    var inputError = massCreateInputError(req.body.week, req.body.seasonType);
+    if (inputError) {
+        return res.status(400).json({ message: inputError });
+    }
+
     const response = await fetch(`https://api.collegefootballdata.com/games?year=${year}&week=${req.body.week}&seasonType=${req.body.seasonType}&division=fbs`, {
         method: 'GET',
         headers: {
@@ -131,7 +141,12 @@ router.post('/week/mass-create', async (req, res) => {
     });
 
     var gameData = await response.json();
-        
+
+    var responseError = gamesResponseError(response.ok, response.status, gameData);
+    if (responseError) {
+        return res.status(400).json({ message: responseError });
+    }
+
     for (const game of gameData) {
         var alreadyExists = await Game.find({ id: game.id });
 

--- a/tests/RetrieveGames.spec.js
+++ b/tests/RetrieveGames.spec.js
@@ -1,4 +1,4 @@
-const { dedupeGamesById } = require('../modules/retrieve-games');
+const { dedupeGamesById, massCreateInputError, gamesResponseError } = require('../modules/retrieve-games');
 
 describe('dedupeGamesById', () => {
     it('removes games with duplicate ids (distinct object references)', () => {
@@ -29,5 +29,42 @@ describe('dedupeGamesById', () => {
     it('leaves an already-unique list unchanged', () => {
         const games = [{ id: 1 }, { id: 2 }, { id: 3 }];
         expect(dedupeGamesById(games)).toEqual(games);
+    });
+});
+
+describe('massCreateInputError', () => {
+    it('rejects a missing week (the dropdown-unselected case that crashed the server)', () => {
+        expect(massCreateInputError('', 'regular')).toBe('week and seasonType are required');
+        expect(massCreateInputError(undefined, 'regular')).toBe('week and seasonType are required');
+    });
+
+    it('rejects a missing seasonType', () => {
+        expect(massCreateInputError('5', '')).toBe('week and seasonType are required');
+    });
+
+    it('passes valid inputs', () => {
+        expect(massCreateInputError('5', 'regular')).toBeNull();
+        expect(massCreateInputError('1', 'postseason')).toBeNull();
+    });
+});
+
+describe('gamesResponseError', () => {
+    it('flags a non-OK CFBD response and surfaces its message', () => {
+        // What CFBD returns for an empty week: 400 + a JSON object, not an array.
+        const body = { message: 'Validation Failed', details: { week: {} } };
+        expect(gamesResponseError(false, 400, body)).toBe('Validation Failed');
+    });
+
+    it('flags a non-array body even on a 200 (would otherwise be "not iterable")', () => {
+        expect(gamesResponseError(true, 200, { unexpected: 'shape' })).toBe('CFBD request failed (200)');
+    });
+
+    it('falls back to a status message when there is no error message', () => {
+        expect(gamesResponseError(false, 500, null)).toBe('CFBD request failed (500)');
+    });
+
+    it('passes a normal array of games', () => {
+        expect(gamesResponseError(true, 200, [{ id: 1 }, { id: 2 }])).toBeNull();
+        expect(gamesResponseError(true, 200, [])).toBeNull();
     });
 });


### PR DESCRIPTION
## Problem

The **Retrieve Game Information** admin function posts the selected week to `POST /games/week/mass-create`. With **no week selected**, the dropdown sends an empty string, so the CollegeFootballData request:

```
GET https://api.collegefootballdata.com/games?year=2025&week=&seasonType=regular&division=fbs
```

comes back as **HTTP 400 with a JSON object** (`{"message":"Validation Failed",...}`), not an array. The route then ran `for (const game of gameData)` over that object → `TypeError: gameData is not iterable`. Because the handler is `async` with no wrapping `try/catch`, it became an **unhandled promise rejection**, which on Node 15+ (this repo runs v26) **terminates the process** — the whole server went down mid-request.

## Fix

Two pure, unit-tested guards in [`modules/retrieve-games.js`](modules/retrieve-games.js), used by the route:

- `massCreateInputError(week, seasonType)` — reject a missing week/seasonType with a clean **400 before** calling CFBD at all.
- `gamesResponseError(responseOk, status, gameData)` — if CFBD returns a non-OK status or a non-array body, respond **400 with the API's message** instead of iterating a non-array.

No behavior change for valid requests.

## Notes
- There is still no "all weeks" option — pulling a full season is one call per week. Not in scope here; this PR just stops the crash.
- Adds 7 tests (pure helpers, matching the existing `dedupeGamesById` test style). Full suite: **57 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)