### PR TITLE
Fix: postseason weekly scores accumulate per week instead of overwriting

### DIFF
--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -111,16 +111,26 @@ module.exports= {
             if ((season == "postseason")) {
                 scoreObject["season"] = season;
 
-                if (await user.seasons[0].weeklyScore.some(e => e.season === scoreObject.season)) {
-                    var spliceIndex = user.seasons[0].weeklyScore.findIndex(x => x.season === scoreObject.season);
+                // Key postseason entries by (season, week), not season alone, so
+                // multiple postseason weeks accumulate as separate entries rather
+                // than each call overwriting the previous one. (CFBD currently
+                // packs the FBS postseason into a single week, so today this only
+                // ever creates one entry — it's a safeguard against a future
+                // multi-week postseason.)
+                var postWeek = parseInt(scoreObject.week);
+                if (await user.seasons[0].weeklyScore.some(e => e.season === "postseason" && e.week === postWeek)) {
+                    var spliceIndex = user.seasons[0].weeklyScore.findIndex(x => x.season === "postseason" && x.week === postWeek);
                     user.seasons[0].weeklyScore.splice(spliceIndex, 1, scoreObject);
                     await updateUser(user._id, user.seasons[0].weeklyScore);
                 } else {
                     user.seasons[0].weeklyScore.push(scoreObject);
                     await updateUser(user._id, user.seasons[0].weeklyScore);
                 }
-            } else if (await user.seasons[0].weeklyScore.some(e => e.week === parseInt(scoreObject.week))) {
-                var spliceIndex = user.seasons[0].weeklyScore.findIndex(x => x.week === parseInt(scoreObject.week));
+            } else if (await user.seasons[0].weeklyScore.some(e => e.season !== "postseason" && e.week === parseInt(scoreObject.week))) {
+                // Match regular weeks only (exclude postseason entries), so a
+                // regular week N never clobbers a postseason entry that shares
+                // the same week number.
+                var spliceIndex = user.seasons[0].weeklyScore.findIndex(x => x.season !== "postseason" && x.week === parseInt(scoreObject.week));
                 user.seasons[0].weeklyScore.splice(spliceIndex, 1, scoreObject);
                 await updateUser(user._id, user.seasons[0].weeklyScore);
             } else if (user.seasons[0].weeklyScore.length == 0){

--- a/tests/ScoringAggregation.spec.js
+++ b/tests/ScoringAggregation.spec.js
@@ -101,4 +101,83 @@ describe('scoring aggregation', () => {
             expect(patchBody.weeklyScore[0].week).toBe(1);
         });
     });
+
+    describe('postseason week accumulation', () => {
+        // Regression/safeguard: postseason entries used to be keyed by
+        // season === "postseason" alone, so scoring a second postseason week
+        // overwrote the first. Key by (season, week) so they accumulate.
+        it('keeps a separate entry per postseason week instead of overwriting', async () => {
+            const user = {
+                _id: 'u1',
+                league: 'graham-league',
+                seasons: [{ season: '2025', teams: [{ id: 333, school: 'Alabama' }], weeklyScore: [] }],
+            };
+            const g1 = { id: 11, homeId: 333, awayId: 8, homePoints: 30, awayPoints: 20, seasonType: 'postseason' };
+            const g2 = { id: 22, homeId: 333, awayId: 9, homePoints: 40, awayPoints: 10, seasonType: 'postseason' };
+
+            global.fetch = jest.fn((url, opts) => {
+                if (url.includes('/users/season/')) {
+                    // Same object ref each call, so updateScores' in-place edits persist.
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
+                }
+                if (url.includes('/scoring-config/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+                }
+                if (url.includes('/games/seasonType/postseason/week/1/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([g1]) });
+                }
+                if (url.includes('/games/seasonType/postseason/week/2/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([g2]) });
+                }
+                return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+            });
+            jest.spyOn(scoringModule, 'calculateScoreV2').mockResolvedValue(5);
+
+            await scoringModule.updateScores('postseason', 1);
+            await scoringModule.updateScores('postseason', 2);
+
+            const post = user.seasons[0].weeklyScore.filter(e => e.season === 'postseason');
+            expect(post).toHaveLength(2);
+            expect(post.map(e => e.week).sort()).toEqual([1, 2]);
+        });
+
+        it('a regular week does not clobber a postseason entry with the same week number', async () => {
+            const user = {
+                _id: 'u2',
+                league: 'graham-league',
+                seasons: [{
+                    season: '2025',
+                    teams: [{ id: 333, school: 'Alabama' }],
+                    // Pre-existing postseason entry stored under week 1.
+                    weeklyScore: [{ week: 1, score: 9, season: 'postseason', scoreByTeam: [] }],
+                }],
+            };
+            const regGame = { id: 33, homeId: 333, awayId: 8, homePoints: 30, awayPoints: 20, seasonType: 'regular' };
+
+            global.fetch = jest.fn((url, opts) => {
+                if (url.includes('/users/season/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
+                }
+                if (url.includes('/scoring-config/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+                }
+                if (url.includes('/games/seasonType/regular/week/1/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([regGame]) });
+                }
+                return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+            });
+            jest.spyOn(scoringModule, 'calculateScoreV2').mockResolvedValue(3);
+
+            await scoringModule.updateScores('regular', 1);
+
+            const ws = user.seasons[0].weeklyScore;
+            const post = ws.find(e => e.season === 'postseason' && e.week === 1);
+            const reg = ws.find(e => e.season !== 'postseason' && e.week === 1);
+            expect(post).toBeDefined();
+            expect(post.score).toBe(9);          // postseason entry preserved
+            expect(reg).toBeDefined();
+            expect(reg.score).toBe(3);           // regular week added alongside it
+            expect(ws).toHaveLength(2);
+        });
+    });
 });


### PR DESCRIPTION
## Problem

In `updateScores` ([modules/scoring.js](modules/scoring.js)), postseason results were stored keyed by `season === "postseason"` **alone**:

```js
if (weeklyScore.some(e => e.season === "postseason")) {
    // find the existing "postseason" entry and REPLACE it
}
```

So scoring a second postseason week **overwrote** the first — only the last call's points survived. Separately, the regular-week branch matched by week number without excluding postseason, so a regular week *N* could clobber a postseason entry that happened to share week number *N*.

## Fix

- Key postseason entries by **(season, week)** so multiple postseason weeks accumulate as distinct entries.
- Scope the regular-week match to **non-postseason** entries so a regular week never overwrites a postseason entry with the same week number.

## Non-destructive

CFBD currently packs the entire FBS postseason (first round → quarterfinals → semifinals → championship, plus bowls) into a single postseason "week", so **today this still produces exactly one postseason entry** — identical current behavior. It's a safeguard that only changes anything if the FBS postseason is ever scored across multiple weeks. Verified nothing assumes a single postseason entry (the `standings.js` checks only inspect the last entry's `season`).

## Tests

Adds 2 integration tests to the existing `updateScores` harness: multiple postseason weeks accumulate, and a regular week does not clobber a same-numbered postseason entry. **68 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)