### PR TITLE
Fix scoring-config drop + harden schedule/game-result display

### DIFF
--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -332,7 +332,17 @@ async function getScoringConfig(league) {
             method: 'GET', headers: { 'Accept': 'application/json' }
         });
         var data = await res.json();
-        if (data && data.values) return resolveConfig(league, { model: data.model, values: data.values });
+        // Forward the FULL config — model, values, combineMode AND disabled — so
+        // the scoring jobs honor a commissioner's structural changes (combine
+        // mode, disabled postseason events), not just point values. Dropping
+        // combineMode/disabled here made computed scores silently ignore
+        // structural config while the rules page still showed it.
+        if (data && data.values) return resolveConfig(league, {
+            model: data.model,
+            values: data.values,
+            combineMode: data.combineMode,
+            disabled: data.disabled
+        });
     } catch (e) { /* fall through to defaults */ }
     return resolveConfig(league, null);
 }

--- a/public/standings.js
+++ b/public/standings.js
@@ -456,8 +456,10 @@ async function getGame(season, week, team) {
     return games;
 }
 
-async function getRankings (week, seasonType) {
-    var seasonYear = new Date().getFullYear();
+async function getRankings (week, seasonType, seasonYear) {
+    // Use the league's active season (passed in), not the wall-clock year, so
+    // rankings are fetched for the season actually being displayed.
+    if (seasonYear == null) seasonYear = new Date().getFullYear();
 
     var response = await fetch(`/rankings/${seasonYear}`, {
         method: 'GET',
@@ -482,10 +484,12 @@ async function getRankings (week, seasonType) {
     if (seasonType == 'regular') {
         weekRankings = rankings.find(r => r.week == week && r.season == seasonYear) ? rankings.find(r => r.week == week && r.season == seasonYear)?.polls?.find(p => p.poll == pollName)?.ranks : rankings[0]?.polls?.find(p => p.poll == pollName)?.ranks;
     } else {
-        weekRankings = rankings.find(r => r.week == '16' && r.season == seasonYear)?.polls?.find(p => p.poll == pollName)?.ranks || {};
+        weekRankings = rankings.find(r => r.week == '16' && r.season == seasonYear)?.polls?.find(p => p.poll == pollName)?.ranks;
     }
 
-    return weekRankings;
+    // Always return an array so callers can safely call .findIndex even when the
+    // week/season has no loaded rankings.
+    return Array.isArray(weekRankings) ? weekRankings : [];
 }
 
 async function parseTeamLogos (game, allTeamLogos) {
@@ -528,9 +532,8 @@ async function getAllTeamLogos () {
     }
 }
 
-async function getAllBettingLines () {
-    var seasonYear = new Date().getFullYear();
-    // seasonYear = 2024;
+async function getAllBettingLines (seasonYear) {
+    if (seasonYear == null) seasonYear = new Date().getFullYear();
 
     var bettingPromise = await fetch(`/betting/${seasonYear}`, {
         method: 'GET',
@@ -547,7 +550,23 @@ async function getAllBettingLines () {
         return response;
     } else {
         console.log(response.message);
+        return [];   // degrade gracefully: no lines rather than undefined
     }
+}
+
+// Returns the points a given team earned in a specific game, found by
+// (teamId, gameId) anywhere in the season's weeklyScore — avoiding the fragile
+// weeklyScore[gameWeek - 1] index (which mislocates the postseason bucket) and
+// returning 0 instead of throwing when the game hasn't been scored yet.
+function teamGameScoreById(weeklyScore, teamId, gameId) {
+    if (!Array.isArray(weeklyScore)) return 0;
+    for (var i = 0; i < weeklyScore.length; i++) {
+        var sbt = weeklyScore[i] && weeklyScore[i].scoreByTeam;
+        if (!Array.isArray(sbt)) continue;
+        var match = sbt.find(o => o.teamId == teamId && o.gameId == gameId);
+        if (match && typeof match.score === 'number') return match.score;
+    }
+    return 0;
 }
 
 async function displaySchedule(data) {
@@ -576,19 +595,23 @@ async function displaySchedule(data) {
     var seasonType = "regular";
     var rankingsInfo;
 
+    // Resolve the year from the season being viewed (the users' latest season),
+    // never the wall-clock year.
+    var seasonYear = data[0]?.seasons?.at(-1)?.season;
+
     if (week == "17") {
-        rankingsInfo = await getRankings((week - 1), seasonType);
+        rankingsInfo = await getRankings((week - 1), seasonType, seasonYear);
 
         seasonType = "postseason";
         week = 1;
         gameWeek = "17"
     } else {
         gameWeek = week;
-        rankingsInfo = await getRankings(week, seasonType);
+        rankingsInfo = await getRankings(week, seasonType, seasonYear);
     }
 
     var allTeamLogos = await getAllTeamLogos();
-    var allBettingLines = await getAllBettingLines();
+    var allBettingLines = await getAllBettingLines(seasonYear) || [];
 
     for (var iterUsers = 0; iterUsers < data.length; iterUsers++) {
 
@@ -609,7 +632,7 @@ async function displaySchedule(data) {
                 var bettingLine;
 
                 if (bettingLineObj) {
-                    bettingLine = (bettingLineObj.find(line => line.provider == "DraftKings") ? bettingLineObj.find(line => line.provider == "DraftKings") : bettingLineObj[0])?.formattedSpread.split("-");
+                    bettingLine = (bettingLineObj.find(line => line.provider == "DraftKings") ? bettingLineObj.find(line => line.provider == "DraftKings") : bettingLineObj[0])?.formattedSpread?.split("-");
                 }
                 var awayLine = '';
                 var homeLine = '';
@@ -703,26 +726,12 @@ async function displaySchedule(data) {
         
                     if (game.completed) {   
 
-                        if (game.seasonType == "postseason" && game.notes.toLowerCase().includes("playoff")) {
+                        if (game.seasonType == "postseason" && game.notes && game.notes.toLowerCase().includes("playoff")) {
                             shouldReplace = true;
-                            var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-
-                            var homeTeamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.homeId;
-                            });
-
-                            var awayTeamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.awayId;
-                            });
-
-                            var scoreDisplay = 0;
-                            if ((homeTeamScoreObject.length > 0) || (awayTeamScoreObject.length > 0)) {
-                                var scoreObject = ( homeTeamScoreObject.length > 0 ) ? homeTeamScoreObject : awayTeamScoreObject;
-                                scoreDisplay = scoreObject.find((item) => item.gameId == game.id).score;
-                            }
-    
-                            var awayScoreAdded = '<strong style="color: #F2A93B;">+' + scoreDisplay + '<strong>';
-                            var homeScoreAdded = '<strong style="color: #F2A93B;">+' + scoreDisplay + '<strong>';
+                            // Each team's own points (the old code showed one team's
+                            // score for both), found safely by (teamId, gameId).
+                            var awayScoreAdded = '<strong style="color: #F2A93B;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                            var homeScoreAdded = '<strong style="color: #F2A93B;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
 
                             if (game.awayPoints > game.homePoints) {
                                 topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';
@@ -734,36 +743,21 @@ async function displaySchedule(data) {
 
                         } else if ( game.awayPoints > game.homePoints ) {
                             if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                                var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                    return obj.teamId == game.awayId;
-                                });
-        
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                             }
                             topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             bottomData = (game.homePoints || '-');
                         } else if (game.homePoints > game.awayPoints) {
-        
+
                             if(!isAway) {
-                                var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                    return obj.teamId == game.homeId;
-                                });
-        
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
                             }
-        
+
                             topData = (game.awayPoints || '-');
                             bottomData = (game.homePoints || '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                         } else {
-                            if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
-                                var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                    return obj.teamId == game.awayId;
-                                });
-        
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                            if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                             }
                             topData = (game.awayPoints || '-');
                             bottomData = (game.homePoints || '-');
@@ -861,27 +855,17 @@ async function displaySchedule(data) {
                             if( game.awayPoints > game.homePoints ) {
                                 if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
                                     shouldReplace = true;
-                                    var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                    var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                        return obj.teamId == game.awayId;
-                                    });
-            
-                                    scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                                    scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                                 }
                                 topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                                 bottomData = (game.homePoints || '-');
                             } else {
-            
+
                                 if(game.homeId == userData.seasons.at(-1).teams[iterNum].id) {
                                     shouldReplace = true;
-                                    var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                    var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                        return obj.teamId == game.homeId;
-                                    });
-            
-                                    scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                                    scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
                                 }
-            
+
                                 topData = (game.awayPoints || '-');
                                 bottomData = (game.homePoints || '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             }

--- a/public/team.js
+++ b/public/team.js
@@ -81,15 +81,17 @@ async function getTeam() {
     const teamRecordInfo = await getRecord(teamData);
     const conferenceRecords = await getConferenceRecords(teamData);
     const allTeamLogos = await getTeamLogos(conferenceRecords);
-    const recruiting = await getRecruitingRankings(teamData.school);
+    const recruiting = await getRecruitingRankings(teamData.school, teamData.seasons.at(-1).season);
 
     renderConferenceStandings(conferenceRecords, teamData, allTeamLogos);
     renderTeamInfo(teamData, teamRecordInfo, recruiting);
 }
 
 async function getRecord(teamData) {
-    var currentYear = new Date().getFullYear();
-    // currentYear = 2024;
+    // Use the season being viewed (the team's latest season), not the wall-clock
+    // year — otherwise records are fetched for a year with no data once the
+    // calendar drifts past the season.
+    var currentYear = teamData?.seasons?.at(-1)?.season || new Date().getFullYear();
 
     const response = await fetch(`/records/${currentYear}/${teamData.school}`, {
         method: 'GET',
@@ -104,8 +106,7 @@ async function getRecord(teamData) {
 }
 
 async function getConferenceRecords(teamData) {
-    var currentYear = new Date().getFullYear();
-    // currentYear = 2024;
+    var currentYear = teamData?.seasons?.at(-1)?.season || new Date().getFullYear();
 
     const response = await fetch(`/records/${currentYear}/conference/${teamData.seasons.at(-1).conference}`, {
         method: 'GET',
@@ -121,10 +122,12 @@ async function getConferenceRecords(teamData) {
 
 async function getSchedule() {
     const urlParams = new URLSearchParams(window.location.search);
-    var seasonYear = new Date().getFullYear();
-    // seasonYear = 2024;
+    const teamId = urlParams.get('team');
+    // Resolve the season from the team's own data, not the wall-clock year, so
+    // the schedule/rankings/lines match the season actually being shown.
+    var seasonYear = await getTeamSeasonYear(teamId);
 
-    const response = await fetch(`/games/season/${seasonYear}/teamId/${urlParams.get('team')}`, {
+    const response = await fetch(`/games/season/${seasonYear}/teamId/${teamId}`, {
         method: 'GET',
         headers: {
         'Accept': 'application/json',
@@ -136,10 +139,25 @@ async function getSchedule() {
         var scheduleData = data;
         const allTeamLogos = await getTeamLogos(data);
         const allRankings = await getRankings(seasonYear);
-        const allBettingLines = await getAllBettingLines();
+        const allBettingLines = await getAllBettingLines(seasonYear);
 
         renderTeamScheduleInfo(scheduleData, allTeamLogos, allRankings, allBettingLines, seasonYear);
     });
+}
+
+// Looks up the team's latest season (the one being viewed). Falls back to the
+// calendar year if the team can't be fetched.
+async function getTeamSeasonYear(teamId) {
+    try {
+        const res = await fetch(`/teams/info/${teamId}`, {
+            method: 'GET',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+        });
+        const data = await res.json();
+        const season = data?.[0]?.seasons?.at(-1)?.season;
+        if (season != null) return season;
+    } catch (e) { /* fall through */ }
+    return new Date().getFullYear();
 }
 
 async function getTeamLogos () {
@@ -161,9 +179,8 @@ async function getTeamLogos () {
     }
 }
 
-async function getAllBettingLines () {
-    var seasonYear = new Date().getFullYear();
-    // seasonYear = 2024;
+async function getAllBettingLines (seasonYear) {
+    if (seasonYear == null) seasonYear = new Date().getFullYear();
 
     var bettingPromise = await fetch(`/betting/${seasonYear}`, {
         method: 'GET',
@@ -187,7 +204,10 @@ async function getAllBettingLines () {
 function renderTeamInfo(team, record, recruiting) {
     const leagueCode = window.localStorage.getItem("leagueCode");
     const container = document.getElementById("team-container");
-    var scoreCode = (leagueCode == 'gg') ? 'cumulativeScoreV1' : 'cumulativeScoreV2';
+    // Claunts = V1, Graham = V2. leagueCode is 'claunts-league'/'graham-league'
+    // (never 'gg'), so the old 'gg' test always fell through to V2 and showed
+    // every viewer the Graham score.
+    var scoreCode = (leagueCode == 'claunts-league') ? 'cumulativeScoreV1' : 'cumulativeScoreV2';
     var formatConference = team.seasons.at(-1).conference;
     var confLogo = getConferenceLogo(team.seasons.at(-1).conference);
 
@@ -207,14 +227,14 @@ function renderTeamInfo(team, record, recruiting) {
         <div class="team-details">
             <div>
                 <h4>${team.seasons.at(-1).season} Record</h4>
-                <p class="score">${record?.total.wins || 0}-${record?.total.losses || 0}    Overall</p>
-                <p class="score">${record?.conferenceGames.wins || 0}-${record?.conferenceGames.losses || 0}    Conference</p>
+                <p class="score">${record?.total?.wins || 0}-${record?.total?.losses || 0}    Overall</p>
+                <p class="score">${record?.conferenceGames?.wins || 0}-${record?.conferenceGames?.losses || 0}    Conference</p>
             </div>
             <div>
                 <h4>📈 Season Score</h4>
                 <p class="score">${team.seasons.at(-1)[scoreCode] || 0} Points</p>
                 <h4>Recruiting Rank</h4>
-                <p class="score">#${recruiting.rank || 0}</p>
+                <p class="score">#${recruiting?.rank || 0}</p>
             </div>
             <div>
                 <h4>🏟 Stadium</h4>
@@ -278,8 +298,12 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year) {
             if (game.seasonType == 'regular') {
                 weekRankings = rankings.find(r => r.week == game.week && r.season == year) ? rankings.find(r => r.week == game.week && r.season == year)?.polls?.find(p => p.poll == pollName)?.ranks : rankings[0]?.polls?.find(p => p.poll == pollName)?.ranks;
             } else {
-                weekRankings = rankings.find(r => r.week == '16' && r.season == year)?.polls?.find(p => p.poll == pollName)?.ranks || {};
+                weekRankings = rankings.find(r => r.week == '16' && r.season == year)?.polls?.find(p => p.poll == pollName)?.ranks;
             }
+            // A week with no loaded rankings (or a poll that lacks this team)
+            // leaves weekRankings undefined; default to [] so .length/.find below
+            // don't throw and the schedule still renders without ranks.
+            if (!Array.isArray(weekRankings)) weekRankings = [];
 
             var homeRank = '';
             var awayRank = '';
@@ -424,7 +448,7 @@ async function renderConferenceStandings(data, teamData, logos) {
         //     });
     }
 
-    if (standings.length > 0 && teamData.conference != 'FBS Independents') {
+    if (standings.length > 0 && teamData.seasons.at(-1).conference != 'FBS Independents') {
         // Build table HTML
         let html = `
             <div class="standing-head">
@@ -560,7 +584,9 @@ function getConferenceLogo(conference) {
     ]
 
     const logoObj = allLogos.find(logo => logo.confName == conference);
-    return logoObj.url;
+    // A renamed/new/absent conference isn't in the list above; return '' rather
+    // than throwing on logoObj.url (which would break the whole team header).
+    return logoObj ? logoObj.url : '';
 }
 
 async function getRankings (season) {
@@ -599,9 +625,8 @@ async function getConferenceTeams (conference) {
     return conferences;
 }
 
-async function getRecruitingRankings(team) {
-    var seasonYear = new Date().getFullYear();
-    // seasonYear = 2024;
+async function getRecruitingRankings(team, seasonYear) {
+    if (seasonYear == null) seasonYear = new Date().getFullYear();
 
     var response = await fetch(`/recruiting/${seasonYear}/${team}`, {
         method: 'GET',

--- a/public/team.js
+++ b/public/team.js
@@ -81,17 +81,29 @@ async function getTeam() {
     const teamRecordInfo = await getRecord(teamData);
     const conferenceRecords = await getConferenceRecords(teamData);
     const allTeamLogos = await getTeamLogos(conferenceRecords);
-    const recruiting = await getRecruitingRankings(teamData.school, teamData.seasons.at(-1).season);
+    const recruiting = await getRecruitingRankings(teamData.school, (latestPlayedSeason(teamData.seasons) || teamData.seasons.at(-1)).season);
 
     renderConferenceStandings(conferenceRecords, teamData, allTeamLogos);
     renderTeamInfo(teamData, teamRecordInfo, recruiting);
 }
 
+// The latest season that actually has games played (a non-empty weeklyScore).
+// Team docs can carry a future-season stub (e.g. a preseason 2026 with 0 games)
+// as their LAST entry; using seasons.at(-1) would show an empty page, so prefer
+// the newest season with real data and fall back to the last season.
+function latestPlayedSeason(seasons) {
+    if (!Array.isArray(seasons) || seasons.length === 0) return null;
+    for (var i = seasons.length - 1; i >= 0; i--) {
+        var s = seasons[i];
+        if (s && Array.isArray(s.weeklyScore) && s.weeklyScore.length > 0) return s;
+    }
+    return seasons[seasons.length - 1];
+}
+
 async function getRecord(teamData) {
-    // Use the season being viewed (the team's latest season), not the wall-clock
-    // year — otherwise records are fetched for a year with no data once the
-    // calendar drifts past the season.
-    var currentYear = teamData?.seasons?.at(-1)?.season || new Date().getFullYear();
+    // Use the season actually being viewed (latest season with games), not the
+    // wall-clock year and not a future-season stub with no data.
+    var currentYear = latestPlayedSeason(teamData?.seasons)?.season || new Date().getFullYear();
 
     const response = await fetch(`/records/${currentYear}/${teamData.school}`, {
         method: 'GET',
@@ -106,7 +118,7 @@ async function getRecord(teamData) {
 }
 
 async function getConferenceRecords(teamData) {
-    var currentYear = teamData?.seasons?.at(-1)?.season || new Date().getFullYear();
+    var currentYear = latestPlayedSeason(teamData?.seasons)?.season || new Date().getFullYear();
 
     const response = await fetch(`/records/${currentYear}/conference/${teamData.seasons.at(-1).conference}`, {
         method: 'GET',
@@ -154,7 +166,7 @@ async function getTeamSeasonYear(teamId) {
             headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
         });
         const data = await res.json();
-        const season = data?.[0]?.seasons?.at(-1)?.season;
+        const season = latestPlayedSeason(data?.[0]?.seasons)?.season;
         if (season != null) return season;
     } catch (e) { /* fall through */ }
     return new Date().getFullYear();
@@ -208,8 +220,11 @@ function renderTeamInfo(team, record, recruiting) {
     // (never 'gg'), so the old 'gg' test always fell through to V2 and showed
     // every viewer the Graham score.
     var scoreCode = (leagueCode == 'claunts-league') ? 'cumulativeScoreV1' : 'cumulativeScoreV2';
-    var formatConference = team.seasons.at(-1).conference;
-    var confLogo = getConferenceLogo(team.seasons.at(-1).conference);
+    // Show the season actually being viewed (latest with games), not an empty
+    // future-season stub.
+    var seasonObj = latestPlayedSeason(team.seasons) || team.seasons.at(-1);
+    var formatConference = seasonObj.conference;
+    var confLogo = getConferenceLogo(seasonObj.conference);
 
     const html = `
         
@@ -226,13 +241,13 @@ function renderTeamInfo(team, record, recruiting) {
 
         <div class="team-details">
             <div>
-                <h4>${team.seasons.at(-1).season} Record</h4>
+                <h4>${seasonObj.season} Record</h4>
                 <p class="score">${record?.total?.wins || 0}-${record?.total?.losses || 0}    Overall</p>
                 <p class="score">${record?.conferenceGames?.wins || 0}-${record?.conferenceGames?.losses || 0}    Conference</p>
             </div>
             <div>
                 <h4>📈 Season Score</h4>
-                <p class="score">${team.seasons.at(-1)[scoreCode] || 0} Points</p>
+                <p class="score">${seasonObj[scoreCode] || 0} Points</p>
                 <h4>Recruiting Rank</h4>
                 <p class="score">#${recruiting?.rank || 0}</p>
             </div>

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -319,6 +319,22 @@ async function getAllBettingLines (seasonYear) {
     }
 }
 
+// Returns the points a given team earned in a specific game, found by
+// (teamId, gameId) anywhere in the season's weeklyScore. This avoids the old
+// weeklyScore[gameWeek - 1] index math — which broke for the postseason bucket
+// (gameWeek "17" indexed slot 16, which only lines up by coincidence) — and
+// safely returns 0 when the game hasn't been scored yet instead of throwing.
+function teamGameScoreById(weeklyScore, teamId, gameId) {
+    if (!Array.isArray(weeklyScore)) return 0;
+    for (var i = 0; i < weeklyScore.length; i++) {
+        var sbt = weeklyScore[i] && weeklyScore[i].scoreByTeam;
+        if (!Array.isArray(sbt)) continue;
+        var match = sbt.find(o => o.teamId == teamId && o.gameId == gameId);
+        if (match && typeof match.score === 'number') return match.score;
+    }
+    return 0;
+}
+
 async function displaySchedule(data) {
     const scheduleContainer = document.querySelector('[schedule-body]');
     const leagueCode = window.localStorage.getItem("leagueCode");
@@ -416,12 +432,7 @@ async function displaySchedule(data) {
     
                     if( game.awayPoints > game.homePoints ) {
                         if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
-                            var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                            var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.awayId;
-                            });
-    
-                            scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                         }
 
                         if (isBowlParticipant(game) && (leagueCode == "claunts-league")) {
@@ -435,25 +446,14 @@ async function displaySchedule(data) {
                     } else if (game.homePoints > game.awayPoints) {
     
                         if(!isAway) {
-                            var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                            var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.homeId;
-                            });
-    
-                            var teamObjectScore = (teamScoreObject.find((item) => item.gameId == game.id).score || 0);
-                            scoreAdded = '<strong style="color: #22C37A;">+' + teamObjectScore + '<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
                         }
-    
+
                         topData = (game.awayPoints || '0');
                         bottomData = (game.homePoints || '0')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                     } else {
                         if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
-                            var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                            var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.awayId;
-                            });
-    
-                            scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                         }
                         topData = (game.awayPoints || '0');
                         bottomData = (game.homePoints || '0');
@@ -527,19 +527,10 @@ async function displaySchedule(data) {
                         }
         
         
-                        if (game.seasonType == "postseason" && game.notes.toLowerCase().includes("playoff")) {
+                        if (game.seasonType == "postseason" && game.notes && game.notes.toLowerCase().includes("playoff")) {
                             shouldReplace = true;
-                            var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-
-                            var awayTeamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.awayId;
-                            });
-                            var homeTeamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                return obj.teamId == game.homeId;
-                            });
-    
-                            awayScoreAdded = '<strong style="color: #22C37A;">+' + awayTeamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
-                            homeScoreAdded = '<strong style="color: #22C37A;">+' + homeTeamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                            awayScoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                            homeScoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
 
                             if (game.awayPoints > game.homePoints) {
                                 topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';
@@ -552,25 +543,15 @@ async function displaySchedule(data) {
                         } else if ( game.awayPoints > game.homePoints ) {
                             if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
                                 shouldReplace = true;
-                                var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                    return obj.teamId == game.awayId;
-                                });
-        
-                                scoreAdded = '<strong style="color: #22C37A;">+' +  teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                             }
                             topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             bottomData = (game.homePoints || '-');
                         } else {
-        
+
                             if(game.homeId == data.seasons.at(-1).teams[iterNum].id) {
                                 shouldReplace = true;
-                                var weeklyScore = userData.seasons.at(-1).weeklyScore[(parseInt(gameWeek) - 1)];
-                                var teamScoreObject = weeklyScore.scoreByTeam.filter(obj => {
-                                    return obj.teamId == game.homeId;
-                                });
-        
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamScoreObject.find((item) => item.gameId == game.id).score + '<strong>';
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
                             }
         
                             topData = (game.awayPoints || '-');

--- a/tests/ScoringAggregation.spec.js
+++ b/tests/ScoringAggregation.spec.js
@@ -1,4 +1,5 @@
 const scoringModule = require('../modules/scoring.js');
+const { CLAUNTS_DEFAULTS } = require('../modules/scoring-defaults');
 
 // These exercise the aggregation paths that were previously untested and that
 // the #171 fixes touched: the cumulative-score reduce and the first-week
@@ -99,6 +100,59 @@ describe('scoring aggregation', () => {
             expect(patchBody.weeklyScore).toHaveLength(1);
             expect(patchBody.weeklyScore[0].score).toBe(7);
             expect(patchBody.weeklyScore[0].week).toBe(1);
+        });
+    });
+
+    describe('structural config is honored end-to-end', () => {
+        // Regression: getScoringConfig forwarded only { model, values } to
+        // resolveConfig, dropping combineMode/disabled — so the scoring jobs
+        // ignored structural config even though the API returned it and the
+        // rules page showed it. This drives updateScores with the REAL engine
+        // (calculateScoreV1 not mocked) and asserts a saved combineMode changes
+        // the computed score.
+        function runWithConfig(configResponse, game) {
+            const user = {
+                _id: 'u1',
+                league: 'claunts-league',
+                seasons: [{ season: '2025', teams: [{ id: 333, school: 'Alabama' }], weeklyScore: [] }],
+            };
+            let patchBody;
+            global.fetch = jest.fn((url, opts) => {
+                if (url.includes('/users/season/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
+                }
+                if (url.includes('/scoring-config/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve(configResponse) });
+                }
+                if (url.includes('/games/seasonType/')) {
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve([game]) });
+                }
+                if (url.includes('/rankings/')) {
+                    return Promise.resolve({ json: () => Promise.resolve({ polls: [{ poll: 'AP Top 25', ranks: [] }] }) });
+                }
+                patchBody = JSON.parse(opts.body); // PATCH /users/:id
+                return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+            });
+            return scoringModule.updateScores('regular', 5).then(() => patchBody);
+        }
+
+        // Conference win vs an unranked opponent.
+        const confWin = {
+            id: 1, seasonType: 'regular', notes: null, conferenceGame: true,
+            homeId: 333, awayId: 8, homeTeam: 'Alabama', awayTeam: 'Auburn',
+            homePoints: 30, awayPoints: 20, homeConference: 'SEC', awayConference: 'SEC',
+        };
+
+        it('default (first) combine mode scores a conference win as 2', async () => {
+            const cfg = { model: 'claunts', combineMode: 'first', values: CLAUNTS_DEFAULTS, disabled: [] };
+            const patchBody = await runWithConfig(cfg, confWin);
+            expect(patchBody.weeklyScore[0].score).toBe(2);
+        });
+
+        it("a saved 'sum' combine mode is honored (conf 2 + base 1 = 3)", async () => {
+            const cfg = { model: 'claunts', combineMode: 'sum', values: CLAUNTS_DEFAULTS, disabled: [] };
+            const patchBody = await runWithConfig(cfg, confWin);
+            expect(patchBody.weeklyScore[0].score).toBe(3);
         });
     });
 


### PR DESCRIPTION
Addresses the bugs from the scoring + schedule/game-results review.

## Scoring logic (the important one)
`getScoringConfig` — the loader the scoring **jobs** use (`updateScores`, `calculateTeamScores`) — forwarded only `{ model, values }` to `resolveConfig`, dropping **`combineMode`** and **`disabled`**. The `/scoring-config` API returns them and the `/rules` page reflects them, but computed scores ignored them: point-value changes worked, structural changes (combine mode, disabled postseason events) silently didn't, so the rules page could disagree with the scores. Now forwards the full config.
- New end-to-end test drives `updateScores` with the **real engine** and asserts a saved `'sum'` combine mode changes the score (conf win 2 → 3). Pre-fix it stayed 2.

## Schedule / game-results display
`userHome.js`, `standings.js`, `team.js`:

1. **Same crash `#181` only fixed in userHome** — `standings.js`/`team.js` still used `new Date().getFullYear()` and let `getRankings` return `undefined`/`{}`, so `findIndex`/`.length` threw. Ported the fix: resolve the season from the data being viewed (users'/team's latest season) and always return a ranks array.
2. **Team page always showed the Graham score** — [team.js:190](public/team.js:190) tested `leagueCode == 'gg'` (never true, and inverted). Now Claunts → V1, Graham → V2.
3. **Fragile postseason score index** — `weeklyScore[parseInt(gameWeek) - 1]` mislocated the postseason bucket (`"17"` → slot 16, correct only by coincidence) and `.find(...).score` was unguarded. Replaced across both files with a `teamGameScoreById(weeklyScore, teamId, gameId)` helper that looks the score up by `(teamId, gameId)` and returns 0 instead of throwing when a game isn't scored yet.
4. **Misc guards/fixes** — `standings.js` was showing one team's score for both teams in the postseason branch; a `data.seasons` → `userData.seasons` typo (crashed on a tied final); `team.js` `recruiting.rank`/`record.total`/`getConferenceLogo`/FBS-Independents field; null `game.notes`; betting `formattedSpread` split.

## Verification
- `node --check` on all three client files; `70` tests passing.
- `userHome`/`standings`/`team` are Auth0-gated, so the logged-in pages need a maintainer reload to confirm visually; the scoring fix is covered by the new automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)