### PR TITLE
Admin console redesign: grouped tools + derived status strip

### DIFF
--- a/modules/admin-status.js
+++ b/modules/admin-status.js
@@ -1,0 +1,56 @@
+// Pure, DB-free computation of the admin console's "current state" summary.
+// Kept free of Mongoose/Express so it can be unit-tested directly; the route
+// (routes/scores.js GET /status/:season) fetches the users + games and hands
+// them here.
+//
+// Given the season's users (each with seasons[].teams and weeklyScore) and that
+// season's games, it derives:
+//   scoredThroughWeek      - latest regular week present in users' weeklyScore
+//   gamesLoadedThroughWeek - latest regular week with a completed, scored game
+//   unscoredResults        - completed games involving a drafted team whose game
+//                            id isn't in any user's scoreByTeam yet (results the
+//                            scheduled scoring jobs haven't picked up)
+//   upToDate               - nothing outstanding to score
+function computeAdminStatus(users, games, season) {
+    const draftedIds = new Set();
+    const scoredGameIds = new Set();
+    let scoredThroughWeek = 0;
+
+    (users || []).forEach(u => {
+        const seasons = (u && u.seasons) || [];
+        const s = seasons.find(x => String(x.season) === String(season)) || seasons[seasons.length - 1] || {};
+        (s.teams || []).forEach(t => { if (t && t.id != null) draftedIds.add(Number(t.id)); });
+        (s.weeklyScore || []).forEach(w => {
+            if (w && w.season !== 'postseason' && typeof w.week === 'number' && w.week > scoredThroughWeek) {
+                scoredThroughWeek = w.week;
+            }
+            ((w && w.scoreByTeam) || []).forEach(st => { if (st && st.gameId != null) scoredGameIds.add(Number(st.gameId)); });
+        });
+    });
+
+    let gamesLoadedThroughWeek = 0;
+    let unscoredResults = 0;
+    (games || []).forEach(g => {
+        const hasScore = typeof g.homePoints === 'number' && (g.homePoints || g.awayPoints);
+        const done = g.completed && hasScore;
+        if (!done) return;
+        if (g.seasonType === 'regular' && typeof g.week === 'number' && g.week > gamesLoadedThroughWeek) {
+            gamesLoadedThroughWeek = g.week;
+        }
+        const involvesDrafted = draftedIds.has(Number(g.homeId)) || draftedIds.has(Number(g.awayId));
+        if (involvesDrafted && !scoredGameIds.has(Number(g.id))) unscoredResults++;
+    });
+
+    // "Up to date" is precisely: no completed drafted-team result is waiting to
+    // be scored. The week fields are informational only — comparing them would
+    // false-positive on non-drafted games or bye weeks.
+    return {
+        season: String(season),
+        scoredThroughWeek,
+        gamesLoadedThroughWeek,
+        unscoredResults,
+        upToDate: unscoredResults === 0
+    };
+}
+
+module.exports = { computeAdminStatus };

--- a/public/admin.css
+++ b/public/admin.css
@@ -421,7 +421,8 @@
 .draft-config-form .scoring-field {
     flex-direction: row;
     align-items: center;
-    gap: 12px;
+    gap: 14px;
+    margin-bottom: 12px;
 }
 .scoring-field label {
     flex: 1;
@@ -429,8 +430,21 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    line-height: 1.3;
+    line-height: 1.35;
 }
+
+/* Section labels ("Regular season" / "Postseason") inside the scoring config:
+   give them room so the two groups read as distinct blocks. */
+[scoring-config-fields] .draft-status-row {
+    margin: 18px 0 10px;
+    font-weight: 500;
+    color: #AEB4CC;
+}
+[scoring-config-fields] .draft-status-row:first-child { margin-top: 4px; }
+
+/* Combine-mode dropdown: full width so "Sum all bonuses" isn't truncated on
+   mobile (the shared .sub-container select is only 45% wide there). */
+select[scoring-config-combine-mode] { width: 100%; }
 .scoring-field .num-stepper { flex: none; }
 
 /* Custom number stepper: native spinners hidden, themed -/+ buttons flanking a

--- a/public/admin.css
+++ b/public/admin.css
@@ -369,14 +369,19 @@
 
 /* Read-only "current state" summary at the top of the console. */
 .admin-status {
-    width: 100%;
+    width: auto;
     max-width: 1100px;
-    margin: 0 auto 1.75em;
+    /* Side gutters so the card doesn't run into the device edges on mobile;
+       centers via auto margins once there's room (see media query below). */
+    margin: 0 16px 1.75em;
     background: #141A2E;
     border: 1px solid #2A2E42;
     border-radius: 12px;
     padding: 14px 16px;
     color: #F4F6FB;
+}
+@media (min-width: 1132px) {
+    .admin-status { margin-left: auto; margin-right: auto; }
 }
 .admin-status[hidden] { display: none; }
 .admin-status .ss-head {

--- a/public/admin.css
+++ b/public/admin.css
@@ -322,17 +322,7 @@
     background-color: #ed5858;
 }
 
-/* ---------- Admin console redesign: intro, groups, status strip ---------- */
-.admin-intro {
-    color: #AEB4CC;
-    max-width: 760px;
-    margin: 0 auto 1.25em;
-    padding: 0 1em;
-    text-align: center;
-    font-size: 0.95em;
-    line-height: 1.5;
-}
-
+/* ---------- Admin console redesign: groups, status strip ---------- */
 .admin-group {
     width: 100%;
     max-width: 1100px;

--- a/public/admin.css
+++ b/public/admin.css
@@ -282,10 +282,34 @@
     flex: 1;
 }
 
+/* Reorder controls: explicit sizing so they don't inherit the full-width red
+   .sub-container button style, and a large enough tap target to hit reliably
+   (the old 0.75em / 2px buttons were nearly impossible to tap, especially on
+   mobile). */
+.draft-order-move {
+    display: flex;
+    gap: 6px;
+    flex: none;
+}
 .draft-order-move button {
-    padding: 2px 6px;
-    font-size: 0.75em;
-    margin-left: 2px;
+    width: 36px;
+    height: 36px;
+    min-height: 36px;
+    padding: 0;
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #232842;
+    color: #F4F6FB;
+    border: 1px solid #2A2E42;
+    border-radius: 8px;
+    box-shadow: none;
+}
+.draft-order-move button:hover {
+    background-color: #2A2E42;
 }
 
 .draft-config-actions {
@@ -389,4 +413,26 @@
 /* Highlight the Update Scores tool when results are waiting to be scored. */
 .function-container.attn .button-container button {
     box-shadow: inset 3px 0 0 #F2C14E, 0px 0px 2px 2px #1A1F33;
+}
+
+/* Scoring config: label and its (small) value input on one row, so each rule
+   reads as "label … value" instead of a tall stack. Overrides the base
+   .draft-field column layout (matched specificity, declared later). */
+.draft-config-form .scoring-field {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+}
+.scoring-field label {
+    flex: 1;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    line-height: 1.3;
+}
+.scoring-field input[type="number"] {
+    flex: none;
+    width: 64px;
+    text-align: center;
 }

--- a/public/admin.css
+++ b/public/admin.css
@@ -431,8 +431,86 @@
     gap: 8px;
     line-height: 1.3;
 }
-.scoring-field input[type="number"] {
-    flex: none;
-    width: 64px;
+.scoring-field .num-stepper { flex: none; }
+
+/* Custom number stepper: native spinners hidden, themed -/+ buttons flanking a
+   compact value field, as one segmented control. */
+.num-stepper {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid #2A2E42;
+    border-radius: 8px;
+    overflow: hidden;
+    background-color: #101322;
+}
+.num-stepper input[type="number"] {
+    width: 44px;
     text-align: center;
+    border: none;
+    border-radius: 0;
+    background-color: transparent;
+    color: #F4F6FB;
+    padding: 7px 0;
+    -moz-appearance: textfield;
+    appearance: textfield;
+}
+.num-stepper input[type="number"]::-webkit-outer-spin-button,
+.num-stepper input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+.num-stepper button {
+    width: 30px;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    background-color: #1A1F33;
+    color: #AEB4CC;
+    font-size: 1.05rem;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.num-stepper button:hover { background-color: #2A2E42; color: #F4F6FB; }
+.num-stepper .step-dn { border-right: 1px solid #2A2E42; }
+.num-stepper .step-up { border-left: 1px solid #2A2E42; }
+
+/* Enable/disable toggles for postseason events: themed checkbox, green = on. */
+.scoring-toggle {
+    appearance: none;
+    -webkit-appearance: none;
+    flex: none;
+    width: 18px;
+    height: 18px;
+    margin: 0;
+    border: 1px solid #3A4060;
+    border-radius: 5px;
+    background-color: #101322;
+    cursor: pointer;
+    position: relative;
+}
+.scoring-toggle:hover { border-color: #5B6690; }
+.scoring-toggle:checked {
+    background-color: #71D28D;
+    border-color: #71D28D;
+}
+.scoring-toggle:checked::after {
+    content: '';
+    position: absolute;
+    left: 5px;
+    top: 2px;
+    width: 4px;
+    height: 8px;
+    border: solid #0C0F1C;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+.scoring-toggle:focus-visible {
+    outline: 2px solid #64B5F6;
+    outline-offset: 2px;
 }

--- a/public/admin.css
+++ b/public/admin.css
@@ -297,3 +297,96 @@
 .draft-config-actions button[draft-reset-btn] {
     background-color: #ed5858;
 }
+
+/* ---------- Admin console redesign: intro, groups, status strip ---------- */
+.admin-intro {
+    color: #AEB4CC;
+    max-width: 760px;
+    margin: 0 auto 1.25em;
+    padding: 0 1em;
+    text-align: center;
+    font-size: 0.95em;
+    line-height: 1.5;
+}
+
+.admin-group {
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto 1.75em;
+    padding: 0 0.5em;
+}
+
+.group-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 0.25em 0.55em;
+    border-bottom: 1px solid #2A2E42;
+    margin-bottom: 0.9em;
+}
+
+.group-head h2 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    color: #767D9C;
+    margin: 0;
+    font-weight: 500;
+}
+
+.group-count {
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    color: #AEB4CC;
+    border-radius: 20px;
+    padding: 1px 8px;
+    font-size: 0.7rem;
+}
+
+.job-tag {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.7rem;
+    color: #64B5F6;
+    padding: 5px 0.5em 0;
+}
+.job-tag i { font-size: 0.75rem; }
+
+/* Read-only "current state" summary at the top of the console. */
+.admin-status {
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto 1.75em;
+    background: #141A2E;
+    border: 1px solid #2A2E42;
+    border-radius: 12px;
+    padding: 14px 16px;
+    color: #F4F6FB;
+}
+.admin-status[hidden] { display: none; }
+.admin-status .ss-head {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.13em;
+    color: #767D9C; margin-bottom: 11px;
+}
+.admin-status .ss-row { display: flex; flex-wrap: wrap; gap: 20px; }
+.admin-status .ss-item { display: flex; flex-direction: column; gap: 2px; }
+.admin-status .ss-item small { color: #767D9C; font-size: 0.68rem; }
+.admin-status .ss-item b { font-weight: 500; font-size: 1rem; display: flex; align-items: center; gap: 7px; }
+.admin-status .dot { width: 7px; height: 7px; border-radius: 50%; }
+.admin-status .dot.g { background: #71D28D; }
+.admin-status .dot.b { background: #64B5F6; }
+.admin-status .dot.a { background: #F2C14E; }
+.admin-status .ss-note {
+    margin-top: 12px; padding-top: 11px; border-top: 1px solid #222741;
+    font-size: 0.82rem; display: flex; gap: 8px; align-items: flex-start; color: #AEB4CC;
+}
+.admin-status.ok .ss-note { color: #71D28D; }
+.admin-status.warn .ss-note { color: #F2C14E; }
+.admin-status .ss-note a { color: inherit; font-weight: 500; text-decoration: underline; cursor: pointer; }
+
+/* Highlight the Update Scores tool when results are waiting to be scored. */
+.function-container.attn .button-container button {
+    box-shadow: inset 3px 0 0 #F2C14E, 0px 0px 2px 2px #1A1F33;
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -1315,7 +1315,11 @@ function renderScoringFields() {
             : '';
         return `<div class="draft-field scoring-field${f.enabled ? '' : ' scoring-disabled'}" data-condition="${f.condition}">
             <label>${toggle}${f.additive ? '+ ' : ''}${f.label}</label>
-            <input type="number" step="1" min="0" data-key="${f.key}" value="${vals[f.key]}">
+            <div class="num-stepper">
+                <button type="button" class="step-dn" tabindex="-1" aria-label="Decrease points">&#8722;</button>
+                <input type="number" step="1" min="0" data-key="${f.key}" value="${vals[f.key]}">
+                <button type="button" class="step-up" tabindex="-1" aria-label="Increase points">+</button>
+            </div>
         </div>`;
     }
 
@@ -1331,6 +1335,18 @@ function renderScoringFields() {
             var row = wrap.querySelector('.scoring-field[data-condition="' + cb.getAttribute('data-condition') + '"]');
             if (row) row.classList.toggle('scoring-disabled', !cb.checked);
         });
+    });
+
+    // Custom +/- steppers (native number spinners are hidden via CSS).
+    wrap.querySelectorAll('.num-stepper').forEach(function (st) {
+        var inp = st.querySelector('input[type="number"]');
+        function step(delta) {
+            var v = parseInt(inp.value, 10);
+            if (isNaN(v)) v = 0;
+            inp.value = Math.max(0, v + delta);
+        }
+        st.querySelector('.step-up').addEventListener('click', function () { step(1); });
+        st.querySelector('.step-dn').addEventListener('click', function () { step(-1); });
     });
 }
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -251,6 +251,62 @@ async function getUserProfile() {
     });
 }
 
+// Read-only "current state" strip: shows how far scoring/games have progressed
+// and, when completed results are still unscored, flags it and points at the
+// Update Scores tool. All derived server-side from existing data.
+async function loadAdminStatus() {
+    var el = document.querySelector('[admin-status]');
+    if (!el) return;
+    var year = window.APP_YEAR || new Date().getFullYear();
+    try {
+        var res = await fetch(`/scores/status/${year}`, { headers: { 'Accept': 'application/json' } });
+        if (!res.ok) return;
+        var s = await res.json();
+        var api = null;
+        try {
+            var apiRes = await fetch('/games/info', { headers: { 'Accept': 'application/json' } });
+            if (apiRes.ok) { var a = await apiRes.json(); api = a && a.remainingCalls; }
+        } catch (e) { /* API count is optional */ }
+        renderAdminStatus(el, s, api, year);
+    } catch (e) { /* leave the strip hidden on error */ }
+}
+
+function renderAdminStatus(el, s, api, year) {
+    var behind = !s.upToDate;
+    var items = [
+        ['Scored through', (s.scoredThroughWeek ? 'Week ' + s.scoredThroughWeek : '—'), behind ? 'a' : 'g'],
+        ['Games loaded', (s.gamesLoadedThroughWeek ? 'Week ' + s.gamesLoadedThroughWeek : '—'), 'g']
+    ];
+    if (api != null) items.push(['CFBD calls left', Number(api).toLocaleString(), null]);
+
+    var rows = items.map(function (it) {
+        var dot = it[2] ? '<span class="dot ' + it[2] + '"></span>' : '';
+        return '<div class="ss-item"><small>' + it[0] + '</small><b>' + dot + it[1] + '</b></div>';
+    }).join('');
+
+    var note = behind
+        ? '<i class="fa-solid fa-bolt"></i><span>' + s.unscoredResults + ' completed result' + (s.unscoredResults === 1 ? '' : 's') +
+          ' not scored yet. <a data-fix-scores>Force update scores</a></span>'
+        : '<i class="fa-solid fa-bolt"></i><span>Everything’s current through Week ' + (s.scoredThroughWeek || 0) +
+          '. Automation is keeping scores up to date — nothing to do here.</span>';
+
+    el.className = 'admin-status ' + (behind ? 'warn' : 'ok');
+    el.innerHTML = '<div class="ss-head"><i class="fa-solid fa-circle-info"></i> Current state · ' + year + ' season</div>' +
+        '<div class="ss-row">' + rows + '</div>' +
+        '<div class="ss-note">' + note + '</div>';
+    el.hidden = false;
+
+    var tool = document.querySelector('[scores-tool]');
+    if (tool) tool.classList.toggle('attn', behind);
+
+    var fix = el.querySelector('[data-fix-scores]');
+    if (fix) fix.addEventListener('click', function () {
+        var c = document.querySelector('[scores-container]');
+        if (c && c.style.display === 'none') displayScoresContainer();
+        if (tool) tool.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+}
+
 window.onload = async function() {
     function initNavbarToggle() {
         const toggleButton = document.querySelector('.toggle-button');
@@ -274,6 +330,7 @@ window.onload = async function() {
     setSeasonOptions();
     setSeasonTypeOptions();
     setWeekOptions();
+    loadAdminStatus();
 };
 
 const createForm = document.getElementById('create-form')

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -1,6 +1,26 @@
 const express = require('express');
 const router = express.Router();
 const scoringModule = require('../modules/scoring.js');
+const User = require('../models/user');
+const Game = require('../models/game');
+const { computeAdminStatus } = require('../modules/admin-status');
+
+// Read-only status summary for the admin console: how far scoring/games have
+// progressed and whether any completed results are still unscored. Derived from
+// existing data — no new job instrumentation.
+router.get('/status/:season', async (req, res) => {
+    try {
+        const season = req.params.season;
+        const users = await User.find({ "seasons.season": season });
+        const games = await Game.find(
+            { season: Number(season) },
+            { id: 1, week: 1, seasonType: 1, completed: 1, homeId: 1, awayId: 1, homePoints: 1, awayPoints: 1, _id: 0 }
+        );
+        res.json(computeAdminStatus(users, games, season));
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
 
 // Recalculating & Updating Scores
 router.post('/update', async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -173,7 +173,7 @@ app.get('/admin', (req, res) => {
         }
         const userState = safeJson(req.oidc.user);
 
-        res.render('admin', {user, userState});
+        res.render('admin', {user, userState, year: process.env.YEAR});
     } else {
         res.redirect("/login");
     }

--- a/tests/AdminStatus.spec.js
+++ b/tests/AdminStatus.spec.js
@@ -1,0 +1,68 @@
+const { computeAdminStatus } = require('../modules/admin-status');
+
+// One user who drafted team 1, scored through regular week 2.
+function user(weeklyScore) {
+    return { seasons: [{ season: '2025', teams: [{ id: 1 }], weeklyScore }] };
+}
+function scored(week, gameId, season) {
+    return { week, season, scoreByTeam: [{ teamId: 1, gameId, score: 2 }] };
+}
+function game(id, week, opts = {}) {
+    return Object.assign({
+        id, season: 2025, week, seasonType: 'regular', completed: true,
+        homeId: 1, awayId: 99, homePoints: 30, awayPoints: 20
+    }, opts);
+}
+
+describe('computeAdminStatus', () => {
+    it('reports up to date when every completed drafted-team game is scored', () => {
+        const users = [user([scored(1, 100), scored(2, 101)])];
+        const games = [game(100, 1), game(101, 2)];
+        const s = computeAdminStatus(users, games, '2025');
+        expect(s).toMatchObject({ scoredThroughWeek: 2, gamesLoadedThroughWeek: 2, unscoredResults: 0, upToDate: true });
+    });
+
+    it('flags a completed drafted-team game that has not been scored', () => {
+        const users = [user([scored(1, 100), scored(2, 101)])];
+        const games = [game(100, 1), game(101, 2), game(102, 3)]; // wk3 result, not scored
+        const s = computeAdminStatus(users, games, '2025');
+        expect(s.gamesLoadedThroughWeek).toBe(3);
+        expect(s.scoredThroughWeek).toBe(2);
+        expect(s.unscoredResults).toBe(1);
+        expect(s.upToDate).toBe(false);
+    });
+
+    it('ignores games that do not involve a drafted team', () => {
+        const users = [user([scored(1, 100)])];
+        const games = [game(100, 1), game(200, 2, { homeId: 998, awayId: 999 })];
+        const s = computeAdminStatus(users, games, '2025');
+        expect(s.unscoredResults).toBe(0);
+        expect(s.upToDate).toBe(true);
+    });
+
+    it('ignores incomplete or unscored games', () => {
+        const users = [user([scored(1, 100)])];
+        const games = [
+            game(100, 1),
+            game(300, 4, { completed: false }),           // not final
+            game(301, 4, { homePoints: null, awayPoints: null }) // final flag but no score
+        ];
+        const s = computeAdminStatus(users, games, '2025');
+        expect(s.gamesLoadedThroughWeek).toBe(1);
+        expect(s.unscoredResults).toBe(0);
+        expect(s.upToDate).toBe(true);
+    });
+
+    it('does not let postseason entries raise the regular scored-through week', () => {
+        const users = [user([scored(1, 100), scored(1, 500, 'postseason')])];
+        const games = [game(100, 1)];
+        const s = computeAdminStatus(users, games, '2025');
+        expect(s.scoredThroughWeek).toBe(1);
+    });
+
+    it('handles empty inputs without throwing', () => {
+        expect(computeAdminStatus([], [], '2025')).toMatchObject({
+            scoredThroughWeek: 0, gamesLoadedThroughWeek: 0, unscoredResults: 0, upToDate: true, season: '2025'
+        });
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -37,8 +37,6 @@
         </div>
     </div>
 
-    <p class="admin-intro">Scores, games and expected wins update automatically on schedule. Use these tools to force a run or fix data when something looks off.</p>
-
     <div class="get-users-container" get-users-container>
         <div class="table-wrapper">
             <table class="fl-table">

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -24,12 +24,23 @@
             var userState = <%- userState %>;
         </script>
     <% } %>
+    <script>
+        // Authoritative active season from the server (process.env.YEAR), so the
+        // status strip queries the season the league is actually playing rather
+        // than the wall-clock year.
+        window.APP_YEAR = "<%= year %>";
+    </script>
 
     <div class="header">
         <div class="header-title">
             Admin
         </div>
     </div>
+
+    <p class="admin-intro">Scores, games and expected wins update automatically on schedule. Use these tools to force a run or fix data when something looks off.</p>
+
+    <div class="admin-status" admin-status hidden></div>
+
     <div class="get-users-container" get-users-container>
         <div class="table-wrapper">
             <table class="fl-table">
@@ -44,279 +55,304 @@
             </table>
         </div>
     </div>
-    <div class="admin-functions">
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayDraftConfigContainer()">
-                    <i class="fa-solid fa-list-ol" style="padding-right: 5px;"></i>
-                    Configure Draft
-                </button>
+
+    <section class="admin-group">
+        <div class="group-head"><h2>Scoring — force a run</h2><span class="group-count">3</span></div>
+        <div class="admin-functions">
+            <div class="function-container" scores-tool>
+                <div class="button-container">
+                    <button onclick="displayScoresContainer()">
+                        <i class="fa-solid fa-calculator" style="padding-right: 5px;"></i>
+                        Update Scores
+                    </button>
+                </div>
+                <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · nightly + Saturday/Sunday jobs</div>
+                <div class="sub-container" scores-container style="display: none">
+                    <form id="scores-form">
+                        <div><select score-week week-options></select></div>
+                        <div><select score-season-type season-type-options></select></div>
+                        <div><button type="submit">Update Scores</button></div>
+                    </form>
+                </div>
             </div>
-            <div class="sub-container" draft-config-container style="display: none">
-                <form id="draft-config-form" class="draft-config-form">
-                    <div class="draft-status-row">
-                        Status: <span draft-status class="draft-status-badge">—</span>
-                    </div>
-                    <div class="draft-field">
-                        <label>Season</label>
-                        <select draft-season></select>
-                    </div>
-                    <div class="draft-field">
-                        <label>Draft date &amp; time</label>
-                        <input type="datetime-local" draft-datetime>
-                    </div>
-                    <div class="draft-field">
-                        <label>Rounds</label>
-                        <input type="number" draft-rounds min="1" max="20" value="10">
-                    </div>
-                    <div class="draft-field">
-                        <label>Type</label>
-                        <select draft-type>
-                            <option value="snake">Snake</option>
-                            <option value="linear">Linear</option>
-                        </select>
-                    </div>
-                    <div class="draft-field">
-                        <label><input type="checkbox" draft-autoopen> Auto-open room at scheduled time</label>
-                    </div>
-                    <div class="draft-order-header">
-                        <label>Draft order</label>
-                        <div class="draft-order-buttons">
-                            <button type="button" onclick="autoOrderStandings()">Auto (reverse standings)</button>
-                            <button type="button" onclick="randomizeOrder()">Randomize</button>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayTeamContainer()">
+                        <i class="fa-solid fa-calculator" style="padding-right: 5px;"></i>
+                        Calculate Team Score
+                    </button>
+                </div>
+                <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · with the scores jobs</div>
+                <div class="sub-container" calculate-team-score-container style="display: none">
+                    <form id="score-form">
+                        <div class="team-picker-container" team-picker-container>
+                            <select class="calculate-team-picker" id="calculate-team-picker" calculate-team-options>
+                            </select>
                         </div>
-                    </div>
-                    <ol draft-order-list class="draft-order-list"></ol>
-                    <div class="draft-config-actions">
-                        <button type="submit">Save Draft Settings</button>
-                        <button type="button" draft-reset-btn onclick="resetDraft()" style="display:none;">Reset Draft</button>
-                    </div>
-                </form>
-                <hr>
+                        <div><select team-score-season season-options></select></div>
+                        <div><button type="submit">Calculate Score</button></div>
+                    </form>
+                    <form id="all-score-form">
+                        <button type="submit">Calculate Scores for all teams</button>
+                    </form>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayExpectedWinsContainer()">
+                        <i class="fa-solid fa-arrows-rotate" style="padding-right: 5px;"></i>
+                        Refresh Expected Wins
+                    </button>
+                </div>
+                <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · expected-wins job</div>
+                <div class="sub-container" expected-wins-container style="display: none">
+                    <form id="expected-wins-form">
+                        <div><select expected-wins-season season-options></select></div>
+                        <div><button type="submit">Refresh Expected Wins</button></div>
+                    </form>
+                </div>
             </div>
         </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayScoringConfigContainer()">
-                    <i class="fa-solid fa-sliders" style="padding-right: 5px;"></i>
-                    Configure Scoring
-                </button>
+    </section>
+
+    <section class="admin-group">
+        <div class="group-head"><h2>Data sync · College Football Data</h2><span class="group-count">6</span></div>
+        <div class="admin-functions">
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayGamesContainer()">
+                        <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
+                        Retrieve Game Information
+                    </button>
+                </div>
+                <div class="sub-container" games-container style="display: none">
+                    <form id="games-form">
+                        <div><select game-week week-options></select></div>
+                        <div><select game-season-type season-type-options></select></div>
+                        <div><button type="submit">Retrieve Games</button></div>
+                    </form>
+                </div>
             </div>
-            <div class="sub-container" scoring-config-container style="display: none">
-                <form id="scoring-config-form" class="draft-config-form">
-                    <div class="draft-status-row">League: <span scoring-config-model></span></div>
-                    <div class="draft-field">
-                        <label>Regular-season combine mode</label>
-                        <select scoring-config-combine-mode>
-                            <option value="first">First match wins (priority)</option>
-                            <option value="sum">Sum all bonuses (additive)</option>
-                        </select>
-                    </div>
-                    <div scoring-config-fields></div>
-                    <div class="draft-config-actions">
-                        <button type="submit">Save Scoring Config</button>
-                    </div>
-                    <p scoring-config-note class="draft-status-row" style="display:none">
-                        Saved. Run a full-season rescore to apply structural changes to existing scores.
-                    </p>
-                </form>
-                <hr>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayRankingsContainer()">
+                        <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
+                        Retrieve Rankings
+                    </button>
+                </div>
+                <div class="sub-container" rankings-container style="display: none">
+                    <form id="rankings-form">
+                        <div><select rankings-season season-options></select></div>
+                        <div><select season-type-options></select></div>
+                        <div><select week-options></select></div>
+                        <div><button type="submit">Retrieve Rankings</button></div>
+                    </form>
+                </div>
             </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayCreateUserContainer()">
-                    <i class="fa-solid fa-user-plus" style="padding-right: 5px;"></i>
-                    Add a Player
-                </button>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayRecruitRankingsContainer()">
+                        <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
+                        Retrieve Recruiting Rankings
+                    </button>
+                </div>
+                <div class="sub-container" recruit-rankings-container style="display: none">
+                    <form id="recruit-rankings-form">
+                        <div><select recruiting-season season-options></select></div>
+                        <div><button type="submit">Retrieve Recruiting Rankings</button></div>
+                    </form>
+                </div>
             </div>
-            <div class="sub-container" create-user-container style="display: none">
-                <form id="create-form">
-                    <input type="text" class="first-name" first-name placeholder="First Name">
-                    <input type="text" class="last-name" last-name placeholder="Last Name">
-                    <div style="padding-top: 5px;">
-                        <label style="padding-right: 5px;">Display Color</label>
-                        <input style="border-radius: 5px;" type="color" class="display-color" display-color>
-                    </div>
-                    <div class="team-container" team-container>
-                        <select class="team-picker" id="team-picker" team-options>
-                        </select>
-                    </div>
-                    <button type="submit">Create Player</button>
-                </form>
-                <hr>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayTeamRecordsContainer()">
+                        <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
+                        Retrieve Team Records
+                    </button>
+                </div>
+                <div class="sub-container" team-records-container style="display: none">
+                    <form id="team-records-form">
+                        <div><select record-season season-options></select></div>
+                        <div><button type="submit">Retrieve Team Records</button></div>
+                    </form>
+                </div>
             </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayRemoveUserContainer()">
-                    <i class="fa-solid fa-user-minus" style="padding-right: 5px;"></i>
-                    Remove a Player
-                </button>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayBettingLinesContainer()">
+                        <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
+                        Retrieve Betting Lines
+                    </button>
+                </div>
+                <div class="sub-container" betting-lines-container style="display: none">
+                    <form id="betting-lines-form">
+                        <div><select betting-season season-options></select></div>
+                        <div><button type="submit">Retrieve Betting Lines</button></div>
+                    </form>
+                </div>
             </div>
-            
-            <div class="sub-container" remove-user-container style="display: none">
-                <form id="remove-form">
-                    <div class="user-container" user-container>
-                        <select class="user-picker" id="user-picker" user-options>
-                        </select>
-                    </div>
-                    <button type="submit">Remove Player</button>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayTeamContainer()">
-                    <i class="fa-solid fa-calculator" style="padding-right: 5px;"></i>
-                    Calculate Team Score
-                </button>
-            </div>
-            <div class="sub-container" calculate-team-score-container style="display: none">
-                <form id="score-form">
-                    <div class="team-picker-container" team-picker-container>
-                        <select class="calculate-team-picker" id="calculate-team-picker" calculate-team-options>
-                        </select>
-                    </div>
-                    <div><select team-score-season season-options></select></div>
-                    <div><button type="submit">Calculate Score</button></div>
-                </form>
-                <form id="all-score-form">
-                    <button type="submit">Calculate Scores for all teams</button>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayRankingsContainer()">
-                    <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
-                    Retrieve Rankings
-                </button>
-            </div>
-            <div class="sub-container" rankings-container style="display: none">
-                <form id="rankings-form">
-                    <div><select rankings-season season-options></select></div>
-                    <div><select season-type-options></select></div>
-                    <div><select week-options></select></div>
-                    <div><button type="submit">Retrieve Rankings</button></div>
-                </form>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayRefreshTeamsContainer()">
+                        <i class="fa-solid fa-arrows-rotate" style="padding-right: 5px;"></i>
+                        Refresh Teams
+                    </button>
+                </div>
+                <div class="sub-container" refresh-teams-container style="display: none">
+                    <form id="refresh-teams-form">
+                        <div><select refresh-season season-options></select></div>
+                        <div><button type="submit">Refresh Teams</button></div>
+                    </form>
+                </div>
             </div>
         </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayRecruitRankingsContainer()">
-                    <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
-                    Retrieve Recruiting Rankings
-                </button>
+    </section>
+
+    <section class="admin-group">
+        <div class="group-head"><h2>League setup</h2><span class="group-count">4</span></div>
+        <div class="admin-functions">
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayDraftConfigContainer()">
+                        <i class="fa-solid fa-list-ol" style="padding-right: 5px;"></i>
+                        Configure Draft
+                    </button>
+                </div>
+                <div class="sub-container" draft-config-container style="display: none">
+                    <form id="draft-config-form" class="draft-config-form">
+                        <div class="draft-status-row">
+                            Status: <span draft-status class="draft-status-badge">—</span>
+                        </div>
+                        <div class="draft-field">
+                            <label>Season</label>
+                            <select draft-season></select>
+                        </div>
+                        <div class="draft-field">
+                            <label>Draft date &amp; time</label>
+                            <input type="datetime-local" draft-datetime>
+                        </div>
+                        <div class="draft-field">
+                            <label>Rounds</label>
+                            <input type="number" draft-rounds min="1" max="20" value="10">
+                        </div>
+                        <div class="draft-field">
+                            <label>Type</label>
+                            <select draft-type>
+                                <option value="snake">Snake</option>
+                                <option value="linear">Linear</option>
+                            </select>
+                        </div>
+                        <div class="draft-field">
+                            <label><input type="checkbox" draft-autoopen> Auto-open room at scheduled time</label>
+                        </div>
+                        <div class="draft-order-header">
+                            <label>Draft order</label>
+                            <div class="draft-order-buttons">
+                                <button type="button" onclick="autoOrderStandings()">Auto (reverse standings)</button>
+                                <button type="button" onclick="randomizeOrder()">Randomize</button>
+                            </div>
+                        </div>
+                        <ol draft-order-list class="draft-order-list"></ol>
+                        <div class="draft-config-actions">
+                            <button type="submit">Save Draft Settings</button>
+                            <button type="button" draft-reset-btn onclick="resetDraft()" style="display:none;">Reset Draft</button>
+                        </div>
+                    </form>
+                    <hr>
+                </div>
             </div>
-            <div class="sub-container" recruit-rankings-container style="display: none">
-                <form id="recruit-rankings-form">
-                    <div><select recruiting-season season-options></select></div>
-                    <div><button type="submit">Retrieve Recruiting Rankings</button></div>
-                </form>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayScoringConfigContainer()">
+                        <i class="fa-solid fa-sliders" style="padding-right: 5px;"></i>
+                        Configure Scoring
+                    </button>
+                </div>
+                <div class="sub-container" scoring-config-container style="display: none">
+                    <form id="scoring-config-form" class="draft-config-form">
+                        <div class="draft-status-row">League: <span scoring-config-model></span></div>
+                        <div class="draft-field">
+                            <label>Regular-season combine mode</label>
+                            <select scoring-config-combine-mode>
+                                <option value="first">First match wins (priority)</option>
+                                <option value="sum">Sum all bonuses (additive)</option>
+                            </select>
+                        </div>
+                        <div scoring-config-fields></div>
+                        <div class="draft-config-actions">
+                            <button type="submit">Save Scoring Config</button>
+                        </div>
+                        <p scoring-config-note class="draft-status-row" style="display:none">
+                            Saved. Run a full-season rescore to apply structural changes to existing scores.
+                        </p>
+                    </form>
+                    <hr>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayCreateUserContainer()">
+                        <i class="fa-solid fa-user-plus" style="padding-right: 5px;"></i>
+                        Add a Player
+                    </button>
+                </div>
+                <div class="sub-container" create-user-container style="display: none">
+                    <form id="create-form">
+                        <input type="text" class="first-name" first-name placeholder="First Name">
+                        <input type="text" class="last-name" last-name placeholder="Last Name">
+                        <div style="padding-top: 5px;">
+                            <label style="padding-right: 5px;">Display Color</label>
+                            <input style="border-radius: 5px;" type="color" class="display-color" display-color>
+                        </div>
+                        <div class="team-container" team-container>
+                            <select class="team-picker" id="team-picker" team-options>
+                            </select>
+                        </div>
+                        <button type="submit">Create Player</button>
+                    </form>
+                    <hr>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayRemoveUserContainer()">
+                        <i class="fa-solid fa-user-minus" style="padding-right: 5px;"></i>
+                        Remove a Player
+                    </button>
+                </div>
+                <div class="sub-container" remove-user-container style="display: none">
+                    <form id="remove-form">
+                        <div class="user-container" user-container>
+                            <select class="user-picker" id="user-picker" user-options>
+                            </select>
+                        </div>
+                        <button type="submit">Remove Player</button>
+                    </form>
+                </div>
             </div>
         </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayGamesContainer()">
-                    <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
-                    Retrieve Game Information
-                </button>
-            </div>
-            <div class="sub-container" games-container style="display: none">
-                <form id="games-form">
-                    <div><select game-week week-options></select></div>
-                    <div><select game-season-type season-type-options></select></div>
-                    <div><button type="submit">Retrieve Games</button></div>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayScoresContainer()">
-                    <i class="fa-solid fa-calculator" style="padding-right: 5px;"></i>
-                    Update Scores
-                </button>
-            </div>
-            <div class="sub-container" scores-container style="display: none">
-                <form id="scores-form">
-                    <div><select score-week week-options></select></div>
-                    <div><select score-season-type season-type-options></select></div>
-                    <div><button type="submit">Update Scores</button></div>
-                </form>
+    </section>
+
+    <section class="admin-group">
+        <div class="group-head"><h2>Monitoring</h2><span class="group-count">1</span></div>
+        <div class="admin-functions">
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayApiCallsContainer()">
+                        <i class="fa-solid fa-eye" style="padding-right: 5px;"></i>
+                        View API calls this month
+                    </button>
+                </div>
+                <div class="sub-container" api-calls-container style="display: none">
+                    <form id="api-calls-form">
+                        <div><button type="submit">View API calls remaining</button></div>
+                        <div class="api-info"><p class="api-info" api-calls-remaining></p></div>
+                    </form>
+                </div>
             </div>
         </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayRefreshTeamsContainer()">
-                    <i class="fa-solid fa-arrows-rotate" style="padding-right: 5px;"></i>
-                    Refresh Teams
-                </button>
-            </div>
-            <div class="sub-container" refresh-teams-container style="display: none">
-                <form id="refresh-teams-form">
-                    <div><select refresh-season season-options></select></div>
-                    <div><button type="submit">Refresh Teams</button></div>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayTeamRecordsContainer()">
-                    <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
-                    Retrieve Team Records
-                </button>
-            </div>
-            <div class="sub-container" team-records-container style="display: none">
-                <form id="team-records-form">
-                    <div><select record-season season-options></select></div>
-                    <div><button type="submit">Retrieve Team Records</button></div>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayBettingLinesContainer()">
-                    <i class="fa-solid fa-download" style="padding-right: 5px;"></i>
-                    Retrieve Betting Lines
-                </button>
-            </div>
-            <div class="sub-container" betting-lines-container style="display: none">
-                <form id="betting-lines-form">
-                    <div><select betting-season season-options></select></div>
-                    <div><button type="submit">Retrieve Betting Lines</button></div>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayExpectedWinsContainer()">
-                    <i class="fa-solid fa-arrows-rotate" style="padding-right: 5px;"></i>
-                    Refresh Expected Wins
-                </button>
-            </div>
-            <div class="sub-container" expected-wins-container style="display: none">
-                <form id="expected-wins-form">
-                    <div><select expected-wins-season season-options></select></div>
-                    <div><button type="submit">Refresh Expected Wins</button></div>
-                </form>
-            </div>
-        </div>
-        <div class="function-container">
-            <div class="button-container">
-                <button onclick="displayApiCallsContainer()">
-                    <i class="fa-solid fa-eye" style="padding-right: 5px;"></i>
-                    View API calls this month
-                </button>
-            </div>
-            <div class="sub-container" api-calls-container style="display: none">
-                <form id="api-calls-form">
-                    <div><button type="submit">View API calls remaining</button></div>
-                    <div class="api-info"><p class="api-info" api-calls-remaining></p></div>
-                </form>
-            </div>
-        </div>
-    </div>
+    </section>
+
     <footer>
         <a href="https://collegefootballdata.com/" class="cfb-data">Powered by College Football Data</a>
     </footer>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -39,8 +39,6 @@
 
     <p class="admin-intro">Scores, games and expected wins update automatically on schedule. Use these tools to force a run or fix data when something looks off.</p>
 
-    <div class="admin-status" admin-status hidden></div>
-
     <div class="get-users-container" get-users-container>
         <div class="table-wrapper">
             <table class="fl-table">
@@ -55,6 +53,8 @@
             </table>
         </div>
     </div>
+
+    <div class="admin-status" admin-status hidden></div>
 
     <section class="admin-group">
         <div class="group-head"><h2>Scoring — force a run</h2><span class="group-count">3</span></div>


### PR DESCRIPTION
Reframes the admin page from 14 flat buttons into a **troubleshooting / override console**. The routine weekly updates run via the Heroku scheduled jobs (`update-daily/saturday/sunday-scores`, `update-expected-wins`); these functions exist to force a run or fix data — so the page is organized for fast, occasional, confident use.

Design was pitched and chosen from an interactive mockup (three directions); this implements the recommended "status + grouped tools" direction.

## What changed
- **Grouping** — the 14 functions become four labeled sections with counts: **Scoring** (force a run), **Data sync · CFBD**, **League setup**, **Monitoring**. Every `function-container`, form id, `onclick`, and `[attr]` selector is preserved verbatim, so `admin.js`'s existing handlers keep working — this is a markup regroup, not a rewrite.
- **Job-mapping captions** on the scoring tools tie each lever to the automation it backs (e.g. "Automated · nightly + Saturday/Sunday jobs").
- **Status strip** (new, read-only) at the top: season · scored-through week · games-loaded week · CFBD calls left. When completed drafted-team results are still unscored it flags them, highlights the **Update Scores** tool, and links to it — answering "do I even need to touch anything?" first.

## Implementation
- [`modules/admin-status.js`](modules/admin-status.js) — pure `computeAdminStatus(users, games, season)`; `unscoredResults` = completed games involving a drafted team whose id isn't in any user's `scoreByTeam`. `upToDate = unscoredResults === 0`. Unit-tested (6 cases).
- [`routes/scores.js`](routes/scores.js) — `GET /status/:season` fetches users + games and returns the summary (read-only; session/token gated).
- [`server.js`](server.js) — passes `YEAR` to the view; `admin.ejs` exposes it as `window.APP_YEAR` so the strip uses the active season, not the wall-clock year.
- [`public/admin.js`](public/admin.js) — `loadAdminStatus()` on load renders the strip + toggles the attention highlight. Purely additive.

## Verification
- 76 tests passing (6 new).
- `GET /scores/status/2025` against the test DB returns `{scoredThroughWeek:16, gamesLoadedThroughWeek:16, unscoredResults:0, upToDate:true}` — matches the full-season state.
- `admin.ejs` renders (4 groups, status strip, all 15 forms intact). The page is Auth0-gated, so the final logged-in check (each form still submits; strip shows correct state) is a maintainer reload.

## Honest limit
The strip detects **that** scores are behind, not **why** — a Saturday still in progress looks the same as a failed job. Attribution needs the separate job run-logging task (already spun off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)