### PR TITLE
Run score-update jobs in-process on a schedule, with run logging

### DIFF
--- a/models/jobRun.js
+++ b/models/jobRun.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+// One document per scheduled-job execution. `status` moves running -> success
+// or error. Kept as a rolling history: a TTL index expires documents ~60 days
+// after they start, so the collection stays small without any manual cleanup.
+const jobRunSchema = new mongoose.Schema({
+    jobName: { type: String, required: true },
+    status: { type: String, enum: ['running', 'success', 'error'], default: 'running' },
+    startedAt: { type: Date, default: Date.now },
+    finishedAt: { type: Date },
+    message: { type: String },
+    season: { type: String },
+    week: { type: Number },
+    seasonType: { type: String }
+});
+
+// Auto-expire old runs after 60 days (Mongo prunes them; no cron needed).
+jobRunSchema.index({ startedAt: 1 }, { expireAfterSeconds: 60 * 24 * 60 * 60 });
+// Fast "latest per job" lookups.
+jobRunSchema.index({ jobName: 1, startedAt: -1 });
+
+module.exports = mongoose.model('JobRun', jobRunSchema);

--- a/modules/job-logger.js
+++ b/modules/job-logger.js
@@ -1,0 +1,36 @@
+const { internalFetch } = require('./internal-api');
+
+// Records job runs via the /job-runs API (not the model directly) so it works
+// the same whether a job fires in-process from the scheduler or standalone via
+// `node update-*-job.js`. Logging must never break the job itself, so every
+// call is best-effort and swallows its own errors.
+
+async function startRun(jobName, meta) {
+    try {
+        const res = await internalFetch(`${process.env.URL}/job-runs`, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify(Object.assign({ jobName }, meta || {}))
+        });
+        const data = await res.json();
+        return (res.status === 201 && data && data._id) ? data._id : null;
+    } catch (e) {
+        console.log('job-run start log failed:', e.message);
+        return null;
+    }
+}
+
+async function finishRun(id, status, message, meta) {
+    if (!id) return;
+    try {
+        await internalFetch(`${process.env.URL}/job-runs/${id}`, {
+            method: 'PATCH',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify(Object.assign({ status, message }, meta || {}))
+        });
+    } catch (e) {
+        console.log('job-run finish log failed:', e.message);
+    }
+}
+
+module.exports = { startRun, finishRun };

--- a/modules/job-mailer.js
+++ b/modules/job-mailer.js
@@ -1,0 +1,37 @@
+const nodemailer = require('nodemailer');
+
+// Shared status email for the scheduled jobs (was duplicated ~90 lines per job
+// file). Best-effort — a mail failure is logged, never thrown.
+async function sendJobEmail({ label, when, ok, detail }) {
+    const transporter = nodemailer.createTransport({
+        service: 'gmail',
+        auth: { user: process.env.GMAIL_USER, pass: process.env.GMAIL_APP_PASSWORD }
+    });
+
+    const heading = ok ? '✅ Update Complete' : '❌ Update Failed';
+    const accent = ok ? '#90caf9' : '#ef5350';
+    const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Campus Clash - ${label}</title></head>
+<body style="font-family:Arial,sans-serif;background-color:#121212;margin:0;padding:0;color:#e0e0e0;">
+  <div style="max-width:600px;margin:0 auto;background-color:#1e1e1e;border-radius:8px;overflow:hidden;">
+    <div style="background-color:#0d47a1;color:#fff;padding:20px;text-align:center;"><h1 style="margin:0;font-size:24px;">🏈 Campus Clash - ${label}</h1></div>
+    <div style="padding:20px;border-bottom:1px solid #333;"><h2 style="margin-top:0;font-size:18px;color:${accent};">${heading}</h2><p style="color:#e0e0e0;">${detail || ''}</p></div>
+    <div style="padding:20px;"><h2 style="margin-top:0;font-size:18px;color:#90caf9;">📅 When</h2><p style="color:#e0e0e0;">${when}</p></div>
+  </div>
+</body></html>`;
+
+    try {
+        const info = await transporter.sendMail({
+            from: process.env.GMAIL_USER,
+            to: 'gwadegraham@gmail.com',
+            subject: `Campus Clash | ${label}${ok ? '' : ' FAILED'}`,
+            html
+        });
+        console.log('Email sent: ' + info.response);
+    } catch (mailErr) {
+        console.log(mailErr);
+    }
+}
+
+module.exports = { sendJobEmail };

--- a/modules/job-runs-util.js
+++ b/modules/job-runs-util.js
@@ -1,0 +1,15 @@
+// Pure helper: given job-run records, return the most recent run per jobName.
+// DB-free so it can be unit-tested; the route feeds it the query results.
+function latestPerJob(runs) {
+    var byJob = {};
+    (runs || []).forEach(function (r) {
+        if (!r || !r.jobName) return;
+        var cur = byJob[r.jobName];
+        if (!cur || new Date(r.startedAt) > new Date(cur.startedAt)) {
+            byJob[r.jobName] = r;
+        }
+    });
+    return Object.keys(byJob).map(function (k) { return byJob[k]; });
+}
+
+module.exports = { latestPerJob };

--- a/modules/scheduler.js
+++ b/modules/scheduler.js
@@ -1,0 +1,35 @@
+const schedule = require('node-schedule');
+
+// All schedules are Central time. node-schedule honors the tz (DST-aware),
+// unlike a UTC-only cron. Specs are data so tests can assert them.
+const TZ = 'America/Chicago';
+
+const JOB_SCHEDULES = [
+    { job: 'daily-scores', modulePath: '../update-daily-scores-job', rule: { hour: 23, minute: 0 } },
+    { job: 'saturday-scores', modulePath: '../update-saturday-scores-job', rule: { dayOfWeek: 6, hour: [15, 18, 22], minute: 0 } },
+    { job: 'sunday-scores', modulePath: '../update-sunday-scores-job', rule: { dayOfWeek: 0, hour: [3, 6], minute: 0 } }
+];
+
+function toRule(spec) {
+    const r = new schedule.RecurrenceRule();
+    if (spec.dayOfWeek != null) r.dayOfWeek = spec.dayOfWeek;
+    r.hour = spec.hour;
+    r.minute = spec.minute;
+    r.tz = TZ;
+    return r;
+}
+
+// Registers the recurring jobs. Each job's own run() already logs and emails;
+// we just guard against an unhandled rejection here.
+function start() {
+    JOB_SCHEDULES.forEach(function (s) {
+        const mod = require(s.modulePath);
+        schedule.scheduleJob(toRule(s.rule), function () {
+            Promise.resolve().then(function () { return mod.run(); })
+                .catch(function (err) { console.error(`Scheduled ${s.job} failed:`, err); });
+        });
+        console.log(`Scheduled ${s.job}:`, JSON.stringify(s.rule), TZ);
+    });
+}
+
+module.exports = { start, JOB_SCHEDULES, TZ, toRule };

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -1,0 +1,132 @@
+const { internalFetch } = require('./internal-api');
+const { withRetry } = require('./retry');
+
+// Configure CFB Data
+const CFBD_API_KEY = process.env.CFBD_API_KEY;
+var cfb = require('cfb.js');
+var defaultClient = cfb.ApiClient.instance;
+var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
+ApiKeyAuth.apiKey = CFBD_API_KEY;
+
+const retrieveGamesModule = require('./retrieve-games.js');
+const scoringModule = require('./scoring.js');
+const teamScoringModule = require('./team-scoring.js');
+const recordsModule = require('./records.js');
+const bettingModule = require('./betting.js');
+
+// The shared "update everything for the current week" pipeline that the daily /
+// Saturday / Sunday jobs all run. Determines the current week from the CFBD
+// calendar, ensures rankings exist, pulls games, then updates scores, cumulative
+// scores, team scores and records. `withBetting` also refreshes betting lines —
+// only the daily job did that historically, so it stays opt-in.
+// Returns { week, seasonType } for logging.
+async function runFullUpdate({ withBetting = false } = {}) {
+
+    var gamesApi = new cfb.GamesApi();
+    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
+    var weekNumber = 1;
+    var isPostseason = false;
+
+    if (calendar) {
+        for (const calendarWeek of calendar) {
+            var startDate = new Date(calendarWeek.firstGameStart);
+            var endDate = new Date(calendarWeek.lastGameStart);
+            var currentDate = new Date();
+
+            if ((currentDate > startDate) && (currentDate < endDate)) {
+                weekNumber = calendarWeek.week;
+                if (calendarWeek.seasonType == "postseason") {
+                    isPostseason = true;
+                }
+                break;
+            } else if ((currentDate < startDate) && (calendarWeek.week == 1)) {
+                weekNumber = 1;
+                break;
+            } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
+                weekNumber = (calendarWeek.week - 1);
+                break;
+            }
+        }
+    }
+
+    console.log("It is currently Week", weekNumber);
+    console.log("Is it the postseason yet? ", isPostseason);
+
+    const season = process.env.YEAR;
+    var seasonType = '';
+    var week = weekNumber;
+
+    if (!isPostseason) {
+        seasonType = "regular";
+    } else {
+        seasonType = "postseason";
+        week = 1;
+    }
+
+    var response = await internalFetch(`${process.env.URL}/rankings/${season}/${week}/${seasonType}`, {
+        method: 'GET',
+        headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+        }
+    });
+
+    var rankings = await response;
+
+    if (rankings.status == 200) {
+        console.log(`Rankings already in system for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`);
+    } else {
+        const response = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
+            method: 'POST',
+            headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+            },
+            body: `{
+            "season": "${season}",
+            "seasonType": "${seasonType}",
+            "week": "${week}"
+            }`,
+        });
+
+        await response.json().then(data => {
+            if (response.status == 201) {
+                console.log("New Rankings", data);
+            } else {
+                console.log(response.status + " Rankings could not be retrieved");
+            }
+        });
+    }
+
+    if (isPostseason) {
+        var teams = await retrieveGamesModule.retrieveTeams();
+        console.log("number of returned teams", teams.length);
+
+        var games = await retrieveGamesModule.retrievePostseasonGames(teams, 1);
+        console.log("number of returned games", games.length);
+
+        await retrieveGamesModule.saveGames(games);
+        await scoringModule.updateScores("postseason", 1);
+        await scoringModule.updateCumulativeScores();
+        await teamScoringModule.updateAllTeamScores();
+        await recordsModule.updateAllTeamRecords();
+        if (withBetting) await bettingModule.updateAllBettingLines();
+    } else {
+        var teams = await retrieveGamesModule.retrieveTeams();
+        console.log("number of returned teams", teams.length);
+
+        var games = await retrieveGamesModule.massRetrieveGames(weekNumber, "regular");
+        console.log("number of returned new games", games.newGames.length);
+        console.log("number of returned existing games", games.existingGames.length);
+
+        await scoringModule.updateScores("regular", weekNumber);
+        await scoringModule.updateCumulativeScores();
+        await teamScoringModule.updateAllTeamScores();
+        await recordsModule.updateAllTeamRecords();
+        if (withBetting) await bettingModule.updateAllBettingLines();
+    }
+
+    return { week, seasonType };
+}
+
+module.exports = { runFullUpdate };

--- a/public/admin.css
+++ b/public/admin.css
@@ -397,6 +397,15 @@
 .admin-status .dot.g { background: #71D28D; }
 .admin-status .dot.b { background: #64B5F6; }
 .admin-status .dot.a { background: #F2C14E; }
+.admin-status .dot.r { background: #ED5858; }
+
+/* Automated-jobs last-run summary. */
+.ss-jobs { margin-top: 12px; padding-top: 11px; border-top: 1px solid #222741; }
+.ss-jobs > small { color: #767D9C; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.1em; }
+.ss-jobs-row { display: flex; flex-wrap: wrap; gap: 8px 18px; margin-top: 8px; }
+.ss-job { display: flex; align-items: center; gap: 7px; font-size: 0.82rem; }
+.ss-job b { font-weight: 500; }
+.ss-job-meta { color: #767D9C; }
 .admin-status .ss-note {
     margin-top: 12px; padding-top: 11px; border-top: 1px solid #222741;
     font-size: 0.82rem; display: flex; gap: 8px; align-items: flex-start; color: #AEB4CC;

--- a/public/admin.js
+++ b/public/admin.js
@@ -267,11 +267,33 @@ async function loadAdminStatus() {
             var apiRes = await fetch('/games/info', { headers: { 'Accept': 'application/json' } });
             if (apiRes.ok) { var a = await apiRes.json(); api = a && a.remainingCalls; }
         } catch (e) { /* API count is optional */ }
-        renderAdminStatus(el, s, api, year);
+        var jobs = [];
+        try {
+            var jobsRes = await fetch('/job-runs', { headers: { 'Accept': 'application/json' } });
+            if (jobsRes.ok) { jobs = await jobsRes.json(); }
+        } catch (e) { /* job history is optional */ }
+        renderAdminStatus(el, s, api, year, jobs);
     } catch (e) { /* leave the strip hidden on error */ }
 }
 
-function renderAdminStatus(el, s, api, year) {
+// Human-friendly "how long ago" for a timestamp.
+function timeAgo(iso) {
+    if (!iso) return '';
+    var diff = Date.now() - new Date(iso).getTime();
+    if (isNaN(diff)) return '';
+    var mins = Math.round(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + 'm ago';
+    var hrs = Math.round(mins / 60);
+    if (hrs < 24) return hrs + 'h ago';
+    return Math.round(hrs / 24) + 'd ago';
+}
+
+var JOB_LABELS = {
+    'daily-scores': 'Daily', 'saturday-scores': 'Saturday', 'sunday-scores': 'Sunday'
+};
+
+function renderAdminStatus(el, s, api, year, jobs) {
     var behind = !s.upToDate;
     var items = [
         ['Scored through', (s.scoredThroughWeek ? 'Week ' + s.scoredThroughWeek : '—'), behind ? 'a' : 'g'],
@@ -290,10 +312,27 @@ function renderAdminStatus(el, s, api, year) {
         : '<i class="fa-solid fa-bolt"></i><span>Everything’s current through Week ' + (s.scoredThroughWeek || 0) +
           '. Automation is keeping scores up to date — nothing to do here.</span>';
 
+    // Automated-job last-run summary (green success, red error, amber running).
+    var jobsBlock = '';
+    if (jobs && jobs.length) {
+        var order = ['daily-scores', 'saturday-scores', 'sunday-scores'];
+        var sorted = jobs.slice().sort(function (a, b) { return order.indexOf(a.jobName) - order.indexOf(b.jobName); });
+        var jobItems = sorted.map(function (j) {
+            var dot = j.status === 'success' ? 'g' : (j.status === 'error' ? 'r' : 'a');
+            var label = JOB_LABELS[j.jobName] || j.jobName;
+            var when = timeAgo(j.finishedAt || j.startedAt);
+            var outcome = j.status === 'error' ? 'failed' : (j.status === 'running' ? 'running' : 'ran');
+            return '<div class="ss-job"><span class="dot ' + dot + '"></span><b>' + label + '</b>' +
+                '<span class="ss-job-meta">' + outcome + (when ? ' · ' + when : '') + '</span></div>';
+        }).join('');
+        jobsBlock = '<div class="ss-jobs"><small>Automated jobs</small><div class="ss-jobs-row">' + jobItems + '</div></div>';
+    }
+
     el.className = 'admin-status ' + (behind ? 'warn' : 'ok');
     el.innerHTML = '<div class="ss-head"><i class="fa-solid fa-circle-info"></i> Current state · ' + year + ' season</div>' +
         '<div class="ss-row">' + rows + '</div>' +
-        '<div class="ss-note">' + note + '</div>';
+        '<div class="ss-note">' + note + '</div>' +
+        jobsBlock;
     el.hidden = false;
 
     var tool = document.querySelector('[scores-tool]');

--- a/routes/jobRuns.js
+++ b/routes/jobRuns.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const router = express.Router();
+const JobRun = require('../models/jobRun');
+const { latestPerJob } = require('../modules/job-runs-util');
+
+// Latest run per job — powers the admin status strip's "last run / outcome".
+router.get('/', async (req, res) => {
+    try {
+        // Pull recent runs (newest first) and reduce to the latest per job.
+        const runs = await JobRun.find({}, null, { sort: { startedAt: -1 }, limit: 200 }).lean();
+        res.json(latestPerJob(runs));
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Record the start of a run (status 'running'); returns the new run's id.
+router.post('/', async (req, res) => {
+    try {
+        const { jobName, season, week, seasonType } = req.body;
+        if (!jobName) return res.status(400).json({ message: 'jobName is required' });
+        const doc = await JobRun.create({ jobName, season, week, seasonType, status: 'running', startedAt: new Date() });
+        res.status(201).json(doc);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+// Finish a run: set outcome, finishedAt, and any resolved week/season details.
+router.patch('/:id', async (req, res) => {
+    try {
+        const { status, message, week, seasonType, season } = req.body;
+        const update = { finishedAt: new Date() };
+        if (status) update.status = status;
+        if (message != null) update.message = message;
+        if (week != null) update.week = week;
+        if (seasonType != null) update.seasonType = seasonType;
+        if (season != null) update.season = season;
+        const doc = await JobRun.findByIdAndUpdate(req.params.id, { $set: update }, { new: true });
+        if (!doc) return res.status(404).json({ message: 'run not found' });
+        res.json(doc);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -223,7 +223,7 @@ app.use('/teams', (req, res, next) => {
     if (req.method === 'GET' || (req.method === 'POST' && req.path === '/teamLogos')) return next();
     return requireCommissioner(req, res, next);
 });
-app.use(['/users', '/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/draft', '/scoring-config'], (req, res, next) => {
+app.use(['/users', '/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/draft', '/scoring-config', '/job-runs'], (req, res, next) => {
     if (req.method === 'GET') return next();
     return requireCommissioner(req, res, next);
 });
@@ -258,6 +258,9 @@ app.use('/draft', requireAuthOrToken, draftRouter);
 const scoringConfigRouter = require('./routes/scoringConfig');
 app.use('/scoring-config', requireAuthOrToken, scoringConfigRouter);
 
+const jobRunsRouter = require('./routes/jobRuns');
+app.use('/job-runs', requireAuthOrToken, jobRunsRouter);
+
 app.get('/calculate-team-score/:season/:teamId/:teamName', requireCommissioner, async (req, res) => {
     var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);
 
@@ -275,4 +278,12 @@ registerDraftSockets(io);
 
 server.listen(process.env.PORT || 3000, () =>{
     console.log('Server Started');
+
+    // Run the score-update jobs in-process on a schedule (America/Chicago),
+    // replacing Heroku Scheduler. Gated so it only runs on the deployed dyno,
+    // not on local dev machines or in tests.
+    if (process.env.NODE_ENV === 'production' || process.env.ENABLE_SCHEDULER === 'true') {
+        require('./modules/scheduler').start();
+        console.log('In-process job scheduler started');
+    }
 });

--- a/tests/JobRuns.spec.js
+++ b/tests/JobRuns.spec.js
@@ -1,0 +1,22 @@
+const { latestPerJob } = require('../modules/job-runs-util');
+
+describe('latestPerJob', () => {
+    it('returns the most recent run for each job', () => {
+        const runs = [
+            { jobName: 'daily-scores', startedAt: '2025-01-03T05:00:00Z', status: 'success' },
+            { jobName: 'daily-scores', startedAt: '2025-01-02T05:00:00Z', status: 'error' },
+            { jobName: 'saturday-scores', startedAt: '2025-01-04T20:00:00Z', status: 'success' }
+        ];
+        const latest = latestPerJob(runs);
+        expect(latest).toHaveLength(2);
+        const daily = latest.find(r => r.jobName === 'daily-scores');
+        expect(daily.startedAt).toBe('2025-01-03T05:00:00Z');
+        expect(daily.status).toBe('success');
+    });
+
+    it('handles empty / malformed input', () => {
+        expect(latestPerJob([])).toEqual([]);
+        expect(latestPerJob(undefined)).toEqual([]);
+        expect(latestPerJob([{ startedAt: '2025-01-01' }])).toEqual([]); // no jobName -> skipped
+    });
+});

--- a/tests/Scheduler.spec.js
+++ b/tests/Scheduler.spec.js
@@ -1,0 +1,26 @@
+const { JOB_SCHEDULES, TZ, toRule } = require('../modules/scheduler');
+
+describe('scheduler config', () => {
+    it('schedules exactly the three score jobs (expected wins is manual)', () => {
+        const jobs = JOB_SCHEDULES.map(s => s.job).sort();
+        expect(jobs).toEqual(['daily-scores', 'saturday-scores', 'sunday-scores']);
+        expect(JOB_SCHEDULES.find(s => s.job === 'expected-wins')).toBeUndefined();
+    });
+
+    it('matches the intended Central-time schedule', () => {
+        const byJob = {};
+        JOB_SCHEDULES.forEach(s => { byJob[s.job] = s.rule; });
+        expect(byJob['daily-scores']).toEqual({ hour: 23, minute: 0 });
+        expect(byJob['saturday-scores']).toEqual({ dayOfWeek: 6, hour: [15, 18, 22], minute: 0 });
+        expect(byJob['sunday-scores']).toEqual({ dayOfWeek: 0, hour: [3, 6], minute: 0 });
+    });
+
+    it('builds a timezone-aware recurrence rule', () => {
+        expect(TZ).toBe('America/Chicago');
+        const rule = toRule({ dayOfWeek: 6, hour: [15, 18, 22], minute: 0 });
+        expect(rule.tz).toBe('America/Chicago');
+        expect(rule.hour).toEqual([15, 18, 22]);
+        expect(rule.minute).toBe(0);
+        expect(rule.dayOfWeek).toBe(6);
+    });
+});

--- a/update-daily-scores-job.js
+++ b/update-daily-scores-job.js
@@ -1,268 +1,34 @@
-const { internalFetch } = require('./modules/internal-api');
-const { withRetry } = require('./modules/retry');
 if (process.env.NODE_ENV !== 'production') {
-    require('dotenv').config()
+    require('dotenv').config();
 }
 
-// Configure CFB Data
-const CFBD_API_KEY = process.env.CFBD_API_KEY;
-var cfb = require('cfb.js');
-var defaultClient = cfb.ApiClient.instance;
-var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
-ApiKeyAuth.apiKey = CFBD_API_KEY;
+const { runFullUpdate } = require('./modules/score-update');
+const { startRun, finishRun } = require('./modules/job-logger');
+const { sendJobEmail } = require('./modules/job-mailer');
 
-const retrieveGamesModule = require('./modules/retrieve-games.js');
-const scoringModule = require('./modules/scoring.js');
-const teamScoringModule = require('./modules/team-scoring.js');
-const recordsModule = require('./modules/records.js');
-const bettingModule = require('./modules/betting.js');
+const JOB_NAME = 'daily-scores';
+const LABEL = 'Daily Update';
 
-async function updateScores () {
-
-    var gamesApi = new cfb.GamesApi();
-    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
-    var weekNumber = 1;
-    var isPostseason = false;
-
-    if (calendar) {
-        for (const calendarWeek of calendar) {
-            var startDate = new Date(calendarWeek.firstGameStart);
-            var endDate = new Date(calendarWeek.lastGameStart);
-            var currentDate = new Date();
-
-
-            if ((currentDate > startDate) && (currentDate < endDate)) {
-                weekNumber = calendarWeek.week;
-                if (calendarWeek.seasonType == "postseason") {
-                    isPostseason = true;
-                }
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week == 1)) {
-                weekNumber = 1;
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
-                weekNumber = (calendarWeek.week - 1);
-                break;
-            }
-        }
-    }
-
-    console.log("It is currently Week", weekNumber);
-    console.log("Is it the postseason yet? ", isPostseason);
-
-    const season = process.env.YEAR;
-    var seasonType = '';
-    var week = weekNumber;
-
-    if (!isPostseason) {
-        seasonType = "regular";
-    } else {
-        seasonType = "postseason";
-        week = 1;
-    }
-
-    var response = await internalFetch(`${process.env.URL}/rankings/${season}/${week}/${seasonType}`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
-
-    var rankings = await response;
-
-    if (rankings.status == 200) {
-        console.log(`Rankings already in system for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`);
-    } else {
-        const response = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
-            method: 'POST',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: `{
-            "season": "${season}",
-            "seasonType": "${seasonType}",
-            "week": "${week}"
-            }`,
-        });
-
-        response.json().then(data => {
-            if (response.status == 201) {
-                console.log("New Rankings", data);
-            } else {
-                console.log(response.status + " Rankings could not be retrieved");
-            }
-        });
-    }
-
-    if (isPostseason) {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
-
-        var games = await retrieveGamesModule.retrievePostseasonGames(teams, 1);
-        console.log("number of returned games", games.length);
-
-        await retrieveGamesModule.saveGames(games);
-        await scoringModule.updateScores("postseason", 1);
-        await scoringModule.updateCumulativeScores();
-        await teamScoringModule.updateAllTeamScores();
-        await recordsModule.updateAllTeamRecords();
-        await bettingModule.updateAllBettingLines();
-    } else {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
-
-        var games = await retrieveGamesModule.massRetrieveGames(weekNumber, "regular");
-        console.log("number of returned new games", games.newGames.length);
-        console.log("number of returned existing games", games.existingGames.length);
-        
-        await scoringModule.updateScores("regular", weekNumber);
-        await scoringModule.updateCumulativeScores();
-        await teamScoringModule.updateAllTeamScores();
-        await recordsModule.updateAllTeamRecords();
-        await bettingModule.updateAllBettingLines();
+// Daily full update (also refreshes betting lines). Timing is owned by the
+// in-process scheduler (modules/scheduler.js); running this file directly still
+// works as a manual fallback.
+async function run() {
+    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+    console.log(`${LABEL} starting`, when);
+    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
+    try {
+        const { week, seasonType } = await runFullUpdate({ withBetting: true });
+        await finishRun(id, 'success', `Updated ${seasonType} week ${week}`, { week, seasonType });
+        await sendJobEmail({ label: LABEL, when, ok: true, detail: `Updated ${seasonType} week ${week}.` });
+        return { week, seasonType };
+    } catch (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        console.error(`❌ ${LABEL} failed:`, err);
+        await finishRun(id, 'error', msg);
+        await sendJobEmail({ label: LABEL, when, ok: false, detail: (err && err.stack) ? err.stack : msg });
+        throw err;
     }
 }
 
-// Current time in Central (America/Chicago), DST-aware. The old fixed -5
-// offset was wrong for the CST half of the CFB season.
-const todayDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-
-var dayText = "";
-
-let nodemailer = require('nodemailer');
-
-let transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.GMAIL_USER,
-    pass: process.env.GMAIL_APP_PASSWORD
-  }
-});
-
-var emailMessage = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Campus Clash - Weekly Recap</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      background-color: #121212;
-      margin: 0;
-      padding: 0;
-      color: #e0e0e0;
-    }
-    .email-container {
-      max-width: 600px;
-      margin: 0 auto;
-      background-color: #1e1e1e;
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .header {
-      background-color: #0d47a1;
-      color: #ffffff;
-      padding: 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-    }
-    .section {
-      padding: 20px;
-      border-bottom: 1px solid #333333;
-    }
-    .section h2 {
-      margin-top: 0;
-      font-size: 18px;
-      color: #90caf9;
-    }
-    .stat {
-      margin: 6px 0;
-      line-height: 1.4em;
-    }
-    .highlight {
-      font-weight: bold;
-      color: #64b5f6;
-    }
-    .footer {
-      text-align: center;
-      padding: 15px;
-      font-size: 12px;
-      color: #888888;
-      background-color: #121212;
-    }
-    ol {
-      padding-left: 18px;
-    }
-    @media (max-width: 600px) {
-      .section h2 {
-        font-size: 16px;
-      }
-    }
-  </style>
-</head>
-<body>
-  <div class="email-container" style="background-color: #1e1e1e;">
-
-    <div class="header">
-      <h1>🏈 Campus Clash - Daily Update</h1>
-    </div>
-
-    <div class="section">
-      <h2>✅ Update Complete</h2>
-      <p class="stat" style="color: #e0e0e0;">Games & scores are being updated daily at 11PM.</p>
-    </div>
-
-    <div class="section">
-      <h2>📅 Current Date & Time</h2>
-      <p style="color: #e0e0e0;">${todayDate.toLocaleString()}</p>
-    </div>
-    
-  </div>
-</body>
-</html>
-`;
-
-let mailOptions = {
-  from: process.env.GMAIL_USER,
-  to: 'gwadegraham@gmail.com',
-  subject: 'Campus Clash | Daily Update',
-  html: emailMessage
-};
-
-if ((todayDate.getHours() == 23)) {
-    dayText = "Daily Update at 11PM";
-    console.log(dayText);
-    console.log("Current Date", todayDate.toLocaleString());
-    
-    // Await the update so the email reflects the real outcome, and don't
-    // swallow failures: previously updateScores() was fire-and-forget, so the
-    // "Update Complete" email was sent before scores finished (and any error
-    // was an unhandled rejection with a green email still going out).
-    (async () => {
-        try {
-            await updateScores();
-        } catch (err) {
-            console.error("❌ Daily score update failed:", err);
-            mailOptions.subject = 'Campus Clash | Daily Update FAILED';
-            mailOptions.html = `<p>The daily score update failed at ${todayDate.toLocaleString()}.</p><pre>${(err && err.stack) ? err.stack : err}</pre>`;
-        }
-
-        try {
-            const info = await transporter.sendMail(mailOptions);
-            console.log('Email sent: ' + info.response);
-        } catch (mailErr) {
-            console.log(mailErr);
-        }
-    })();
-
-} else {
-    dayText = "Time is not 11PM, so no updates run.";
-    console.log(dayText);
-    console.log("Current Date", todayDate.toLocaleString());
-}
+module.exports = { run, JOB_NAME };
+if (require.main === module) { run(); }

--- a/update-saturday-scores-job.js
+++ b/update-saturday-scores-job.js
@@ -1,263 +1,33 @@
-const { internalFetch } = require('./modules/internal-api');
-const { withRetry } = require('./modules/retry');
 if (process.env.NODE_ENV !== 'production') {
-    require('dotenv').config()
+    require('dotenv').config();
 }
 
-// Configure CFB Data
-const CFBD_API_KEY = process.env.CFBD_API_KEY;
-var cfb = require('cfb.js');
-var defaultClient = cfb.ApiClient.instance;
-var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
-ApiKeyAuth.apiKey = CFBD_API_KEY;
+const { runFullUpdate } = require('./modules/score-update');
+const { startRun, finishRun } = require('./modules/job-logger');
+const { sendJobEmail } = require('./modules/job-mailer');
 
-const retrieveGamesModule = require('./modules/retrieve-games.js');
-const scoringModule = require('./modules/scoring.js');
-const teamScoringModule = require('./modules/team-scoring.js');
-const recordsModule = require('./modules/records.js');
+const JOB_NAME = 'saturday-scores';
+const LABEL = 'Saturday Update';
 
-async function updateScores () {
-
-    var gamesApi = new cfb.GamesApi();
-    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
-    var weekNumber = 1;
-    var isPostseason = false;
-
-    if (calendar) {
-        for (const calendarWeek of calendar) {
-            var startDate = new Date(calendarWeek.firstGameStart);
-            var endDate = new Date(calendarWeek.lastGameStart);
-            var currentDate = new Date();
-
-
-            if ((currentDate > startDate) && (currentDate < endDate)) {
-                weekNumber = calendarWeek.week;
-                if (calendarWeek.seasonType == "postseason") {
-                    isPostseason = true;
-                }
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week == 1)) {
-                weekNumber = 1;
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
-                weekNumber = (calendarWeek.week - 1);
-                break;
-            }
-        }
-    }
-
-    console.log("It is currently Week", weekNumber);
-    console.log("Is it the postseason yet? ", isPostseason);
-
-    const season = process.env.YEAR;
-    var seasonType = '';
-    var week = weekNumber;
-
-    if (!isPostseason) {
-        seasonType = "regular";
-    } else {
-        seasonType = "postseason";
-        week = 1;
-    }
-
-    var response = await internalFetch(`${process.env.URL}/rankings/${season}/${week}/${seasonType}`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
-
-    var rankings = await response;
-
-    if (rankings.status == 200) {
-        console.log(`Rankings already in system for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`);
-    } else {
-        const response = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
-            method: 'POST',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: `{
-            "season": "${season}",
-            "seasonType": "${seasonType}",
-            "week": "${week}"
-            }`,
-        });
-
-        response.json().then(data => {
-            if (response.status == 201) {
-                console.log("New Rankings", data);
-            } else {
-                console.log(response.status + " Rankings could not be retrieved");
-            }
-        });
-    }
-
-    if (isPostseason) {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
-
-        var games = await retrieveGamesModule.retrievePostseasonGames(teams, 1);
-        console.log("number of returned games", games.length);
-
-        await retrieveGamesModule.saveGames(games);
-        await scoringModule.updateScores("postseason", 1);
-        await scoringModule.updateCumulativeScores();
-        await teamScoringModule.updateAllTeamScores();
-        await recordsModule.updateAllTeamRecords();
-    } else {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
-
-        var games = await retrieveGamesModule.massRetrieveGames(weekNumber, "regular");
-        console.log("number of returned new games", games.newGames.length);
-        console.log("number of returned existing games", games.existingGames.length);
-        
-        await scoringModule.updateScores("regular", weekNumber);
-        await scoringModule.updateCumulativeScores();
-        await teamScoringModule.updateAllTeamScores();
-        await recordsModule.updateAllTeamRecords();
+// Saturday game-day refresh (no betting-line update). Timing is owned by the
+// in-process scheduler; running this file directly still works as a fallback.
+async function run() {
+    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+    console.log(`${LABEL} starting`, when);
+    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
+    try {
+        const { week, seasonType } = await runFullUpdate({ withBetting: false });
+        await finishRun(id, 'success', `Updated ${seasonType} week ${week}`, { week, seasonType });
+        await sendJobEmail({ label: LABEL, when, ok: true, detail: `Updated ${seasonType} week ${week}.` });
+        return { week, seasonType };
+    } catch (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        console.error(`❌ ${LABEL} failed:`, err);
+        await finishRun(id, 'error', msg);
+        await sendJobEmail({ label: LABEL, when, ok: false, detail: (err && err.stack) ? err.stack : msg });
+        throw err;
     }
 }
 
-// Current time in Central (America/Chicago), DST-aware. The old fixed -5
-// offset was wrong for the CST half of the CFB season.
-const todayDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-
-var dayText = "";
-
-let nodemailer = require('nodemailer');
-
-let transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.GMAIL_USER,
-    pass: process.env.GMAIL_APP_PASSWORD
-  }
-});
-
-var emailMessage = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Campus Clash - Weekly Recap</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      background-color: #121212;
-      margin: 0;
-      padding: 0;
-      color: #e0e0e0;
-    }
-    .email-container {
-      max-width: 600px;
-      margin: 0 auto;
-      background-color: #1e1e1e;
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .header {
-      background-color: #0d47a1;
-      color: #ffffff;
-      padding: 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-    }
-    .section {
-      padding: 20px;
-      border-bottom: 1px solid #333333;
-    }
-    .section h2 {
-      margin-top: 0;
-      font-size: 18px;
-      color: #90caf9;
-    }
-    .stat {
-      margin: 6px 0;
-      line-height: 1.4em;
-    }
-    .highlight {
-      font-weight: bold;
-      color: #64b5f6;
-    }
-    .footer {
-      text-align: center;
-      padding: 15px;
-      font-size: 12px;
-      color: #888888;
-      background-color: #121212;
-    }
-    ol {
-      padding-left: 18px;
-    }
-    @media (max-width: 600px) {
-      .section h2 {
-        font-size: 16px;
-      }
-    }
-  </style>
-</head>
-<body>
-  <div class="email-container" style="background-color: #1e1e1e;">
-
-    <div class="header">
-      <h1>🏈 Campus Clash - Saturday Update</h1>
-    </div>
-
-    <div class="section">
-      <h2>✅ Update Complete</h2>
-      <p class="stat" style="color: #e0e0e0;">Games & scores are being updated during the 3PM, 6PM, and 10PM windows.</p>
-    </div>
-
-    <div class="section">
-      <h2>📅 Current Date & Time</h2>
-      <p style="color: #e0e0e0;">${todayDate.toLocaleString()}</p>
-    </div>
-    
-  </div>
-</body>
-</html>
-`;
-
-let mailOptions = {
-  from: process.env.GMAIL_USER,
-  to: 'gwadegraham@gmail.com',
-  subject: 'Campus Clash | Saturday Update',
-  html: emailMessage
-};
-
-if ((todayDate.getDay() == 6) && ((todayDate.getHours() == 15) || (todayDate.getHours() == 18) || (todayDate.getHours() == 22))) {
-    dayText = "Today is Saturday, so games & scores are being updated during the 3PM, 6PM, and 10PM windows.";
-    console.log(dayText);
-    console.log("Current Date", todayDate.toLocaleString());
-    
-    // Await the update so the email reflects the real outcome, and don't
-    // swallow failures (see comment in update-daily-scores-job.js).
-    (async () => {
-        try {
-            await updateScores();
-        } catch (err) {
-            console.error("❌ Saturday score update failed:", err);
-            mailOptions.subject = 'Campus Clash | Saturday Update FAILED';
-            mailOptions.html = `<p>The Saturday score update failed at ${todayDate.toLocaleString()}.</p><pre>${(err && err.stack) ? err.stack : err}</pre>`;
-        }
-
-        try {
-            const info = await transporter.sendMail(mailOptions);
-            console.log('Email sent: ' + info.response);
-        } catch (mailErr) {
-            console.log(mailErr);
-        }
-    })();
-
-} else {
-    dayText = "Today is not Saturday, so games & scores are NOT being updated.";
-    console.log(dayText);
-    console.log("Current Date", todayDate.toLocaleString());
-}
+module.exports = { run, JOB_NAME };
+if (require.main === module) { run(); }

--- a/update-sunday-scores-job.js
+++ b/update-sunday-scores-job.js
@@ -1,264 +1,33 @@
-const { internalFetch } = require('./modules/internal-api');
-const { withRetry } = require('./modules/retry');
 if (process.env.NODE_ENV !== 'production') {
-    require('dotenv').config()
+    require('dotenv').config();
 }
 
-// Configure CFB Data
-const CFBD_API_KEY = process.env.CFBD_API_KEY;
-var cfb = require('cfb.js');
-var defaultClient = cfb.ApiClient.instance;
-var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
-ApiKeyAuth.apiKey = CFBD_API_KEY;
+const { runFullUpdate } = require('./modules/score-update');
+const { startRun, finishRun } = require('./modules/job-logger');
+const { sendJobEmail } = require('./modules/job-mailer');
 
-const retrieveGamesModule = require('./modules/retrieve-games.js');
-const scoringModule = require('./modules/scoring.js');
-const teamScoringModule = require('./modules/team-scoring.js');
-const recordsModule = require('./modules/records.js');
+const JOB_NAME = 'sunday-scores';
+const LABEL = 'Sunday Update';
 
-async function updateScores () {
-
-    var gamesApi = new cfb.GamesApi();
-    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
-    var weekNumber = 1;
-    var isPostseason = false;
-
-    if (calendar) {
-        for (const calendarWeek of calendar) {
-            var startDate = new Date(calendarWeek.firstGameStart);
-            var endDate = new Date(calendarWeek.lastGameStart);
-            var currentDate = new Date();
-
-
-            if ((currentDate > startDate) && (currentDate < endDate)) {
-                weekNumber = calendarWeek.week;
-                if (calendarWeek.seasonType == "postseason") {
-                    isPostseason = true;
-                }
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week == 1)) {
-                weekNumber = 1;
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
-                weekNumber = (calendarWeek.week - 1);
-                break;
-            }
-        }
-    }
-
-    console.log("It is currently Week", weekNumber);
-    console.log("Is it the postseason yet? ", isPostseason);
-
-    const season = process.env.YEAR;
-    var seasonType = '';
-    var week = weekNumber;
-
-    if (!isPostseason) {
-        seasonType = "regular";
-    } else {
-        seasonType = "postseason";
-        week = 1;
-    }
-
-    var response = await internalFetch(`${process.env.URL}/rankings/${season}/${week}/${seasonType}`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
-
-    var rankings = await response;
-
-    if (rankings.status == 200) {
-        console.log(`Rankings already in system for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`);
-    } else {
-        const response = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
-            method: 'POST',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: `{
-            "season": "${season}",
-            "seasonType": "${seasonType}",
-            "week": "${week}"
-            }`,
-        });
-
-        response.json().then(data => {
-            if (response.status == 201) {
-                console.log("New Rankings", data);
-            } else {
-                console.log(response.status + " Rankings could not be retrieved");
-            }
-        });
-    }
-
-    if (isPostseason) {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
-
-        var games = await retrieveGamesModule.retrievePostseasonGames(teams, 1);
-        console.log("number of returned games", games.length);
-
-        await retrieveGamesModule.saveGames(games);
-        await scoringModule.updateScores("postseason", 1);
-        await scoringModule.updateCumulativeScores();
-        await teamScoringModule.updateAllTeamScores();
-        await recordsModule.updateAllTeamRecords();
-    } else {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
-
-        var games = await retrieveGamesModule.massRetrieveGames(weekNumber, "regular");
-        console.log("number of returned new games", games.newGames.length);
-        console.log("number of returned existing games", games.existingGames.length);
-        
-        await scoringModule.updateScores("regular", weekNumber);
-        await scoringModule.updateCumulativeScores();
-        await teamScoringModule.updateAllTeamScores();
-        await recordsModule.updateAllTeamRecords();
+// Sunday morning refresh to catch late Saturday games (no betting-line update).
+// Timing is owned by the in-process scheduler; direct runs still work.
+async function run() {
+    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+    console.log(`${LABEL} starting`, when);
+    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
+    try {
+        const { week, seasonType } = await runFullUpdate({ withBetting: false });
+        await finishRun(id, 'success', `Updated ${seasonType} week ${week}`, { week, seasonType });
+        await sendJobEmail({ label: LABEL, when, ok: true, detail: `Updated ${seasonType} week ${week}.` });
+        return { week, seasonType };
+    } catch (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        console.error(`❌ ${LABEL} failed:`, err);
+        await finishRun(id, 'error', msg);
+        await sendJobEmail({ label: LABEL, when, ok: false, detail: (err && err.stack) ? err.stack : msg });
+        throw err;
     }
 }
 
-// Current time in Central (America/Chicago), DST-aware. The old fixed -5
-// offset was wrong for the CST half of the CFB season.
-const todayDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-
-var dayText = "";
-
-let nodemailer = require('nodemailer');
-
-let transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.GMAIL_USER,
-    pass: process.env.GMAIL_APP_PASSWORD
-  }
-});
-
-var emailMessage = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Campus Clash - Weekly Recap</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      background-color: #121212;
-      margin: 0;
-      padding: 0;
-      color: #e0e0e0;
-    }
-    .email-container {
-      max-width: 600px;
-      margin: 0 auto;
-      background-color: #1e1e1e;
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .header {
-      background-color: #0d47a1;
-      color: #ffffff;
-      padding: 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-    }
-    .section {
-      padding: 20px;
-      border-bottom: 1px solid #333333;
-    }
-    .section h2 {
-      margin-top: 0;
-      font-size: 18px;
-      color: #90caf9;
-    }
-    .stat {
-      margin: 6px 0;
-      line-height: 1.4em;
-    }
-    .highlight {
-      font-weight: bold;
-      color: #64b5f6;
-    }
-    .footer {
-      text-align: center;
-      padding: 15px;
-      font-size: 12px;
-      color: #888888;
-      background-color: #121212;
-    }
-    ol {
-      padding-left: 18px;
-    }
-    @media (max-width: 600px) {
-      .section h2 {
-        font-size: 16px;
-      }
-    }
-  </style>
-</head>
-<body>
-  <div class="email-container" style="background-color: #1e1e1e;">
-
-    <div class="header">
-      <h1>🏈 Campus Clash - Sunday Update</h1>
-    </div>
-
-    <div class="section">
-      <h2>✅ Update Complete</h2>
-      <p class="stat" style="color: #e0e0e0;">Games & scores are being updated during the 3AM & 6AM windows.</p>
-    </div>
-
-    <div class="section">
-      <h2>📅 Current Date & Time</h2>
-      <p style="color: #e0e0e0;">${todayDate.toLocaleString()}</p>
-    </div>
-    
-  </div>
-</body>
-</html>
-`;
-
-let mailOptions = {
-  from: process.env.GMAIL_USER,
-  to: 'gwadegraham@gmail.com',
-  subject: 'Campus Clash | Sunday Update',
-  html: emailMessage
-};
-
-if (todayDate.getDay() == 0) {
-  if ((todayDate.getHours() == 3) || (todayDate.getHours() == 6)) {
-    dayText = "Today is Sunday, so games & scores are being updated during the 3AM & 6AM windows.";
-    console.log(dayText);
-    console.log("Current Date", todayDate.toLocaleString());
-
-    // Await the update so the email reflects the real outcome, and don't
-    // swallow failures (see comment in update-daily-scores-job.js).
-    (async () => {
-        try {
-            await updateScores();
-        } catch (err) {
-            console.error("❌ Sunday score update failed:", err);
-            mailOptions.subject = 'Campus Clash | Sunday Update FAILED';
-            mailOptions.html = `<p>The Sunday score update failed at ${todayDate.toLocaleString()}.</p><pre>${(err && err.stack) ? err.stack : err}</pre>`;
-        }
-
-        try {
-            const info = await transporter.sendMail(mailOptions);
-            console.log('Email sent: ' + info.response);
-        } catch (mailErr) {
-            console.log(mailErr);
-        }
-    })();
-  }
-} else {
-    dayText = "Today is not Sunday, so games & scores are NOT being updated.";
-    console.log(dayText);
-    console.log("Current Date", todayDate.toLocaleString());
-}
+module.exports = { run, JOB_NAME };
+if (require.main === module) { run(); }


### PR DESCRIPTION
Replaces Heroku Scheduler (inconsistent, hard to manage, cold-start one-off dynos) with an **in-process `node-schedule`** scheduler inside the always-on Basic web dyno, plus **run logging** surfaced on the admin status strip.

## Scheduling
- `modules/scheduler.js` registers the three score jobs with `tz: 'America/Chicago'` (DST-aware, which a UTC cron can't do):
  - **Daily** 11 PM · **Saturday** 3/6/10 PM · **Sunday** 3/6 AM (the exact times previously encoded in each job's self-gate).
- `server.js` starts it after `listen()`, gated to `NODE_ENV==='production'` / `ENABLE_SCHEDULER` so it never fires on a dev machine or in tests.
- **Expected wins is intentionally not scheduled** — it stays a manual once-a-year job (admin button / `node update-expected-wins-job.js`).

## Job refactor
- `modules/score-update.js` holds the shared pipeline (the only difference between jobs was that daily also refreshes betting lines → now a `withBetting` flag). Returns `{ week, seasonType }`.
- The three job files become thin wrappers that `export run()` and self-run only via `require.main === module`, so requiring them to schedule doesn't fire them and `node update-*-job.js` still works as a manual fallback.
- Shared status email extracted to `modules/job-mailer.js` (~90 duplicated lines per file removed).

## Run logging (rolling history)
- `models/jobRun.js` — one doc per run, **TTL-expired after 60 days** so the collection stays tiny with no manual cleanup.
- `routes/jobRuns.js` — `POST` (start), `PATCH /:id` (finish), `GET` (latest per job); token/commissioner-gated.
- `modules/job-logger.js` records `running → success/error` via the API, so it logs identically whether fired in-process or standalone. Best-effort — logging never breaks the job.
- Admin status strip now shows each job's last run + outcome (green/red/amber), giving the "why" behind a stale-scores warning.

## Verification
- **81 tests** passing (new: scheduler config, `latestPerJob`, plus existing suite green).
- `/job-runs` exercised end-to-end against Mongo (start → finish → latest-per-job).
- Job modules load without auto-running (the `require.main` guard); status strip renders the jobs block (verified in a harness).

## ⚠️ Deploy steps (maintainer)
1. Set `ENABLE_SCHEDULER=true` (or rely on `NODE_ENV=production`) on the dyno.
2. **Delete the Heroku Scheduler entries** for these scripts — otherwise both the old Scheduler dynos *and* the in-process scheduler run them (double updates; idempotent but wasteful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)