### PR TITLE
Richer run-report status email for scheduled jobs

### DIFF
--- a/modules/job-mailer.js
+++ b/modules/job-mailer.js
@@ -31,7 +31,7 @@ function buildJobEmailHtml({ label, when, ok, rows, error }) {
     return `<!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Campus Clash - ${escapeHtml(label)}</title></head>
-<body style="font-family:Arial,sans-serif;background-color:#121212;margin:0;padding:0;color:#e0e0e0;">
+<body style="font-family:Arial,sans-serif;background-color:#eceff1;margin:0;padding:24px 12px;color:#e0e0e0;">
   <div style="max-width:600px;margin:0 auto;background-color:#1e1e1e;border-radius:8px;overflow:hidden;">
     <div style="background-color:#0d47a1;color:#fff;padding:20px;text-align:center;"><h1 style="margin:0;font-size:24px;">🏈 Campus Clash · ${escapeHtml(label)}</h1></div>
     <div style="padding:20px;border-bottom:1px solid #333;">

--- a/modules/job-mailer.js
+++ b/modules/job-mailer.js
@@ -1,31 +1,61 @@
 const nodemailer = require('nodemailer');
 
-// Shared status email for the scheduled jobs (was duplicated ~90 lines per job
-// file). Best-effort — a mail failure is logged, never thrown.
-async function sendJobEmail({ label, when, ok, detail }) {
+function escapeHtml(v) {
+    return String(v == null ? '' : v)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Builds the run-report email HTML: outcome, a stat table (season/week/games/
+// teams/duration on success), and the error stack on failure. Pure (no I/O) so
+// it can be unit-tested and previewed.
+function buildJobEmailHtml({ label, when, ok, rows, error }) {
+    const heading = ok ? '✅ Update complete' : '❌ Update failed';
+    const accent = ok ? '#71d28d' : '#ef5350';
+
+    const statRows = (rows || []).map(function (r) {
+        return `<tr>
+            <td style="padding:6px 12px;color:#9e9e9e;border-bottom:1px solid #2a2a2a;">${escapeHtml(r[0])}</td>
+            <td style="padding:6px 12px;color:#e0e0e0;text-align:right;border-bottom:1px solid #2a2a2a;">${escapeHtml(r[1])}</td>
+        </tr>`;
+    }).join('');
+
+    const statTable = statRows
+        ? `<table style="width:100%;border-collapse:collapse;font-size:14px;margin-top:8px;">${statRows}</table>`
+        : '';
+
+    const errorBlock = (!ok && error)
+        ? `<div style="padding:20px;"><h2 style="margin:0 0 8px;font-size:16px;color:#ef5350;">Error</h2>
+            <pre style="white-space:pre-wrap;word-break:break-word;background:#121212;color:#ef9a9a;padding:12px;border-radius:6px;font-size:12px;margin:0;">${escapeHtml(error)}</pre></div>`
+        : '';
+
+    return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Campus Clash - ${escapeHtml(label)}</title></head>
+<body style="font-family:Arial,sans-serif;background-color:#121212;margin:0;padding:0;color:#e0e0e0;">
+  <div style="max-width:600px;margin:0 auto;background-color:#1e1e1e;border-radius:8px;overflow:hidden;">
+    <div style="background-color:#0d47a1;color:#fff;padding:20px;text-align:center;"><h1 style="margin:0;font-size:24px;">🏈 Campus Clash · ${escapeHtml(label)}</h1></div>
+    <div style="padding:20px;border-bottom:1px solid #333;">
+      <h2 style="margin:0 0 4px;font-size:18px;color:${accent};">${heading}</h2>
+      ${statTable}
+    </div>
+    ${errorBlock}
+    <div style="padding:16px 20px;font-size:12px;color:#888;">Run at ${escapeHtml(when)} (Central)</div>
+  </div>
+</body></html>`;
+}
+
+// Sends the run-report email. Best-effort — a mail failure is logged, never thrown.
+async function sendJobEmail(opts) {
     const transporter = nodemailer.createTransport({
         service: 'gmail',
         auth: { user: process.env.GMAIL_USER, pass: process.env.GMAIL_APP_PASSWORD }
     });
-
-    const heading = ok ? '✅ Update Complete' : '❌ Update Failed';
-    const accent = ok ? '#90caf9' : '#ef5350';
-    const html = `<!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Campus Clash - ${label}</title></head>
-<body style="font-family:Arial,sans-serif;background-color:#121212;margin:0;padding:0;color:#e0e0e0;">
-  <div style="max-width:600px;margin:0 auto;background-color:#1e1e1e;border-radius:8px;overflow:hidden;">
-    <div style="background-color:#0d47a1;color:#fff;padding:20px;text-align:center;"><h1 style="margin:0;font-size:24px;">🏈 Campus Clash - ${label}</h1></div>
-    <div style="padding:20px;border-bottom:1px solid #333;"><h2 style="margin-top:0;font-size:18px;color:${accent};">${heading}</h2><p style="color:#e0e0e0;">${detail || ''}</p></div>
-    <div style="padding:20px;"><h2 style="margin-top:0;font-size:18px;color:#90caf9;">📅 When</h2><p style="color:#e0e0e0;">${when}</p></div>
-  </div>
-</body></html>`;
-
+    const html = buildJobEmailHtml(opts);
     try {
         const info = await transporter.sendMail({
             from: process.env.GMAIL_USER,
             to: 'gwadegraham@gmail.com',
-            subject: `Campus Clash | ${label}${ok ? '' : ' FAILED'}`,
+            subject: `Campus Clash | ${opts.label}${opts.ok ? '' : ' FAILED'}`,
             html
         });
         console.log('Email sent: ' + info.response);
@@ -34,4 +64,4 @@ async function sendJobEmail({ label, when, ok, detail }) {
     }
 }
 
-module.exports = { sendJobEmail };
+module.exports = { sendJobEmail, buildJobEmailHtml };

--- a/modules/score-job.js
+++ b/modules/score-job.js
@@ -1,0 +1,49 @@
+const { runFullUpdate } = require('./score-update');
+const { startRun, finishRun } = require('./job-logger');
+const { sendJobEmail } = require('./job-mailer');
+
+// Builds a job's run(): logs the run (start -> success/error), executes the
+// shared pipeline, and emails a run report. The three score jobs differ only in
+// name/label and whether they refresh betting lines, so they share this.
+function makeJob({ jobName, label, withBetting }) {
+    return async function run() {
+        const startMs = Date.now();
+        const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+        console.log(`${label} starting`, when);
+        const id = await startRun(jobName, { season: process.env.YEAR });
+        try {
+            const r = await runFullUpdate({ withBetting: !!withBetting });
+            const secs = Math.round((Date.now() - startMs) / 1000);
+            const summary = `Updated ${r.seasonType} week ${r.week} · ${r.gamesNew} new / ${r.gamesUpdated} updated games · ${r.teams} teams (${secs}s)`;
+            await finishRun(id, 'success', summary, { week: r.week, seasonType: r.seasonType });
+            await sendJobEmail({
+                label: label,
+                when: when,
+                ok: true,
+                rows: [
+                    ['Season', `${r.seasonType} ${process.env.YEAR}`],
+                    ['Week', String(r.week)],
+                    ['Games', `${r.gamesNew} new · ${r.gamesUpdated} updated`],
+                    ['Teams', String(r.teams)],
+                    ['Duration', `${secs}s`]
+                ]
+            });
+            return r;
+        } catch (err) {
+            const secs = Math.round((Date.now() - startMs) / 1000);
+            const msg = (err && err.message) ? err.message : String(err);
+            console.error(`❌ ${label} failed:`, err);
+            await finishRun(id, 'error', msg);
+            await sendJobEmail({
+                label: label,
+                when: when,
+                ok: false,
+                rows: [['Failed after', `${secs}s`]],
+                error: (err && err.stack) ? err.stack : msg
+            });
+            throw err;
+        }
+    };
+}
+
+module.exports = { makeJob };

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -98,12 +98,18 @@ async function runFullUpdate({ withBetting = false } = {}) {
         });
     }
 
+    var teamCount = 0;
+    var gamesNew = 0;
+    var gamesUpdated = 0;
+
     if (isPostseason) {
         var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
+        teamCount = teams.length;
+        console.log("number of returned teams", teamCount);
 
         var games = await retrieveGamesModule.retrievePostseasonGames(teams, 1);
-        console.log("number of returned games", games.length);
+        gamesNew = games.length;
+        console.log("number of returned games", gamesNew);
 
         await retrieveGamesModule.saveGames(games);
         await scoringModule.updateScores("postseason", 1);
@@ -113,11 +119,14 @@ async function runFullUpdate({ withBetting = false } = {}) {
         if (withBetting) await bettingModule.updateAllBettingLines();
     } else {
         var teams = await retrieveGamesModule.retrieveTeams();
-        console.log("number of returned teams", teams.length);
+        teamCount = teams.length;
+        console.log("number of returned teams", teamCount);
 
         var games = await retrieveGamesModule.massRetrieveGames(weekNumber, "regular");
-        console.log("number of returned new games", games.newGames.length);
-        console.log("number of returned existing games", games.existingGames.length);
+        gamesNew = games.newGames.length;
+        gamesUpdated = games.existingGames.length;
+        console.log("number of returned new games", gamesNew);
+        console.log("number of returned existing games", gamesUpdated);
 
         await scoringModule.updateScores("regular", weekNumber);
         await scoringModule.updateCumulativeScores();
@@ -126,7 +135,7 @@ async function runFullUpdate({ withBetting = false } = {}) {
         if (withBetting) await bettingModule.updateAllBettingLines();
     }
 
-    return { week, seasonType };
+    return { week, seasonType, teams: teamCount, gamesNew, gamesUpdated };
 }
 
 module.exports = { runFullUpdate };

--- a/tests/JobEmail.spec.js
+++ b/tests/JobEmail.spec.js
@@ -1,0 +1,41 @@
+const { buildJobEmailHtml } = require('../modules/job-mailer');
+
+describe('buildJobEmailHtml', () => {
+    it('renders a success run report with the stat rows', () => {
+        const html = buildJobEmailHtml({
+            label: 'Daily Update',
+            when: '7/17/2026, 11:00:00 PM',
+            ok: true,
+            rows: [['Season', 'regular 2025'], ['Week', '16'], ['Games', '7 new · 305 updated'], ['Teams', '138'], ['Duration', '41s']]
+        });
+        expect(html).toContain('Update complete');
+        expect(html).toContain('Daily Update');
+        expect(html).toContain('regular 2025');
+        expect(html).toContain('7 new · 305 updated');
+        expect(html).toContain('138');
+        expect(html).not.toContain('Update failed');
+        expect(html).not.toContain('>Error<');
+    });
+
+    it('renders a failure report with the error block', () => {
+        const html = buildJobEmailHtml({
+            label: 'Saturday Update',
+            when: '7/17/2026, 3:00:00 PM',
+            ok: false,
+            rows: [['Failed after', '8s']],
+            error: 'Error: CFBD request failed (500)'
+        });
+        expect(html).toContain('Update failed');
+        expect(html).toContain('Failed after');
+        expect(html).toContain('Error: CFBD request failed (500)');
+    });
+
+    it('escapes HTML in values so an error string cannot break the markup', () => {
+        const html = buildJobEmailHtml({
+            label: 'Daily Update', when: 'now', ok: false, rows: [],
+            error: '<script>alert(1)</script>'
+        });
+        expect(html).toContain('&lt;script&gt;');
+        expect(html).not.toContain('<script>alert(1)</script>');
+    });
+});

--- a/update-daily-scores-job.js
+++ b/update-daily-scores-job.js
@@ -2,33 +2,13 @@ if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config();
 }
 
-const { runFullUpdate } = require('./modules/score-update');
-const { startRun, finishRun } = require('./modules/job-logger');
-const { sendJobEmail } = require('./modules/job-mailer');
-
-const JOB_NAME = 'daily-scores';
-const LABEL = 'Daily Update';
+const { makeJob } = require('./modules/score-job');
 
 // Daily full update (also refreshes betting lines). Timing is owned by the
 // in-process scheduler (modules/scheduler.js); running this file directly still
 // works as a manual fallback.
-async function run() {
-    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
-    console.log(`${LABEL} starting`, when);
-    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
-    try {
-        const { week, seasonType } = await runFullUpdate({ withBetting: true });
-        await finishRun(id, 'success', `Updated ${seasonType} week ${week}`, { week, seasonType });
-        await sendJobEmail({ label: LABEL, when, ok: true, detail: `Updated ${seasonType} week ${week}.` });
-        return { week, seasonType };
-    } catch (err) {
-        const msg = (err && err.message) ? err.message : String(err);
-        console.error(`❌ ${LABEL} failed:`, err);
-        await finishRun(id, 'error', msg);
-        await sendJobEmail({ label: LABEL, when, ok: false, detail: (err && err.stack) ? err.stack : msg });
-        throw err;
-    }
-}
+const JOB_NAME = 'daily-scores';
+const run = makeJob({ jobName: JOB_NAME, label: 'Daily Update', withBetting: true });
 
 module.exports = { run, JOB_NAME };
 if (require.main === module) { run(); }

--- a/update-saturday-scores-job.js
+++ b/update-saturday-scores-job.js
@@ -2,32 +2,12 @@ if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config();
 }
 
-const { runFullUpdate } = require('./modules/score-update');
-const { startRun, finishRun } = require('./modules/job-logger');
-const { sendJobEmail } = require('./modules/job-mailer');
-
-const JOB_NAME = 'saturday-scores';
-const LABEL = 'Saturday Update';
+const { makeJob } = require('./modules/score-job');
 
 // Saturday game-day refresh (no betting-line update). Timing is owned by the
 // in-process scheduler; running this file directly still works as a fallback.
-async function run() {
-    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
-    console.log(`${LABEL} starting`, when);
-    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
-    try {
-        const { week, seasonType } = await runFullUpdate({ withBetting: false });
-        await finishRun(id, 'success', `Updated ${seasonType} week ${week}`, { week, seasonType });
-        await sendJobEmail({ label: LABEL, when, ok: true, detail: `Updated ${seasonType} week ${week}.` });
-        return { week, seasonType };
-    } catch (err) {
-        const msg = (err && err.message) ? err.message : String(err);
-        console.error(`❌ ${LABEL} failed:`, err);
-        await finishRun(id, 'error', msg);
-        await sendJobEmail({ label: LABEL, when, ok: false, detail: (err && err.stack) ? err.stack : msg });
-        throw err;
-    }
-}
+const JOB_NAME = 'saturday-scores';
+const run = makeJob({ jobName: JOB_NAME, label: 'Saturday Update', withBetting: false });
 
 module.exports = { run, JOB_NAME };
 if (require.main === module) { run(); }

--- a/update-sunday-scores-job.js
+++ b/update-sunday-scores-job.js
@@ -2,32 +2,12 @@ if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config();
 }
 
-const { runFullUpdate } = require('./modules/score-update');
-const { startRun, finishRun } = require('./modules/job-logger');
-const { sendJobEmail } = require('./modules/job-mailer');
-
-const JOB_NAME = 'sunday-scores';
-const LABEL = 'Sunday Update';
+const { makeJob } = require('./modules/score-job');
 
 // Sunday morning refresh to catch late Saturday games (no betting-line update).
 // Timing is owned by the in-process scheduler; direct runs still work.
-async function run() {
-    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
-    console.log(`${LABEL} starting`, when);
-    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
-    try {
-        const { week, seasonType } = await runFullUpdate({ withBetting: false });
-        await finishRun(id, 'success', `Updated ${seasonType} week ${week}`, { week, seasonType });
-        await sendJobEmail({ label: LABEL, when, ok: true, detail: `Updated ${seasonType} week ${week}.` });
-        return { week, seasonType };
-    } catch (err) {
-        const msg = (err && err.message) ? err.message : String(err);
-        console.error(`❌ ${LABEL} failed:`, err);
-        await finishRun(id, 'error', msg);
-        await sendJobEmail({ label: LABEL, when, ok: false, detail: (err && err.stack) ? err.stack : msg });
-        throw err;
-    }
-}
+const JOB_NAME = 'sunday-scores';
+const run = makeJob({ jobName: JOB_NAME, label: 'Sunday Update', withBetting: false });
 
 module.exports = { run, JOB_NAME };
 if (require.main === module) { run(); }


### PR DESCRIPTION
Follow-up to #185. Turns the job status email from a generic "done/failed" shell into a real **run report**, using the data each run now produces.

## Changes
- `modules/score-update.js` returns the counts it already computes — `teams`, `gamesNew`, `gamesUpdated` — alongside `{ week, seasonType }`.
- `modules/score-job.js` — new `makeJob({ jobName, label, withBetting })` builds each job's `run()` (logging → pipeline → timing → email). The three job files collapse to thin 3-line wrappers, so the run logic isn't triplicated.
- `modules/job-mailer.js` — the email now shows a **stat table** on success (season · week · games new/updated · teams · duration) and the **error stack** on failure. The HTML builder is split out as a pure, HTML-escaping `buildJobEmailHtml()`.

## Verification
- Previewed both variants in the browser (success run report + failure error block) — [screenshots in the thread].
- **84 tests** passing, incl. 3 new `buildJobEmailHtml` tests (success rows, failure error block, HTML escaping).
- Recipient unchanged (`gwadegraham@gmail.com`); `GMAIL_USER` / `GMAIL_APP_PASSWORD` unchanged.

No deploy steps beyond the usual merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)