### PR TITLE
Standings: advanced highlights (Overachiever, Draft Steal, Biggest Upset)

### DIFF
--- a/modules/standings-highlights.js
+++ b/modules/standings-highlights.js
@@ -65,11 +65,13 @@ function draftStealCard(picks, scoreById) {
 }
 
 // Biggest upset: the drafted team that won as the largest betting underdog.
-// games: [{ id, homeTeam, awayTeam, homePoints, awayPoints, completed }]
+// games: [{ id, week, homeTeam, awayTeam, homePoints, awayPoints, completed }]
 // spreadByGameId: { [gameId]: homeSpread } where a POSITIVE home spread means
 //   the home team was the underdog by that many points (CFBD convention), so a
 //   negative spread means the home team was favored.
-function biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName) {
+// fantasyByGameId: { [gameId]: { [teamName]: fantasyPoints } } — the points the
+//   drafting owner banked from that team in that game (used for the card detail).
+function biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName, fantasyByGameId) {
     let best = null;
     (games || []).forEach(g => {
         if (!g.completed) return;
@@ -85,22 +87,34 @@ function biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName) {
         // (spread > 0), or away won while the home team was favored (spread < 0).
         const margin = homeWon ? (spread > 0 ? spread : null) : (spread < 0 ? -spread : null);
         if (margin == null || margin <= 0) return;
-        if (!best || margin > best.margin) best = { winner, loser, margin };
+        if (!best || margin > best.margin) best = { game: g, winner, loser, margin, homeWon };
     });
     if (!best) return null;
+    const g = best.game;
     const meta = (metaByName && metaByName[best.winner]) || null;
+    const winScore = best.homeWon ? g.homePoints : g.awayPoints;
+    const loseScore = best.homeWon ? g.awayPoints : g.homePoints;
+    const fantasy = fantasyByGameId && fantasyByGameId[g.id] ? fantasyByGameId[g.id][best.winner] : undefined;
+
+    // Fantasy points the owner banked lead the card (that's the payoff); the
+    // matchup, final score and underdog margin sit in the detail line.
+    const value = typeof fantasy === 'number'
+        ? `+${round(fantasy)} pts`
+        : `${round(best.margin)}-pt dog`;
+    const detail = `beat ${escapeHtml(best.loser)} ${winScore}–${loseScore} · ${round(best.margin)}-pt underdog`;
     return {
-        icon: '🎲', title: 'Biggest Upset', tag: 'season',
+        icon: '🎲', title: 'Biggest Upset',
+        tag: g.week != null ? `week ${g.week}` : 'season',
         name: `${logoImg(meta)}${teamLabel(meta, best.winner)}`,
-        value: `beat ${escapeHtml(best.loser)} as a ${round(best.margin)}-pt dog`, tone: 'good'
+        value, sub: detail, tone: 'good'
     };
 }
 
-function buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName }) {
+function buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName, fantasyByGameId }) {
     return [
         overachieverCard(records, metaById),
         draftStealCard(picks, scoreById),
-        biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName)
+        biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName, fantasyByGameId)
     ].filter(Boolean);
 }
 

--- a/modules/standings-highlights.js
+++ b/modules/standings-highlights.js
@@ -64,11 +64,12 @@ function draftStealCard(picks, scoreById) {
     };
 }
 
-// Giant killer: drafted team's win over the highest-ranked opponent (where the
-// winner was unranked or lower-ranked — a genuine upset).
-// games: [{ homeTeam, awayTeam, homePoints, awayPoints, week, completed }]
-// rankByWeek: { [week]: { [school]: rank } }; draftedNames: Set of school names
-function giantKillerCard(games, rankByWeek, draftedNames, metaByName) {
+// Biggest upset: the drafted team that won as the largest betting underdog.
+// games: [{ id, homeTeam, awayTeam, homePoints, awayPoints, completed }]
+// spreadByGameId: { [gameId]: homeSpread } where a POSITIVE home spread means
+//   the home team was the underdog by that many points (CFBD convention), so a
+//   negative spread means the home team was favored.
+function biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName) {
     let best = null;
     (games || []).forEach(g => {
         if (!g.completed) return;
@@ -78,28 +79,29 @@ function giantKillerCard(games, rankByWeek, draftedNames, metaByName) {
         const winner = homeWon ? g.homeTeam : g.awayTeam;
         const loser = homeWon ? g.awayTeam : g.homeTeam;
         if (!draftedNames.has(winner)) return;
-        const wk = (rankByWeek && rankByWeek[g.week]) || {};
-        const loserRank = wk[loser];
-        if (!loserRank) return;                       // opponent must be ranked
-        const winnerRank = wk[winner];
-        if (winnerRank && winnerRank <= loserRank) return; // winner favored → not an upset
-        if (!best || loserRank < best.loserRank) best = { winner, loser, loserRank };
+        const spread = spreadByGameId ? spreadByGameId[g.id] : undefined;
+        if (spread == null) return;
+        // Underdog margin for the winner: home won while a home underdog
+        // (spread > 0), or away won while the home team was favored (spread < 0).
+        const margin = homeWon ? (spread > 0 ? spread : null) : (spread < 0 ? -spread : null);
+        if (margin == null || margin <= 0) return;
+        if (!best || margin > best.margin) best = { winner, loser, margin };
     });
     if (!best) return null;
     const meta = (metaByName && metaByName[best.winner]) || null;
     return {
-        icon: '🐉', title: 'Giant Killer', tag: 'season',
+        icon: '🎲', title: 'Biggest Upset', tag: 'season',
         name: `${logoImg(meta)}${teamLabel(meta, best.winner)}`,
-        value: `beat #${best.loserRank} ${escapeHtml(best.loser)}`, tone: 'good'
+        value: `beat ${escapeHtml(best.loser)} as a ${round(best.margin)}-pt dog`, tone: 'good'
     };
 }
 
-function buildAdvancedHighlights({ records, metaById, picks, scoreById, games, rankByWeek, draftedNames, metaByName }) {
+function buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName }) {
     return [
         overachieverCard(records, metaById),
         draftStealCard(picks, scoreById),
-        giantKillerCard(games, rankByWeek, draftedNames, metaByName)
+        biggestUpsetCard(games, spreadByGameId, draftedNames, metaByName)
     ].filter(Boolean);
 }
 
-module.exports = { overachieverCard, draftStealCard, giantKillerCard, buildAdvancedHighlights };
+module.exports = { overachieverCard, draftStealCard, biggestUpsetCard, buildAdvancedHighlights };

--- a/modules/standings-highlights.js
+++ b/modules/standings-highlights.js
@@ -1,0 +1,105 @@
+// Pure computation of the "advanced" league highlights that need data the
+// Standings page doesn't itself load (records/xWins, games+rankings, draft
+// order). routes/standings.js gathers the data from Mongo and hands it here.
+// DB-free so it's unit-testable. Each builder returns a highlight card in the
+// same shape the client renderer (buildHighlightsHtml) expects, or null.
+
+function escapeHtml(v) {
+    return String(v == null ? '' : v).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+const round = (v) => Math.round(v * 10) / 10;
+function ordinal(n) {
+    const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+function logoImg(meta) {
+    return (meta && meta.logos && meta.logos.length) ? `<img src="${meta.logos[meta.logos.length - 1]}" class="hl-logo">` : '';
+}
+function teamLabel(meta, fallback) {
+    return escapeHtml((meta && meta.mascot) || fallback || '');
+}
+
+// Overachiever: drafted team whose actual wins most exceed its expected wins.
+// records: [{ teamId, team, expectedWins, total: { wins } }] (drafted teams only)
+function overachieverCard(records, metaById) {
+    let best = null;
+    (records || []).forEach(r => {
+        const wins = r.total && typeof r.total.wins === 'number' ? r.total.wins : null;
+        const xw = typeof r.expectedWins === 'number' ? r.expectedWins : null;
+        if (wins == null || xw == null) return;
+        const diff = wins - xw;
+        if (!best || diff > best.diff) best = { teamId: r.teamId, team: r.team, diff };
+    });
+    if (!best || best.diff < 0.5) return null;   // only when meaningfully over
+    const meta = (metaById && metaById[best.teamId]) || null;
+    return {
+        icon: '📊', title: 'Overachiever', tag: 'vs expected wins',
+        name: `${logoImg(meta)}${teamLabel(meta, best.team)}`,
+        value: `+${round(best.diff)} wins`, tone: 'good'
+    };
+}
+
+// Draft steal: the pick that scored far better than where it was drafted —
+// biggest positive gap between pick order and points rank.
+// picks: [{ overall, team: { id, mascot, school, logos } }]; scoreById: { id: pts }
+function draftStealCard(picks, scoreById) {
+    const rows = (picks || [])
+        .filter(p => p && p.team && p.team.id != null)
+        .map(p => ({ id: p.team.id, overall: p.overall, meta: p.team, score: (scoreById && scoreById[p.team.id]) || 0 }));
+    if (rows.length < 3) return null;
+
+    rows.slice().sort((a, b) => a.overall - b.overall).forEach((r, i) => { r.pickRank = i + 1; });
+    rows.slice().sort((a, b) => b.score - a.score).forEach((r, i) => { r.scoreRank = i + 1; });
+
+    let best = null;
+    rows.forEach(r => {
+        const edge = r.pickRank - r.scoreRank;   // + = scored better than drafted
+        if (r.score > 0 && (!best || edge > best.edge)) best = { ...r, edge };
+    });
+    if (!best || best.edge <= 0) return null;
+    return {
+        icon: '💎', title: 'Draft Steal', tag: 'season',
+        name: `${logoImg(best.meta)}${teamLabel(best.meta, best.meta.school)}`,
+        value: `pick #${best.overall}, ${ordinal(best.scoreRank)} in points`, tone: 'good'
+    };
+}
+
+// Giant killer: drafted team's win over the highest-ranked opponent (where the
+// winner was unranked or lower-ranked — a genuine upset).
+// games: [{ homeTeam, awayTeam, homePoints, awayPoints, week, completed }]
+// rankByWeek: { [week]: { [school]: rank } }; draftedNames: Set of school names
+function giantKillerCard(games, rankByWeek, draftedNames, metaByName) {
+    let best = null;
+    (games || []).forEach(g => {
+        if (!g.completed) return;
+        const homeWon = g.homePoints > g.awayPoints;
+        const awayWon = g.awayPoints > g.homePoints;
+        if (!homeWon && !awayWon) return;
+        const winner = homeWon ? g.homeTeam : g.awayTeam;
+        const loser = homeWon ? g.awayTeam : g.homeTeam;
+        if (!draftedNames.has(winner)) return;
+        const wk = (rankByWeek && rankByWeek[g.week]) || {};
+        const loserRank = wk[loser];
+        if (!loserRank) return;                       // opponent must be ranked
+        const winnerRank = wk[winner];
+        if (winnerRank && winnerRank <= loserRank) return; // winner favored → not an upset
+        if (!best || loserRank < best.loserRank) best = { winner, loser, loserRank };
+    });
+    if (!best) return null;
+    const meta = (metaByName && metaByName[best.winner]) || null;
+    return {
+        icon: '🐉', title: 'Giant Killer', tag: 'season',
+        name: `${logoImg(meta)}${teamLabel(meta, best.winner)}`,
+        value: `beat #${best.loserRank} ${escapeHtml(best.loser)}`, tone: 'good'
+    };
+}
+
+function buildAdvancedHighlights({ records, metaById, picks, scoreById, games, rankByWeek, draftedNames, metaByName }) {
+    return [
+        overachieverCard(records, metaById),
+        draftStealCard(picks, scoreById),
+        giantKillerCard(games, rankByWeek, draftedNames, metaByName)
+    ].filter(Boolean);
+}
+
+module.exports = { overachieverCard, draftStealCard, giantKillerCard, buildAdvancedHighlights };

--- a/public/standings.js
+++ b/public/standings.js
@@ -139,6 +139,7 @@ async function getUsers() {
             displayUsers(data);
             displayLastUpdated(data);
             displayHighlights(data);
+            loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
             displaySchedule(data);
             setNavbarUserId(userMetadata, usersData);
             // Chart is responsive now, so show it on mobile too.
@@ -188,6 +189,22 @@ function displayLastUpdated(data) {
         const lastUpdated = document.querySelector('[last-updated]');
         lastUpdated.innerHTML = `Last Updated ${formatTime}`;
     }
+}
+
+// Advanced highlights (Overachiever, Draft Steal, Giant Killer) come from the
+// server since they need records/games/rankings/draft data the roster payload
+// doesn't carry. Appended to the highlights grid; failures are silent.
+async function loadAdvancedHighlights(league, season) {
+    if (!league || season == null) return;
+    try {
+        const res = await fetch(`/standings/highlights/${league}/${season}`, { headers: { 'Accept': 'application/json' } });
+        if (!res.ok) return;
+        const cards = await res.json();
+        const container = document.querySelector('.highlights-container');
+        if (container && Array.isArray(cards) && cards.length) {
+            container.insertAdjacentHTML('beforeend', buildHighlightsHtml(cards));
+        }
+    } catch (e) { /* advanced highlights are best-effort */ }
 }
 
 function displayHighlights(users) {

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -4,7 +4,7 @@ const User = require('../models/user');
 const Team = require('../models/team');
 const Record = require('../models/record');
 const Game = require('../models/game');
-const Ranking = require('../models/ranking');
+const Betting = require('../models/bettingLine');
 const Draft = require('../models/draft');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 
@@ -53,23 +53,21 @@ router.get('/highlights/:league/:season', async (req, res) => {
         const draft = await Draft.findOne({ league: league, season: seasonNum });
         const picks = (draft && draft.picks) || [];
 
-        // Regular-season games involving drafted teams + rankings by week (Giant Killer).
+        // Regular-season games involving drafted teams + betting spreads by game
+        // (for Biggest Upset).
         const games = await Game.find(
             { season: seasonNum, seasonType: 'regular', $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
-            { homeTeam: 1, awayTeam: 1, homePoints: 1, awayPoints: 1, week: 1, completed: 1, _id: 0 }
+            { id: 1, homeTeam: 1, awayTeam: 1, homePoints: 1, awayPoints: 1, completed: 1, _id: 0 }
         );
-        const rankings = await Ranking.find({ season: seasonNum, seasonType: 'regular' });
-        const rankByWeek = {};
-        rankings.forEach(rk => {
-            const poll = (rk.polls || []).find(p => p.poll === 'Playoff Committee Rankings')
-                || (rk.polls || []).find(p => p.poll === 'AP Top 25');
-            if (!poll) return;
-            const map = {};
-            (poll.ranks || []).forEach(rr => { map[rr.school] = rr.rank; });
-            rankByWeek[rk.week] = map;
+        const betting = await Betting.find({ season: seasonNum, seasonType: 'regular' }, { id: 1, lines: 1, _id: 0 });
+        const spreadByGameId = {};
+        betting.forEach(b => {
+            const lines = b.lines || [];
+            const line = lines.find(l => l.provider === 'DraftKings') || lines[0];
+            if (line && typeof line.spread === 'number') spreadByGameId[b.id] = line.spread;
         });
 
-        res.json(buildAdvancedHighlights({ records, metaById, picks, scoreById, games, rankByWeek, draftedNames, metaByName }));
+        res.json(buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName }));
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -34,6 +34,19 @@ router.get('/highlights/:league/:season', async (req, res) => {
                 metaByName[t.school] = meta;
             });
         });
+
+        // Fantasy points each owner banked from a team in a given game, keyed
+        // gameId -> { teamName -> points } (for the Biggest Upset detail line).
+        const fantasyByGameId = {};
+        users.forEach(u => {
+            const s = (u.seasons || []).find(x => String(x.season) === String(season));
+            ((s && s.weeklyScore) || []).forEach(wk => {
+                (wk.scoreByTeam || []).forEach(st => {
+                    if (st.gameId == null || st.team == null) return;
+                    (fantasyByGameId[st.gameId] || (fantasyByGameId[st.gameId] = {}))[st.team] = st.score || 0;
+                });
+            });
+        });
         const idList = [...draftedIds];
         if (!idList.length) return res.json([]);
 
@@ -57,7 +70,7 @@ router.get('/highlights/:league/:season', async (req, res) => {
         // (for Biggest Upset).
         const games = await Game.find(
             { season: seasonNum, seasonType: 'regular', $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
-            { id: 1, homeTeam: 1, awayTeam: 1, homePoints: 1, awayPoints: 1, completed: 1, _id: 0 }
+            { id: 1, week: 1, homeTeam: 1, awayTeam: 1, homePoints: 1, awayPoints: 1, completed: 1, _id: 0 }
         );
         const betting = await Betting.find({ season: seasonNum, seasonType: 'regular' }, { id: 1, lines: 1, _id: 0 });
         const spreadByGameId = {};
@@ -67,7 +80,7 @@ router.get('/highlights/:league/:season', async (req, res) => {
             if (line && typeof line.spread === 'number') spreadByGameId[b.id] = line.spread;
         });
 
-        res.json(buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName }));
+        res.json(buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName, fantasyByGameId }));
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -1,0 +1,78 @@
+const express = require('express');
+const router = express.Router();
+const User = require('../models/user');
+const Team = require('../models/team');
+const Record = require('../models/record');
+const Game = require('../models/game');
+const Ranking = require('../models/ranking');
+const Draft = require('../models/draft');
+const { buildAdvancedHighlights } = require('../modules/standings-highlights');
+
+// Advanced league highlights that need data the Standings payload doesn't carry
+// (records/xWins, games+rankings, draft order). Read-only; returns cards in the
+// same shape the client's buildHighlightsHtml renders.
+router.get('/highlights/:league/:season', async (req, res) => {
+    try {
+        const league = req.params.league;
+        const season = req.params.season;          // users store season as a string
+        const seasonNum = Number(season);
+        const scoreKey = league === 'graham-league' ? 'cumulativeScoreV2' : 'cumulativeScoreV1';
+
+        // Drafted teams across the league's rosters.
+        const users = await User.find({ league: league, 'seasons.season': season });
+        const draftedIds = new Set();
+        const draftedNames = new Set();
+        const metaById = {};
+        const metaByName = {};
+        users.forEach(u => {
+            const s = (u.seasons || []).find(x => String(x.season) === String(season));
+            ((s && s.teams) || []).forEach(t => {
+                draftedIds.add(Number(t.id));
+                draftedNames.add(t.school);
+                const meta = { id: t.id, mascot: t.mascot, school: t.school, logos: t.logos };
+                metaById[t.id] = meta;
+                metaByName[t.school] = meta;
+            });
+        });
+        const idList = [...draftedIds];
+        if (!idList.length) return res.json([]);
+
+        // Per-team season score in this league's model (for Draft Steal).
+        const teams = await Team.find({ id: { $in: idList } }, { id: 1, seasons: 1 });
+        const scoreById = {};
+        teams.forEach(t => {
+            const s = (t.seasons || []).find(x => Number(x.season) === seasonNum);
+            if (s) scoreById[t.id] = s[scoreKey] || 0;
+        });
+
+        // Records (actual wins + expected wins) for drafted teams.
+        const records = (await Record.find({ year: seasonNum, teamId: { $in: idList } }))
+            .map(r => ({ teamId: r.teamId, team: r.team, expectedWins: r.expectedWins, total: r.total }));
+
+        // Draft pick order (for Draft Steal).
+        const draft = await Draft.findOne({ league: league, season: seasonNum });
+        const picks = (draft && draft.picks) || [];
+
+        // Regular-season games involving drafted teams + rankings by week (Giant Killer).
+        const games = await Game.find(
+            { season: seasonNum, seasonType: 'regular', $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
+            { homeTeam: 1, awayTeam: 1, homePoints: 1, awayPoints: 1, week: 1, completed: 1, _id: 0 }
+        );
+        const rankings = await Ranking.find({ season: seasonNum, seasonType: 'regular' });
+        const rankByWeek = {};
+        rankings.forEach(rk => {
+            const poll = (rk.polls || []).find(p => p.poll === 'Playoff Committee Rankings')
+                || (rk.polls || []).find(p => p.poll === 'AP Top 25');
+            if (!poll) return;
+            const map = {};
+            (poll.ranks || []).forEach(rr => { map[rr.school] = rr.rank; });
+            rankByWeek[rk.week] = map;
+        });
+
+        res.json(buildAdvancedHighlights({ records, metaById, picks, scoreById, games, rankByWeek, draftedNames, metaByName }));
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -261,6 +261,9 @@ app.use('/scoring-config', requireAuthOrToken, scoringConfigRouter);
 const jobRunsRouter = require('./routes/jobRuns');
 app.use('/job-runs', requireAuthOrToken, jobRunsRouter);
 
+const standingsRouter = require('./routes/standings');
+app.use('/standings', requireAuthOrToken, standingsRouter);
+
 app.get('/calculate-team-score/:season/:teamId/:teamName', requireCommissioner, async (req, res) => {
     var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);
 

--- a/tests/StandingsHighlights.spec.js
+++ b/tests/StandingsHighlights.spec.js
@@ -1,0 +1,71 @@
+const { overachieverCard, draftStealCard, giantKillerCard } = require('../modules/standings-highlights');
+
+describe('overachieverCard', () => {
+    it('picks the team most over its expected wins', () => {
+        const records = [
+            { teamId: 1, team: 'Indiana', expectedWins: 6, total: { wins: 11 } },   // +5
+            { teamId: 2, team: 'Georgia', expectedWins: 10, total: { wins: 11 } }    // +1
+        ];
+        const card = overachieverCard(records, { 1: { mascot: 'Hoosiers', logos: ['x.png'] } });
+        expect(card.title).toBe('Overachiever');
+        expect(card.name).toContain('Hoosiers');
+        expect(card.value).toBe('+5 wins');
+    });
+    it('returns null when nobody meaningfully beat expectation', () => {
+        expect(overachieverCard([{ teamId: 1, team: 'A', expectedWins: 8, total: { wins: 8 } }], {})).toBeNull();
+        expect(overachieverCard([], {})).toBeNull();
+    });
+});
+
+describe('draftStealCard', () => {
+    it('flags the late pick that scored near the top', () => {
+        const picks = [
+            { overall: 1, team: { id: 1, school: 'A', mascot: 'Aces' } },
+            { overall: 2, team: { id: 2, school: 'B', mascot: 'Bears' } },
+            { overall: 3, team: { id: 3, school: 'C', mascot: 'Cats' } }
+        ];
+        // last pick (C) scored the most -> pickRank 3, scoreRank 1, edge +2
+        const card = draftStealCard(picks, { 1: 10, 2: 20, 3: 40 });
+        expect(card.title).toBe('Draft Steal');
+        expect(card.name).toContain('Cats');
+        expect(card.value).toContain('pick #3');
+        expect(card.value).toContain('1st in points');
+    });
+    it('returns null with too few picks or no edge', () => {
+        expect(draftStealCard([{ overall: 1, team: { id: 1 } }], {})).toBeNull();
+        const evenPicks = [
+            { overall: 1, team: { id: 1 } }, { overall: 2, team: { id: 2 } }, { overall: 3, team: { id: 3 } }
+        ];
+        // score order matches pick order -> no steal
+        expect(draftStealCard(evenPicks, { 1: 30, 2: 20, 3: 10 })).toBeNull();
+    });
+});
+
+describe('giantKillerCard', () => {
+    const metaByName = { 'Vanderbilt': { mascot: 'Commodores', logos: ['v.png'] } };
+    const drafted = new Set(['Vanderbilt']);
+    it('finds a drafted team beating the highest-ranked opponent', () => {
+        const games = [
+            { homeTeam: 'Vanderbilt', awayTeam: 'Alabama', homePoints: 40, awayPoints: 35, week: 6, completed: true },
+            { homeTeam: 'Vanderbilt', awayTeam: 'Kentucky', homePoints: 20, awayPoints: 13, week: 7, completed: true }
+        ];
+        const rankByWeek = { 6: { Alabama: 1 }, 7: { Kentucky: 18 } };  // beat #1 and #18
+        const card = giantKillerCard(games, rankByWeek, drafted, metaByName);
+        expect(card.title).toBe('Giant Killer');
+        expect(card.name).toContain('Commodores');
+        expect(card.value).toBe('beat #1 Alabama');
+    });
+    it('ignores wins over unranked teams and games the drafted team lost', () => {
+        const games = [
+            { homeTeam: 'Vanderbilt', awayTeam: 'Rice', homePoints: 50, awayPoints: 3, week: 1, completed: true },     // unranked
+            { homeTeam: 'Georgia', awayTeam: 'Vanderbilt', homePoints: 44, awayPoints: 10, week: 2, completed: true }  // Vandy lost
+        ];
+        const rankByWeek = { 2: { Georgia: 2 } };
+        expect(giantKillerCard(games, rankByWeek, drafted, metaByName)).toBeNull();
+    });
+    it('does not count a win where the winner was already higher-ranked (not an upset)', () => {
+        const games = [{ homeTeam: 'Vanderbilt', awayTeam: 'Auburn', homePoints: 30, awayPoints: 20, week: 3, completed: true }];
+        const rankByWeek = { 3: { Vanderbilt: 2, Auburn: 10 } };  // favored winner
+        expect(giantKillerCard(games, rankByWeek, drafted, metaByName)).toBeNull();
+    });
+});

--- a/tests/StandingsHighlights.spec.js
+++ b/tests/StandingsHighlights.spec.js
@@ -47,8 +47,8 @@ describe('biggestUpsetCard', () => {
 
     it('finds the drafted team that won as the biggest underdog', () => {
         const games = [
-            { id: 1, homeTeam: 'Vanderbilt', awayTeam: 'Alabama', homePoints: 40, awayPoints: 35, completed: true }, // home won
-            { id: 2, homeTeam: 'Ohio State', awayTeam: 'Northwestern', homePoints: 10, awayPoints: 14, completed: true } // away won
+            { id: 1, week: 3, homeTeam: 'Vanderbilt', awayTeam: 'Alabama', homePoints: 40, awayPoints: 35, completed: true }, // home won
+            { id: 2, week: 8, homeTeam: 'Ohio State', awayTeam: 'Northwestern', homePoints: 10, awayPoints: 14, completed: true } // away won
         ];
         // g1: home spread +14 -> Vanderbilt a 14-pt home dog, won.
         // g2: home spread -21 -> Ohio State favored by 21 -> Northwestern a 21-pt away dog, won.
@@ -56,8 +56,24 @@ describe('biggestUpsetCard', () => {
         const card = biggestUpsetCard(games, spreadByGameId, drafted, metaByName);
         expect(card.title).toBe('Biggest Upset');
         expect(card.name).toContain('Wildcats');           // 21 > 14
-        expect(card.value).toContain('21-pt');
-        expect(card.value).toContain('beat Ohio State');
+        expect(card.tag).toBe('week 8');
+        expect(card.sub).toContain('21-pt');
+        expect(card.sub).toContain('beat Ohio State');
+        expect(card.sub).toContain('14–10');               // final score (winner–loser)
+        expect(card.sub).toContain('underdog');
+        // No fantasy map -> value falls back to the underdog margin.
+        expect(card.value).toBe('21-pt dog');
+    });
+
+    it('leads with the owner\'s fantasy points when available', () => {
+        const games = [
+            { id: 2, week: 8, homeTeam: 'Ohio State', awayTeam: 'Northwestern', homePoints: 10, awayPoints: 14, completed: true }
+        ];
+        const spreadByGameId = { 2: -21 };
+        const fantasyByGameId = { 2: { Northwestern: 18.5 } };
+        const card = biggestUpsetCard(games, spreadByGameId, drafted, metaByName, fantasyByGameId);
+        expect(card.value).toBe('+18.5 pts');
+        expect(card.sub).toContain('beat Ohio State 14–10 · 21-pt underdog');
     });
 
     it('ignores favored wins, losses, and games with no line', () => {

--- a/tests/StandingsHighlights.spec.js
+++ b/tests/StandingsHighlights.spec.js
@@ -1,4 +1,4 @@
-const { overachieverCard, draftStealCard, giantKillerCard } = require('../modules/standings-highlights');
+const { overachieverCard, draftStealCard, biggestUpsetCard } = require('../modules/standings-highlights');
 
 describe('overachieverCard', () => {
     it('picks the team most over its expected wins', () => {
@@ -41,31 +41,32 @@ describe('draftStealCard', () => {
     });
 });
 
-describe('giantKillerCard', () => {
-    const metaByName = { 'Vanderbilt': { mascot: 'Commodores', logos: ['v.png'] } };
-    const drafted = new Set(['Vanderbilt']);
-    it('finds a drafted team beating the highest-ranked opponent', () => {
+describe('biggestUpsetCard', () => {
+    const metaByName = { 'Vanderbilt': { mascot: 'Commodores', logos: ['v.png'] }, 'Northwestern': { mascot: 'Wildcats' } };
+    const drafted = new Set(['Vanderbilt', 'Northwestern']);
+
+    it('finds the drafted team that won as the biggest underdog', () => {
         const games = [
-            { homeTeam: 'Vanderbilt', awayTeam: 'Alabama', homePoints: 40, awayPoints: 35, week: 6, completed: true },
-            { homeTeam: 'Vanderbilt', awayTeam: 'Kentucky', homePoints: 20, awayPoints: 13, week: 7, completed: true }
+            { id: 1, homeTeam: 'Vanderbilt', awayTeam: 'Alabama', homePoints: 40, awayPoints: 35, completed: true }, // home won
+            { id: 2, homeTeam: 'Ohio State', awayTeam: 'Northwestern', homePoints: 10, awayPoints: 14, completed: true } // away won
         ];
-        const rankByWeek = { 6: { Alabama: 1 }, 7: { Kentucky: 18 } };  // beat #1 and #18
-        const card = giantKillerCard(games, rankByWeek, drafted, metaByName);
-        expect(card.title).toBe('Giant Killer');
-        expect(card.name).toContain('Commodores');
-        expect(card.value).toBe('beat #1 Alabama');
+        // g1: home spread +14 -> Vanderbilt a 14-pt home dog, won.
+        // g2: home spread -21 -> Ohio State favored by 21 -> Northwestern a 21-pt away dog, won.
+        const spreadByGameId = { 1: 14, 2: -21 };
+        const card = biggestUpsetCard(games, spreadByGameId, drafted, metaByName);
+        expect(card.title).toBe('Biggest Upset');
+        expect(card.name).toContain('Wildcats');           // 21 > 14
+        expect(card.value).toContain('21-pt');
+        expect(card.value).toContain('beat Ohio State');
     });
-    it('ignores wins over unranked teams and games the drafted team lost', () => {
+
+    it('ignores favored wins, losses, and games with no line', () => {
         const games = [
-            { homeTeam: 'Vanderbilt', awayTeam: 'Rice', homePoints: 50, awayPoints: 3, week: 1, completed: true },     // unranked
-            { homeTeam: 'Georgia', awayTeam: 'Vanderbilt', homePoints: 44, awayPoints: 10, week: 2, completed: true }  // Vandy lost
+            { id: 1, homeTeam: 'Vanderbilt', awayTeam: 'Rice', homePoints: 50, awayPoints: 3, completed: true },    // favored
+            { id: 2, homeTeam: 'Georgia', awayTeam: 'Vanderbilt', homePoints: 44, awayPoints: 10, completed: true }, // Vandy lost
+            { id: 3, homeTeam: 'Vanderbilt', awayTeam: 'LSU', homePoints: 20, awayPoints: 17, completed: true }      // no line
         ];
-        const rankByWeek = { 2: { Georgia: 2 } };
-        expect(giantKillerCard(games, rankByWeek, drafted, metaByName)).toBeNull();
-    });
-    it('does not count a win where the winner was already higher-ranked (not an upset)', () => {
-        const games = [{ homeTeam: 'Vanderbilt', awayTeam: 'Auburn', homePoints: 30, awayPoints: 20, week: 3, completed: true }];
-        const rankByWeek = { 3: { Vanderbilt: 2, Auburn: 10 } };  // favored winner
-        expect(giantKillerCard(games, rankByWeek, drafted, metaByName)).toBeNull();
+        const spreadByGameId = { 1: -30, 2: -21 };   // g1 home favored; g3 absent
+        expect(biggestUpsetCard(games, spreadByGameId, drafted, metaByName)).toBeNull();
     });
 });


### PR DESCRIPTION
Re-targets the advanced-highlights work to **main**. The original PR #188 was stacked on \`feature/standings-ux\` (#187) and merged into that branch ~9s *after* #187 had already merged to main — so these commits never reached main. This PR lands them.

Adds a read-only \`GET /standings/highlights/:league/:season\` endpoint plus client wiring that appends three data-gated League Highlights cards:
- **Overachiever** — drafted team most over its expected wins.
- **Draft Steal** — pick that scored far above its draft slot.
- **Biggest Upset** — drafted team that won as the biggest betting underdog, showing the week, final score, and the fantasy points the owner banked.

Pure compute lives in \`modules/standings-highlights.js\` (unit-tested); the route does the Mongo joins. No changes to #187's work — diff is all additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)