### PR TITLE
Standings: logo centering, mobile polish, and clickable tie reveal

### DIFF
--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -176,8 +176,18 @@ export function buildHighlights(users) {
         const teamNames = [...new Set(topGames.map(g => g.team))];
         if (teamNames.length > 1) {
             const shown = teamNames.slice(0, 4).map(escapeHtml).join(', ');
-            const more = teamNames.length > 4 ? ` +${teamNames.length - 4}` : '';
-            cards.push({ icon: '⚡', title: 'Top Single Game', tag: `${teamNames.length}-way tie`, name: shown + more, value: `+${topScore}`, tone: 'good' });
+            let name = shown;
+            if (teamNames.length > 4) {
+                // "+N" is a button that reveals the full list in a popover
+                // (standings.js wires the toggle); the popover carries every
+                // tied team so nothing is hidden for good.
+                const extra = teamNames.length - 4;
+                const full = teamNames.map(escapeHtml).join(', ');
+                name += ` <button type="button" class="hl-more" aria-expanded="false">+${extra}</button>`
+                    + `<span class="hl-popover" role="tooltip" hidden>`
+                    + `<span class="hl-popover-title">All ${teamNames.length} tied teams</span>${full}</span>`;
+            }
+            cards.push({ icon: '⚡', title: 'Top Single Game', tag: `${teamNames.length}-way tie`, name, value: `+${topScore}`, tone: 'good' });
         } else {
             cards.push({ icon: '⚡', title: 'Top Single Game', tag: 'one game', name: `${escapeHtml(topGames[0].team)} <span class="hl-sub">(${escapeHtml(topGames[0].owner)})</span>`, value: `+${topScore}`, tone: 'good' });
         }

--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -72,7 +72,7 @@ export function buildStandingsRowsHtml(rows) {
         return `<tr class="standings-row${medal}">
             <th class="sticky-header rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</th>
             <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${crown}${escapeHtml(r.name)}</a></th>
-            <td class="team-item">${logos}</td>
+            <td class="team-item"><div class="team-logos">${logos}</div></td>
             <th class="sticky-header-score"><span class="score-num" data-count="${r.score}">${r.score}</span><br>${gap}</th>
         </tr>`;
     }).join('');

--- a/public/standings.css
+++ b/public/standings.css
@@ -432,6 +432,55 @@
 .highlight-info .hl-value.bad { color: #ED5858; }
 .highlight-info .hl-value.neutral { color: #64B5F6; }
 
+/* Tie popover: the "+N" pill on the Top Single Game card opens a small
+   popover listing every tied team (standings.js toggles [hidden]). */
+.highlight-info .hl-name { position: relative; }
+.hl-more {
+    display: inline-block;
+    margin-left: 4px;
+    padding: 1px 7px;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #C9CEE6;
+    background: #2A2E42;
+    border: 1px solid #3A3F58;
+    border-radius: 20px;
+    line-height: 1.4;
+    cursor: pointer;
+}
+.hl-more:hover { background: #343954; color: #F4F6FB; }
+.hl-more[aria-expanded="true"] { background: #8E8CF0; border-color: #8E8CF0; color: #fff; }
+.hl-popover {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    top: calc(100% + 6px);
+    z-index: 20;
+    width: max-content;
+    /* Cap to ~a grid column so a card in either column keeps the centered
+       popover on-screen on mobile; desktop takes the 240px cap. */
+    max-width: min(240px, 42vw);
+    padding: 10px 12px;
+    background: #232840;
+    border: 1px solid #3A3F58;
+    border-radius: 10px;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.45);
+    font-size: 0.82rem;
+    color: #C9CEE6;
+    line-height: 1.5;
+    text-align: left;
+    white-space: normal;
+}
+.hl-popover .hl-popover-title {
+    display: block;
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #8E93AE;
+    margin-bottom: 4px;
+}
+
 /* Path to the Championship: responsive canvas + Points/Rank toggle */
 .chart-canvas-wrap { position: relative; height: 340px; width: 100%; max-width: 1000px; margin: 0 auto; padding: 0 10px; box-sizing: border-box; }
 .chart-mode-toggle { display: flex; justify-content: center; margin: 10px 0 4px; }

--- a/public/standings.css
+++ b/public/standings.css
@@ -403,6 +403,17 @@
 .gap.leader { color: #5BD08D; }
 .score-num { font-weight: 700; }
 
+/* Team logos: keep the cell a real table cell so it fills the row height and
+   vertical-align:middle applies; the logos live in an inner flex row. A
+   display:flex <td> instead collapses to its content height, stranding the
+   logos at the top of taller rows. Scoped so admin/userHome .team-item keep
+   their own flex layout. */
+.standings-row .team-item { display: table-cell; vertical-align: middle; }
+.standings-row .team-logos { display: flex; align-items: center; width: 100%; }
+@media only screen and (min-width: 64em) {
+    .standings-row .team-logos { justify-content: space-between; }
+}
+
 /* Highlight cards: flow all cards, spaced tags, colored values */
 @media only screen and (min-width: 64em) {
     /* 3 across on desktop — better density for the fuller set of highlight cards. */

--- a/public/standings.js
+++ b/public/standings.js
@@ -212,6 +212,33 @@ function displayHighlights(users) {
     if (container) container.innerHTML = buildHighlightsHtml(buildHighlights(users));
 }
 
+// Toggles the "+N" tie popover on the Top Single Game card. Wired once via
+// delegation so it survives re-renders; closes on outside click or Escape.
+function setupTiePopovers() {
+    const container = document.querySelector('.highlights-container');
+    if (!container) return;
+    const closeAll = (except) => container.querySelectorAll('.hl-popover:not([hidden])').forEach(p => {
+        if (p === except) return;
+        p.hidden = true;
+        const btn = p.previousElementSibling;
+        if (btn && btn.classList.contains('hl-more')) btn.setAttribute('aria-expanded', 'false');
+    });
+    container.addEventListener('click', (e) => {
+        const btn = e.target.closest('.hl-more');
+        if (!btn || !container.contains(btn)) { closeAll(); return; }
+        const pop = btn.nextElementSibling;
+        if (!pop || !pop.classList.contains('hl-popover')) return;
+        const willOpen = pop.hidden;
+        closeAll(pop);
+        pop.hidden = !willOpen;
+        btn.setAttribute('aria-expanded', String(willOpen));
+        e.stopPropagation();
+    });
+    document.addEventListener('click', (e) => { if (!e.target.closest('.hl-popover, .hl-more')) closeAll(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeAll(); });
+}
+setupTiePopovers();
+
 async function getGame(season, week, team) {
 
     var gamePromise = await fetch(`/games/seasonType/${season}/week/${week}/team/${team.id}`, {

--- a/public/styles.css
+++ b/public/styles.css
@@ -423,7 +423,10 @@ footer {
     }
 
     .header {
-        height: 50px;
+        /* min-height, not height: a fixed height combined with
+           align-items:flex-end makes a wrapped title (e.g. "Path to the
+           Championship") overflow upward and collide with the content above. */
+        min-height: 50px;
     }
 
     .header-title {

--- a/public/styles.css
+++ b/public/styles.css
@@ -242,6 +242,7 @@ footer {
 
 .fl-table td, .fl-table th {
     text-align: center;
+    vertical-align: middle;
     padding: 8px;
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -401,6 +401,19 @@ footer {
         margin-right: 10px
     }
 
+    /* The Score column is frozen to the right while the logos scroll under it.
+       Give it a real gutter (so it doesn't jam against the last logo) and a
+       soft divider shadow that reads as "content scrolls beneath this". */
+    .fl-table th.sticky-header-score {
+        padding-left: 12px;
+        padding-right: 12px;
+        box-shadow: -8px 0 8px -6px rgba(0, 0, 0, 0.6);
+    }
+
+    .fl-table th.sticky-header-score .gap {
+        white-space: nowrap;
+    }
+
     .cfb-data {
         font-size: 1rem;
     }


### PR DESCRIPTION
A batch of Standings polish.

**Vertically center the team logos in each row.** `.team-item` was a `display:flex` `<td>`, which collapses to its content height and ignores `vertical-align`, leaving logos stranded at the top of the taller Score-cell rows. Wrap the logos in an inner `.team-logos` flex row and keep the cell a real `table-cell`. Scoped to `.standings-row`.

**Roomier mobile Score column.** The frozen Score column had no gutter — the last logo jammed against and peeked out behind it. Added horizontal padding and a soft left divider shadow. Scoped to `max-width: 767px`.

**Fix wrapped headers overlapping content on mobile.** The mobile `.header` had a fixed `height: 50px` with `align-items:flex-end`, so a two-line title ("Path to the Championship") overflowed upward into the card above. Use `min-height`.

**Clickable tie reveal on "Top Single Game".** A multi-way tie showed the first 4 teams and a bare "+N" with no way to see the rest. "+N" is now a button that toggles a small popover listing every tied team; dismiss on outside click or Esc. Popover width caps to a grid column so it stays on-screen in either mobile column.

All verified via mock renders at desktop and mobile widths (including open/close/aria-expanded state and on-screen bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)