### PR TITLE
Profile: fix weekly table (postseason column, byes, future weeks, layout)

### DIFF
--- a/public/userHome.css
+++ b/public/userHome.css
@@ -50,7 +50,7 @@
     .team-header {
         padding: 0em 0em 0em 0.5em !important;
         text-align: center !important;
-        min-width: 4em;
+        min-width: 2.6em;
     }
 
     .sticky-header {
@@ -67,8 +67,27 @@
 
     .fl-table td {
         padding: 0em 0em 0em 0.5em;
-        min-width: 4em;
+        min-width: 2.6em;
     }
+
+    /* The Postseason header was clipped to "Po" — give its column room to fit. */
+    .fl-table thead th:nth-last-child(2) {
+        min-width: 6em;
+        white-space: nowrap;
+    }
+
+    /* Frozen Team Score column: gutter + divider so it doesn't crowd/overlap
+       the Postseason column as the table scrolls. */
+    .sticky-header-score {
+        padding-left: 1em;
+        box-shadow: -8px 0 8px -6px rgba(0, 0, 0, 0.6);
+    }
+
+    /* Unplayed weeks read as blank (not a scored 0); byes as a muted dash. */
+    td.cell-bye { color: #4A4F68; }
+
+    /* Set the cumulative row apart from the per-team rows. */
+    .cumulative-row td, .cumulative-row th { border-top: 2px solid #2A2E42; font-weight: 600; }
 
     .game-notes {
         font-size: 0.75em;
@@ -184,6 +203,10 @@
 
     .content {
         margin-top: 0px;
+        /* The flex-centered body shrink-wraps .content, which made the table
+           wrapper collapse narrower than the table and clip the last column.
+           Stretch it so percentage-width children resolve against the viewport. */
+        width: 100%;
     }
 
     .brand-title {
@@ -204,9 +227,23 @@
         width: auto;
     }
 
+    /* On desktop the table fits without horizontal scroll, so the frozen
+       Team Score column has nothing to scroll over — left sticky it just
+       detaches to the container edge and paints over the Postseason column.
+       Let it sit in normal flow here; it stays sticky on mobile where the
+       table actually scrolls. */
+    .sticky-header-score {
+        position: static;
+        box-shadow: none;
+    }
+
     .fl-table {
         font-size: 1em;
         line-height: 3em;
+        /* Size to content (not stretched to the wrapper): with the score column
+           no longer sticky on desktop, min-width:100% only padded the table out
+           and pushed the last column off-screen. */
+        min-width: 0;
     }
 
     .hr-subtle {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -123,67 +123,69 @@ function changeHeader(data) {
 
 }
 
-function displayTeams(data) {
-    const userTableBody = document.querySelector('[user-table-body]');
-    var str = '';
+// Column model for the weekly table: regular weeks 1-16 keyed by week number,
+// plus one aggregated Postseason column. Building columns by week (rather than
+// by array position) keeps each score under its correct header even when weeks
+// are missing or a postseason entry is present — the old positional rendering
+// dropped the postseason bonus into whatever column index it happened to land.
+function weeklyColumns(season) {
+    const weekly = (season && season.weeklyScore) || [];
+    const isPost = (w) => w.season === 'postseason' || w.week > 16;
 
-    var currentWeeksLength = data.seasons.at(-1).weeklyScore.length;
+    const regularByWeek = {};
+    weekly.forEach(w => { if (!isPost(w)) regularByWeek[w.week] = w; });
 
-    data.seasons.at(-1).teams.forEach( (team, index) => {
-        var totalScore = 0;
-
-        str += '<tr>';
-        var refLink = `/team?team=${team.id}`;
-
-        str += '<th class="team-header sticky-header">';
-        str += '<a href="' + refLink + '"><img src="' + team.logos.at(-1) + '" alt="' + escapeHtml(team.mascot) + '">'
-        str += escapeHtml(team.school);
-        str += '</a></th>';
-        
-        data.seasons.at(-1).weeklyScore.forEach(week => {
-            var result = week.scoreByTeam.filter(obj => {
-                return obj.team == team.school
-              });
-
-            var tableWeeklyScore = 0;
-            if (result.length > 0) {
-                for (const repeatedScore of result) {
-                    tableWeeklyScore += repeatedScore.score;
-                }
-            }
-
-            if (result[0]) {
-                str += '<td>' + tableWeeklyScore + '</td>';
-                totalScore += tableWeeklyScore;
-            } else {
-                str += '<td>0</td>';
-            }
-        });
-
-
-        for(var i = 0; i < (17 - currentWeeksLength); i++) {
-            str += '<td>0</td>';
-        }
-
-        str += '<th class="sticky-header-score">' + totalScore + '</th>';
-        str += '</tr>';
-    });
-
-    str += '<tr>';
-    str += '<th class="team-header sticky-header">';
-    str += 'Cumulative Score';
-    str += '</th>';
-
-    data.seasons.at(-1).weeklyScore.forEach(week => {
-        str += '<td>' + week.score + '</td>'
-    });
-
-    for(var i = 0; i < (17 - currentWeeksLength); i++) {
-        str += '<td>0</td>';
+    // Fold any/all postseason entries into a single synthetic column.
+    const postEntries = weekly.filter(isPost);
+    let postseason = null;
+    if (postEntries.length) {
+        postseason = {
+            score: postEntries.reduce((s, w) => s + (w.score || 0), 0),
+            scoreByTeam: postEntries.flatMap(w => w.scoreByTeam || [])
+        };
     }
 
-    str += '<th class="sticky-header-score">' + (data.seasons.at(-1).cumulativeScore || 0) + '</th>';
-    str += '</tr>';
+    const columns = [];
+    for (let wk = 1; wk <= 16; wk++) columns.push(regularByWeek[wk] || null);
+    columns.push(postseason);   // Postseason column (null until it exists)
+    return columns;
+}
+
+function displayTeams(data) {
+    const userTableBody = document.querySelector('[user-table-body]');
+    const season = data.seasons.at(-1) || {};
+    const columns = weeklyColumns(season);
+    var str = '';
+
+    (season.teams || []).forEach(team => {
+        var totalScore = 0;
+        var cells = '';
+
+        columns.forEach(entry => {
+            // No entry -> week hasn't been played yet (blank, not a scored 0).
+            if (!entry) { cells += '<td class="cell-future"></td>'; return; }
+            const games = (entry.scoreByTeam || []).filter(o => o.team === team.school);
+            // Week was scored but this team had no game -> bye (muted dash).
+            if (!games.length) { cells += '<td class="cell-bye">–</td>'; return; }
+            const sum = games.reduce((s, g) => s + (g.score || 0), 0);
+            totalScore += sum;
+            cells += '<td>' + sum + '</td>';
+        });
+
+        const refLink = `/team?team=${team.id}`;
+        str += '<tr><th class="team-header sticky-header">'
+            + '<a href="' + refLink + '"><img src="' + team.logos.at(-1) + '" alt="' + escapeHtml(team.mascot) + '">'
+            + escapeHtml(team.school) + '</a></th>'
+            + cells
+            + '<th class="sticky-header-score">' + totalScore + '</th></tr>';
+    });
+
+    // Cumulative row: the whole-week total per column.
+    str += '<tr class="cumulative-row"><th class="team-header sticky-header">Cumulative Score</th>';
+    columns.forEach(entry => {
+        str += entry ? '<td>' + (entry.score || 0) + '</td>' : '<td class="cell-future"></td>';
+    });
+    str += '<th class="sticky-header-score">' + (season.cumulativeScore || 0) + '</th></tr>';
 
     userTableBody.innerHTML = str;
 }

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -56,7 +56,7 @@
                     </tr>
                     </thead>
                     <tbody user-table-body>
-                    <tbody>
+                    </tbody>
                 </table>
             </div>
         </div>
@@ -101,7 +101,7 @@
                 <table class="schedule-table">
                     <tbody schedule-body>
                         <div id="no-games-container"></div>
-                    <tbody>
+                    </tbody>
                 </table>
             </div>
         </div>


### PR DESCRIPTION
First PR of the profile-view rework — the **P0 correctness/layout bugs** from the audit. No new features; the franchise-name / avatar / onboarding work comes in follow-up PRs.

### Fixes
- **Postseason score in the wrong column.** Cells were rendered by `weeklyScore` array position, so a postseason bonus fell under whatever numeric column it happened to land in (and the real "Postseason" column showed 0). Now mapped to columns by week number, with a dedicated aggregated Postseason column.
- **Overloaded zeros.** Unplayed weeks now render blank and byes render a muted "–", instead of every empty cell showing `0`.
- **"Postseason" header clipped to "Po" / column hidden.** The frozen Team Score column detached over it. Widened the column; on desktop the score column now sits in normal flow (sticky only helps when the table actually scrolls, i.e. mobile).
- **Table clipped its last column.** It was stretched past its content (`min-width:100%`) inside a wrapper the flex-centered body had shrink-wrapped. Size the table to content and stretch `.content`; trim the over-wide week columns so the whole thing fits on desktop.
- **Malformed `<tbody>`** tags in the view.

### Verification
Rendered the table with mock data (played weeks, a bye, unplayed weeks, and a postseason entry) at desktop and mobile widths: postseason lands in its column (12/12/–/24), byes show "–", future weeks are blank, all 18 columns and the Team Score are visible on desktop, and the frozen Team/Score columns + horizontal scroll work on mobile. Full suite green (91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)