### PR TITLE
Profile identity: franchise names, avatars, and first-login onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,5 +27,5 @@ GMAIL_APP_PASSWORD=                  # Gmail app password (NOT your account pass
 # --- Cloudinary (profile picture uploads) ---
 # Both are PUBLIC (they ship to the browser for unsigned uploads), not secrets.
 # The upload preset must be created as "Unsigned" in the Cloudinary console.
-CLOUDINARY_CLOUD_NAME=               # e.g. loa85ael
+CLOUDINARY_CLOUD_NAME=               # e.g. dxxxxxxx (from your Cloudinary dashboard)
 CLOUDINARY_UPLOAD_PRESET=            # the unsigned upload preset name

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ INTERNAL_API_TOKEN=                  # long random string
 # --- Email (nodemailer / Gmail) ---
 GMAIL_USER=                          # sender Gmail address
 GMAIL_APP_PASSWORD=                  # Gmail app password (NOT your account password)
+
+# --- Cloudinary (profile picture uploads) ---
+# Both are PUBLIC (they ship to the browser for unsigned uploads), not secrets.
+# The upload preset must be created as "Unsigned" in the Cloudinary console.
+CLOUDINARY_CLOUD_NAME=               # e.g. loa85ael
+CLOUDINARY_UPLOAD_PRESET=            # the unsigned upload preset name

--- a/models/user.js
+++ b/models/user.js
@@ -147,6 +147,11 @@ const seasonSchema = new mongoose.Schema({
     season: {
         type: Number
     },
+    // The manager's custom franchise name for this season (e.g. "Garrett's
+    // Gridiron Gang"). Season-scoped so it can change year to year.
+    franchiseName: {
+        type: String
+    },
     draftPosition: {
         type: Number
     },
@@ -188,6 +193,17 @@ const userSchema = new mongoose.Schema({
     },
     lastUpdated: {
         type: String
+    },
+    // Profile picture: a Cloudinary delivery URL (validated server-side). Held
+    // at the account level since a person's photo doesn't change per season.
+    avatarUrl: {
+        type: String
+    },
+    // Set once the user has seen the "add a photo / name your team" onboarding
+    // prompt, so we only show it the first time after the feature launched.
+    profilePrompted: {
+        type: Boolean,
+        default: false
     },
 });
 

--- a/modules/profile-update.js
+++ b/modules/profile-update.js
@@ -1,0 +1,89 @@
+// Validation + config helpers for self-service profile edits (franchise name +
+// avatar). DB-free so it can be unit-tested; routes/users.js applies the result.
+
+const FRANCHISE_NAME_MAX = 40;
+
+// Cloudinary settings the browser needs for unsigned uploads. Both values are
+// public (they ship to the client), so they live in plain env vars, not secrets.
+function cloudinaryConfig() {
+    return {
+        cloudName: process.env.CLOUDINARY_CLOUD_NAME || '',
+        uploadPreset: process.env.CLOUDINARY_UPLOAD_PRESET || ''
+    };
+}
+
+// An avatar URL is only accepted if it's an https Cloudinary delivery URL for
+// OUR cloud. That stops an authenticated client from stashing an arbitrary
+// external/hotlinked URL (or a javascript:/data: payload) on their profile.
+function isValidAvatarUrl(url, cloudName) {
+    if (typeof url !== 'string' || !cloudName) return false;
+    let parsed;
+    try { parsed = new URL(url); } catch (e) { return false; }
+    if (parsed.protocol !== 'https:') return false;
+    if (parsed.hostname !== 'res.cloudinary.com') return false;
+    // Path is /<cloudName>/image/upload/...
+    return parsed.pathname.startsWith('/' + cloudName + '/');
+}
+
+// Removes ASCII control characters (0-31 and 127) from a string, keeping normal
+// printable text (letters, spaces, punctuation, accented/unicode chars).
+function stripControlChars(s) {
+    let out = '';
+    for (const ch of s) {
+        const code = ch.charCodeAt(0);
+        if (code >= 32 && code !== 127) out += ch;
+    }
+    return out;
+}
+
+// Normalizes a self-service profile update. Only fields actually present in the
+// body are returned, so a partial update (e.g. just the flag) leaves the rest
+// untouched. Throws Error(message) on invalid input -> the route maps to 400.
+// Passing an explicit empty string clears franchiseName/avatarUrl (set to null).
+function sanitizeProfileUpdate(body, cloudName) {
+    const b = body || {};
+    const out = {};
+
+    if (Object.prototype.hasOwnProperty.call(b, 'franchiseName')) {
+        const raw = b.franchiseName;
+        if (raw === null || raw === '') {
+            out.franchiseName = null;
+        } else if (typeof raw === 'string') {
+            // Collapse whitespace (incl. tabs/newlines) to single spaces first,
+            // THEN strip any remaining control chars, so a tab between words
+            // becomes a space rather than fusing the words together.
+            const name = stripControlChars(raw.replace(/\s+/g, ' ')).trim();
+            if (!name) {
+                out.franchiseName = null;
+            } else if (name.length > FRANCHISE_NAME_MAX) {
+                throw new Error(`Team name must be ${FRANCHISE_NAME_MAX} characters or fewer.`);
+            } else {
+                out.franchiseName = name;
+            }
+        } else {
+            throw new Error('Team name must be text.');
+        }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(b, 'avatarUrl')) {
+        const raw = b.avatarUrl;
+        if (raw === null || raw === '') {
+            out.avatarUrl = null;
+        } else if (isValidAvatarUrl(raw, cloudName)) {
+            out.avatarUrl = raw;
+        } else {
+            throw new Error('Avatar must be an uploaded image URL.');
+        }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(b, 'prompted')) {
+        out.prompted = !!b.prompted;
+    }
+
+    if (Object.keys(out).length === 0) {
+        throw new Error('Nothing to update.');
+    }
+    return out;
+}
+
+module.exports = { cloudinaryConfig, isValidAvatarUrl, sanitizeProfileUpdate, FRANCHISE_NAME_MAX };

--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -12,6 +12,7 @@ const season = (u) => (u && u.seasons && u.seasons[0]) || {};
 const weekly = (u) => season(u).weeklyScore || [];
 const cum = (u) => season(u).cumulativeScore || 0;
 const initialName = (u) => `${u.firstName} ${u.lastName ? u.lastName[0] : ''}.`;
+const franchiseName = (u) => season(u).franchiseName || null;
 // Cumulative points through the first `n` weekly entries (matches how the
 // season total is summed).
 const cumThrough = (u, n) => weekly(u).slice(0, n).reduce((s, w) => s + (w.score || 0), 0);
@@ -45,6 +46,7 @@ export function rankedRows(users) {
         rank: i + 1,
         id: u._id,
         name: initialName(u),
+        franchise: franchiseName(u),
         teams: season(u).teams || [],
         score: cum(u),
         gap: i === 0 ? 0 : leader - cum(u),
@@ -71,7 +73,7 @@ export function buildStandingsRowsHtml(rows) {
             : (r.gap === 0 ? '<span class="gap">Tied</span>' : `<span class="gap">-${r.gap} back</span>`);
         return `<tr class="standings-row${medal}">
             <th class="sticky-header rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</th>
-            <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${crown}${escapeHtml(r.name)}</a></th>
+            <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${crown}${escapeHtml(r.franchise || r.name)}${r.franchise ? `<span class="std-manager">${escapeHtml(r.name)}</span>` : ''}</a></th>
             <td class="team-item"><div class="team-logos">${logos}</div></td>
             <th class="sticky-header-score"><span class="score-num" data-count="${r.score}">${r.score}</span><br>${gap}</th>
         </tr>`;

--- a/public/standings.css
+++ b/public/standings.css
@@ -490,3 +490,17 @@
 .chart-mode-toggle button:first-child { border-radius: 8px 0 0 8px; }
 .chart-mode-toggle button:last-child { border-radius: 0 8px 8px 0; border-left: none; }
 .chart-mode-toggle button.active { background: #8E8CF0; color: #fff; border-color: #8E8CF0; }
+
+/* ---------- First-login profile onboarding modal ---------- */
+.welcome-backdrop { position: fixed; inset: 0; background: rgba(8,10,20,0.72); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 1em; }
+.welcome-backdrop[hidden] { display: none; }
+.welcome-card { background: #1A1F33; border: 1px solid #2A2E42; border-radius: 14px; padding: 2em 1.75em; width: 100%; max-width: 400px; text-align: center; box-shadow: 0 12px 40px rgba(0,0,0,0.5); }
+.welcome-emoji { font-size: 2.5rem; margin-bottom: 0.25em; }
+.welcome-card h2 { font-size: 1.4rem; color: #F4F6FB; margin: 0 0 0.5em; }
+.welcome-card p { font-size: 0.92rem; color: #A4A9C2; line-height: 1.5; margin: 0 0 1.5em; }
+.welcome-actions { display: flex; justify-content: center; gap: 0.75em; }
+.welcome-actions button { font: inherit; font-size: 0.9rem; border-radius: 8px; padding: 9px 18px; cursor: pointer; border: 1px solid transparent; }
+.welcome-actions .btn-primary { background: #8E8CF0; color: #fff; border-color: #8E8CF0; }
+.welcome-actions .btn-primary:hover { background: #7d7be8; }
+.welcome-actions .btn-ghost { background: transparent; color: #A4A9C2; }
+.welcome-actions .btn-ghost:hover { color: #F4F6FB; }

--- a/public/standings.css
+++ b/public/standings.css
@@ -492,7 +492,7 @@
 .chart-mode-toggle button.active { background: #8E8CF0; color: #fff; border-color: #8E8CF0; }
 
 /* ---------- First-login profile onboarding modal ---------- */
-.welcome-backdrop { position: fixed; inset: 0; background: rgba(8,10,20,0.72); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 1em; }
+.welcome-backdrop { position: fixed; inset: 0; background: rgba(10,12,24,0.55); -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 1em; }
 .welcome-backdrop[hidden] { display: none; }
 .welcome-card { background: #1A1F33; border: 1px solid #2A2E42; border-radius: 14px; padding: 2em 1.75em; width: 100%; max-width: 400px; text-align: center; box-shadow: 0 12px 40px rgba(0,0,0,0.5); }
 .welcome-emoji { font-size: 2.5rem; margin-bottom: 0.25em; }

--- a/public/standings.css
+++ b/public/standings.css
@@ -402,6 +402,8 @@
 .gap { display: inline-block; font-size: 0.68rem; color: #767D9C; font-weight: 400; }
 .gap.leader { color: #5BD08D; }
 .score-num { font-weight: 700; }
+/* Manager's name under a custom franchise name in the ranked table. */
+.name-cell .std-manager { display: block; font-size: 0.68rem; font-weight: 400; color: #767D9C; line-height: 1.1; }
 
 /* Team logos: keep the cell a real table cell so it fills the row height and
    vertical-align:middle applies; the logos live in an inner flex row. A

--- a/public/standings.js
+++ b/public/standings.js
@@ -137,6 +137,7 @@ async function getUsers() {
                 }
             }
             displayUsers(data);
+            maybePromptProfileSetup(data);
             displayLastUpdated(data);
             displayHighlights(data);
             loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
@@ -210,6 +211,38 @@ async function loadAdvancedHighlights(league, season) {
 function displayHighlights(users) {
     const container = document.querySelector('.highlights-container');
     if (container) container.innerHTML = buildHighlightsHtml(buildHighlights(users));
+}
+
+// First-login nudge: if the logged-in manager hasn't been prompted yet, invite
+// them to name their team + add a photo. Either choice marks them prompted so
+// it never shows again; "Set up" sends them to their profile with the editor
+// auto-opened.
+function maybePromptProfileSetup(data) {
+    try {
+        const myId = (userState.user_metadata.metadata.userId) || window.localStorage.getItem('userId');
+        if (!myId) return;
+        const me = data.find(u => String(u._id) === String(myId));
+        if (!me || me.profilePrompted) return;
+        const modal = document.querySelector('[welcome-modal]');
+        if (!modal || modal.dataset.wired) return;
+        modal.dataset.wired = '1';
+
+        const dismiss = async (navigate) => {
+            modal.hidden = true;
+            try {
+                await fetch('/users/me/profile', {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ prompted: true })
+                });
+            } catch (e) { /* non-blocking */ }
+            if (navigate) window.location.href = `/userHome?user=${myId}&setup=1`;
+        };
+
+        modal.querySelector('[welcome-later]').addEventListener('click', () => dismiss(false));
+        modal.querySelector('[welcome-setup]').addEventListener('click', () => dismiss(true));
+        modal.hidden = false;
+    } catch (e) { /* onboarding is best-effort */ }
 }
 
 // Toggles the "+N" tie popover on the Top Single Game card. Wired once via

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -116,6 +116,9 @@
         color: #A4A9C2;
         padding-left: 1em;
         align-content: center;
+        /* Keep the spread together (e.g. "-1.5") so it never breaks between
+           the sign and the number when the team column gets tight. */
+        white-space: nowrap;
     }
 
     .hr-subtle {

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -86,6 +86,9 @@
     /* Unplayed weeks read as blank (not a scored 0); byes as a muted dash. */
     td.cell-bye { color: #4A4F68; }
 
+    /* Season standouts: best single team-game and best weekly total. */
+    td.cell-best { color: #F2C14E; font-weight: 700; }
+
     /* Set the cumulative row apart from the per-team rows. */
     .cumulative-row td, .cumulative-row th { border-top: 2px solid #2A2E42; font-weight: 600; }
 
@@ -356,3 +359,8 @@
         margin-right: auto;
     }
 }
+
+/* ---------- Season Progress chart ---------- */
+.profile-chart-section { width: 95%; max-width: 900px; margin: 1.5em auto 0; }
+.profile-chart-section .header { justify-content: flex-start; }
+.profile-chart-wrap { position: relative; height: 260px; width: 100%; padding: 0 10px 1em; box-sizing: border-box; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -367,8 +367,29 @@
 
 /* ---------- Games schedule: responsive card grid ---------- */
 .schedule-grid { display: flex; flex-wrap: wrap; gap: 1em; justify-content: center; padding: 1em; width: 100%; box-sizing: border-box; }
-.game-card { flex: 0 1 340px; max-width: 100%; }
-.game-card .game-table { width: 100%; display: table; margin: 0; }
+/* The card itself is the rounded, clipped container; the inner table is made
+   transparent/borderless so its square corners can't poke a triangular notch
+   through the rounded border (a table doesn't clip to border-radius on its own). */
+.game-card {
+    flex: 0 1 340px;
+    max-width: 100%;
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 10px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    padding: 1em;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+.game-card .game-table {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+}
 .game-card .gc-team { text-align: left; }
 .game-card .gc-divider { width: 1px; border-left: 1px solid #A4A9C2; }
 .game-card .gc-score { text-align: right; white-space: nowrap; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -271,3 +271,69 @@
         height: 2rem;
     }
 }
+/* ---------- Profile hero + edit modal ---------- */
+.profile-hero {
+    display: flex;
+    align-items: center;
+    gap: 1.25em;
+    width: 95%;
+    max-width: 900px;
+    margin: 1.5em auto 0.5em;
+    padding: 1.25em 1.5em;
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 14px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    box-sizing: border-box;
+}
+.profile-meta { flex: 1; min-width: 0; }
+.franchise-name { font-size: 1.6rem; font-weight: 700; color: #F4F6FB; margin: 0; line-height: 1.15; word-break: break-word; }
+.manager-name { font-size: 0.9rem; color: #A4A9C2; margin: 2px 0 0; }
+.profile-stats { display: flex; flex-wrap: wrap; gap: 1.5em; margin-top: 0.9em; }
+.profile-stats .stat { display: flex; flex-direction: column; }
+.profile-stats .stat .stat-value { font-size: 1.25rem; font-weight: 700; color: #F4F6FB; display: flex; align-items: center; gap: 6px; }
+.profile-stats .stat .stat-value img { height: 1.2rem; width: auto; }
+.profile-stats .stat .stat-label { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.06em; color: #767D9C; margin-top: 2px; }
+
+/* Avatar: image or colored initials */
+.avatar { border-radius: 50%; display: flex; align-items: center; justify-content: center; overflow: hidden; flex-shrink: 0; font-weight: 700; color: #fff; background-size: cover; background-position: center; }
+.avatar img { width: 100%; height: 100%; object-fit: cover; }
+.avatar-lg { width: 88px; height: 88px; font-size: 2rem; }
+.avatar-md { width: 72px; height: 72px; font-size: 1.6rem; }
+
+.edit-profile-btn { align-self: flex-start; background: #2A2E42; color: #C9CEE6; border: 1px solid #3A3F58; border-radius: 20px; padding: 6px 14px; font: inherit; font-size: 0.82rem; cursor: pointer; white-space: nowrap; }
+.edit-profile-btn:hover { background: #343954; color: #F4F6FB; }
+
+/* Edit modal */
+.modal-backdrop { position: fixed; inset: 0; background: rgba(8,10,20,0.72); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 1em; }
+.modal-backdrop[hidden] { display: none; }
+.profile-modal-card { background: #1A1F33; border: 1px solid #2A2E42; border-radius: 14px; padding: 1.5em; width: 100%; max-width: 420px; box-shadow: 0 12px 40px rgba(0,0,0,0.5); }
+.profile-modal-card h2 { font-size: 1.3rem; margin: 0 0 1em; color: #F4F6FB; }
+.field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 1.25em; }
+.field span { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.06em; color: #A4A9C2; }
+.field input { background: #101322; border: 1px solid #3A3F58; border-radius: 8px; padding: 10px 12px; color: #F4F6FB; font: inherit; }
+.field input:focus { outline: none; border-color: #8E8CF0; }
+.avatar-edit { display: flex; align-items: center; gap: 1em; margin-bottom: 1em; }
+.avatar-edit-controls { display: flex; flex-direction: column; gap: 6px; }
+.upload-status { font-size: 0.75rem; color: #767D9C; }
+.modal-error { color: #ED5858; font-size: 0.82rem; margin: 0 0 0.75em; }
+.modal-error[hidden] { display: none; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 0.75em; }
+.btn-primary, .btn-secondary, .btn-ghost { font: inherit; font-size: 0.9rem; border-radius: 8px; padding: 8px 16px; cursor: pointer; border: 1px solid transparent; }
+.btn-primary { background: #8E8CF0; color: #fff; border-color: #8E8CF0; }
+.btn-primary:hover { background: #7d7be8; }
+.btn-primary:disabled { opacity: 0.5; cursor: default; }
+.btn-secondary { background: #2A2E42; color: #C9CEE6; border-color: #3A3F58; }
+.btn-secondary:hover { background: #343954; }
+.btn-ghost { background: transparent; color: #A4A9C2; }
+.btn-ghost:hover { color: #F4F6FB; }
+
+@media only screen and (max-width: 40em) {
+    .profile-hero { flex-direction: column; align-items: center; text-align: center; gap: 0.75em; }
+    .avatar-lg { width: 72px; height: 72px; font-size: 1.6rem; }
+    .franchise-name { font-size: 1.35rem; }
+    .profile-stats { justify-content: center; gap: 1.25em; margin-top: 0.5em; }
+    .profile-stats .stat { align-items: center; }
+    .profile-stats .stat .stat-value { justify-content: center; }
+    .edit-profile-btn { order: 4; align-self: center; }
+}

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -342,15 +342,17 @@
     .edit-profile-btn { order: 4; align-self: center; }
 }
 
-/* Desktop hero alignment — placed after the base .profile-hero rule so it wins
-   on cascade order. Left-align the hero with the table below it: the table
-   content starts at the centered wrapper's left inset (get-users-container 2.5%
-   + table-wrapper 20px margin), so match that and opt out of the body's
-   centering, instead of the hero floating centered over a left-aligned table. */
+/* Desktop layout: center the content column so the hero and the (roughly
+   fixed-width) weekly table sit balanced in the viewport rather than hugging
+   the left with a lonely right gutter. The hero centers via its base margin
+   auto; shrink the table wrapper to the table's width and center it too, so
+   both are symmetric about the middle. Placed after the base rules so it wins
+   on cascade order. */
 @media only screen and (min-width: 64em) {
-    .profile-hero {
-        align-self: flex-start;
-        margin-left: calc(2.5% + 20px);
-        margin-right: 0;
+    .table-wrapper {
+        width: fit-content;
+        max-width: 100%;
+        margin-left: auto;
+        margin-right: auto;
     }
 }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -392,4 +392,8 @@
 }
 .game-card .gc-team { text-align: left; }
 .game-card .gc-divider { width: 1px; border-left: 1px solid #A4A9C2; }
-.game-card .gc-score { text-align: right; white-space: nowrap; }
+/* Left-align the score so the numbers line up at the same x on both rows
+   (the winner row trails a caret + points badge, which would otherwise push
+   its number out of line under right-alignment). */
+.game-card .gc-score { text-align: left; white-space: nowrap; padding-left: 0.9em; width: 1%; }
+.game-card .score-added { white-space: nowrap; padding-left: 0.5em; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -364,3 +364,11 @@
 .profile-chart-section { width: 95%; max-width: 900px; margin: 1.5em auto 0; }
 .profile-chart-section .header { justify-content: flex-start; }
 .profile-chart-wrap { position: relative; height: 260px; width: 100%; padding: 0 10px 1em; box-sizing: border-box; }
+
+/* ---------- Games schedule: responsive card grid ---------- */
+.schedule-grid { display: flex; flex-wrap: wrap; gap: 1em; justify-content: center; padding: 1em; width: 100%; box-sizing: border-box; }
+.game-card { flex: 0 1 340px; max-width: 100%; }
+.game-card .game-table { width: 100%; display: table; margin: 0; }
+.game-card .gc-team { text-align: left; }
+.game-card .gc-divider { width: 1px; border-left: 1px solid #A4A9C2; }
+.game-card .gc-score { text-align: right; white-space: nowrap; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -341,3 +341,16 @@
     .profile-stats .stat .stat-value { justify-content: center; }
     .edit-profile-btn { order: 4; align-self: center; }
 }
+
+/* Desktop hero alignment — placed after the base .profile-hero rule so it wins
+   on cascade order. Left-align the hero with the table below it: the table
+   content starts at the centered wrapper's left inset (get-users-container 2.5%
+   + table-wrapper 20px margin), so match that and opt out of the body's
+   centering, instead of the hero floating centered over a left-aligned table. */
+@media only screen and (min-width: 64em) {
+    .profile-hero {
+        align-self: flex-start;
+        margin-left: calc(2.5% + 20px);
+        margin-right: 0;
+    }
+}

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -305,7 +305,11 @@
 .edit-profile-btn:hover { background: #343954; color: #F4F6FB; }
 
 /* Edit modal */
-.modal-backdrop { position: fixed; inset: 0; background: rgba(8,10,20,0.72); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 1em; }
+/* Keep a file input reachable by a programmatic .click() (display:none inputs
+   don't reliably open the picker) while hiding it visually. */
+.visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); border: 0; opacity: 0; }
+
+.modal-backdrop { position: fixed; inset: 0; background: rgba(10,12,24,0.55); -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 1em; }
 .modal-backdrop[hidden] { display: none; }
 .profile-modal-card { background: #1A1F33; border: 1px solid #2A2E42; border-radius: 14px; padding: 1.5em; width: 100%; max-width: 420px; box-shadow: 0 12px 40px rgba(0,0,0,0.5); }
 .profile-modal-card h2 { font-size: 1.3rem; margin: 0 0 1em; color: #F4F6FB; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -267,6 +267,9 @@ function setupEditModal(data, season) {
 
     btn.addEventListener('click', open);
     cancelBtn.addEventListener('click', close);
+
+    // Arriving from the first-login onboarding nudge opens the editor straight away.
+    if (new URLSearchParams(window.location.search).get('setup') === '1') open();
     modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
     document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !modal.hidden) close(); });
 

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -94,7 +94,7 @@ if ($(".dropdown-menu-week")) {
         window.localStorage.setItem("weekCode", selectedWeekCode);
 
         document.querySelector('.football-loader').style.display = "flex";
-        document.querySelector('.schedule-table').style.display = "none";
+        document.querySelector('[schedule-body]').style.display = "none";
         displaySchedule(userData);
     });
 }
@@ -115,8 +115,29 @@ async function getUser() {
         renderHero(data[0]);
         displayTeams(data[0]);
         renderProfileChart(data[0]);
+        ensureWeekSelected(data[0]);
         displaySchedule(data[0]);
     });
+}
+
+// The Games week defaults to the latest played week when nothing is stored,
+// so the dropdown never shows the literal "Week X" placeholder (and
+// displaySchedule never reads a null weekCode) on a fresh visit.
+function ensureWeekSelected(data) {
+    if (window.localStorage.getItem('weekCode') && window.localStorage.getItem('week')) return;
+    const weekly = (data.seasons.at(-1) || {}).weeklyScore || [];
+    let maxWeek = 0, hasPost = false;
+    weekly.forEach(w => {
+        if (w.season === 'postseason' || w.week > 16) hasPost = true;
+        else if (w.week > maxWeek) maxWeek = w.week;
+    });
+    let code = 'week-1', label = 'Week 1';
+    if (hasPost) { code = 'week-17'; label = 'Postseason'; }
+    else if (maxWeek > 0) { code = 'week-' + maxWeek; label = 'Week ' + maxWeek; }
+    window.localStorage.setItem('weekCode', code);
+    window.localStorage.setItem('week', label);
+    weekCode = code;
+    $('#dropdownMenuButtonWeek').text(label);
 }
 // ---------- Profile hero ----------
 
@@ -610,10 +631,36 @@ function teamGameScoreById(weeklyScore, teamId, gameId) {
     return 0;
 }
 
+// Fetch every team logo the week's games need in ONE request, returning a
+// { teamId: <img html> } map. Replaces the old per-game POST to
+// /teams/teamLogos (one round-trip per game); missing teams fall back to the
+// helmet icon at lookup time.
+async function batchTeamLogos(games) {
+    const ids = [...new Set((games || []).flatMap(g => [g.awayId, g.homeId]))];
+    const map = {};
+    if (!ids.length) return map;
+    try {
+        const res = await fetch('/teams/teamLogos', {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ teams: ids })
+        });
+        if (res.status === 200) {
+            (await res.json()).forEach(t => {
+                if (t && t.logos && t.logos.length) map[t.id] = '<img src="' + t.logos.at(-1) + '" style="padding-right: 5px;">';
+            });
+        }
+    } catch (e) { /* fall back to helmet icons */ }
+    return map;
+}
+function logoHtmlFromMap(map, teamId) {
+    return map[teamId] || '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
+}
+
 async function displaySchedule(data) {
     const scheduleContainer = document.querySelector('[schedule-body]');
     const leagueCode = window.localStorage.getItem("leagueCode");
-    var str = '<tr>';
+    var str = '';
     var gameIds = [];
     var gameTables = [];
 
@@ -639,9 +686,16 @@ async function displaySchedule(data) {
 
     var allBettingLines = await getAllBettingLines(seasonYear) || [];
 
-    for (var iterNum = 0; iterNum < data.seasons.at(-1).teams.length; iterNum++) {
+    // Fetch each roster team's games in parallel (was a sequential await per
+    // team), then fetch all logos in a single batched request up front — the
+    // schedule used to make one /teams/teamLogos round-trip per game.
+    const teamsList = data.seasons.at(-1).teams;
+    const gamesPerTeam = await Promise.all(teamsList.map(t => getGame(seasonType, week, t)));
+    const logoMap = await batchTeamLogos(gamesPerTeam.flat());
 
-        var gamesInfo = await getGame(seasonType, week, data.seasons.at(-1).teams[iterNum]);
+    for (var iterNum = 0; iterNum < teamsList.length; iterNum++) {
+
+        var gamesInfo = gamesPerTeam[iterNum];
 
         for (const [i, game] of gamesInfo.entries()) {
 
@@ -683,9 +737,8 @@ async function displaySchedule(data) {
                 var awayTeam = '';
                 var homeTeam = '';
                 var isAway = false;
-                var teamLogos = await getTeamLogos(game);
-                var awayImg = teamLogos.awayTeamLogo;
-                var homeImg = teamLogos.homeTeamLogo;
+                var awayImg = logoHtmlFromMap(logoMap, game.awayId);
+                var homeImg = logoHtmlFromMap(logoMap, game.homeId);
 
                 if (game.awayId == data.seasons.at(-1).teams[iterNum].id) {
 
@@ -756,20 +809,20 @@ async function displaySchedule(data) {
                     bottomData = standardTime;
                 }
     
-                var teamTable = '<td><table class="schedule-table game-table"><tbody><tr></tr><tr><td style="width: 250px;">';
+                var teamTable = '<div class="game-card"><table class="game-table"><tbody><tr></tr><tr><td class="gc-team">';
 
                 var awayLineHtml = `<span class="betting-line">${awayLine ? '-' + awayLine : ''}</span>`;
                 var homeLineHtml = `<span class="betting-line">${homeLine ? '-' + homeLine : ''}</span>`;
     
                 teamTable += awayImg + awayRank + awayTeam + awayLineHtml;
-                teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 70px;">' + topData;
-                teamTable += '</tr><tr><td style="width: 250px;">';
+                teamTable += '</td><td class="gc-divider"></td><td class="gc-score">' + topData;
+                teamTable += '</tr><tr><td class="gc-team">';
     
                 teamTable += homeImg + homeRank + homeTeam + homeLineHtml;
-                teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
+                teamTable += '</td><td class="gc-divider"></td><td class="gc-score">' + bottomData;
                 teamTable += `</tr><tr><td class="game-notes">`;
                 teamTable += game.notes || '';
-                teamTable += '</td></tr></tbody></table></td>';
+                teamTable += '</td></tr></tbody></table></div>';
     
                 var gameInfo = {
                     id: game.id,
@@ -855,23 +908,22 @@ async function displaySchedule(data) {
                     }
                     
 
-                    var teamLogos = await getTeamLogos(game);
-                    var awayImg = teamLogos.awayTeamLogo;
-                    var homeImg = teamLogos.homeTeamLogo;
+                    var awayImg = logoHtmlFromMap(logoMap, game.awayId);
+                    var homeImg = logoHtmlFromMap(logoMap, game.homeId);
                     var awayLineHtml = `<span class="betting-line">${awayLine ? '-' + awayLine : ''}</span>`;
                     var homeLineHtml = `<span class="betting-line">${homeLine ? '-' + homeLine : ''}</span>`;
 
-                    var teamTable = '<td><table class="schedule-table game-table"><tbody><tr></tr><tr><td style="width: 250px;">';
+                    var teamTable = '<div class="game-card"><table class="game-table"><tbody><tr></tr><tr><td class="gc-team">';
     
                     teamTable += awayImg + awayRank + awayTeam + awayLineHtml;
-                    teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 70px;">' + topData;
-                    teamTable += '</tr><tr><td style="width: 250px;">';
+                    teamTable += '</td><td class="gc-divider"></td><td class="gc-score">' + topData;
+                    teamTable += '</tr><tr><td class="gc-team">';
         
                     teamTable += homeImg + homeRank + homeTeam + homeLineHtml;
-                    teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
+                    teamTable += '</td><td class="gc-divider"></td><td class="gc-score">' + bottomData;
                     teamTable += `</tr><tr><td class="game-notes">`;
                     teamTable += game.notes || '';
-                    teamTable += '</td></tr></tbody></table></td>';
+                    teamTable += '</td></tr></tbody></table></div>';
         
                     var gameInfo = {
                         id: game.id,
@@ -895,23 +947,10 @@ async function displaySchedule(data) {
         return new Date(a.startDate) - new Date(b.startDate);
     });
 
-    for(var k = 0; k < gameTables.length; k++) {
-        if (isMobile) {
-            str += '</tr><tr>';
-        }
-        
-        if ((k + 1) > gameTables.length) {
-            str += '</td></tr>'
-        }
-        else if (((k) % 3 == 0) && (k > 0)) {
-            str += '</tr><tr>';
-        }
-
+    // Cards flow into a responsive flex grid (CSS wraps them by width), so no
+    // more manual row breaks or userAgent-based one-per-row handling.
+    for (var k = 0; k < gameTables.length; k++) {
         str += gameTables[k].table;
-
-        if (isMobile) {
-            str += '</tr><tr>';
-        }
     }
 
     if (gameTables.length == 0) {
@@ -920,7 +959,7 @@ async function displaySchedule(data) {
 
     scheduleContainer.innerHTML = str;
     document.querySelector('.football-loader').style.display = "none";
-    document.querySelector('.schedule-table').style.display = "flex";
+    document.querySelector('[schedule-body]').style.display = "flex";
 }
 
 if ($("[league-selector]")) {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -114,6 +114,7 @@ async function getUser() {
         userData = data[0];
         renderHero(data[0]);
         displayTeams(data[0]);
+        renderProfileChart(data[0]);
         displaySchedule(data[0]);
     });
 }
@@ -323,17 +324,19 @@ function setupEditModal(data, season) {
     });
 }
 
-// Column model for the weekly table: regular weeks 1-16 keyed by week number,
-// plus one aggregated Postseason column. Building columns by week (rather than
-// by array position) keeps each score under its correct header even when weeks
-// are missing or a postseason entry is present — the old positional rendering
-// dropped the postseason bonus into whatever column index it happened to land.
+// Column model for the weekly table. Each entry is mapped to its real week
+// (regular weeks by number, postseason folded into one column) rather than by
+// array position, so scores never land under the wrong header. Only weeks that
+// have actually been played are included (plus Postseason once it exists), so
+// the table isn't padded out with a wall of empty future columns — which also
+// keeps it far narrower on mobile.
 function weeklyColumns(season) {
     const weekly = (season && season.weeklyScore) || [];
     const isPost = (w) => w.season === 'postseason' || w.week > 16;
 
     const regularByWeek = {};
-    weekly.forEach(w => { if (!isPost(w)) regularByWeek[w.week] = w; });
+    let maxWeek = 0;
+    weekly.forEach(w => { if (!isPost(w)) { regularByWeek[w.week] = w; if (w.week > maxWeek) maxWeek = w.week; } });
 
     // Fold any/all postseason entries into a single synthetic column.
     const postEntries = weekly.filter(isPost);
@@ -346,48 +349,118 @@ function weeklyColumns(season) {
     }
 
     const columns = [];
-    for (let wk = 1; wk <= 16; wk++) columns.push(regularByWeek[wk] || null);
-    columns.push(postseason);   // Postseason column (null until it exists)
+    for (let wk = 1; wk <= maxWeek; wk++) {
+        columns.push({ label: String(wk), ariaLabel: 'Week ' + wk, entry: regularByWeek[wk] || null });
+    }
+    if (postseason) columns.push({ label: 'Post&shy;season', ariaLabel: 'Postseason', entry: postseason });
     return columns;
 }
 
+// The points a team banked in one column (bye / not yet played -> null).
+function columnTeamScore(entry, teamSchool) {
+    if (!entry) return null;
+    const games = (entry.scoreByTeam || []).filter(o => o.team === teamSchool);
+    if (!games.length) return null;
+    return games.reduce((s, g) => s + (g.score || 0), 0);
+}
+
 function displayTeams(data) {
-    const userTableBody = document.querySelector('[user-table-body]');
+    const head = document.querySelector('[user-table-head]');
+    const body = document.querySelector('[user-table-body]');
     const season = data.seasons.at(-1) || {};
+    const teams = season.teams || [];
     const columns = weeklyColumns(season);
-    var str = '';
 
-    (season.teams || []).forEach(team => {
-        var totalScore = 0;
-        var cells = '';
+    // Header (generated so it always matches the columns actually shown, and so
+    // the week numbers carry an accessible "Week N" label for screen readers).
+    let headHtml = '<tr><th class="sticky-header team-header" scope="col">Team</th>';
+    columns.forEach(c => {
+        headHtml += `<th class="team-header" scope="col" aria-label="${c.ariaLabel}">${c.label}</th>`;
+    });
+    headHtml += '<th class="sticky-header-score team-header" scope="col">Team Score</th></tr>';
+    if (head) head.innerHTML = headHtml;
 
-        columns.forEach(entry => {
-            // No entry -> week hasn't been played yet (blank, not a scored 0).
-            if (!entry) { cells += '<td class="cell-future"></td>'; return; }
-            const games = (entry.scoreByTeam || []).filter(o => o.team === team.school);
-            // Week was scored but this team had no game -> bye (muted dash).
-            if (!games.length) { cells += '<td class="cell-bye">–</td>'; return; }
-            const sum = games.reduce((s, g) => s + (g.score || 0), 0);
-            totalScore += sum;
-            cells += '<td>' + sum + '</td>';
+    // Highlight the season's best single team-game and best week (top weekly
+    // total) — the standout cells, tie-inclusive.
+    let bestGame = 0;
+    teams.forEach(t => columns.forEach(c => { const s = columnTeamScore(c.entry, t.school); if (s != null && s > bestGame) bestGame = s; }));
+    let bestWeek = 0;
+    columns.forEach(c => { if (c.entry && (c.entry.score || 0) > bestWeek) bestWeek = c.entry.score || 0; });
+
+    let str = '';
+    teams.forEach(team => {
+        let totalScore = 0;
+        let cells = '';
+        columns.forEach(c => {
+            const s = columnTeamScore(c.entry, team.school);
+            if (!c.entry) { cells += '<td class="cell-future"></td>'; return; }   // week not played yet
+            if (s == null) { cells += '<td class="cell-bye">–</td>'; return; }    // bye / no game
+            totalScore += s;
+            const best = (s === bestGame && s > 0) ? ' cell-best' : '';
+            cells += `<td class="${best}">${s}</td>`;
         });
-
         const refLink = `/team?team=${team.id}`;
-        str += '<tr><th class="team-header sticky-header">'
+        str += '<tr><th class="team-header sticky-header" scope="row">'
             + '<a href="' + refLink + '"><img src="' + team.logos.at(-1) + '" alt="' + escapeHtml(team.mascot) + '">'
             + escapeHtml(team.school) + '</a></th>'
             + cells
             + '<th class="sticky-header-score">' + totalScore + '</th></tr>';
     });
 
-    // Cumulative row: the whole-week total per column.
-    str += '<tr class="cumulative-row"><th class="team-header sticky-header">Cumulative Score</th>';
-    columns.forEach(entry => {
-        str += entry ? '<td>' + (entry.score || 0) + '</td>' : '<td class="cell-future"></td>';
+    // Cumulative row: the whole-week total per column, best week highlighted.
+    str += '<tr class="cumulative-row"><th class="team-header sticky-header" scope="row">Cumulative Score</th>';
+    columns.forEach(c => {
+        if (!c.entry) { str += '<td class="cell-future"></td>'; return; }
+        const v = c.entry.score || 0;
+        const best = (v === bestWeek && v > 0) ? ' cell-best' : '';
+        str += `<td class="${best}">${v}</td>`;
     });
     str += '<th class="sticky-header-score">' + (season.cumulativeScore || 0) + '</th></tr>';
 
-    userTableBody.innerHTML = str;
+    body.innerHTML = str;
+}
+
+// Cumulative-points-over-the-season line chart for this manager. Hidden until
+// there are at least two scored weeks (a single point isn't a trend).
+let profileChart = null;
+function renderProfileChart(data) {
+    const section = document.querySelector('[profile-chart-section]');
+    const canvas = document.getElementById('profile-chart');
+    if (!section || !canvas || typeof Chart === 'undefined') return;
+
+    const season = data.seasons.at(-1) || {};
+    const cols = weeklyColumns(season);
+    let cum = 0;
+    const labels = [], points = [];
+    cols.forEach(c => {
+        if (!c.entry) return;   // skip any unplayed gap
+        cum += c.entry.score || 0;
+        labels.push(c.ariaLabel === 'Postseason' ? 'Post' : c.ariaLabel.replace('Week', 'Wk'));
+        points.push(cum);
+    });
+
+    if (points.length < 2) { section.hidden = true; return; }
+    section.hidden = false;
+    if (profileChart) profileChart.destroy();
+    profileChart = new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: {
+            labels,
+            datasets: [{
+                label: 'Cumulative points', data: points,
+                borderColor: '#8E8CF0', backgroundColor: 'rgba(142,140,240,0.15)',
+                fill: true, tension: 0.3, pointRadius: 3, pointBackgroundColor: '#8E8CF0'
+            }]
+        },
+        options: {
+            responsive: true, maintainAspectRatio: false,
+            plugins: { legend: { display: false }, tooltip: { intersect: false, mode: 'index' } },
+            scales: {
+                x: { grid: { color: '#2A2E42' }, ticks: { color: '#A4A9C2' } },
+                y: { beginAtZero: true, grid: { color: '#2A2E42' }, ticks: { color: '#A4A9C2' } }
+            }
+        }
+    });
 }
 
 async function getGame(season, week, team) {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -112,15 +112,213 @@ async function getUser() {
 
     response.json().then(async data => {
         userData = data[0];
-        changeHeader(data[0]);
+        renderHero(data[0]);
         displayTeams(data[0]);
         displaySchedule(data[0]);
     });
 }
-function changeHeader(data) {
-    var pageHeader = data.firstName + ' ' + data.lastName;
-    document.getElementsByClassName('header-title')[0].innerText = pageHeader;
+// ---------- Profile hero ----------
 
+function ordinal(n) {
+    const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+function initials(data) {
+    return (((data.firstName || '')[0] || '') + ((data.lastName || '')[0] || '')).toUpperCase();
+}
+
+// Stable color for the initials avatar: the user's stored color if any, else a
+// hue hashed from their name so each manager gets a consistent shade.
+function colorFor(data) {
+    if (data.color) return data.color;
+    const s = (data.firstName || '') + (data.lastName || '');
+    let h = 0;
+    for (const c of s) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+    return `hsl(${h % 360}, 45%, 45%)`;
+}
+
+// Deliver the avatar as a face-centered 256px square (Cloudinary transformation
+// inserted into the stored delivery URL).
+function cloudinaryAvatar(url) {
+    if (typeof url === 'string' && url.indexOf('/upload/') !== -1) {
+        return url.replace('/upload/', '/upload/c_fill,g_face,w_256,h_256,q_auto,f_auto/');
+    }
+    return url;
+}
+
+function renderAvatar(el, data) {
+    if (!el) return;
+    el.innerHTML = '';
+    if (data.avatarUrl) {
+        const img = document.createElement('img');
+        img.src = cloudinaryAvatar(data.avatarUrl);
+        img.alt = '';
+        el.style.background = 'transparent';
+        el.appendChild(img);
+    } else {
+        el.textContent = initials(data) || '?';
+        el.style.background = colorFor(data);
+    }
+}
+
+// Highest-scoring team on the roster this season (summed from scoreByTeam).
+function bestTeam(season) {
+    const weekly = season.weeklyScore || [];
+    let best = null;
+    (season.teams || []).forEach(t => {
+        let total = 0;
+        weekly.forEach(w => (w.scoreByTeam || []).forEach(st => { if (st.team === t.school) total += (st.score || 0); }));
+        if (!best || total > best.total) best = { team: t, total };
+    });
+    return best;
+}
+
+// League rank for the profile user, by current-season cumulative score.
+async function computeRank(data) {
+    try {
+        if (!data.league) return null;
+        const res = await fetch(`/users/league/${data.league}`, { headers: { 'Accept': 'application/json' } });
+        if (!res.ok) return null;
+        const users = await res.json();
+        const ranked = users
+            .map(u => ({ id: u._id, score: (u.seasons && u.seasons[0] && u.seasons[0].cumulativeScore) || 0 }))
+            .sort((a, b) => b.score - a.score);
+        const idx = ranked.findIndex(r => r.id === data._id);
+        return idx < 0 ? null : { rank: idx + 1, total: ranked.length };
+    } catch (e) { return null; }
+}
+
+function statTile(valueHtml, label) {
+    return `<div class="stat"><span class="stat-value">${valueHtml}</span><span class="stat-label">${escapeHtml(label)}</span></div>`;
+}
+
+// The logged-in user's own id (from the Auth0 session), used to decide whether
+// to show the Edit control.
+function currentUserId() {
+    try { return (userState.user_metadata.metadata.userId) || window.localStorage.getItem('userId'); }
+    catch (e) { return window.localStorage.getItem('userId'); }
+}
+
+async function renderHero(data) {
+    const season = data.seasons.at(-1) || {};
+    const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
+    const franchise = season.franchiseName;
+
+    document.querySelector('[profile-franchise]').textContent = franchise || `${data.firstName || 'Unnamed'}'s Team`;
+    document.querySelector('[profile-manager]').textContent = franchise ? `Managed by ${manager}` : manager;
+    document.title = `${franchise || manager} · Campus Clash`;
+    renderAvatar(document.querySelector('[profile-avatar]'), data);
+
+    const statsEl = document.querySelector('[profile-stats]');
+    let html = '';
+    const rank = await computeRank(data);
+    if (rank) html += statTile(escapeHtml(ordinal(rank.rank)), `of ${rank.total} teams`);
+    html += statTile(String(season.cumulativeScore || 0), 'Total points');
+    const bt = bestTeam(season);
+    if (bt && bt.total > 0) {
+        html += statTile(`<img src="${bt.team.logos.at(-1)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
+    }
+    statsEl.innerHTML = html;
+
+    // Edit is only offered on the viewer's own profile (the endpoint enforces
+    // this too, from the session).
+    if (currentUserId() && String(currentUserId()) === String(data._id)) {
+        setupEditModal(data, season);
+    }
+}
+
+// ---------- Edit modal (franchise name + avatar upload) ----------
+
+function setupEditModal(data, season) {
+    const btn = document.querySelector('[edit-profile-btn]');
+    const modal = document.querySelector('[profile-modal]');
+    const nameInput = document.querySelector('[profile-name-input]');
+    const modalAvatar = document.querySelector('[profile-modal-avatar]');
+    const fileInput = document.querySelector('[profile-file-input]');
+    const uploadBtn = document.querySelector('[profile-upload-btn]');
+    const status = document.querySelector('[profile-upload-status]');
+    const errorEl = document.querySelector('[profile-modal-error]');
+    const saveBtn = document.querySelector('[profile-save-btn]');
+    const cancelBtn = document.querySelector('[profile-cancel-btn]');
+    if (!btn || !modal || btn.dataset.wired) return;
+    btn.dataset.wired = '1';
+    btn.hidden = false;
+
+    let pendingAvatar; // undefined = unchanged; string/null = new value to save
+
+    const cloudinaryReady = !!(CLOUDINARY && CLOUDINARY.cloudName && CLOUDINARY.uploadPreset);
+    if (!cloudinaryReady) {
+        uploadBtn.disabled = true;
+        status.textContent = 'Photo upload unavailable';
+    }
+
+    function showError(msg) { errorEl.textContent = msg; errorEl.hidden = !msg; }
+
+    function open() {
+        pendingAvatar = undefined;
+        nameInput.value = season.franchiseName || '';
+        renderAvatar(modalAvatar, data);
+        status.textContent = '';
+        showError('');
+        modal.hidden = false;
+    }
+    function close() { modal.hidden = true; }
+
+    btn.addEventListener('click', open);
+    cancelBtn.addEventListener('click', close);
+    modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !modal.hidden) close(); });
+
+    uploadBtn.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', async () => {
+        const file = fileInput.files && fileInput.files[0];
+        if (!file) return;
+        showError('');
+        status.textContent = 'Uploading…';
+        uploadBtn.disabled = true;
+        try {
+            const form = new FormData();
+            form.append('file', file);
+            form.append('upload_preset', CLOUDINARY.uploadPreset);
+            const res = await fetch(`https://api.cloudinary.com/v1_1/${CLOUDINARY.cloudName}/image/upload`, { method: 'POST', body: form });
+            if (!res.ok) throw new Error('Upload failed');
+            const out = await res.json();
+            pendingAvatar = out.secure_url;
+            renderAvatar(modalAvatar, { avatarUrl: pendingAvatar });
+            status.textContent = 'Photo ready — click Save';
+        } catch (e) {
+            status.textContent = '';
+            showError('Upload failed. Try a different image.');
+        } finally {
+            uploadBtn.disabled = !cloudinaryReady;
+            fileInput.value = '';
+        }
+    });
+
+    saveBtn.addEventListener('click', async () => {
+        showError('');
+        saveBtn.disabled = true;
+        const body = { franchiseName: nameInput.value };
+        if (pendingAvatar !== undefined) body.avatarUrl = pendingAvatar;
+        try {
+            const res = await fetch('/users/me/profile', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            const out = await res.json();
+            if (!res.ok) throw new Error(out.message || 'Save failed');
+            data.avatarUrl = out.avatarUrl;
+            season.franchiseName = out.franchiseName;
+            renderHero(data);
+            close();
+        } catch (e) {
+            showError(e.message || 'Save failed.');
+        } finally {
+            saveBtn.disabled = false;
+        }
+    });
 }
 
 // Column model for the weekly table: regular weeks 1-16 keyed by week number,

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -679,7 +679,7 @@ async function displaySchedule(data) {
 
                 var topData = '';
                 var bottomData = '';
-                var scoreAdded = '<strong style="color: white;">+0<strong>';
+                var scoreAdded = '<strong style="color: white;">+0</strong>';
                 var awayTeam = '';
                 var homeTeam = '';
                 var isAway = false;
@@ -707,11 +707,11 @@ async function displaySchedule(data) {
     
                     if( game.awayPoints > game.homePoints ) {
                         if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
-                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '</strong>';
                         }
 
                         if (isBowlParticipant(game) && (leagueCode == "claunts-league")) {
-                            scoreAdded = '<strong style="color: #22C37A;">+4<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+4</strong>';
                             topData = (game.awayPoints || '0') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>';
                             bottomData = (game.homePoints || '0') + '<td class="score-added">' + scoreAdded + '</td>';
                         } else {
@@ -721,14 +721,14 @@ async function displaySchedule(data) {
                     } else if (game.homePoints > game.awayPoints) {
     
                         if(!isAway) {
-                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '</strong>';
                         }
 
                         topData = (game.awayPoints || '0');
                         bottomData = (game.homePoints || '0')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                     } else {
                         if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
-                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                            scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '</strong>';
                         }
                         topData = (game.awayPoints || '0');
                         bottomData = (game.homePoints || '0');
@@ -769,7 +769,7 @@ async function displaySchedule(data) {
                 teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                 teamTable += `</tr><tr><td class="game-notes">`;
                 teamTable += game.notes || '';
-                teamTable += '</td></tr><tbody></table></td>';
+                teamTable += '</td></tr></tbody></table></td>';
     
                 var gameInfo = {
                     id: game.id,
@@ -804,8 +804,8 @@ async function displaySchedule(data) {
         
                         if (game.seasonType == "postseason" && game.notes && game.notes.toLowerCase().includes("playoff")) {
                             shouldReplace = true;
-                            awayScoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
-                            homeScoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
+                            awayScoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '</strong>';
+                            homeScoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '</strong>';
 
                             if (game.awayPoints > game.homePoints) {
                                 topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';
@@ -818,7 +818,7 @@ async function displaySchedule(data) {
                         } else if ( game.awayPoints > game.homePoints ) {
                             if(game.awayId == data.seasons.at(-1).teams[iterNum].id) {
                                 shouldReplace = true;
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '</strong>';
                             }
                             topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             bottomData = (game.homePoints || '-');
@@ -826,7 +826,7 @@ async function displaySchedule(data) {
 
                             if(game.homeId == data.seasons.at(-1).teams[iterNum].id) {
                                 shouldReplace = true;
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
+                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '</strong>';
                             }
         
                             topData = (game.awayPoints || '-');
@@ -871,7 +871,7 @@ async function displaySchedule(data) {
                     teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                     teamTable += `</tr><tr><td class="game-notes">`;
                     teamTable += game.notes || '';
-                    teamTable += '</td></tr><tbody></table></td>';
+                    teamTable += '</td></tr></tbody></table></td>';
         
                     var gameInfo = {
                         id: game.id,

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -248,10 +248,6 @@ function setupEditModal(data, season) {
     let pendingAvatar; // undefined = unchanged; string/null = new value to save
 
     const cloudinaryReady = !!(CLOUDINARY && CLOUDINARY.cloudName && CLOUDINARY.uploadPreset);
-    if (!cloudinaryReady) {
-        uploadBtn.disabled = true;
-        status.textContent = 'Photo upload unavailable';
-    }
 
     function showError(msg) { errorEl.textContent = msg; errorEl.hidden = !msg; }
 
@@ -259,8 +255,11 @@ function setupEditModal(data, season) {
         pendingAvatar = undefined;
         nameInput.value = season.franchiseName || '';
         renderAvatar(modalAvatar, data);
-        status.textContent = '';
         showError('');
+        // Set the upload control's state every open so a missing Cloudinary
+        // config surfaces a persistent reason rather than a silently-dead button.
+        uploadBtn.disabled = !cloudinaryReady;
+        status.textContent = cloudinaryReady ? '' : 'Photo upload unavailable';
         modal.hidden = false;
     }
     function close() { modal.hidden = true; }

--- a/routes/users.js
+++ b/routes/users.js
@@ -91,7 +91,7 @@ router.get('/league/:leagueCodeReq', async (req, res) => {
     try {
         console.log("finding all users in league", leagueCode);
         const users = await User.find({"seasons.season": {"$eq": process.env.YEAR}, "league": leagueCode},
-                    {"firstName": 1, "lastName": 1, "email": 1, "league": 1, "lastUpdated": 1, "color": 1, "seasons": {"$elemMatch": {"season": {"$eq": process.env.YEAR}}}});
+                    {"firstName": 1, "lastName": 1, "email": 1, "league": 1, "lastUpdated": 1, "color": 1, "avatarUrl": 1, "profilePrompted": 1, "seasons": {"$elemMatch": {"season": {"$eq": process.env.YEAR}}}});
         res.json(users);
     } catch (err) {
         res.status(500).json({message: err.message});

--- a/routes/users.js
+++ b/routes/users.js
@@ -2,6 +2,55 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
 const scoring = require('../modules/scoring');
+const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
+
+// Self-service profile edit: a signed-in user updates THEIR OWN franchise name
+// / avatar / onboarding flag. The identity comes from the Auth0 session (never
+// from the client), so a user can only edit their own record. This route is
+// exempted from the commissioner gate in server.js precisely because it's
+// self-scoped. franchiseName is stored on the current season; the rest are
+// account-level.
+router.patch('/me/profile', async (req, res) => {
+    const oidcUser = req.oidc && req.oidc.user;
+    const meta = oidcUser && oidcUser.user_metadata && oidcUser.user_metadata.metadata;
+    const userId = meta && meta.userId;
+    if (!userId) {
+        return res.status(401).json({ message: 'No profile in session.' });
+    }
+
+    let clean;
+    try {
+        clean = sanitizeProfileUpdate(req.body, cloudinaryConfig().cloudName);
+    } catch (err) {
+        return res.status(400).json({ message: err.message });
+    }
+
+    try {
+        const user = await User.findById(userId);
+        if (!user) return res.status(404).json({ message: 'User not found.' });
+
+        if (clean.avatarUrl !== undefined) user.avatarUrl = clean.avatarUrl;
+        if (clean.prompted !== undefined) user.profilePrompted = clean.prompted;
+
+        if (clean.franchiseName !== undefined) {
+            const year = Number(process.env.YEAR);
+            const season = (user.seasons || []).find(s => Number(s.season) === year)
+                || (user.seasons && user.seasons[user.seasons.length - 1]);
+            if (season) season.franchiseName = clean.franchiseName;
+        }
+
+        await user.save();
+        const current = (user.seasons || []).find(s => Number(s.season) === Number(process.env.YEAR))
+            || (user.seasons && user.seasons[user.seasons.length - 1]);
+        res.json({
+            avatarUrl: user.avatarUrl || null,
+            profilePrompted: user.profilePrompted,
+            franchiseName: (current && current.franchiseName) || null
+        });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
 
 //Getting All
 router.get('/', async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const ScoringConfig = require('./models/scoringConfig');
 const { resolveConfig, fieldsForModel } = require('./modules/scoring-defaults');
 const draftToken = require('./modules/draft-token');
 const registerDraftSockets = require('./modules/draft-socket');
+const { cloudinaryConfig } = require('./modules/profile-update');
 
 // Serializes an object to JSON that is safe to embed inside an inline <script>
 // tag. Escapes the characters that could break out of the script context
@@ -195,7 +196,7 @@ app.get('/userHome', async function(req, res) {
         const user = buildUserContext(req.oidc.user);
         const userState = safeJson(req.oidc.user);
 
-        res.render('userHome', {user, userState});
+        res.render('userHome', {user, userState, cloudinary: cloudinaryConfig()});
     } else {
         res.redirect("/login");
     }
@@ -225,6 +226,9 @@ app.use('/teams', (req, res, next) => {
 });
 app.use(['/users', '/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/draft', '/scoring-config', '/job-runs'], (req, res, next) => {
     if (req.method === 'GET') return next();
+    // Self-service profile edit is scoped to the caller's own record (identity
+    // comes from the session in the handler), so it doesn't need commissioner.
+    if (req.method === 'PATCH' && req.path === '/me/profile') return next();
     return requireCommissioner(req, res, next);
 });
 

--- a/tests/ProfileUpdate.spec.js
+++ b/tests/ProfileUpdate.spec.js
@@ -1,0 +1,60 @@
+const { sanitizeProfileUpdate, isValidAvatarUrl, FRANCHISE_NAME_MAX } = require('../modules/profile-update');
+
+const CLOUD = 'loa85ael';
+
+describe('isValidAvatarUrl', () => {
+    it('accepts an https Cloudinary URL for our cloud', () => {
+        expect(isValidAvatarUrl(`https://res.cloudinary.com/${CLOUD}/image/upload/v1/campus-clash/avatars/x.jpg`, CLOUD)).toBe(true);
+    });
+    it('rejects other hosts, other clouds, non-https, and junk', () => {
+        expect(isValidAvatarUrl(`http://res.cloudinary.com/${CLOUD}/x.jpg`, CLOUD)).toBe(false);   // not https
+        expect(isValidAvatarUrl('https://evil.example.com/x.jpg', CLOUD)).toBe(false);              // wrong host
+        expect(isValidAvatarUrl('https://res.cloudinary.com/someoneelse/x.jpg', CLOUD)).toBe(false);// wrong cloud
+        expect(isValidAvatarUrl('javascript:alert(1)', CLOUD)).toBe(false);
+        expect(isValidAvatarUrl('not a url', CLOUD)).toBe(false);
+        expect(isValidAvatarUrl(null, CLOUD)).toBe(false);
+    });
+    it('rejects everything when no cloud is configured', () => {
+        expect(isValidAvatarUrl(`https://res.cloudinary.com/${CLOUD}/x.jpg`, '')).toBe(false);
+    });
+});
+
+describe('sanitizeProfileUpdate', () => {
+    it('keeps a normal franchise name with spaces and punctuation', () => {
+        expect(sanitizeProfileUpdate({ franchiseName: "Garrett's Gridiron Gang" }, CLOUD))
+            .toEqual({ franchiseName: "Garrett's Gridiron Gang" });
+    });
+    it('trims, collapses whitespace, and strips control chars', () => {
+        expect(sanitizeProfileUpdate({ franchiseName: '  The\t\tBig   Dogs ' }, CLOUD))
+            .toEqual({ franchiseName: 'The Big Dogs' });
+    });
+    it('treats blank/whitespace-only name as a clear (null)', () => {
+        expect(sanitizeProfileUpdate({ franchiseName: '   ' }, CLOUD)).toEqual({ franchiseName: null });
+        expect(sanitizeProfileUpdate({ franchiseName: '' }, CLOUD)).toEqual({ franchiseName: null });
+        expect(sanitizeProfileUpdate({ franchiseName: null }, CLOUD)).toEqual({ franchiseName: null });
+    });
+    it('rejects an over-long name', () => {
+        expect(() => sanitizeProfileUpdate({ franchiseName: 'x'.repeat(FRANCHISE_NAME_MAX + 1) }, CLOUD)).toThrow(/characters or fewer/);
+    });
+    it('rejects a non-string name', () => {
+        expect(() => sanitizeProfileUpdate({ franchiseName: 123 }, CLOUD)).toThrow(/must be text/);
+    });
+    it('accepts a valid avatar URL and rejects an invalid one', () => {
+        const good = `https://res.cloudinary.com/${CLOUD}/image/upload/v1/a.jpg`;
+        expect(sanitizeProfileUpdate({ avatarUrl: good }, CLOUD)).toEqual({ avatarUrl: good });
+        expect(() => sanitizeProfileUpdate({ avatarUrl: 'https://evil.com/x.jpg' }, CLOUD)).toThrow(/uploaded image URL/);
+    });
+    it('clears the avatar with empty string / null', () => {
+        expect(sanitizeProfileUpdate({ avatarUrl: '' }, CLOUD)).toEqual({ avatarUrl: null });
+    });
+    it('coerces prompted to a boolean', () => {
+        expect(sanitizeProfileUpdate({ prompted: 1 }, CLOUD)).toEqual({ prompted: true });
+        expect(sanitizeProfileUpdate({ prompted: false }, CLOUD)).toEqual({ prompted: false });
+    });
+    it('returns only the fields present (partial update)', () => {
+        expect(sanitizeProfileUpdate({ prompted: true }, CLOUD)).toEqual({ prompted: true });
+    });
+    it('throws when there is nothing to update', () => {
+        expect(() => sanitizeProfileUpdate({}, CLOUD)).toThrow(/Nothing to update/);
+    });
+});

--- a/tests/ProfileUpdate.spec.js
+++ b/tests/ProfileUpdate.spec.js
@@ -1,10 +1,10 @@
 const { sanitizeProfileUpdate, isValidAvatarUrl, FRANCHISE_NAME_MAX } = require('../modules/profile-update');
 
-const CLOUD = 'loa85ael';
+const CLOUD = 'testcloud';
 
 describe('isValidAvatarUrl', () => {
     it('accepts an https Cloudinary URL for our cloud', () => {
-        expect(isValidAvatarUrl(`https://res.cloudinary.com/${CLOUD}/image/upload/v1/campus-clash/avatars/x.jpg`, CLOUD)).toBe(true);
+        expect(isValidAvatarUrl(`https://res.cloudinary.com/${CLOUD}/image/upload/v1/avatars/x.jpg`, CLOUD)).toBe(true);
     });
     it('rejects other hosts, other clouds, non-https, and junk', () => {
         expect(isValidAvatarUrl(`http://res.cloudinary.com/${CLOUD}/x.jpg`, CLOUD)).toBe(false);   // not https

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -30,6 +30,18 @@
         </script>
     <% } %>
 
+    <div class="welcome-backdrop" welcome-modal hidden>
+        <div class="welcome-card" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
+            <div class="welcome-emoji">🏈</div>
+            <h2 id="welcome-title">Make it yours</h2>
+            <p>New this season: give your team a name and add a profile photo so you stand out in the standings.</p>
+            <div class="welcome-actions">
+                <button type="button" class="btn-ghost" welcome-later>Maybe later</button>
+                <button type="button" class="btn-primary" welcome-setup>Set up my profile</button>
+            </div>
+        </div>
+    </div>
+
     <div class="header">
         <div class="header-title">
             Standings

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -24,9 +24,43 @@
             var userState = <%- userState %>;
         </script>
     <% } %>
+    <script>
+        var CLOUDINARY = <%- JSON.stringify(cloudinary || { cloudName: '', uploadPreset: '' }) %>;
+    </script>
 
-    <div class="header">
-        <div class="header-title" poll-name></div>
+    <div class="profile-hero" profile-hero>
+        <div class="avatar avatar-lg" profile-avatar></div>
+        <div class="profile-meta">
+            <h1 class="franchise-name" profile-franchise></h1>
+            <p class="manager-name" profile-manager></p>
+            <div class="profile-stats" profile-stats></div>
+        </div>
+        <button type="button" class="edit-profile-btn" edit-profile-btn hidden>
+            <i class="fa-solid fa-pen"></i> Edit profile
+        </button>
+    </div>
+
+    <div class="modal-backdrop" profile-modal hidden>
+        <div class="profile-modal-card" role="dialog" aria-modal="true" aria-labelledby="profile-modal-title">
+            <h2 id="profile-modal-title">Edit your profile</h2>
+            <label class="field">
+                <span>Team name</span>
+                <input type="text" profile-name-input maxlength="40" placeholder="Name your team">
+            </label>
+            <div class="avatar-edit">
+                <div class="avatar avatar-md" profile-modal-avatar></div>
+                <div class="avatar-edit-controls">
+                    <input type="file" accept="image/png,image/jpeg,image/webp,image/gif" profile-file-input hidden>
+                    <button type="button" class="btn-secondary" profile-upload-btn>Upload photo</button>
+                    <span class="upload-status" profile-upload-status></span>
+                </div>
+            </div>
+            <p class="modal-error" profile-modal-error hidden></p>
+            <div class="modal-actions">
+                <button type="button" class="btn-ghost" profile-cancel-btn>Cancel</button>
+                <button type="button" class="btn-primary" profile-save-btn>Save</button>
+            </div>
+        </div>
     </div>
     <div class="content">
         <div class="get-users-container" get-users-container>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -50,7 +50,7 @@
             <div class="avatar-edit">
                 <div class="avatar avatar-md" profile-modal-avatar></div>
                 <div class="avatar-edit-controls">
-                    <input type="file" accept="image/png,image/jpeg,image/webp,image/gif" profile-file-input hidden>
+                    <input type="file" accept="image/png,image/jpeg,image/webp,image/gif" profile-file-input class="visually-hidden">
                     <button type="button" class="btn-secondary" profile-upload-btn>Upload photo</button>
                     <span class="upload-status" profile-upload-status></span>
                 </div>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -10,7 +10,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
     <script defer src="userHome.js"></script>
     <title>Campus Clash</title>
@@ -66,34 +67,16 @@
         <div class="get-users-container" get-users-container>
             <div class="table-wrapper">
                 <table class="fl-table">
-                    <thead>
-                    <tr>
-                        <th class="sticky-header team-header">Team</th>
-                        <th class="team-header">1</th>
-                        <th class="team-header">2</th>
-                        <th class="team-header">3</th>
-                        <th class="team-header">4</th>
-                        <th class="team-header">5</th>
-                        <th class="team-header">6</th>
-                        <th class="team-header">7</th>
-                        <th class="team-header">8</th>
-                        <th class="team-header">9</th>
-                        <th class="team-header">10</th>
-                        <th class="team-header">11</th>
-                        <th class="team-header">12</th>
-                        <th class="team-header">13</th>
-                        <th class="team-header">14</th>
-                        <th class="team-header">15</th>
-                        <th class="team-header">16</th>
-                        <th class="team-header">Post&shy;season</th>
-                        <th class="sticky-header-score team-header">Team Score</th>
-                    </tr>
-                    </thead>
+                    <thead user-table-head></thead>
                     <tbody user-table-body>
                     </tbody>
                 </table>
             </div>
         </div>
+    </div>
+    <div class="profile-chart-section" profile-chart-section hidden>
+        <div class="header"><div class="header-title">Season Progress</div></div>
+        <div class="profile-chart-wrap"><canvas id="profile-chart"></canvas></div>
     </div>
     <hr class="hr-subtle">
     <div class="header">

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -115,11 +115,9 @@
         </div>
         <div class="get-users-container">
             <div class="schedule-wrapper" schedule-container>
-                <table class="schedule-table">
-                    <tbody schedule-body>
-                        <div id="no-games-container"></div>
-                    </tbody>
-                </table>
+                <div class="schedule-grid" schedule-body>
+                    <div id="no-games-container"></div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adds the two requested profile features and the first-login prompt for them. Builds on the merged table fixes (#191).

## What's new
- **Franchise names** (per season). Managers can name their team; it shows as the primary label in the Standings ranked table (with their real name as a muted sub-line), in the profile hero, and the page title. Falls back to the person's name when unset.
- **Profile pictures** via Cloudinary (unsigned upload). Upload/replace from the edit modal; delivered face-cropped. Falls back to colored initials.
- **Profile hero** on `/userHome`: avatar + franchise name + "Managed by …" + stat tiles (league rank, total points, best team) + an Edit control (own profile only).
- **First-login onboarding**: a one-time welcome modal on the Standings landing page nudges managers to name their team and add a photo; "Set up" opens the profile editor, "Maybe later" dismisses — either way they're marked prompted so it never repeats.

## Backend
- Model: `season.franchiseName`, account-level `user.avatarUrl` + `user.profilePrompted`.
- `PATCH /users/me/profile`: self-scoped (identity from the Auth0 session, not the client); exempted from the commissioner gate accordingly.
- `modules/profile-update.js` (13 unit tests): validates the update; avatar URLs are only accepted if they're https Cloudinary URLs for our cloud (blocks arbitrary/hotlinked/`javascript:` URLs).

## Config
Requires two Cloudinary env vars — set them locally (`.env`) and on Heroku. See `.env.example` for the keys:
```
CLOUDINARY_CLOUD_NAME=<your cloud name>
CLOUDINARY_UPLOAD_PRESET=<your unsigned upload preset>
```

## Verification
- Unit tests: 104 green (13 new for the validator).
- Auth boundary confirmed via curl: no session → 401; token but no session → 401; other `/users` writes still 403.
- Mock-data harnesses (desktop + mobile): profile hero render, rank/best-team stats, own-profile gating, name-edit + save round-trip, Standings franchise + manager sub-line, and the onboarding modal.
- **Not yet exercised against real Cloudinary** (harnesses stubbed the upload) — worth one manual upload test with a live session before/after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)