### PR TITLE
Standings: desktop density + row identity (avatar, single name)

### DIFF
--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -47,11 +47,35 @@ export function rankedRows(users) {
         id: u._id,
         name: initialName(u),
         franchise: franchiseName(u),
+        avatarUrl: u.avatarUrl || null,
+        initials: (((u.firstName || '')[0] || '') + ((u.lastName || '')[0] || '')).toUpperCase(),
+        color: u.color || avatarColor(u),
         teams: season(u).teams || [],
         score: cum(u),
         gap: i === 0 ? 0 : leader - cum(u),
         delta: (prevRankById && prevRankById[u._id] != null) ? (prevRankById[u._id] - i) : null
     }));
+}
+
+// Stable fallback color for the initials avatar when a user has no stored
+// color (hue hashed from the name so each manager gets a consistent shade).
+const avatarColor = (u) => {
+    const s = (u.firstName || '') + (u.lastName || '');
+    let h = 0;
+    for (const c of s) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+    return `hsl(${h % 360}, 45%, 45%)`;
+};
+
+// Small round avatar for a ranked row: the uploaded photo (face-cropped) or a
+// colored initials fallback.
+function stdAvatarHtml(r) {
+    if (r.avatarUrl) {
+        const src = r.avatarUrl.indexOf('/upload/') !== -1
+            ? r.avatarUrl.replace('/upload/', '/upload/c_fill,g_face,w_48,h_48,q_auto,f_auto/')
+            : r.avatarUrl;
+        return `<span class="std-avatar"><img src="${src}" alt=""></span>`;
+    }
+    return `<span class="std-avatar std-avatar-initials" style="background:${r.color}">${escapeHtml(r.initials || '?')}</span>`;
 }
 
 function movementHtml(delta) {
@@ -73,7 +97,7 @@ export function buildStandingsRowsHtml(rows) {
             : (r.gap === 0 ? '<span class="gap">Tied</span>' : `<span class="gap">-${r.gap} back</span>`);
         return `<tr class="standings-row${medal}">
             <th class="sticky-header rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</th>
-            <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${crown}${escapeHtml(r.franchise || r.name)}${r.franchise ? `<span class="std-manager">${escapeHtml(r.name)}</span>` : ''}</a></th>
+            <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${crown}${stdAvatarHtml(r)}<span class="std-name">${escapeHtml(r.franchise || r.name)}</span></a></th>
             <td class="team-item"><div class="team-logos">${logos}</div></td>
             <th class="sticky-header-score"><span class="score-num" data-count="${r.score}">${r.score}</span><br>${gap}</th>
         </tr>`;

--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -88,7 +88,6 @@ function movementHtml(delta) {
 export function buildStandingsRowsHtml(rows) {
     return rows.map(r => {
         const medal = r.rank <= 3 ? ` medal-${r.rank}` : '';
-        const crown = r.rank === 1 ? '<span class="crown" aria-label="Leader">👑</span> ' : '';
         const logos = r.teams.map(t =>
             `<a href="/team?team=${t.id}"><img src="${t.logos.at(-1)}" alt="${escapeHtml(t.mascot)}"></a>`
         ).join('');
@@ -97,7 +96,7 @@ export function buildStandingsRowsHtml(rows) {
             : (r.gap === 0 ? '<span class="gap">Tied</span>' : `<span class="gap">-${r.gap} back</span>`);
         return `<tr class="standings-row${medal}">
             <th class="sticky-header rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</th>
-            <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${crown}${stdAvatarHtml(r)}<span class="std-name">${escapeHtml(r.franchise || r.name)}</span></a></th>
+            <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${stdAvatarHtml(r)}<span class="std-name">${escapeHtml(r.franchise || r.name)}</span></a></th>
             <td class="team-item"><div class="team-logos">${logos}</div></td>
             <th class="sticky-header-score"><span class="score-num" data-count="${r.score}">${r.score}</span><br>${gap}</th>
         </tr>`;

--- a/public/standings.css
+++ b/public/standings.css
@@ -310,8 +310,8 @@
     }
 
     .header-title {
-        font-size: 3.4rem;
-        padding: 35px 35px 35px 0px;
+        font-size: 2.6rem;
+        padding: 20px 20px 20px 0px;
     }
 
     .last-updated {
@@ -321,7 +321,18 @@
 
     .fl-table {
         font-size: 1em;
-        line-height: 4em;
+        /* was 4em — rows were ~64px tall, which felt oversized on laptop/iPad
+           where this breakpoint kicks in at 1024px. */
+        line-height: 2.6em;
+    }
+
+    /* Cap + center the main content so it doesn't sprawl edge-to-edge on wide
+       screens (the table container is width:100%); gives comfortable margins
+       on laptops/large monitors. */
+    .table-wrapper {
+        max-width: 1200px;
+        margin-left: auto;
+        margin-right: auto;
     }
 
     .team-item {
@@ -329,7 +340,7 @@
     }
 
     .team-item img {
-        height: 35px !important;
+        height: 28px !important;
     }
 
     .highlights-container {
@@ -338,6 +349,9 @@
         gap: 2em;
         padding: 2em;
         width: 95%;
+        max-width: 1200px;
+        margin-left: auto;
+        margin-right: auto;
     }
 
     .highlight-title {
@@ -345,7 +359,7 @@
     }
 
     .highlights-header {
-        font-size: 3.4rem;
+        font-size: 2.6rem;
     }
 
     .highlight-info span{

--- a/public/standings.css
+++ b/public/standings.css
@@ -417,7 +417,12 @@
 .gap.leader { color: #5BD08D; }
 .score-num { font-weight: 700; }
 /* Manager's name under a custom franchise name in the ranked table. */
-.name-cell .std-manager { display: block; font-size: 0.68rem; font-weight: 400; color: #767D9C; line-height: 1.1; }
+/* Ranked-row identity: round avatar (photo or colored initials) + name. */
+.name-cell a { display: inline-flex; align-items: center; gap: 8px; }
+.std-avatar { width: 26px; height: 26px; border-radius: 50%; overflow: hidden; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
+.std-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.std-avatar-initials { font-size: 0.62rem; font-weight: 700; color: #fff; }
+.std-name { white-space: nowrap; }
 
 /* Team logos: keep the cell a real table cell so it fills the row height and
    vertical-align:middle applies; the logos live in an inner flex row. A

--- a/public/standings.css
+++ b/public/standings.css
@@ -420,7 +420,9 @@
 /* Ranked-row identity: round avatar (photo or colored initials) + name. */
 .name-cell a { display: inline-flex; align-items: center; gap: 8px; }
 .std-avatar { width: 26px; height: 26px; border-radius: 50%; overflow: hidden; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
-.std-avatar img { width: 100%; height: 100%; object-fit: cover; }
+/* Specific enough to beat the global `.fl-table tbody img { height:… }` rule,
+   which was shrinking the photo so it didn't fill its circle. */
+.name-cell .std-avatar img { width: 100%; height: 100%; object-fit: cover; margin: 0; }
 .std-avatar-initials { font-size: 0.62rem; font-weight: 700; color: #fff; }
 .std-name { white-space: nowrap; }
 


### PR DESCRIPTION
Standings polish, in two parts.

## Desktop sizing (iPad Pro / laptop)
The `min-width: 64em` breakpoint kicks in at 1024px and jumped straight to big-monitor sizing, so the page looked oversized with little edge room.
- Table rows: `line-height` 4em → 2.6em (rows were ~64px per line).
- Titles: `.header-title` and `.highlights-header` 3.4rem → 2.6rem (+ less padding).
- Team logos: 35px → 28px.
- Cap the table wrapper + highlights at `max-width: 1200px`, centered — no more edge-to-edge sprawl on wide screens.

## Ranked-row identity
- **Drop the manager sub-line** — show just the franchise name when set, otherwise the person's name (was showing both).
- **Add the manager's profile pic** to each row: the uploaded photo (face-cropped) or a colored-initials fallback. Uses `avatarUrl`/`color` already present in the `/users/league` payload.

## Verification (live app)
- 1024 (iPad Pro) + 1440 (laptop): six rows + highlights fit comfortably; wide screens get ~120px side margins.
- Ranked rows: Heartbreak Hogs shows its Cloudinary photo + "Heartbreak Hogs" (no sub-line); other managers show initials avatars + their names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)