### PR TITLE
Animations (3/3): draft room pick reveal, on-the-clock pulse, ticker

### DIFF
--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -340,6 +340,58 @@
     border-radius: 4px;
 }
 
+/* ==================================================================== */
+/* Draft-room animations. Entrance/urgency effects gated behind         */
+/* prefers-reduced-motion:no-preference (the ticker's loop-scroll is    */
+/* also disabled in JS when reduced). Confetti on your own pick is      */
+/* fired from draftRoom.js (also reduced-motion aware).                 */
+/* ==================================================================== */
+@media (prefers-reduced-motion: no-preference) {
+    /* A freshly drafted logo flips + pops onto the board */
+    .draft-board-cell.just-picked img { animation: dr-pick-reveal .55s cubic-bezier(.2, 1.3, .3, 1) both; }
+
+    /* The active pick cell pulses so the eye finds it */
+    .on-clock-cell { animation: dr-cell-pulse 1.4s ease-in-out infinite; }
+
+    /* When it's YOUR turn, the whole banner pulses with urgency */
+    .on-the-clock.your-turn { animation: dr-clock-pulse 1.1s ease-in-out infinite; }
+
+    /* Recent-picks ticker loop-scroll (class added in JS only when it overflows) */
+    .pick-ticker-track.scroll { animation: dr-ticker 22s linear infinite; padding-left: 100%; }
+}
+
+@keyframes dr-pick-reveal { 0% { opacity: 0; transform: rotateY(90deg) scale(.6); } 60% { opacity: 1; transform: rotateY(0) scale(1.14); } 100% { transform: scale(1); } }
+@keyframes dr-cell-pulse { 0%, 100% { box-shadow: inset 0 0 0 2px #ed5858; } 50% { box-shadow: inset 0 0 0 2px #ed5858, 0 0 12px rgba(237, 88, 88, .6); } }
+@keyframes dr-clock-pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(113, 210, 141, .4); } 50% { box-shadow: 0 0 0 6px rgba(113, 210, 141, 0); } }
+@keyframes dr-ticker { to { transform: translateX(-100%); } }
+
+/* Recent-picks ticker */
+.pick-ticker {
+    overflow: hidden;
+    margin-bottom: 14px;
+    padding: 7px 0;
+    background: #141829;
+    border: 1px solid #2A2E42;
+    border-radius: 10px;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+}
+.pick-ticker:empty { display: none; }
+.pick-ticker-track { display: inline-flex; gap: 8px; white-space: nowrap; }
+.pick-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 999px;
+    padding: 4px 11px;
+    font-size: 0.82em;
+    color: #F4F6FB;
+}
+.pick-chip img { width: 18px; height: 18px; object-fit: contain; }
+.pick-chip .pk { color: #ed5858; font-weight: 700; }
+
 /* Draft action buttons in the team list */
 .draft-pick-btn {
     background-color: #71d28d;

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -14,6 +14,11 @@ var leagueVersion = 'V2';
 var season = new Date().getFullYear();
 var isMobile = false;
 var countdownTimer;
+var justPickedKey = null;    // "userId-round" of the pick to animate in once
+
+function ccReduced() {
+    return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 function escapeHtml(value) {
     return String(value == null ? '' : value)
@@ -257,11 +262,18 @@ function onDraftState(state) {
 
 function onPickMade({ pick, state }) {
     draft = state;
+    // Mark this pick's board cell so renderBoard animates just it (once).
+    justPickedKey = String(pick.userId) + '-' + pick.round;
     renderAll();
     var member = membersById[String(pick.userId)];
     var name = member ? `${member.firstName} ${member.lastName.substring(0, 1)}.` : 'Someone';
     successToast.options.text = `${name} drafted ${pick.team.school}`;
     successToast.showToast();
+    // Celebrate your own pick with a short confetti burst.
+    if (String(pick.userId) === String(myUserId) && !ccReduced() && typeof startConfetti === 'function') {
+        startConfetti();
+        setTimeout(function () { if (typeof stopConfetti === 'function') stopConfetti(); }, 2500);
+    }
 }
 
 function onDraftComplete(state) {
@@ -294,8 +306,29 @@ function undoPick() {
 function renderAll() {
     renderStatus();
     renderBoard();
+    renderTicker();
     renderOnTheClock();
     renderPool();
+}
+
+// Scrolling ribbon of recent picks above the board (most recent first).
+function renderTicker() {
+    var el = document.getElementById('pick-ticker');
+    if (!el) return;
+    if (!draft || !draft.picks || !draft.picks.length ||
+        (draft.status !== 'active' && draft.status !== 'complete')) {
+        el.innerHTML = '';
+        return;
+    }
+    var recent = draft.picks.slice(-16).reverse();
+    var chips = recent.map(function (p) {
+        var logo = (p.team.logos && p.team.logos.length) ? p.team.logos.at(-1) : '';
+        return `<span class="pick-chip"><span class="pk">#${p.overall}</span>`
+            + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</span>`;
+    }).join('');
+    // Only loop-scroll when there are enough picks to overflow and motion is OK.
+    var scroll = !ccReduced() && recent.length > 5;
+    el.innerHTML = `<div class="pick-ticker-track${scroll ? ' scroll' : ''}">${scroll ? chips + chips : chips}</div>`;
 }
 
 function renderStatus() {
@@ -363,7 +396,8 @@ function renderBoard() {
             var isClock = onClock.userId === String(userId) && onClock.round === round;
             var cls = isClock ? 'draft-board-cell on-clock-cell' : 'draft-board-cell';
             if (pick) {
-                bodyStr += `<td class="${cls}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}" title="${escapeHtml(pick.team.school)}"></td>`;
+                var freshCls = (justPickedKey === String(userId) + '-' + round) ? ' just-picked' : '';
+                bodyStr += `<td class="${cls}${freshCls}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}" title="${escapeHtml(pick.team.school)}"></td>`;
             } else {
                 bodyStr += `<td class="${cls}"></td>`;
             }
@@ -371,15 +405,19 @@ function renderBoard() {
         bodyStr += '</tr>';
     });
     body.innerHTML = bodyStr;
+    justPickedKey = null;   // consumed — don't re-animate on the next render
 }
 
 function renderOnTheClock() {
     var el = document.getElementById('on-the-clock');
-    if (!draft || draft.status !== 'active' || !draft.onTheClock) { el.innerHTML = ''; return; }
+    if (!draft || draft.status !== 'active' || !draft.onTheClock) { el.innerHTML = ''; el.classList.remove('your-turn'); return; }
     var oc = draft.onTheClock;
     var member = membersById[String(oc.userId)];
     var name = member ? `${member.firstName} ${member.lastName}` : 'Unknown';
-    if (String(oc.userId) === String(myUserId)) {
+    var mine = String(oc.userId) === String(myUserId);
+    // .your-turn drives the urgency pulse in CSS (only when it's you).
+    el.classList.toggle('your-turn', mine);
+    if (mine) {
         el.innerHTML = `<span class="you-are-up">🟢 You're on the clock! — Round ${oc.round}, Pick #${oc.overall}</span>`;
     } else {
         el.innerHTML = `<span>On the clock: <strong>${escapeHtml(name)}</strong> — Round ${oc.round}, Pick #${oc.overall}</span>`;

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -38,6 +38,7 @@
 
     <!-- Live draft board (members x rounds), shown once active -->
     <div id="draft-board-wrap" class="draft-board-wrap" style="display:none;">
+        <div id="pick-ticker" class="pick-ticker"></div>
         <div id="on-the-clock" class="on-the-clock"></div>
         <div id="draft-board" style="overflow-x: auto;">
             <table id="draft-table">


### PR DESCRIPTION
Batch 3 from the [mockup](https://claude.ai/code/artifact/a81aba96-2e95-4332-88b3-bc493607b847). Draft room (`draftRoom.js` / `draftRoom.css` / `draftRoom.ejs`), all gated behind `prefers-reduced-motion`.

- **Pick reveal** — a freshly drafted logo flips + pops onto the board (cell tagged `.just-picked` for exactly one render)
- **Confetti on your pick** — reuses the existing `confetti.js` (already used on draft-complete)
- **On-the-clock pulse** — the active board cell pulses; when it's *your* turn the whole banner pulses (`.your-turn`)
- **Pick ticker** — a scrolling ribbon of recent picks above the board (loops only when it overflows and motion is allowed)

> Note: the draft state has no per-pick deadline, so "on the clock" is a **pulse** (urgency without a fake countdown) rather than a ticking timer.

## Verification
Live draft is socket-driven, so verified via a repro loading the real `draftRoom.css`: all four animations resolve (`dr-pick-reveal`, `dr-cell-pulse`, `dr-clock-pulse`, `dr-ticker`), ticker chips + on-the-clock banner + board render correctly. JS + EJS syntax checked.

Batch 4 (weekly-winner celebration on userHome) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)