### PR TITLE
Animations: team page, brand, standings, draft room (all 17)

### DIFF
--- a/public/confetti.js
+++ b/public/confetti.js
@@ -10,7 +10,8 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 	stopConfetti = stopConfettiInner;
 	toggleConfetti = toggleConfettiInner;
 	removeConfetti = removeConfettiInner;
-	var colors = ["DodgerBlue", "OliveDrab", "Gold", "Pink", "SlateBlue", "LightBlue", "Violet", "PaleGreen", "SteelBlue", "SandyBrown", "Chocolate", "Crimson"]
+	var defaultColors = ["DodgerBlue", "OliveDrab", "Gold", "Pink", "SlateBlue", "LightBlue", "Violet", "PaleGreen", "SteelBlue", "SandyBrown", "Chocolate", "Crimson"];
+	var colors = defaultColors;
 	var streamingConfetti = false;
 	var animationTimer = null;
 	var particles = [];
@@ -27,7 +28,10 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 		return particle;
 	}
 
-	function startConfettiInner() {
+	// Optional customColors (array) overrides the default rainbow for this run;
+	// omit to keep the default mix (draft-complete, weekly-winner).
+	function startConfettiInner(customColors) {
+		colors = (customColors && customColors.length) ? customColors : defaultColors;
 		var width = window.innerWidth;
 		var height = window.innerHeight;
 		window.requestAnimFrame = (function() {

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -356,14 +356,16 @@
     /* When it's YOUR turn, the whole banner pulses with urgency */
     .on-the-clock.your-turn { animation: dr-clock-pulse 2.5s ease-in-out infinite; }
 
-    /* Recent-picks ticker loop-scroll (class added in JS only when it overflows) */
-    .pick-ticker-track.scroll { animation: dr-ticker 60s linear infinite; padding-left: 100%; }
+    /* Recent-picks ticker loop-scroll (class added in JS only when it overflows;
+       the track is duplicated in JS and animation-duration is set inline so the
+       on-screen speed stays constant regardless of how many picks there are). */
+    .pick-ticker-track.scroll { animation: dr-ticker 60s linear infinite; }
 }
 
 @keyframes dr-pick-reveal { 0% { opacity: 0; transform: rotateY(90deg) scale(.6); } 60% { opacity: 1; transform: rotateY(0) scale(1.14); } 100% { transform: scale(1); } }
 @keyframes dr-cell-pulse { 0%, 100% { box-shadow: inset 0 0 0 2px #ed5858; } 50% { box-shadow: inset 0 0 0 2px #ed5858, 0 0 12px rgba(237, 88, 88, .6); } }
 @keyframes dr-clock-pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(113, 210, 141, .4); } 50% { box-shadow: 0 0 0 6px rgba(113, 210, 141, 0); } }
-@keyframes dr-ticker { to { transform: translateX(-100%); } }
+@keyframes dr-ticker { to { transform: translateX(-50%); } }
 
 /* Recent-picks ticker */
 .pick-ticker {

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -354,10 +354,10 @@
     .on-clock-cell { animation: dr-cell-pulse 1.4s ease-in-out infinite; }
 
     /* When it's YOUR turn, the whole banner pulses with urgency */
-    .on-the-clock.your-turn { animation: dr-clock-pulse 1.1s ease-in-out infinite; }
+    .on-the-clock.your-turn { animation: dr-clock-pulse 2.5s ease-in-out infinite; }
 
     /* Recent-picks ticker loop-scroll (class added in JS only when it overflows) */
-    .pick-ticker-track.scroll { animation: dr-ticker 22s linear infinite; padding-left: 100%; }
+    .pick-ticker-track.scroll { animation: dr-ticker 60s linear infinite; padding-left: 100%; }
 }
 
 @keyframes dr-pick-reveal { 0% { opacity: 0; transform: rotateY(90deg) scale(.6); } 60% { opacity: 1; transform: rotateY(0) scale(1.14); } 100% { transform: scale(1); } }

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -340,6 +340,58 @@
     border-radius: 4px;
 }
 
+/* ==================================================================== */
+/* Draft-room animations. Entrance/urgency effects gated behind         */
+/* prefers-reduced-motion:no-preference (the ticker's loop-scroll is    */
+/* also disabled in JS when reduced). Confetti on your own pick is      */
+/* fired from draftRoom.js (also reduced-motion aware).                 */
+/* ==================================================================== */
+@media (prefers-reduced-motion: no-preference) {
+    /* A freshly drafted logo flips + pops onto the board */
+    .draft-board-cell.just-picked img { animation: dr-pick-reveal .55s cubic-bezier(.2, 1.3, .3, 1) both; }
+
+    /* The active pick cell pulses so the eye finds it */
+    .on-clock-cell { animation: dr-cell-pulse 1.4s ease-in-out infinite; }
+
+    /* When it's YOUR turn, the whole banner pulses with urgency */
+    .on-the-clock.your-turn { animation: dr-clock-pulse 1.1s ease-in-out infinite; }
+
+    /* Recent-picks ticker loop-scroll (class added in JS only when it overflows) */
+    .pick-ticker-track.scroll { animation: dr-ticker 22s linear infinite; padding-left: 100%; }
+}
+
+@keyframes dr-pick-reveal { 0% { opacity: 0; transform: rotateY(90deg) scale(.6); } 60% { opacity: 1; transform: rotateY(0) scale(1.14); } 100% { transform: scale(1); } }
+@keyframes dr-cell-pulse { 0%, 100% { box-shadow: inset 0 0 0 2px #ed5858; } 50% { box-shadow: inset 0 0 0 2px #ed5858, 0 0 12px rgba(237, 88, 88, .6); } }
+@keyframes dr-clock-pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(113, 210, 141, .4); } 50% { box-shadow: 0 0 0 6px rgba(113, 210, 141, 0); } }
+@keyframes dr-ticker { to { transform: translateX(-100%); } }
+
+/* Recent-picks ticker */
+.pick-ticker {
+    overflow: hidden;
+    margin-bottom: 14px;
+    padding: 7px 0;
+    background: #141829;
+    border: 1px solid #2A2E42;
+    border-radius: 10px;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+}
+.pick-ticker:empty { display: none; }
+.pick-ticker-track { display: inline-flex; gap: 8px; white-space: nowrap; }
+.pick-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 999px;
+    padding: 4px 11px;
+    font-size: 0.82em;
+    color: #F4F6FB;
+}
+.pick-chip img { width: 18px; height: 18px; object-fit: contain; }
+.pick-chip .pk { color: #ed5858; font-weight: 700; }
+
 /* Draft action buttons in the team list */
 .draft-pick-btn {
     background-color: #71d28d;

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -14,6 +14,11 @@ var leagueVersion = 'V2';
 var season = new Date().getFullYear();
 var isMobile = false;
 var countdownTimer;
+var justPickedKey = null;    // "userId-round" of the pick to animate in once
+
+function ccReduced() {
+    return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 function escapeHtml(value) {
     return String(value == null ? '' : value)
@@ -257,11 +262,18 @@ function onDraftState(state) {
 
 function onPickMade({ pick, state }) {
     draft = state;
+    // Mark this pick's board cell so renderBoard animates just it (once).
+    justPickedKey = String(pick.userId) + '-' + pick.round;
     renderAll();
     var member = membersById[String(pick.userId)];
     var name = member ? `${member.firstName} ${member.lastName.substring(0, 1)}.` : 'Someone';
     successToast.options.text = `${name} drafted ${pick.team.school}`;
     successToast.showToast();
+    // Celebrate your own pick with a short confetti burst.
+    if (String(pick.userId) === String(myUserId) && !ccReduced() && typeof startConfetti === 'function') {
+        startConfetti();
+        setTimeout(function () { if (typeof stopConfetti === 'function') stopConfetti(); }, 2500);
+    }
 }
 
 function onDraftComplete(state) {
@@ -294,8 +306,29 @@ function undoPick() {
 function renderAll() {
     renderStatus();
     renderBoard();
+    renderTicker();
     renderOnTheClock();
     renderPool();
+}
+
+// Scrolling ribbon of recent picks above the board (most recent first).
+function renderTicker() {
+    var el = document.getElementById('pick-ticker');
+    if (!el) return;
+    if (!draft || !draft.picks || !draft.picks.length ||
+        (draft.status !== 'active' && draft.status !== 'complete')) {
+        el.innerHTML = '';
+        return;
+    }
+    var recent = draft.picks.slice(-16).reverse();
+    var chips = recent.map(function (p) {
+        var logo = (p.team.logos && p.team.logos.length) ? p.team.logos.at(-1) : '';
+        return `<span class="pick-chip"><span class="pk">#${p.overall}</span>`
+            + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</span>`;
+    }).join('');
+    // Only loop-scroll when there are enough picks to overflow and motion is OK.
+    var scroll = !ccReduced() && recent.length > 5;
+    el.innerHTML = `<div class="pick-ticker-track${scroll ? ' scroll' : ''}">${scroll ? chips + chips : chips}</div>`;
 }
 
 function renderStatus() {
@@ -363,7 +396,8 @@ function renderBoard() {
             var isClock = onClock.userId === String(userId) && onClock.round === round;
             var cls = isClock ? 'draft-board-cell on-clock-cell' : 'draft-board-cell';
             if (pick) {
-                bodyStr += `<td class="${cls}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}" title="${escapeHtml(pick.team.school)}"></td>`;
+                var freshCls = (justPickedKey === String(userId) + '-' + round) ? ' just-picked' : '';
+                bodyStr += `<td class="${cls}${freshCls}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}" title="${escapeHtml(pick.team.school)}"></td>`;
             } else {
                 bodyStr += `<td class="${cls}"></td>`;
             }
@@ -371,15 +405,19 @@ function renderBoard() {
         bodyStr += '</tr>';
     });
     body.innerHTML = bodyStr;
+    justPickedKey = null;   // consumed — don't re-animate on the next render
 }
 
 function renderOnTheClock() {
     var el = document.getElementById('on-the-clock');
-    if (!draft || draft.status !== 'active' || !draft.onTheClock) { el.innerHTML = ''; return; }
+    if (!draft || draft.status !== 'active' || !draft.onTheClock) { el.innerHTML = ''; el.classList.remove('your-turn'); return; }
     var oc = draft.onTheClock;
     var member = membersById[String(oc.userId)];
     var name = member ? `${member.firstName} ${member.lastName}` : 'Unknown';
-    if (String(oc.userId) === String(myUserId)) {
+    var mine = String(oc.userId) === String(myUserId);
+    // .your-turn drives the urgency pulse in CSS (only when it's you).
+    el.classList.toggle('your-turn', mine);
+    if (mine) {
         el.innerHTML = `<span class="you-are-up">🟢 You're on the clock! — Round ${oc.round}, Pick #${oc.overall}</span>`;
     } else {
         el.innerHTML = `<span>On the clock: <strong>${escapeHtml(name)}</strong> — Round ${oc.round}, Pick #${oc.overall}</span>`;

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -311,7 +311,7 @@ function renderAll() {
     renderPool();
 }
 
-// Scrolling ribbon of recent picks above the board (most recent first).
+// Scrolling ribbon of every pick, in draft order (pick #1 → most recent).
 function renderTicker() {
     var el = document.getElementById('pick-ticker');
     if (!el) return;
@@ -320,14 +320,15 @@ function renderTicker() {
         el.innerHTML = '';
         return;
     }
-    var recent = draft.picks.slice(-16).reverse();
-    var chips = recent.map(function (p) {
+    // Chronological order (defensive sort in case picks aren't stored ordered).
+    var ordered = draft.picks.slice().sort(function (a, b) { return (a.overall || 0) - (b.overall || 0); });
+    var chips = ordered.map(function (p) {
         var logo = (p.team.logos && p.team.logos.length) ? p.team.logos.at(-1) : '';
         return `<span class="pick-chip"><span class="pk">#${p.overall}</span>`
             + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</span>`;
     }).join('');
     // Only loop-scroll when there are enough picks to overflow and motion is OK.
-    var scroll = !ccReduced() && recent.length > 5;
+    var scroll = !ccReduced() && ordered.length > 5;
     el.innerHTML = `<div class="pick-ticker-track${scroll ? ' scroll' : ''}">${scroll ? chips + chips : chips}</div>`;
 }
 

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -325,8 +325,12 @@ function renderTicker() {
             + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</span>`;
     }).join('');
     // Only loop-scroll when there are enough picks to overflow and motion is OK.
+    // Duration scales with pick count (~2s per chip) so the on-screen speed
+    // stays constant as the draft grows. The track is duplicated so a -50%
+    // translate loops seamlessly.
     var scroll = !ccReduced() && ordered.length > 5;
-    el.innerHTML = `<div class="pick-ticker-track${scroll ? ' scroll' : ''}">${scroll ? chips + chips : chips}</div>`;
+    var durStyle = scroll ? ` style="animation-duration:${Math.max(12, ordered.length * 2)}s"` : '';
+    el.innerHTML = `<div class="pick-ticker-track${scroll ? ' scroll' : ''}"${durStyle}>${scroll ? chips + chips : chips}</div>`;
 }
 
 function renderStatus() {

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -266,9 +266,12 @@ function onPickMade({ pick, state }) {
     justPickedKey = String(pick.userId) + '-' + pick.round;
     renderAll();
     // No per-pick toast — the board pick-reveal and the ticker already show it.
-    // Celebrate your own pick with a short confetti burst.
+    // Celebrate your own pick with a short confetti burst in white + the
+    // drafted team's colour.
     if (String(pick.userId) === String(myUserId) && !ccReduced() && typeof startConfetti === 'function') {
-        startConfetti();
+        var tc = pick.team && pick.team.color;
+        if (tc && tc.charAt(0) !== '#') tc = '#' + tc;
+        startConfetti(tc ? ['#ffffff', tc] : undefined);
         setTimeout(function () { if (typeof stopConfetti === 'function') stopConfetti(); }, 2500);
     }
 }

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -265,10 +265,7 @@ function onPickMade({ pick, state }) {
     // Mark this pick's board cell so renderBoard animates just it (once).
     justPickedKey = String(pick.userId) + '-' + pick.round;
     renderAll();
-    var member = membersById[String(pick.userId)];
-    var name = member ? `${member.firstName} ${member.lastName.substring(0, 1)}.` : 'Someone';
-    successToast.options.text = `${name} drafted ${pick.team.school}`;
-    successToast.showToast();
+    // No per-pick toast — the board pick-reveal and the ticker already show it.
     // Celebrate your own pick with a short confetti burst.
     if (String(pick.userId) === String(myUserId) && !ccReduced() && typeof startConfetti === 'function') {
         startConfetti();

--- a/public/loading.css
+++ b/public/loading.css
@@ -48,3 +48,22 @@
 		opacity: 1;
 	}
 }
+
+/* Yard-line sweep beneath the football — a moving highlight along a track,
+   like a chain crew running the line. Pure CSS (::after), so it applies
+   everywhere the loader is used without markup changes. */
+.football-loader::after {
+	content: "";
+	width: 150px;
+	height: 6px;
+	margin-top: 1.1em;
+	border-radius: 3px;
+	background: linear-gradient(90deg, #1c2237 0%, #1c2237 42%, #ed5858 50%, #1c2237 58%, #1c2237 100%);
+	background-size: 260% 100%;
+	animation: yard-sweep 1.3s ease-in-out infinite;
+}
+
+@keyframes yard-sweep {
+	0%   { background-position: 130% 0; }
+	100% { background-position: -130% 0; }
+}

--- a/public/standings.css
+++ b/public/standings.css
@@ -413,6 +413,16 @@
 .standings-row.medal-2 .rank-num { color: #C7CCDB; }
 .standings-row.medal-3 .rank-num { color: #D8925B; }
 .crown { font-size: 0.85rem; margin-right: 2px; }
+
+/* Leader row treatment — always visible (independent of reduced-motion): a
+   gold rail down the left edge, a warm tint across the row, and a persistent
+   soft glow on the #1. The pulse in the motion block below adds movement on
+   top for viewers who allow motion. */
+.standings-row.medal-1 td,
+.standings-row.medal-1 .sticky-header,
+.standings-row.medal-1 .sticky-header-score { background-color: #1a1710; }
+.standings-row.medal-1 .rank-cell { box-shadow: inset 3px 0 0 #F2C14E; }
+.standings-row.medal-1 .rank-num { text-shadow: 0 0 8px rgba(242, 193, 78, .65); }
 .gap { display: inline-block; font-size: 0.68rem; color: #767D9C; font-weight: 400; }
 .gap.leader { color: #5BD08D; }
 .score-num { font-weight: 700; }

--- a/public/standings.css
+++ b/public/standings.css
@@ -525,3 +525,35 @@
 .welcome-actions .btn-primary:hover { background: #7d7be8; }
 .welcome-actions .btn-ghost { background: transparent; color: #A4A9C2; }
 .welcome-actions .btn-ghost:hover { color: #F4F6FB; }
+
+/* ==================================================================== */
+/* Standings entrance animations. Defined only under                    */
+/* prefers-reduced-motion:no-preference, and they play on the           */
+/* innerHTML insert (buildStandingsRowsHtml) — no JS wiring needed.     */
+/* Count-up on the scores already lives in standings.js (animateScores).*/
+/* ==================================================================== */
+@media (prefers-reduced-motion: no-preference) {
+    /* Ranked rows rise + fade in, staggered top to bottom */
+    .standings-row { animation: std-row-in .42s cubic-bezier(.2, .8, .2, 1) both; }
+    .standings-row:nth-child(1)  { animation-delay: .04s; }
+    .standings-row:nth-child(2)  { animation-delay: .10s; }
+    .standings-row:nth-child(3)  { animation-delay: .16s; }
+    .standings-row:nth-child(4)  { animation-delay: .22s; }
+    .standings-row:nth-child(5)  { animation-delay: .28s; }
+    .standings-row:nth-child(6)  { animation-delay: .34s; }
+    .standings-row:nth-child(7)  { animation-delay: .40s; }
+    .standings-row:nth-child(8)  { animation-delay: .46s; }
+    .standings-row:nth-child(9)  { animation-delay: .52s; }
+    .standings-row:nth-child(10) { animation-delay: .58s; }
+    .standings-row:nth-child(n+11) { animation-delay: .64s; }
+
+    /* Leader: a soft gold glow pulses on the rank number */
+    .standings-row.medal-1 .rank-num { animation: std-leader-glow 2.6s ease-in-out infinite; }
+
+    /* Movement arrows pop in after the rows have settled */
+    .move { display: inline-block; animation: std-move-pop .45s cubic-bezier(.2, 1.5, .4, 1) both; animation-delay: .55s; }
+}
+
+@keyframes std-row-in { from { opacity: 0; transform: translateY(9px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes std-leader-glow { 0%, 100% { text-shadow: 0 0 0 rgba(242, 193, 78, 0); } 50% { text-shadow: 0 0 9px rgba(242, 193, 78, .75); } }
+@keyframes std-move-pop { 0% { opacity: 0; transform: scale(0) translateY(-4px); } 60% { transform: scale(1.25); } 100% { opacity: 1; transform: scale(1) translateY(0); } }

--- a/public/standings.css
+++ b/public/standings.css
@@ -560,6 +560,13 @@
     /* Leader: a soft gold glow pulses on the rank number */
     .standings-row.medal-1 .rank-num { display: inline-block; animation: std-leader-glow 2.4s ease-in-out infinite; }
 
+    /* Leader: a warm glow pulses across the whole row so the motion is
+       obvious (the tiny number pulse alone was too easy to miss). */
+    .standings-row.medal-1 td,
+    .standings-row.medal-1 .sticky-header,
+    .standings-row.medal-1 .sticky-header-score { animation: std-leader-tint 2.4s ease-in-out infinite; }
+    .standings-row.medal-1 .rank-cell { animation: std-leader-rail 2.4s ease-in-out infinite; }
+
     /* Movement arrows pop in after the rows have settled */
     .move { display: inline-block; animation: std-move-pop .45s cubic-bezier(.2, 1.5, .4, 1) both; animation-delay: .55s; }
 }
@@ -570,6 +577,8 @@
     50% { text-shadow: 0 0 13px rgba(242, 193, 78, .95), 0 0 24px rgba(242, 193, 78, .5); transform: scale(1.15); }
 }
 @keyframes std-move-pop { 0% { opacity: 0; transform: scale(0) translateY(-4px); } 60% { transform: scale(1.25); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
+@keyframes std-leader-tint { 0%, 100% { background-color: #1a1710; } 50% { background-color: #33290d; } }
+@keyframes std-leader-rail { 0%, 100% { box-shadow: inset 3px 0 0 #F2C14E; } 50% { box-shadow: inset 3px 0 0 #F2C14E, 0 0 16px rgba(242, 193, 78, .55); } }
 
 /* Weekly-winner celebration: the Big Winner trophy bounces when the logged-in
    manager won the week (standings.js adds .celebrate + fires confetti; both

--- a/public/standings.css
+++ b/public/standings.css
@@ -568,7 +568,10 @@
     .standings-row.medal-1 td,
     .standings-row.medal-1 .sticky-header,
     .standings-row.medal-1 .sticky-header-score { animation: std-leader-tint 2.4s ease-in-out infinite; }
-    .standings-row.medal-1 .rank-cell { animation: std-leader-rail 2.4s ease-in-out infinite; }
+    /* The rank cell runs BOTH the tint (background) and rail (box-shadow)
+       animations so its background brightens in sync with the rest of the row
+       — otherwise it stayed dark and looked like a gap by the avatar. */
+    .standings-row.medal-1 .rank-cell { animation: std-leader-tint 2.4s ease-in-out infinite, std-leader-rail 2.4s ease-in-out infinite; }
 
     /* Movement arrows pop in after the rows have settled */
     .move { display: inline-block; animation: std-move-pop .45s cubic-bezier(.2, 1.5, .4, 1) both; animation-delay: .55s; }

--- a/public/standings.css
+++ b/public/standings.css
@@ -557,3 +557,17 @@
 @keyframes std-row-in { from { opacity: 0; transform: translateY(9px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes std-leader-glow { 0%, 100% { text-shadow: 0 0 0 rgba(242, 193, 78, 0); } 50% { text-shadow: 0 0 9px rgba(242, 193, 78, .75); } }
 @keyframes std-move-pop { 0% { opacity: 0; transform: scale(0) translateY(-4px); } 60% { transform: scale(1.25); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
+
+/* Weekly-winner celebration: the Big Winner trophy bounces when the logged-in
+   manager won the week (standings.js adds .celebrate + fires confetti; both
+   are reduced-motion aware and fire once per week). */
+@media (prefers-reduced-motion: no-preference) {
+    .hl-icon.celebrate { display: inline-block; animation: hl-trophy-bounce .9s cubic-bezier(.2, 1.5, .35, 1) 2; }
+}
+@keyframes hl-trophy-bounce {
+    0% { transform: translateY(0) scale(1); }
+    30% { transform: translateY(-11px) scale(1.25); }
+    60% { transform: translateY(0) scale(1); }
+    80% { transform: translateY(-4px); }
+    100% { transform: translateY(0); }
+}

--- a/public/standings.css
+++ b/public/standings.css
@@ -405,6 +405,9 @@
 /* ---------- Standings UX enhancements ---------- */
 /* Ranked table: movement, medals, crown, gap-to-leader */
 .rank-num { font-weight: 700; margin-right: 5px; }
+/* Left gutter on every rank cell so the digit clears the leader's gold rail
+   (applied to all rows so the numbers stay vertically aligned). */
+.standings-row .rank-cell { padding-left: 12px; }
 .move { font-size: 0.68rem; font-weight: 600; white-space: nowrap; }
 .move.up { color: #5BD08D; }
 .move.down { color: #ED5858; }

--- a/public/standings.css
+++ b/public/standings.css
@@ -548,14 +548,17 @@
     .standings-row:nth-child(n+11) { animation-delay: .64s; }
 
     /* Leader: a soft gold glow pulses on the rank number */
-    .standings-row.medal-1 .rank-num { animation: std-leader-glow 2.6s ease-in-out infinite; }
+    .standings-row.medal-1 .rank-num { display: inline-block; animation: std-leader-glow 2.4s ease-in-out infinite; }
 
     /* Movement arrows pop in after the rows have settled */
     .move { display: inline-block; animation: std-move-pop .45s cubic-bezier(.2, 1.5, .4, 1) both; animation-delay: .55s; }
 }
 
 @keyframes std-row-in { from { opacity: 0; transform: translateY(9px); } to { opacity: 1; transform: translateY(0); } }
-@keyframes std-leader-glow { 0%, 100% { text-shadow: 0 0 0 rgba(242, 193, 78, 0); } 50% { text-shadow: 0 0 9px rgba(242, 193, 78, .75); } }
+@keyframes std-leader-glow {
+    0%, 100% { text-shadow: 0 0 2px rgba(242, 193, 78, .35); transform: scale(1); }
+    50% { text-shadow: 0 0 13px rgba(242, 193, 78, .95), 0 0 24px rgba(242, 193, 78, .5); transform: scale(1.15); }
+}
 @keyframes std-move-pop { 0% { opacity: 0; transform: scale(0) translateY(-4px); } 60% { transform: scale(1.25); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
 
 /* Weekly-winner celebration: the Big Winner trophy bounces when the logged-in

--- a/public/standings.js
+++ b/public/standings.js
@@ -140,6 +140,7 @@ async function getUsers() {
             maybePromptProfileSetup(data);
             displayLastUpdated(data);
             displayHighlights(data);
+            maybeCelebrateWeeklyWin(data);
             loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
             displaySchedule(data);
             setNavbarUserId(userMetadata, usersData);
@@ -211,6 +212,49 @@ async function loadAdvancedHighlights(league, season) {
 function displayHighlights(users) {
     const container = document.querySelector('.highlights-container');
     if (container) container.innerHTML = buildHighlightsHtml(buildHighlights(users));
+}
+
+// Reserved celebration: if the logged-in manager posted the top score in the
+// most recent week, bounce the Big Winner trophy and throw confetti — once per
+// week (localStorage-guarded) and never under reduced-motion.
+function maybeCelebrateWeeklyWin(users) {
+    try {
+        const myId = (userState.user_metadata && userState.user_metadata.metadata && userState.user_metadata.metadata.userId)
+            || window.localStorage.getItem('userId');
+        if (!myId || !Array.isArray(users) || !users.length) return;
+
+        const weekOf = (u) => ((u.seasons && u.seasons[0] && u.seasons[0].weeklyScore) || []);
+        const weeks = weekOf(users[0]).length;
+        if (!weeks) return;
+        const lastIdx = weeks - 1;
+
+        const scored = users.map(u => {
+            const wk = weekOf(u)[lastIdx];
+            return { id: String(u._id), score: (wk && wk.score) || 0, wk };
+        });
+        const max = Math.max(...scored.map(s => s.score));
+        if (max <= 0) return;
+
+        const mine = scored.find(s => s.id === String(myId));
+        if (!mine || mine.score !== max) return;   // you didn't (co-)win the week
+
+        // Once per week: key by season + week so it fires the first time only.
+        const season = (users[0].seasons[0].season) || '';
+        const wkLabel = (mine.wk && mine.wk.season === 'postseason') ? 'post' : (mine.wk && mine.wk.week);
+        const key = `weekWin-${season}-${wkLabel}`;
+        if (window.localStorage.getItem(key)) return;
+        window.localStorage.setItem(key, '1');
+
+        if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+        // Big Winner is the first highlight card; bounce its trophy + confetti.
+        const icon = document.querySelector('.highlights-container .sub-highlight-container:first-child .hl-icon');
+        if (icon) icon.classList.add('celebrate');
+        if (typeof startConfetti === 'function') {
+            startConfetti();
+            setTimeout(() => { if (typeof stopConfetti === 'function') stopConfetti(); }, 3500);
+        }
+    } catch (e) { /* celebration is best-effort */ }
 }
 
 // First-login nudge: if the logged-in manager hasn't been prompted yet, invite

--- a/public/styles.css
+++ b/public/styles.css
@@ -438,3 +438,19 @@ footer {
         padding: 5px;
     }
 }
+
+/* Brand wordmark draw-in: the two "Campus Clash" lines wipe on left-to-right
+   on page load. Gated behind prefers-reduced-motion (no-preference only), so
+   the logo just appears normally for readers who opt out. */
+@media (prefers-reduced-motion: no-preference) {
+    .brand-title > div {
+        clip-path: inset(0 100% 0 0);
+        animation: brand-draw .7s cubic-bezier(.4, 0, .2, 1) both;
+    }
+    .brand-title > div:nth-child(1) { animation-delay: .05s; }
+    .brand-title > div:nth-child(2) { animation-delay: .32s; }
+}
+
+@keyframes brand-draw {
+    to { clip-path: inset(0 0 0 0); }
+}

--- a/public/team.css
+++ b/public/team.css
@@ -664,3 +664,79 @@
 .viewed-team-row td:first-child {
     border-left: 3px solid var(--team-accent, #ed5858);
 }
+
+/* ==================================================================== */
+/* Entrance animations. All are defined ONLY inside the                 */
+/* prefers-reduced-motion:no-preference query, so a reader who opts out */
+/* of motion just sees the final state (the .run/.reveal classes are    */
+/* always added, but do nothing without these rules). JS-driven count-  */
+/* ups check the same preference before animating.                      */
+/* ==================================================================== */
+@media (prefers-reduced-motion: no-preference) {
+
+    /* Whole team card eases in on load / season change */
+    #team-container.reveal { animation: cc-card-in .5s cubic-bezier(.2,.8,.2,1) both; }
+
+    /* Header: accent border draws down + a team-colour sheen sweeps once */
+    .team-header { position: relative; overflow: hidden; }
+    .team-header.run::after {
+        content: "";
+        position: absolute; inset: 0;
+        background: linear-gradient(105deg, transparent 34%, rgba(var(--team-accent-rgb, 237,88,88), .22) 50%, transparent 66%);
+        transform: translateX(-120%);
+        animation: cc-sweep 1s ease .15s 1;
+        pointer-events: none;
+    }
+
+    /* Form strip: W/L dots pop in left to right */
+    .form-strip.run .form-dot { animation: cc-pop .42s cubic-bezier(.2,1.5,.4,1) both; }
+    .form-strip.run .form-dot:nth-child(1) { animation-delay: .04s; }
+    .form-strip.run .form-dot:nth-child(2) { animation-delay: .12s; }
+    .form-strip.run .form-dot:nth-child(3) { animation-delay: .20s; }
+    .form-strip.run .form-dot:nth-child(4) { animation-delay: .28s; }
+    .form-strip.run .form-dot:nth-child(5) { animation-delay: .36s; }
+    .form-strip.run .form-dot:nth-child(6) { animation-delay: .44s; }
+
+    /* Weekly points chart: bars grow up from the axis (delay set inline) */
+    .week-bar-fill { transform-origin: bottom; }
+    .week-bars.run .week-bar-fill { animation: cc-grow .6s cubic-bezier(.2,.8,.2,1) both; }
+
+    /* Schedule: result badge stamps down; score flips in */
+    .game-result.run { animation: cc-stamp .4s cubic-bezier(.2,1.4,.3,1) both; }
+    .team-score.run { animation: cc-flip-in .45s ease both; display: inline-block; }
+}
+
+@keyframes cc-card-in { from { opacity: 0; transform: translateY(22px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes cc-sweep { to { transform: translateX(120%); } }
+@keyframes cc-pop { 0% { opacity: 0; transform: scale(0); } 70% { transform: scale(1.18); } 100% { opacity: 1; transform: scale(1); } }
+@keyframes cc-grow { from { transform: scaleY(0); } to { transform: scaleY(1); } }
+@keyframes cc-stamp { 0% { opacity: 0; transform: scale(1.8) rotate(-14deg); } 60% { opacity: 1; transform: scale(.92) rotate(3deg); } 100% { opacity: 1; transform: scale(1) rotate(0); } }
+@keyframes cc-flip-in { 0% { transform: perspective(300px) rotateX(-90deg); opacity: 0; } 100% { transform: perspective(300px) rotateX(0); opacity: 1; } }
+
+/* Smooth collapse/expand for the schedule + standings panels (mobile).
+   Keeps the existing display / flex-wrap / table rendering intact and just
+   animates max-height on the existing .active toggle — so no JS change and no
+   layout regression. Desktop (>=64em) forces them fully open. */
+@media only screen and (min-width: 0em) {
+    .games-container {
+        display: flex;
+        flex-direction: column;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height .35s cubic-bezier(.3,.8,.3,1);
+    }
+    .standings-table {
+        display: block;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height .35s cubic-bezier(.3,.8,.3,1);
+    }
+    .games-container.active, .standings-table.active { max-height: 1500px; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .games-container, .standings-table { transition: none; }
+}
+@media only screen and (min-width: 64em) {
+    /* Desktop: always visible, no clipping */
+    .games-container, .standings-table { max-height: none; overflow: visible; }
+}

--- a/public/team.js
+++ b/public/team.js
@@ -401,6 +401,32 @@ function contrastText(rgb) {
 }
 
 // ---------------------------------------------------------------------------
+// Animation helpers. Entrance animations are CSS-driven and gated behind
+// prefers-reduced-motion in team.css; these JS bits (count-up) check the same
+// preference so a reader who opts out sees final values immediately.
+// ---------------------------------------------------------------------------
+function ccReducedMotion() {
+    return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+// Animate every [data-countup] inside root from 0 to its target.
+function ccCountUp(root) {
+    root.querySelectorAll('[data-countup]').forEach(el => {
+        var to = Number(el.getAttribute('data-countup'));
+        if (isNaN(to)) return;
+        if (ccReducedMotion()) { el.textContent = to; return; }
+        var dur = 850, start = null;
+        function step(ts) {
+            if (start === null) start = ts;
+            var p = Math.min(1, (ts - start) / dur);
+            el.textContent = Math.round(to * (1 - Math.pow(1 - p, 3)));
+            if (p < 1) requestAnimationFrame(step);
+        }
+        requestAnimationFrame(step);
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 function renderTeamError(message) {
@@ -491,7 +517,7 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
 
     // National fantasy-scoring rank alongside the raw point total.
     var rankHtml = fantasyRank
-        ? `<span class="fantasy-rank">#${fantasyRank.rank} of ${fantasyRank.total}</span>`
+        ? `<span class="fantasy-rank">#<span data-countup="${fantasyRank.rank}">0</span> of ${fantasyRank.total}</span>`
         : '';
 
     // Set the tab title to the team being viewed.
@@ -523,7 +549,7 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
             </div>
             <div>
                 <h4>📈 Season Score</h4>
-                <p class="score">${seasonScore} Points ${rankHtml}</p>
+                <p class="score"><span data-countup="${seasonScore}">0</span> Points ${rankHtml}</p>
                 <h4>Recruiting Rank</h4>
                 <p class="score">${recruitingRank}</p>
             </div>
@@ -539,6 +565,12 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
     `;
 
     container.innerHTML = html;
+
+    // Trigger entrance animations (CSS handles reduced-motion by no-op).
+    container.classList.add('reveal');
+    container.querySelector('.team-header')?.classList.add('run');
+    container.querySelector('.form-strip')?.classList.add('run');
+    ccCountUp(container);
 }
 
 // Weekly points bar chart from the season's weeklyScore[] (previously collected
@@ -558,7 +590,7 @@ function renderWeeklyScores(seasonObj, scoreCode) {
         return `
             <div class="week-bar" title="Week ${w.week}: ${v} pts">
                 <span class="week-bar-value">${v}</span>
-                <span class="week-bar-fill" style="height:${pct}%"></span>
+                <span class="week-bar-fill" style="height:${pct}%;animation-delay:${i * 50}ms"></span>
                 <span class="week-bar-label">${label}</span>
             </div>
         `;
@@ -567,7 +599,7 @@ function renderWeeklyScores(seasonObj, scoreCode) {
     return `
         <div class="weekly-scores">
             <h4>📊 Weekly Points</h4>
-            <div class="week-bars">${bars}</div>
+            <div class="week-bars run">${bars}</div>
         </div>
     `;
 }
@@ -593,7 +625,8 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
             return new Date(a.startDate) - new Date(b.startDate);
         });
 
-        schedule.forEach(game => {
+        schedule.forEach((game, gi) => {
+            var animDelay = Math.min(gi * 70, 700);
             var homePoints = '';
             var awayPoints = '';
 
@@ -671,14 +704,14 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
                 var letter = isTie ? 'T' : (us > them ? 'W' : 'L');
                 // Just the W/L/T (the per-team scores already show the numbers);
                 // keep the exact score available on hover.
-                resultBadge = `<span class="game-result ${cls}" title="${us}-${them}">${letter}</span>`;
+                resultBadge = `<span class="game-result ${cls} run" style="animation-delay:${animDelay}ms" title="${us}-${them}">${letter}</span>`;
             }
 
             const awayTeamHTML = `
                 ${awayIsWinner ? '<strong class="game-winner">' : ''}
                <a href="/team?team=${game.awayId}">${awayLogo}${awayRank}${game.awayTeam}</a>
                 ${awayIsWinner ? '</strong>' : ''}
-                </span><span class="betting-line">${awayLine ? '-' + awayLine : ''}</span><span class="team-score">
+                </span><span class="betting-line">${awayLine ? '-' + awayLine : ''}</span><span class="team-score run" style="animation-delay:${animDelay}ms">
                 ${awayIsWinner ? '<strong class="game-winner">' : ''}
                 ${awayPoints ? awayPoints : ''}
                 ${awayIsWinner ? '</strong>' : ''}
@@ -689,7 +722,7 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
                 ${homeIsWinner ? '<strong class="game-winner">' : ''}
                <a href="/team?team=${game.homeId}">${homeLogo}${homeRank}${game.homeTeam}</a>
                 ${homeIsWinner ? '</strong>' : ''}
-                </span><span class="betting-line">${homeLine ? '-' + homeLine : ''}</span><span class="team-score">
+                </span><span class="betting-line">${homeLine ? '-' + homeLine : ''}</span><span class="team-score run" style="animation-delay:${animDelay}ms">
                 ${homeIsWinner ? '<strong class="game-winner">' : ''}
                 ${homePoints ? homePoints : ''}
                 ${homeIsWinner ? '</strong>' : ''}

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -38,6 +38,7 @@
 
     <!-- Live draft board (members x rounds), shown once active -->
     <div id="draft-board-wrap" class="draft-board-wrap" style="display:none;">
+        <div id="pick-ticker" class="pick-ticker"></div>
         <div id="on-the-clock" class="on-the-clock"></div>
         <div id="draft-board" style="overflow-x: auto;">
             <table id="draft-table">

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -9,6 +9,7 @@
     <link href="standings.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">    
+    <script src="confetti.js"></script>
     <script src="standings.js" type="module"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
All 17 animations from the [mockup](https://claude.ai/code/artifact/a81aba96-2e95-4332-88b3-bc493607b847) in one PR (combines the work previously split across #198/#199/#200 so it can be run and reviewed in one place). Every entrance/celebration is gated behind `prefers-reduced-motion`; celebrations are reserved for genuine moments.

## Team page — `team.css` / `team.js`
- Count-up on season score + fantasy rank
- Weekly points bars grow up, staggered
- Form-strip W/L dots pop in
- Header accent border draw + team-colour sheen sweep
- Result badges stamp / scores flip in as the schedule renders
- Whole card fade/slide-up on load
- Smooth collapse/expand for schedule + standings (max-height on the existing `.active` toggle — no layout change)

## Brand — `loading.css` / `styles.css`
- Football loader yard-line sweep
- Navbar "Campus Clash" wordmark draw-in

## Standings — `standings.css` / `standings.js` / `standings.ejs`
- Rows stagger in
- Leader gold-glow pulse
- Movement (▲/▼) arrows pop in
- **Weekly-winner celebration**: trophy bounce + confetti when the logged-in manager tops the week (once/week, localStorage-guarded)

## Draft room — `draftRoom.css` / `draftRoom.js` / `draftRoom.ejs`
- Pick reveal (logo flips + pops onto the board)
- Confetti on your own pick (reuses `confetti.js`)
- On-the-clock pulse (banner + active cell)
- Recent-picks ticker

## Notes
- "On the clock" is a **pulse**, not a countdown (draft state has no per-pick deadline).
- "Live score flip" is a flip-in on render (team page loads static scores; same animation would fire on a live update).
- Reuses the existing `confetti.js` and `.football-loader`; no new dependencies.

## Verification
Auth-gated app, so verified headless: repros loading the real CSS/modules for each screen, computed animation-names confirmed, count-up + collapse measured, win-detection unit-tested (5/5), all JS/EJS syntax-checked. Details in the (now superseded) #198/#199/#200.

## To run locally
```
git fetch origin && git checkout feat/animations-all
npm run devStart   # http://localhost:3000
```
Toggle OS "reduce motion" to see the accessible degrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)