### PR TITLE
Draft room: mobile-friendly overhaul

### DIFF
--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -270,6 +270,8 @@
     font-weight: 800;
     font-size: 1.05em;
 }
+/* No content (between picks / not active) — don't show an empty bordered box. */
+.on-the-clock:empty { display: none; }
 
 #draft-board {
     margin: 0;
@@ -455,6 +457,31 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
 
 .drafted-chip { background: #2a2f42; color: #6b7280; border-radius: 6px; padding: 4px 12px; font-size: 0.85em; }
 
+/* ---------- Mobile pool cards (Sleeper-style; shown <=768px) ---------- */
+.pool-cards { display: none; }   /* desktop uses the table */
+.pool-card {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    background: #131725;
+    border: 1px solid #2A2E42;
+    border-radius: 12px;
+    padding: 10px 12px;
+}
+.pool-card.drafted { opacity: 0.55; }
+.pool-card .card-draft { min-width: 76px; padding: 10px 0; font-size: 0.95em; }
+.pool-card .drafted-chip { min-width: 76px; text-align: center; padding: 9px 0; }
+.pool-card-main { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.pool-card-main .team-cell { font-size: 1.02em; white-space: normal; }
+.pool-card-main .team-cell img { width: 30px; height: 30px; }
+.pool-card-meta { display: flex; align-items: center; gap: 8px; color: #9aa4bf; font-size: 0.82em; min-width: 0; }
+.pc-conf { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pool-card-stats { display: flex; gap: 14px; text-align: center; flex: 0 0 auto; }
+.pool-card-stats span { display: flex; flex-direction: column; line-height: 1.1; }
+.pool-card-stats b { color: #F4F6FB; font-size: 0.98em; font-variant-numeric: tabular-nums; }
+.pool-card-stats small { color: #6b7280; font-size: 0.66em; text-transform: uppercase; letter-spacing: .04em; }
+
 /* ---------- Commissioner undo ---------- */
 .draft-undo-btn {
     background: transparent;
@@ -491,9 +518,8 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
     .pool-spacer { display: none; }
     .pool-count { flex: 1 1 100%; text-align: left; }
 
-    .pool-table thead th, .pool-table tbody td { padding: 6px 8px; font-size: 0.82em; }
-    .pool-table thead th:first-child, .pool-table tbody td:first-child { width: 130px; }
+    /* Swap the wide sortable table for the card list. */
+    .pool-table-wrap { display: none; }
+    .pool-cards { display: flex; flex-direction: column; gap: 8px; }
     .team-cell { gap: 6px; }
-    .team-cell img { width: 20px; height: 20px; }
-    .xwins-bar { width: 44px; }
 }

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -502,7 +502,14 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
     .draft-countdown { font-size: 1.2em; }
     .draft-live-label { font-size: 1.1em; }
 
-    .draft-board-wrap { padding: 0 8px; margin: 6px auto 16px; }
+    /* Constrain the board to the viewport so it scrolls INSIDE #draft-board
+       instead of stretching the whole page sideways (which also pushed the
+       centered on-the-clock text off-screen). */
+    .draft-board-wrap { padding: 0 8px; margin: 6px auto 16px; max-width: 100%; overflow-x: hidden; }
+    #draft-board { width: 100%; max-width: 100%; }
+    /* Let the table keep its natural width (so rounds stay legible) and overflow
+       the board, which then scrolls horizontally on its own. */
+    #draft-table { table-layout: auto; width: max-content; min-width: 620px; }
     .on-the-clock { font-size: 0.95em; padding: 10px; }
 
     #draft-table th, #draft-table td { padding: 5px 3px; }

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -289,7 +289,7 @@
     background: #131725;
 }
 #draft-board-head th:first-child,
-.draft-board-name { width: 150px; }
+.draft-board-name { width: 60px; }
 #draft-table th,
 #draft-table td {
     padding: 8px 6px;
@@ -307,20 +307,31 @@
     position: sticky;
     top: 0;
 }
-#draft-board-head th:first-child { text-align: left; padding-left: 16px; }
+#draft-board-head th:first-child { text-align: center; padding-left: 6px; }
 
-/* Sticky player-name column + zebra striping for readability */
+/* Sticky player column (avatars only) + zebra striping for readability */
 .draft-board-name {
-    text-align: left !important;
+    text-align: center !important;
     white-space: nowrap;
-    font-weight: 600;
     color: #F4F6FB;
     position: sticky;
     left: 0;
     background: #161b2b;
-    padding-left: 16px !important;
-    min-width: 120px;
+    padding: 6px !important;
+    min-width: 56px;
 }
+.board-avatar {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+}
+.board-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.board-avatar-initials { font-size: 0.72rem; font-weight: 700; color: #fff; }
 #draft-board-body tr:nth-child(even) td { background-color: #10131f; }
 #draft-board-body tr:nth-child(even) .draft-board-name { background-color: #141827; }
 
@@ -477,6 +488,7 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
 .pool-card-main .team-cell img { width: 30px; height: 30px; }
 .pool-card-meta { display: flex; align-items: center; gap: 8px; color: #9aa4bf; font-size: 0.82em; min-width: 0; }
 .pc-conf { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pc-conf-logo { height: 20px; width: auto; max-width: 64px; object-fit: contain; flex: 0 0 auto; }
 .pool-card-stats { display: flex; gap: 14px; text-align: center; flex: 0 0 auto; }
 .pool-card-stats span { display: flex; flex-direction: column; line-height: 1.1; }
 .pool-card-stats b { color: #F4F6FB; font-size: 0.98em; font-variant-numeric: tabular-nums; }
@@ -515,8 +527,8 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
     #draft-table th, #draft-table td { padding: 5px 3px; }
     .draft-board-cell { height: 40px; }
     .draft-board-cell img { width: 30px; height: 30px; }
-    #draft-board-head th:first-child, .draft-board-name { width: 92px; min-width: 92px; padding-left: 10px !important; }
-    #draft-board-head th:first-child { padding-left: 10px; }
+    #draft-board-head th:first-child, .draft-board-name { width: 50px; min-width: 50px; padding: 4px !important; }
+    .board-avatar { width: 30px; height: 30px; }
 
     .content.pool { padding: 0 8px; }
     .pool-controls { gap: 8px; }

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -488,7 +488,9 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
 .pool-card-main .team-cell img { width: 30px; height: 30px; }
 .pool-card-meta { display: flex; align-items: center; gap: 8px; color: #9aa4bf; font-size: 0.82em; min-width: 0; }
 .pc-conf { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.pc-conf-logo { height: 20px; width: auto; max-width: 64px; object-fit: contain; flex: 0 0 auto; }
+/* Fixed box + contain so every conference logo occupies the same footprint,
+   regardless of aspect ratio (wide wordmarks like ACC no longer dominate). */
+.pc-conf-logo { width: 42px; height: 18px; object-fit: contain; object-position: left center; flex: 0 0 auto; }
 .pool-card-stats { display: flex; gap: 14px; text-align: center; flex: 0 0 auto; }
 .pool-card-stats span { display: flex; flex-direction: column; line-height: 1.1; }
 .pool-card-stats b { color: #F4F6FB; font-size: 0.98em; font-variant-numeric: tabular-nums; }

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -216,7 +216,9 @@ function renderPool() {
     if (cardsEl) {
         cardsEl.innerHTML = rows.map(p => {
             var drafted = draftedIds.has(String(p.id));
-            var badge = p.rank == null ? '' : `<span class="rank-badge ${p.rank <= 10 ? 'top10' : p.rank <= 25 ? 'top25' : ''}">#${p.rank}</span>`;
+            // Labelled "Rec" so it's clearly the recruiting-class rank, not a
+            // team-strength ranking (e.g. recruiting has Arkansas above Kentucky).
+            var badge = p.rank == null ? '' : `<span class="rank-badge ${p.rank <= 10 ? 'top10' : p.rank <= 25 ? 'top25' : ''}">Rec #${p.rank}</span>`;
             var action = drafted
                 ? '<span class="drafted-chip">Drafted</span>'
                 : `<button class="draft-pick-btn card-draft" onclick="makePick(${p.id})" ${canAct ? '' : 'disabled'}>Draft</button>`;

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -210,6 +210,30 @@ function renderPool() {
         </tr>`;
     }).join('');
 
+    // Mobile card list (CSS shows this instead of the table at <=768px). Built
+    // from the same filtered/sorted rows so search/filter/sort stay in sync.
+    var cardsEl = document.getElementById('pool-cards');
+    if (cardsEl) {
+        cardsEl.innerHTML = rows.map(p => {
+            var drafted = draftedIds.has(String(p.id));
+            var badge = p.rank == null ? '' : `<span class="rank-badge ${p.rank <= 10 ? 'top10' : p.rank <= 25 ? 'top25' : ''}">#${p.rank}</span>`;
+            var action = drafted
+                ? '<span class="drafted-chip">Drafted</span>'
+                : `<button class="draft-pick-btn card-draft" onclick="makePick(${p.id})" ${canAct ? '' : 'disabled'}>Draft</button>`;
+            return `<div class="pool-card${drafted ? ' drafted' : ''}">
+                ${action}
+                <div class="pool-card-main">
+                    <span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span>
+                    <span class="pool-card-meta"><span class="pc-conf">${escapeHtml(p.conf)}</span>${badge}</span>
+                </div>
+                <div class="pool-card-stats">
+                    <span><b>${p.xwins || '-'}</b><small>xWins</small></span>
+                    <span><b>${p.score == null ? '-' : p.score}</b><small>last yr</small></span>
+                </div>
+            </div>`;
+        }).join('');
+    }
+
     var avail = pool.filter(p => !draftedIds.has(String(p.id))).length;
     document.getElementById('poolCount').textContent = `${rows.length} shown · ${avail} available`;
 }

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -33,6 +33,53 @@ var pool = [];               // enriched team rows for the pool table
 var poolSort = { key: 'xwins', dir: -1 };
 var xwMin = 0, xwMax = 0;
 
+// Self-hosted conference logos (same set as the team page) — used instead of
+// conference names in the mobile pool cards so long names don't get cut off.
+function conferenceLogo(conf) {
+    var map = {
+        'ACC': '../images/logo-acc.svg',
+        'American Athletic': '../images/logo-aac.png',
+        'Big 12': '../images/logo-big12.png',
+        'Big Ten': '../images/logo-big-ten.svg',
+        'Conference USA': '../images/logo-cusa.png',
+        'FBS Independents': '../images/logo-fbs-independents.gif',
+        'Mid-American': '../images/logo-mac.png',
+        'Mountain West': '../images/logo-mountain-west.png',
+        'Pac-12': '../images/logo-pac12.png',
+        'Sun Belt': '../images/logo-sun-belt.png',
+        'SEC': '../images/logo-sec.png'
+    };
+    return map[conf] || '';
+}
+
+// Manager display: prefer the season's franchise/team name, fall back to person.
+function managerName(userId) {
+    var m = membersById[String(userId)];
+    return m ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : 'Unknown';
+}
+function managerDisplay(userId) {
+    var m = membersById[String(userId)];
+    if (!m) return 'Unknown';
+    var yr = (draft && draft.season) || season;
+    var s = (m.seasons || []).find(x => String(x.season) === String(yr));
+    return (s && s.franchiseName) || managerName(userId);
+}
+
+// Small round avatar for the board (photo face-crop or colored initials), so the
+// board can show managers by picture and reclaim the space the names used.
+function memberAvatar(userId) {
+    var m = membersById[String(userId)];
+    if (!m) return '<span class="board-avatar board-avatar-initials" style="background:#333">?</span>';
+    var initials = (((m.firstName || '')[0] || '') + ((m.lastName || '')[0] || '')).toUpperCase();
+    if (m.avatarUrl) {
+        var src = m.avatarUrl.indexOf('/upload/') !== -1
+            ? m.avatarUrl.replace('/upload/', '/upload/c_fill,g_face,w_64,h_64,q_auto,f_auto/')
+            : m.avatarUrl;
+        return `<span class="board-avatar"><img src="${src}" alt=""></span>`;
+    }
+    return `<span class="board-avatar board-avatar-initials" style="background:${m.color || '#333'}">${escapeHtml(initials || '?')}</span>`;
+}
+
 window.onload = async function () {
     detectMobile();
     initNavbarToggle();
@@ -111,7 +158,7 @@ function buildPool(teams, recruiting) {
             var r = recruiting.filter(o => o.team == t.school || (t.alternateNames || []).includes(o.team))[0];
             if (r) rank = r.rank;
         }
-        return { id: t.id, name: t.school, logo: (t.logos || []).at(-1), conf, score, xwins, rank };
+        return { id: t.id, name: t.school, logo: (t.logos || []).at(-1), conf, score, xwins, rank, scoreYear: prev ? prev.season : null };
     });
     var xw = pool.map(p => p.xwins).filter(v => v > 0);
     xwMin = xw.length ? Math.min(...xw) : 0;
@@ -222,15 +269,20 @@ function renderPool() {
             var action = drafted
                 ? '<span class="drafted-chip">Drafted</span>'
                 : `<button class="draft-pick-btn card-draft" onclick="makePick(${p.id})" ${canAct ? '' : 'disabled'}>Draft</button>`;
+            var cl = conferenceLogo(p.conf);
+            var confHtml = cl
+                ? `<img class="pc-conf-logo" src="${cl}" alt="${escapeHtml(p.conf)}" title="${escapeHtml(p.conf)}">`
+                : `<span class="pc-conf">${escapeHtml(p.conf)}</span>`;
+            var ptsLabel = p.scoreYear ? `'${String(p.scoreYear).slice(-2)} pts` : 'pts';
             return `<div class="pool-card${drafted ? ' drafted' : ''}">
                 ${action}
                 <div class="pool-card-main">
                     <span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span>
-                    <span class="pool-card-meta"><span class="pc-conf">${escapeHtml(p.conf)}</span>${badge}</span>
+                    <span class="pool-card-meta">${confHtml}${badge}</span>
                 </div>
                 <div class="pool-card-stats">
                     <span><b>${p.xwins || '-'}</b><small>xWins</small></span>
-                    <span><b>${p.score == null ? '-' : p.score}</b><small>last yr</small></span>
+                    <span><b>${p.score == null ? '-' : p.score}</b><small>${ptsLabel}</small></span>
                 </div>
             </div>`;
         }).join('');
@@ -418,10 +470,9 @@ function renderBoard() {
     var onClock = draft.onTheClock || {};
     var bodyStr = '';
     draft.draftOrder.forEach(userId => {
-        var member = membersById[String(userId)];
-        var name = member ? `${member.firstName} ${member.lastName.substring(0, 1)}.` : '—';
         bodyStr += '<tr>';
-        bodyStr += `<td class="draft-board-name">${escapeHtml(name)}</td>`;
+        // Avatar only (name in the tooltip) to save horizontal space.
+        bodyStr += `<td class="draft-board-name" title="${escapeHtml(managerDisplay(userId))}">${memberAvatar(userId)}</td>`;
         for (var round = 1; round <= draft.totalRounds; round++) {
             var pick = draft.picks.find(p => String(p.userId) === String(userId) && p.round === round);
             var isClock = onClock.userId === String(userId) && onClock.round === round;
@@ -443,15 +494,14 @@ function renderOnTheClock() {
     var el = document.getElementById('on-the-clock');
     if (!draft || draft.status !== 'active' || !draft.onTheClock) { el.innerHTML = ''; el.classList.remove('your-turn'); return; }
     var oc = draft.onTheClock;
-    var member = membersById[String(oc.userId)];
-    var name = member ? `${member.firstName} ${member.lastName}` : 'Unknown';
     var mine = String(oc.userId) === String(myUserId);
     // .your-turn drives the urgency pulse in CSS (only when it's you).
     el.classList.toggle('your-turn', mine);
     if (mine) {
         el.innerHTML = `<span class="you-are-up">🟢 You're on the clock! — Round ${oc.round}, Pick #${oc.overall}</span>`;
     } else {
-        el.innerHTML = `<span>On the clock: <strong>${escapeHtml(name)}</strong> — Round ${oc.round}, Pick #${oc.overall}</span>`;
+        // Show the manager's team/franchise name (falls back to their name).
+        el.innerHTML = `<span>On the clock: <strong>${escapeHtml(managerDisplay(oc.userId))}</strong> — Round ${oc.round}, Pick #${oc.overall}</span>`;
     }
 }
 

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -59,12 +59,14 @@
             <span class="pool-spacer"></span>
             <span class="pool-count" id="poolCount"></span>
         </div>
+        <!-- Desktop: sortable table. Mobile (<=768px): card list (CSS toggles). -->
         <div class="pool-table-wrap">
             <table class="pool-table">
                 <thead><tr id="pool-head"></tr></thead>
                 <tbody user-table-body></tbody>
             </table>
         </div>
+        <div class="pool-cards" id="pool-cards"></div>
     </div>
     <footer>
         <a href="https://collegefootballdata.com/" class="cfb-data">Powered by College Football Data</a>


### PR DESCRIPTION
Makes the draft room usable on phones and fixes several board issues found in review. **Scoped to the draft room only** — no API changes (that's a separate branch).

## Available-teams pool → card list (≤768px)
The 6-column table is swapped for a card list (CSS toggle; desktop keeps the table), built from the same filtered/sorted rows so search / conference filter / show-drafted stay in sync:
- Prominent green **Draft** button
- Team logo + name
- **Conference logo** (self-hosted, standardized to a 42×18 box so ACC/Big 12 wordmarks don't dominate) — replaces the conference name that was getting truncated
- Recruiting rank labeled **"Rec #N"** (it's recruiting-class rank, not team strength — was ambiguous)
- **xWins** and **"'YY PTS"** (last-season points — relabeled from "LAST YR", which read like wins)

## Board
- Fixed the real bug: `#draft-board-wrap` was taking its 1200px max-width instead of the viewport, so the board never scrolled internally — it stretched the whole page sideways (dragging "Available Teams" with it) and pushed the centered **on-the-clock** text off-screen (looked blank). Now constrained to the viewport; the table keeps its natural width and scrolls *inside* the board.
- **On the clock** shows the manager's franchise/team name when set (falls back to their name).
- Board **Player column = avatars only** (photo or colored initials, name in tooltip) — reclaims width so an extra round fits on mobile.
- Hide the on-the-clock banner when empty (was an empty bordered box between picks).

## Verification
Driven live on `localhost:3000` at 390px throughout: page contained (no sideways scroll), board scrolls internally, cards render with working Draft buttons, conference logos uniform (42×18), on-the-clock visible. Desktop layout unchanged (table shown, board matrix intact). JS + EJS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)