### PR TITLE
API: SP+/FPI ratings, talent, returning production, coaches, broadcast

### DIFF
--- a/models/game.js
+++ b/models/game.js
@@ -112,6 +112,13 @@ const gameSchema = new mongoose.Schema({
     notes: {
         type: String,
     },
+    // Broadcast info from CFBD /games/media (e.g. outlet "ABC", mediaType "tv").
+    mediaType: {
+        type: String
+    },
+    outlet: {
+        type: String
+    },
     lastUpdated: {
         type: String
     },

--- a/models/team.js
+++ b/models/team.js
@@ -88,6 +88,29 @@ const seasonSchema = new mongoose.Schema({
     },
     expectedWins: {
         type: Number
+    },
+    // --- opponent-agnostic enrichment pulled from CFBD once per week/season ---
+    // (stored here so the team page + draft pool get it without extra reads).
+    spRating: {          // SP+ overall rating (e.g. 18.4)
+        type: Number
+    },
+    spRank: {            // SP+ national ranking (1 = best)
+        type: Number
+    },
+    fpiRating: {         // ESPN FPI rating
+        type: Number
+    },
+    fpiRank: {           // FPI national ranking (computed by sorting fpiRating)
+        type: Number
+    },
+    talent: {            // 247 talent composite
+        type: Number
+    },
+    returningProduction: {   // % of production returning (0-100)
+        type: Number
+    },
+    coach: {             // head coach display name for the season
+        type: String
     }
 });
 

--- a/models/team.js
+++ b/models/team.js
@@ -103,7 +103,10 @@ const seasonSchema = new mongoose.Schema({
     fpiRank: {           // FPI national ranking (computed by sorting fpiRating)
         type: Number
     },
-    talent: {            // 247 talent composite
+    talent: {            // 247 talent composite (raw score, e.g. ~875)
+        type: Number
+    },
+    talentRank: {        // national rank of the talent composite (1 = best)
         type: Number
     },
     returningProduction: {   // % of production returning (0-100)

--- a/modules/scheduler.js
+++ b/modules/scheduler.js
@@ -7,7 +7,10 @@ const TZ = 'America/Chicago';
 const JOB_SCHEDULES = [
     { job: 'daily-scores', modulePath: '../update-daily-scores-job', rule: { hour: 23, minute: 0 } },
     { job: 'saturday-scores', modulePath: '../update-saturday-scores-job', rule: { dayOfWeek: 6, hour: [15, 18, 22], minute: 0 } },
-    { job: 'sunday-scores', modulePath: '../update-sunday-scores-job', rule: { dayOfWeek: 0, hour: [3, 6], minute: 0 } }
+    { job: 'sunday-scores', modulePath: '../update-sunday-scores-job', rule: { dayOfWeek: 0, hour: [3, 6], minute: 0 } },
+    // Weekly enrichment (SP+/FPI/talent/returning/coaches + broadcast outlets).
+    // Tuesday morning, after the weekend's ratings have refreshed. ~6 CFBD calls.
+    { job: 'enrichment', modulePath: '../update-enrichment-job', rule: { dayOfWeek: 2, hour: 5, minute: 30 } }
 ];
 
 function toRule(spec) {

--- a/public/admin.css
+++ b/public/admin.css
@@ -532,3 +532,12 @@ select[scoring-config-combine-mode] { width: 100%; }
     outline: 2px solid #64B5F6;
     outline-offset: 2px;
 }
+
+/* Short explanation shown inside an admin function's expanded panel. */
+.function-description {
+    color: #A4A9C2;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    max-width: 46ch;
+    margin: 0 0 0.75em;
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -722,6 +722,41 @@ if (refreshTeamsForm) {
     });
 }
 
+const enrichmentForm = document.getElementById('enrichment-form');
+
+if (enrichmentForm) {
+    enrichmentForm.addEventListener('submit', async function(event) {
+        event.preventDefault();
+
+        block_screen();
+
+        const season = document.querySelector('[enrichment-season]').value;
+        const opts = { method: 'POST', headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' } };
+
+        try {
+            // Team ratings/talent/returning/coaches, then game broadcasts.
+            const teamsRes = await fetch(`/teams/${season}/enrich`, opts);
+            const teamsData = await teamsRes.json();
+            const mediaRes = await fetch(`/games/${season}/media`, opts);
+            const mediaData = await mediaRes.json();
+
+            unblock_screen();
+
+            if (teamsRes.status == 200) {
+                successToast.options.text = `Enriched ${teamsData.updated} teams + ${mediaData.updated || 0} games for ${season}`;
+                successToast.showToast();
+            } else {
+                failToast.options.text = (teamsData && teamsData.message) || `${teamsRes.status} Enrichment failed`;
+                failToast.showToast();
+            }
+        } catch (err) {
+            unblock_screen();
+            failToast.options.text = 'Enrichment failed: ' + err.message;
+            failToast.showToast();
+        }
+    });
+}
+
 const gamesForm = document.getElementById('games-form');
 
 if (gamesForm) {
@@ -1003,6 +1038,16 @@ function displayExpectedWinsContainer() {
         expectedWinsContainer.style.display = 'none';
     } else {
         expectedWinsContainer.style.display = 'flex';
+    }
+}
+
+function displayEnrichmentContainer() {
+    var enrichmentContainer = document.querySelector('[enrichment-container]');
+
+    if (enrichmentContainer.style.display == 'flex' || enrichmentContainer.style.display=='') {
+        enrichmentContainer.style.display = 'none';
+    } else {
+        enrichmentContainer.style.display = 'flex';
     }
 }
 

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -544,3 +544,6 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
     .pool-cards { display: flex; flex-direction: column; gap: 8px; }
     .team-cell { gap: 6px; }
 }
+
+/* SP+ rank badge in the pool table (power-rating column). */
+.sp-badge { display: inline-block; min-width: 26px; text-align: center; padding: 2px 7px; border-radius: 6px; background: #1f3a2c; color: #8fe0a8; font-weight: 700; font-size: 0.9em; }

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -547,3 +547,11 @@ table.pool-table { width: 100%; border-collapse: collapse; background: #131725; 
 
 /* SP+ rank badge in the pool table (power-rating column). */
 .sp-badge { display: inline-block; min-width: 26px; text-align: center; padding: 2px 7px; border-radius: 6px; background: #1f3a2c; color: #8fe0a8; font-weight: 700; font-size: 0.9em; }
+
+/* Clickable team name/logo → team page (new tab, so a live draft isn't lost). */
+.team-link { display: inline-flex; align-items: center; color: inherit; text-decoration: none; }
+.team-link:hover .team-cell { text-decoration: underline; }
+.draft-board-cell a { display: inline-flex; align-items: center; justify-content: center; }
+.draft-board-cell a:hover img { transform: scale(1.08); transition: transform .12s ease; }
+a.pick-chip { text-decoration: none; }
+a.pick-chip:hover { border-color: #ed5858; }

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -266,7 +266,7 @@ function renderPool() {
             ? '<span class="muted">—</span>'
             : `<span class="sp-badge" title="SP+ rating ${p.sp}">#${p.spRank}</span>`;
         return `<tr class="${drafted ? 'drafted' : ''}">
-            <td><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></td>
+            <td><a class="team-link" href="/team?team=${p.id}" target="_blank" rel="noopener"><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></a></td>
             <td>${escapeHtml(p.conf)}</td>
             <td class="num">${spCell}</td>
             <td class="num">${badge}</td>
@@ -296,7 +296,7 @@ function renderPool() {
             return `<div class="pool-card${drafted ? ' drafted' : ''}">
                 ${action}
                 <div class="pool-card-main">
-                    <span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span>
+                    <a class="team-link" href="/team?team=${p.id}" target="_blank" rel="noopener"><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></a>
                     <span class="pool-card-meta">${confHtml}${badge}</span>
                 </div>
                 <div class="pool-card-stats">
@@ -422,8 +422,8 @@ function renderTicker() {
     var ordered = draft.picks.slice().sort(function (a, b) { return (a.overall || 0) - (b.overall || 0); });
     var chips = ordered.map(function (p) {
         var logo = (p.team.logos && p.team.logos.length) ? p.team.logos.at(-1) : '';
-        return `<span class="pick-chip"><span class="pk">#${p.overall}</span>`
-            + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</span>`;
+        return `<a class="pick-chip" href="/team?team=${p.team.id}" target="_blank" rel="noopener"><span class="pk">#${p.overall}</span>`
+            + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</a>`;
     }).join('');
     // Only loop-scroll when there are enough picks to overflow and motion is OK.
     // Duration scales with pick count (~2s per chip) so the on-screen speed
@@ -499,7 +499,7 @@ function renderBoard() {
             var cls = isClock ? 'draft-board-cell on-clock-cell' : 'draft-board-cell';
             if (pick) {
                 var freshCls = (justPickedKey === String(userId) + '-' + round) ? ' just-picked' : '';
-                bodyStr += `<td class="${cls}${freshCls}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}" title="${escapeHtml(pick.team.school)}"></td>`;
+                bodyStr += `<td class="${cls}${freshCls}"><a href="/team?team=${pick.team.id}" target="_blank" rel="noopener" title="${escapeHtml(pick.team.school)}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}"></a></td>`;
             } else {
                 bodyStr += `<td class="${cls}"></td>`;
             }

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -156,6 +156,12 @@ function buildPool(teams, recruiting) {
                 if (cur.spRating != null) sp = cur.spRating;
                 if (cur.spRank != null) spRank = cur.spRank;
             }
+            // Preseason fallback: before the upcoming season's ratings publish,
+            // use last season's final SP+ as the draft signal.
+            if (sp == null && prev) {
+                if (prev.spRating != null) sp = prev.spRating;
+                if (prev.spRank != null) spRank = prev.spRank;
+            }
         }
         var rank = null;
         if (recruiting && recruiting.length) {

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -145,24 +145,32 @@ async function getTeams() {
 function buildPool(teams, recruiting) {
     var yr = new Date().getFullYear();
     pool = teams.map(t => {
-        var conf = '-', score = null, xwins = 0;
+        var conf = '-', score = null, xwins = 0, sp = null, spRank = null;
         if (t.seasons && t.seasons.length) {
             var prev = t.seasons.find(s => s.season == (yr - 1));
             var cur = t.seasons.find(s => s.season == yr);
             conf = t.seasons.at(-1).conference;
             if (prev) score = (leagueVersion == 'V1') ? prev.cumulativeScoreV1 : prev.cumulativeScoreV2;
-            if (cur) xwins = cur.expectedWins || 0;
+            if (cur) {
+                xwins = cur.expectedWins || 0;
+                if (cur.spRating != null) sp = cur.spRating;
+                if (cur.spRank != null) spRank = cur.spRank;
+            }
         }
         var rank = null;
         if (recruiting && recruiting.length) {
             var r = recruiting.filter(o => o.team == t.school || (t.alternateNames || []).includes(o.team))[0];
             if (r) rank = r.rank;
         }
-        return { id: t.id, name: t.school, logo: (t.logos || []).at(-1), conf, score, xwins, rank, scoreYear: prev ? prev.season : null };
+        return { id: t.id, name: t.school, logo: (t.logos || []).at(-1), conf, score, xwins, rank, sp, spRank, scoreYear: prev ? prev.season : null };
     });
     var xw = pool.map(p => p.xwins).filter(v => v > 0);
     xwMin = xw.length ? Math.min(...xw) : 0;
     xwMax = xw.length ? Math.max(...xw) : 0;
+
+    // Once SP+ is populated (enrichment job has run), default the draft sort to
+    // it — a truer team-strength signal than recruiting/xWins.
+    if (pool.some(p => p.sp != null)) poolSort = { key: 'sp', dir: -1 };
 }
 
 function barWidth(x) {
@@ -195,6 +203,7 @@ function sortVal(p, k) {
     if (k === 'rank') return p.rank == null ? 999 : p.rank;
     if (k === 'score') return p.score == null ? -1 : p.score;
     if (k === 'xwins') return p.xwins == null ? -1 : p.xwins;
+    if (k === 'sp') return p.sp == null ? -Infinity : p.sp;   // higher SP+ = better
     return 0;
 }
 
@@ -231,9 +240,9 @@ function renderPool() {
     var k = poolSort.key, dir = poolSort.dir;
     rows.sort((a, b) => { var av = sortVal(a, k), bv = sortVal(b, k); return (av < bv ? -1 : av > bv ? 1 : 0) * dir; });
 
-    var cols = [['name', 'Team'], ['conf', 'Conference'], ['rank', 'Recruiting'], ['score', 'Last Season'], ['xwins', 'xWins'], ['draft', '']];
+    var cols = [['name', 'Team'], ['conf', 'Conference'], ['sp', 'SP+'], ['rank', 'Recruiting'], ['score', 'Last Season'], ['xwins', 'xWins'], ['draft', '']];
     document.getElementById('pool-head').innerHTML = cols.map(([key, label]) => {
-        var numCls = (key === 'rank' || key === 'score' || key === 'xwins') ? 'num' : '';
+        var numCls = (key === 'rank' || key === 'score' || key === 'xwins' || key === 'sp') ? 'num' : '';
         var sorted = key === poolSort.key;
         var arrow = key === 'draft' ? '' : `<span class="arrow">${sorted ? (poolSort.dir < 0 ? '▼' : '▲') : '↕'}</span>`;
         var onclick = key === 'draft' ? '' : `onclick="sortPool('${key}')"`;
@@ -247,9 +256,13 @@ function renderPool() {
         var action = drafted
             ? '<span class="drafted-chip">Drafted</span>'
             : `<button class="draft-pick-btn" onclick="makePick(${p.id})" ${canAct ? '' : 'disabled'}>Draft</button>`;
+        var spCell = p.spRank == null
+            ? '<span class="muted">—</span>'
+            : `<span class="sp-badge" title="SP+ rating ${p.sp}">#${p.spRank}</span>`;
         return `<tr class="${drafted ? 'drafted' : ''}">
             <td><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></td>
             <td>${escapeHtml(p.conf)}</td>
+            <td class="num">${spCell}</td>
             <td class="num">${badge}</td>
             <td class="num">${p.score == null ? '-' : p.score}</td>
             <td class="num"><span class="xwins-wrap">${p.xwins || '-'}<span class="xwins-bar"><span class="xwins-fill" style="width:${bw}%;background:${barColor(p.xwins)}"></span></span></span></td>
@@ -281,6 +294,7 @@ function renderPool() {
                     <span class="pool-card-meta">${confHtml}${badge}</span>
                 </div>
                 <div class="pool-card-stats">
+                    ${p.spRank != null ? `<span title="SP+ rating ${p.sp}"><b>#${p.spRank}</b><small>SP+</small></span>` : ''}
                     <span><b>${p.xwins || '-'}</b><small>xWins</small></span>
                     <span><b>${p.score == null ? '-' : p.score}</b><small>${ptsLabel}</small></span>
                 </div>

--- a/public/team.css
+++ b/public/team.css
@@ -751,4 +751,17 @@
     gap: 0.4em;
 }
 .team-coach i { color: var(--team-accent, #ed5858); }
-.rating-val { color: #A4A9C2; font-weight: 500; font-size: 0.9em; }
+
+/* Outlook ratings as accent-tinted chips (SP+/FPI/talent/returning). */
+.outlook-chips { display: flex; flex-wrap: wrap; gap: 0.4em; margin-top: 0.35em; }
+.outlook-chip {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--team-accent, #ed5858);
+    background: rgba(var(--team-accent-rgb, 237, 88, 88), 0.12);
+    border: 1px solid rgba(var(--team-accent-rgb, 237, 88, 88), 0.4);
+    border-radius: 999px;
+    padding: 0.25em 0.7em;
+    white-space: nowrap;
+    cursor: default;
+}

--- a/public/team.css
+++ b/public/team.css
@@ -740,3 +740,15 @@
     /* Desktop: always visible, no clipping */
     .games-container, .standings-table { max-height: none; overflow: visible; }
 }
+/* Head coach line in the team header + SP+/FPI rating value in the Outlook block
+   (populated by the weekly enrichment job). */
+.team-coach {
+    color: #A4A9C2;
+    font-size: 0.85rem;
+    margin: 0.2em 0 0;
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+}
+.team-coach i { color: var(--team-accent, #ed5858); }
+.rating-val { color: #A4A9C2; font-weight: 500; font-size: 0.9em; }

--- a/public/team.js
+++ b/public/team.js
@@ -520,6 +520,23 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
         ? `<span class="fantasy-rank">#<span data-countup="${fantasyRank.rank}">0</span> of ${fantasyRank.total}</span>`
         : '';
 
+    // Head coach (from the weekly enrichment job) — a subtle line in the header.
+    var coachHtml = seasonObj.coach
+        ? `<p class="team-coach"><i class="fa-solid fa-clipboard-user"></i> ${seasonObj.coach}</p>`
+        : '';
+
+    // Outlook block: SP+/FPI power ratings, talent, returning production. Only
+    // rendered once the enrichment job has populated these (absent otherwise).
+    var outlookRows = [];
+    if (seasonObj.spRank != null) {
+        var spVal = seasonObj.spRating != null ? ` <span class="rating-val">(${seasonObj.spRating > 0 ? '+' : ''}${seasonObj.spRating})</span>` : '';
+        outlookRows.push(`<p class="score">SP+ #${seasonObj.spRank}${spVal}</p>`);
+    }
+    if (seasonObj.fpiRank != null) outlookRows.push(`<p class="score">FPI #${seasonObj.fpiRank}</p>`);
+    if (seasonObj.talent != null) outlookRows.push(`<p class="score">Talent ${Math.round(seasonObj.talent)}</p>`);
+    if (seasonObj.returningProduction != null) outlookRows.push(`<p class="score">${seasonObj.returningProduction}% returning</p>`);
+    var outlookHtml = outlookRows.length ? `<div><h4>📊 Outlook</h4>${outlookRows.join('')}</div>` : '';
+
     // Set the tab title to the team being viewed.
     document.title = `${team.school} ${team.mascot} · Campus Clash`;
 
@@ -533,6 +550,7 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
                 ${renderSeasonSelector(team.seasons, seasonObj.season)}
             </div>
             <p class="team-conf"><img class="conf-logo" src="${confLogo}" alt="${formatConference}" /> ${formatConference}</p>
+            ${coachHtml}
             <div class="team-meta-links">${twitterHtml}${ownerHtml}</div>
             ${formStrip ? `<div class="form-strip" title="Most recent results">${formStrip}</div>` : ''}
             </div>
@@ -559,6 +577,7 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
                 ${(loc.city && loc.state) ? `<p><small>${loc.city}, ${loc.state}</small></p>` : ''}
                 ${stadiumChips.length ? `<div class="stadium-chips">${stadiumChips.map(c => `<span class="chip">${c}</span>`).join('')}</div>` : ''}
             </div>
+            ${outlookHtml}
         </div>
 
         ${renderWeeklyScores(seasonObj, scoreCode)}
@@ -738,7 +757,7 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
                         <div class="team-row">
                             <span class="team-vs">${homeTeamHTML}
                         </div>
-                        <span class="game-date">${formatDate(game.startTimeTbd, game.startDate)}</span>
+                        <span class="game-date">${formatDate(game.startTimeTbd, game.startDate)}${game.outlet ? ` · <span class="game-tv">📺 ${game.outlet}</span>` : ''}</span>
                         <span class="game-date">${game.neutralSite ? game.venue : ''}</span>
                         <span class="game-date">${game.notes ? game.notes : ''}</span>
                     </div>
@@ -794,7 +813,7 @@ function renderNextGame(schedule, logos, teamId) {
             <span class="next-game-tag">Next Up</span>
             <div class="next-game-body">
                 <span class="next-game-opp">${oppLogo} ${prefix} ${oppName}</span>
-                <span class="next-game-date">${formatDate(game.startTimeTbd, game.startDate)}</span>
+                <span class="next-game-date">${formatDate(game.startTimeTbd, game.startDate)}${game.outlet ? ` · 📺 ${game.outlet}` : ''}</span>
                 ${game.neutralSite && game.venue ? `<span class="next-game-venue">${game.venue}</span>` : ''}
             </div>
         </a>

--- a/public/team.js
+++ b/public/team.js
@@ -527,15 +527,23 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
 
     // Outlook block: SP+/FPI power ratings, talent, returning production. Only
     // rendered once the enrichment job has populated these (absent otherwise).
-    var outlookRows = [];
+    var outlookChips = [];
     if (seasonObj.spRank != null) {
-        var spVal = seasonObj.spRating != null ? ` <span class="rating-val">(${seasonObj.spRating > 0 ? '+' : ''}${seasonObj.spRating})</span>` : '';
-        outlookRows.push(`<p class="score">SP+ #${seasonObj.spRank}${spVal}</p>`);
+        var spTip = seasonObj.spRating != null ? `SP+ ${seasonObj.spRating > 0 ? '+' : ''}${seasonObj.spRating} — projected points per game vs. an average team` : 'SP+ national rank';
+        outlookChips.push(`<span class="outlook-chip" title="${spTip}">SP+ #${seasonObj.spRank}</span>`);
     }
-    if (seasonObj.fpiRank != null) outlookRows.push(`<p class="score">FPI #${seasonObj.fpiRank}</p>`);
-    if (seasonObj.talent != null) outlookRows.push(`<p class="score">Talent ${Math.round(seasonObj.talent)}</p>`);
-    if (seasonObj.returningProduction != null) outlookRows.push(`<p class="score">${seasonObj.returningProduction}% returning</p>`);
-    var outlookHtml = outlookRows.length ? `<div><h4>📊 Outlook</h4>${outlookRows.join('')}</div>` : '';
+    if (seasonObj.fpiRank != null) {
+        outlookChips.push(`<span class="outlook-chip" title="ESPN Football Power Index — national rank">FPI #${seasonObj.fpiRank}</span>`);
+    }
+    if (seasonObj.talentRank != null || seasonObj.talent != null) {
+        var talLabel = seasonObj.talentRank != null ? `Talent #${seasonObj.talentRank}` : `Talent ${Math.round(seasonObj.talent)}`;
+        var talTip = `247Sports Talent Composite${seasonObj.talent != null ? ' (' + Math.round(seasonObj.talent) + ')' : ''} — total blue-chip recruiting talent on the roster; higher = more talent`;
+        outlookChips.push(`<span class="outlook-chip" title="${talTip}">${talLabel}</span>`);
+    }
+    if (seasonObj.returningProduction != null) {
+        outlookChips.push(`<span class="outlook-chip" title="Share of last season's production (PPA) returning">${seasonObj.returningProduction}% returning</span>`);
+    }
+    var outlookHtml = outlookChips.length ? `<div><h4>📊 Outlook</h4><div class="outlook-chips">${outlookChips.join('')}</div></div>` : '';
 
     // Set the tab title to the team being viewed.
     document.title = `${team.school} ${team.mascot} · Campus Clash`;

--- a/routes/games.js
+++ b/routes/games.js
@@ -218,4 +218,44 @@ router.post('/week/mass-create', async (req, res) => {
     }
 });
 
+// Populate broadcast info (TV/web outlet) onto existing game docs from CFBD
+// /games/media. One call covers the whole season; matched by game id.
+router.post('/:season/media', async (req, res) => {
+    if (!/^\d{4}$/.test(req.params.season)) {
+        return res.status(400).json({ message: 'Invalid season' });
+    }
+    const season = Number(req.params.season);
+    try {
+        const response = await fetch(`https://api.collegefootballdata.com/games/media?year=${season}&seasonType=both`, {
+            method: 'GET',
+            headers: { 'Accept': 'application/json', 'Authorization': process.env.CFBD_API_KEY }
+        });
+        const media = await response.json();
+        if (!response.ok || !Array.isArray(media)) {
+            return res.status(400).json({ message: (media && media.message) || 'Could not fetch media' });
+        }
+
+        // A game can have multiple media rows (tv + web); prefer a TV outlet.
+        const byId = new Map();
+        media.forEach(m => {
+            if (m.id == null) return;
+            const existing = byId.get(m.id);
+            if (!existing || (m.mediaType === 'tv' && existing.mediaType !== 'tv')) byId.set(m.id, m);
+        });
+
+        let updated = 0;
+        for (const [id, m] of byId) {
+            const result = await Game.updateOne(
+                { id: id },
+                { $set: { mediaType: m.mediaType || null, outlet: m.outlet || null } }
+            );
+            if (result.modifiedCount) updated++;
+        }
+        res.status(200).json({ season, mediaRows: media.length, updated });
+    } catch (err) {
+        console.log('Error updating game media:', err.message);
+        res.status(400).json({ message: err.message });
+    }
+});
+
 module.exports = router;

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -283,9 +283,13 @@ router.post('/:season/enrich', async (req, res) => {
             .sort((a, b) => b.fpi - a.fpi)
             .forEach((r, i) => fpiMap.set(norm(r.team), { fpi: r.fpi, rank: i + 1 }));
 
+        // CFBD /talent keys the team as `team` (some other endpoints use
+        // `school`). Rank is derived by sorting the composite, like FPI.
         const talentMap = new Map();
-        // CFBD /talent keys the team as `team` (some other endpoints use `school`).
-        (Array.isArray(talent) ? talent : []).forEach(r => talentMap.set(norm(r.team || r.school), r.talent));
+        (Array.isArray(talent) ? talent : [])
+            .filter(r => r.talent != null)
+            .sort((a, b) => b.talent - a.talent)
+            .forEach((r, i) => talentMap.set(norm(r.team || r.school), { value: r.talent, rank: i + 1 }));
 
         const retMap = new Map();
         (Array.isArray(returning) ? returning : []).forEach(r => retMap.set(norm(r.team), r.percentPPA));
@@ -320,7 +324,7 @@ router.post('/:season/enrich', async (req, res) => {
                 if (spR.ranking != null) s.spRank = spR.ranking;
             }
             if (fpiR) { s.fpiRating = fpiR.fpi; s.fpiRank = fpiR.rank; }
-            if (tal != null) s.talent = Number(tal);
+            if (tal) { s.talent = Number(tal.value); s.talentRank = tal.rank; }
             if (ret != null) {
                 // percentPPA arrives as a 0-1 fraction; store as a 0-100 percent.
                 var pct = Number(ret);

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -284,7 +284,8 @@ router.post('/:season/enrich', async (req, res) => {
             .forEach((r, i) => fpiMap.set(norm(r.team), { fpi: r.fpi, rank: i + 1 }));
 
         const talentMap = new Map();
-        (Array.isArray(talent) ? talent : []).forEach(r => talentMap.set(norm(r.school), r.talent));
+        // CFBD /talent keys the team as `team` (some other endpoints use `school`).
+        (Array.isArray(talent) ? talent : []).forEach(r => talentMap.set(norm(r.team || r.school), r.talent));
 
         const retMap = new Map();
         (Array.isArray(returning) ? returning : []).forEach(r => retMap.set(norm(r.team), r.percentPPA));

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -247,6 +247,103 @@ router.post('/:season/expectedWins', async (req, res) => {
     res.status(200).json(updatedTeams);
 });
 
+// Enrich each team's season with opponent-agnostic CFBD data: SP+ / FPI power
+// ratings, 247 talent, returning production, and head coach. One run makes ~5
+// CFBD calls total (each endpoint returns all teams), so it's cheap to schedule
+// weekly. Commissioner/token-gated by the /teams middleware in server.js.
+router.post('/:season/enrich', async (req, res) => {
+    if (!/^\d{4}$/.test(req.params.season)) {
+        return res.status(400).json({message: 'Invalid season'});
+    }
+    const season = Number(req.params.season);
+    const cfbd = (path) => fetch(`https://api.collegefootballdata.com${path}`, {
+        method: 'GET',
+        headers: { 'Accept': 'application/json', 'Authorization': process.env.CFBD_API_KEY }
+    }).then(r => r.ok ? r.json() : []);
+
+    const norm = (s) => String(s == null ? '' : s).toLowerCase().trim();
+
+    try {
+        const [sp, fpi, talent, returning, coaches] = await Promise.all([
+            cfbd(`/ratings/sp?year=${season}`),
+            cfbd(`/ratings/fpi?year=${season}`),
+            cfbd(`/talent?year=${season}`),
+            cfbd(`/player/returning?year=${season}`),
+            cfbd(`/coaches?year=${season}`)
+        ]);
+
+        // Build lookup maps keyed by normalized team name.
+        const spMap = new Map();
+        (Array.isArray(sp) ? sp : []).forEach(r => spMap.set(norm(r.team), r));
+
+        // FPI has no overall rank field, so derive it by sorting the rating.
+        const fpiMap = new Map();
+        (Array.isArray(fpi) ? fpi : [])
+            .filter(r => r.fpi != null)
+            .sort((a, b) => b.fpi - a.fpi)
+            .forEach((r, i) => fpiMap.set(norm(r.team), { fpi: r.fpi, rank: i + 1 }));
+
+        const talentMap = new Map();
+        (Array.isArray(talent) ? talent : []).forEach(r => talentMap.set(norm(r.school), r.talent));
+
+        const retMap = new Map();
+        (Array.isArray(returning) ? returning : []).forEach(r => retMap.set(norm(r.team), r.percentPPA));
+
+        // Coaches are coach-centric; flatten to a team->name map for the season.
+        const coachMap = new Map();
+        (Array.isArray(coaches) ? coaches : []).forEach(c => {
+            (c.seasons || []).forEach(s => {
+                if (Number(s.year) === season && s.school) {
+                    coachMap.set(norm(s.school), `${c.firstName || ''} ${c.lastName || ''}`.trim());
+                }
+            });
+        });
+
+        const teams = await Team.find();
+        let updated = 0;
+        for (const team of teams) {
+            const keys = [norm(team.school), ...((team.alternateNames || []).map(norm))];
+            const pick = (map) => { for (const k of keys) if (map.has(k)) return map.get(k); return undefined; };
+
+            const spR = pick(spMap), fpiR = pick(fpiMap), tal = pick(talentMap), ret = pick(retMap), coach = pick(coachMap);
+            if (spR === undefined && fpiR === undefined && tal === undefined && ret === undefined && coach === undefined) continue;
+
+            let idx = team.seasons.findIndex(x => x.season == season);
+            if (idx === -1) {
+                team.seasons.push({ season: season, conference: team.conference });
+                idx = team.seasons.length - 1;
+            }
+            const s = team.seasons[idx];
+            if (spR) {
+                if (spR.rating != null) s.spRating = spR.rating;
+                if (spR.ranking != null) s.spRank = spR.ranking;
+            }
+            if (fpiR) { s.fpiRating = fpiR.fpi; s.fpiRank = fpiR.rank; }
+            if (tal != null) s.talent = Number(tal);
+            if (ret != null) {
+                // percentPPA arrives as a 0-1 fraction; store as a 0-100 percent.
+                var pct = Number(ret);
+                s.returningProduction = Math.round((pct <= 1 ? pct * 100 : pct) * 10) / 10;
+            }
+            if (coach) s.coach = coach;
+
+            await team.save();
+            updated++;
+        }
+
+        res.status(200).json({
+            season, updated,
+            counts: {
+                sp: (sp || []).length, fpi: (fpi || []).length, talent: (talent || []).length,
+                returning: (returning || []).length, coaches: (coaches || []).length
+            }
+        });
+    } catch (err) {
+        console.log('Error enriching teams:', err.message);
+        res.status(400).json({message: err.message});
+    }
+});
+
 //Refreshing All
 router.post('/refresh', async (req, res) => {
     try {

--- a/tests/Scheduler.spec.js
+++ b/tests/Scheduler.spec.js
@@ -1,9 +1,9 @@
 const { JOB_SCHEDULES, TZ, toRule } = require('../modules/scheduler');
 
 describe('scheduler config', () => {
-    it('schedules exactly the three score jobs (expected wins is manual)', () => {
+    it('schedules the three score jobs plus enrichment (expected wins is manual)', () => {
         const jobs = JOB_SCHEDULES.map(s => s.job).sort();
-        expect(jobs).toEqual(['daily-scores', 'saturday-scores', 'sunday-scores']);
+        expect(jobs).toEqual(['daily-scores', 'enrichment', 'saturday-scores', 'sunday-scores']);
         expect(JOB_SCHEDULES.find(s => s.job === 'expected-wins')).toBeUndefined();
     });
 
@@ -13,6 +13,7 @@ describe('scheduler config', () => {
         expect(byJob['daily-scores']).toEqual({ hour: 23, minute: 0 });
         expect(byJob['saturday-scores']).toEqual({ dayOfWeek: 6, hour: [15, 18, 22], minute: 0 });
         expect(byJob['sunday-scores']).toEqual({ dayOfWeek: 0, hour: [3, 6], minute: 0 });
+        expect(byJob['enrichment']).toEqual({ dayOfWeek: 2, hour: 5, minute: 30 });
     });
 
     it('builds a timezone-aware recurrence rule', () => {

--- a/update-enrichment-job.js
+++ b/update-enrichment-job.js
@@ -1,0 +1,39 @@
+if (process.env.NODE_ENV !== 'production') {
+    require('dotenv').config();
+}
+
+const { internalFetch } = require('./modules/internal-api');
+
+// Pulls opponent-agnostic CFBD data (SP+/FPI ratings, talent, returning
+// production, coaches) onto each team's season, and broadcast outlets onto
+// games. Cheap on the CFBD budget: ~6 calls total per run (each endpoint
+// returns the whole season), so it's safe to run weekly. Timing is owned by
+// modules/scheduler.js; running this file directly is a manual fallback:
+//   node update-enrichment-job.js 2025
+const JOB_NAME = 'enrichment';
+
+async function run() {
+    const season = parseInt(process.argv[2], 10) || parseInt(process.env.YEAR, 10);
+    const results = {};
+
+    async function post(path) {
+        const res = await internalFetch(`${process.env.URL}${path}`, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+        });
+        const body = await res.json().catch(() => ({}));
+        if (res.status !== 200) console.log(`${path} -> ${res.status}:`, body.message || body);
+        return { status: res.status, body };
+    }
+
+    results.teams = await post(`/teams/${season}/enrich`);
+    results.media = await post(`/games/${season}/media`);
+
+    console.log(`[${JOB_NAME}] season ${season}:`,
+        `teams enriched=${results.teams.body.updated}`,
+        `media updated=${results.media.body.updated}`);
+    return results;
+}
+
+module.exports = { run, JOB_NAME };
+if (require.main === module) { run(); }

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -114,7 +114,7 @@
     </section>
 
     <section class="admin-group">
-        <div class="group-head"><h2>Data sync · College Football Data</h2><span class="group-count">6</span></div>
+        <div class="group-head"><h2>Data sync · College Football Data</h2><span class="group-count">7</span></div>
         <div class="admin-functions">
             <div class="function-container">
                 <div class="button-container">
@@ -200,6 +200,26 @@
                     <form id="refresh-teams-form">
                         <div><select refresh-season season-options></select></div>
                         <div><button type="submit">Refresh Teams</button></div>
+                    </form>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayEnrichmentContainer()">
+                        <i class="fa-solid fa-chart-line" style="padding-right: 5px;"></i>
+                        Refresh Ratings &amp; Broadcasts
+                    </button>
+                </div>
+                <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · weekly enrichment job (Tue)</div>
+                <div class="sub-container" enrichment-container style="display: none">
+                    <p class="function-description">
+                        Pulls SP+ &amp; FPI ratings, 247 talent, returning production and head coaches onto every
+                        team, plus TV/broadcast outlets onto games. Powers the team-page Outlook block and the
+                        draft board's SP+ column. Uses ~6 CFBD calls.
+                    </p>
+                    <form id="enrichment-form">
+                        <div><select enrichment-season season-options></select></div>
+                        <div><button type="submit">Run Enrichment</button></div>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
Adds five CFBD datasets, all following the **fetch-once-in-a-job → store in Mongo → serve from the docs the app already loads** pattern, so they add **~0 per-user API calls**. Total CFBD cost: **~6 calls/week** (each endpoint returns the whole season at once) — well under the 1000/month budget.

## Backend
- **Team enrichment** — `POST /teams/:season/enrich` pulls SP+ (`/ratings/sp`), FPI (`/ratings/fpi`, rank derived by sorting), talent (`/talent`), returning production (`/player/returning`), and coaches (`/coaches`), matches them to teams (by school + alternateNames), and writes to each team's `seasons[]` subdoc (alongside `expectedWins`). ~5 calls.
- **Broadcast** — `POST /games/:season/media` writes `mediaType`/`outlet` onto game docs. 1 call.
- **Job + schedule** — `update-enrichment-job.js` runs both; registered weekly (Tue 5:30a CT) in `modules/scheduler.js`.

## Frontend
- **Team page** — new **Outlook** block (SP+ #rank (+rating), FPI #rank, talent, % returning) + **head coach** line in the header.
- **Draft pool** — **SP+** column (table) + stat (cards), sortable; the pool **defaults to SP+ sort once populated** — a truer team-strength signal than recruiting rank (directly addresses the Arkansas-vs-Kentucky concern).
- **Schedule + next-game** — broadcast outlet ("📺 ABC") when present.

All new UI is **conditional** — hidden until the job populates the data, so nothing changes until you run it.

## One manual step
The scheduler handles it going forward, but to backfill now (spends ~6 CFBD calls):
```
node update-enrichment-job.js 2025
```

## Verification
Driven live on `localhost:3000`:
- **Absent-data** (current DB): SP+ column shows "—", no Outlook/coach, zero console errors — degrades cleanly.
- **Present-data** (mock-injected): pool sorts correctly by SP+ rating and shows the badge/stat; team-page Outlook block + coach render (screenshot).
- Backend syntax-checked; both new routes confirmed registered; scheduler entry present.

> Field mappings follow CFBD's documented schemas. I did **not** run the live ingestion (to avoid spending your API budget in dev) — once you run the job, if any field name is off we can adjust in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)