### PR TITLE
Game cards: standardize broadcast (📺 outlet) across standings + userHome

### DIFF
--- a/public/standings.js
+++ b/public/standings.js
@@ -670,7 +670,7 @@ async function displaySchedule(data) {
                     teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                     teamTable += '</tr>';
                     teamTable += `<tr><td><strong>${homeUser}</strong></td></tr>`;
-                    teamTable += `</tr><tr><td class="game-notes">`;
+                    teamTable += `</tr>${game.outlet ? `<tr><td class="game-broadcast">📺 ${game.outlet}</td></tr>` : ''}<tr><td class="game-notes">`;
                     teamTable += game.notes || '';
                     teamTable += '</td></tr><tbody></table></td>';
 
@@ -758,7 +758,7 @@ async function displaySchedule(data) {
                         teamTable += homeImg + homeRank + homeTeam;
                         teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                         teamTable += `<tr><td><strong>${homeUser}</strong></td></tr>`;
-                        teamTable += `</tr><tr><td class="game-notes">`;
+                        teamTable += `</tr>${game.outlet ? `<tr><td class="game-broadcast">📺 ${game.outlet}</td></tr>` : ''}<tr><td class="game-notes">`;
                         teamTable += game.notes || '';
                         teamTable += '</td></tr><tbody></table></td>';
             

--- a/public/styles.css
+++ b/public/styles.css
@@ -468,6 +468,16 @@ footer {
     padding: 3px;
 }
 
+/* Broadcast (📺 network) line on a game card — muted, matching the Team View's
+   game-date/game-tv treatment. Shared here so every game card styles it the
+   same. Only rendered when the game has a stored outlet. */
+.game-broadcast {
+    font-size: 0.75em;
+    color: #A4A9C2;
+    padding-left: 0.5em !important;
+    white-space: nowrap;
+}
+
 #loading {
     position: fixed;
     display: block;

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -707,6 +707,7 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
     return '<div class="game-card"><table class="game-table"><tbody><tr></tr>'
         + '<tr><td class="gc-team">' + awayCol + '</td><td class="gc-divider"></td><td class="gc-score">' + awayScore + '</tr>'
         + '<tr><td class="gc-team">' + homeCol + '</td><td class="gc-divider"></td><td class="gc-score">' + homeScore + '</tr>'
+        + (game.outlet ? '<tr><td class="game-broadcast">📺 ' + game.outlet + '</td></tr>' : '')
         + '<tr><td class="game-notes">' + (game.notes || '') + '</td></tr>'
         + '</tbody></table></div>';
 }


### PR DESCRIPTION
## What

The Team View schedule already shows game time + broadcast network on each game card. This brings the **broadcast line** to the other two places game cards are rendered so it's standard everywhere:

- **Standings** schedule cards
- **userHome** ("My team") game cards

## How

- `standings.js` / `userHome.js`: render a `📺 <outlet>` row on each game card (above notes), only when the game has a stored `outlet`. Both pages already fetch full game docs (which carry `outlet`/`mediaType` from the CFBD media enrichment), so there's no new request.
- `styles.css`: one shared `.game-broadcast` rule — muted, matching the Team View's `game-date`/`game-tv` treatment — so every card styles it identically.

Game time was already present on all three (each in its own format); the broadcast was the piece missing everywhere but the Team View.

## Verification

Live (2025 data): standings shows the row on all 17 cards, userHome on all 5 (📺 ABC / ESPN), muted styling applied, no console errors. Full suite: 14 suites / 104 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)