### PR TITLE
chore: prep for Heroku-24 stack upgrade (pin Node, app.json, Procfile)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web:node server.js
+web: node server.js

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+  "name": "Campus Clash",
+  "description": "Fantasy college football league app.",
+  "stack": "heroku-24"
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": "20.x"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.4.2",
     "bootstrap": "^5.3.1",


### PR DESCRIPTION
## Why

Heroku-22 is deprecated (EOL **2027-04-30**). This preps the repo so moving to `heroku-24` is a controlled, low-risk change.

The app has **no native/compiled dependencies**, so the OS bump itself is low-risk. The real hazard is the Node runtime — which this PR pins.

## Changes

- **`package.json`** — pin `engines.node` to `20.x`. The repo previously pinned no Node version anywhere, so Heroku used the buildpack default, which changes with the stack. Pinning makes the upgrade change only the OS, not silently jump Node too. `20.x` matches CI and keeps Mongoose 7 in its supported range.
- **`app.json`** — declare `"stack": "heroku-24"` so the new stack can be validated via a Review App / test app before touching prod.
- **`Procfile`** — normalize `web:node server.js` → `web: node server.js`.

## What this does NOT do

This does **not** change the production stack. That's still a manual step you run:

```
heroku stack:set heroku-24 --app <name>
git push heroku main   # (or trigger a deploy)
```

## Follow-up

Node 20 is near end-of-maintenance. Plan a **separate** bump to Node 22 + Mongoose 8 afterward — deliberately not bundled here to keep the stack move safe.

## Verification

`package.json` / `app.json` parse clean, Procfile normalized, full suite passes (14 suites / 104 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)