### PR TITLE
Toasts: modern redesign + centralize app-wide

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -22,37 +22,8 @@ function detectMobile() {
     }
 }
 
-var successToast = Toastify({
-    text: "",
-    duration: 4000,
-    close: true,
-    gravity: "top", // `top` or `bottom`
-    position: "left", // `left`, `center` or `right`
-    stopOnFocus: true, // Prevents dismissing of toast on hover
-    style: {
-      background: "#71d28d",
-      color: "#222"
-    },
-    offset: {
-        y: '40px' // vertical axis - can be a number or a string indicating unity. eg: '2em'
-    },
-});
-
-var failToast = Toastify({
-    text: "",
-    duration: 3000,
-    close: true,
-    gravity: "top", // `top` or `bottom`
-    position: "left", // `left`, `center` or `right`
-    stopOnFocus: true, // Prevents dismissing of toast on hover
-    style: {
-      background: "#d27171",
-      color: "#222"
-    },
-    offset: {
-        y: '40px' // vertical axis - can be a number or a string indicating unity. eg: '2em'
-    },
-});
+// successToast / failToast are shared globals defined in public/toast.js
+// (loaded by the navbar partial). Set .options.text then call .showToast().
 
 async function getTeams() {
     fetch("/teams", {

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -520,15 +520,8 @@ function renderOnTheClock() {
 
 // The navbar owns the "My team" link + userId caching (views/partials/navbar.ejs).
 
-var successToast = Toastify({
-    text: "", duration: 4000, close: true, gravity: "top", position: "left", stopOnFocus: true,
-    style: { background: "#71d28d", color: "#222" }, offset: { y: '40px' }
-});
-
-var failToast = Toastify({
-    text: "", duration: 3000, close: true, gravity: "top", position: "left", stopOnFocus: true,
-    style: { background: "#d27171", color: "#222" }, offset: { y: '40px' }
-});
+// successToast / failToast are shared globals defined in public/toast.js
+// (loaded by the navbar partial). Set .options.text then call .showToast().
 
 if ($("[league-selector]")) {
     setTimeout(() => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -13,12 +13,69 @@ button {
     font-family: "Font Awesome 5 Free" !important;
     padding-left: 0.5rem;
 }
-.toast-close {
-    color: #222 !important;
-}
-
 .fa-helmet-un {
     color: #ed5858;
+}
+
+/* ---- Toasts (Toastify) ------------------------------------------------------
+   Modern dark-surface toast with a colored left accent + icon per type. Every
+   toast carries the .cc-toast class (see public/toast.js), so these two-class
+   selectors win over Toastify's base .toastify rules regardless of load order. */
+.toastify.cc-toast {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: 360px;
+    padding: 14px 16px;
+    background: #1A1F33;
+    color: #F4F6FB;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.35;
+    border: 1px solid #2A2E42;
+    border-left: 4px solid #A4A9C2;   /* accent color set per type below */
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+/* Leading status icon (FontAwesome 6, which the app already loads). */
+.toastify.cc-toast::before {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 1.15rem;
+    line-height: 1;
+    flex: 0 0 auto;
+}
+
+.cc-toast--success { border-left-color: #22C37A; }
+.cc-toast--success::before { content: "\f058"; color: #22C37A; }   /* circle-check */
+
+.cc-toast--error { border-left-color: #ED5858; }
+.cc-toast--error::before { content: "\f06a"; color: #ED5858; }     /* circle-exclamation */
+
+.cc-toast--info { border-left-color: #4A90D9; }
+.cc-toast--info::before { content: "\f05a"; color: #4A90D9; }      /* circle-info */
+
+/* Close button: quiet by default, brightens on hover. */
+.toastify.cc-toast .toast-close {
+    color: #A4A9C2;
+    opacity: 0.85;
+    font-size: 1.15rem;
+    line-height: 1;
+    padding: 0 0 0 6px;
+    background: transparent;
+    align-self: flex-start;
+}
+.toastify.cc-toast .toast-close:hover {
+    color: #F4F6FB;
+    opacity: 1;
+}
+
+/* Don't let a toast run off a phone screen. */
+@media (max-width: 600px) {
+    .toastify.cc-toast {
+        max-width: calc(100vw - 32px);
+    }
 }
 
 body {

--- a/public/toast.js
+++ b/public/toast.js
@@ -1,0 +1,38 @@
+// Shared toast setup so every page's notifications look and behave identically.
+// Loaded once via the navbar partial (after Toastify), so it initializes before
+// the deferred page scripts that use it.
+//
+// Two ways to fire a toast, both styled the same:
+//   ccToast.success('Saved');                     // preferred
+//   successToast.options.text = 'Saved'; successToast.showToast();  // legacy
+(function () {
+    if (typeof Toastify === 'undefined') return;
+
+    function make(kind, duration) {
+        return Toastify({
+            text: '',
+            duration: duration,
+            close: true,
+            // Bottom-right clears the sticky navbar and the mobile hamburger, and
+            // avoids Toastify's top-gravity offset bug that hid toasts off-screen
+            // on narrow viewports.
+            gravity: 'bottom',
+            position: 'right',
+            stopOnFocus: true,          // pause the auto-dismiss timer on hover
+            className: 'cc-toast cc-toast--' + kind,
+            offset: { y: '24px', x: '16px' }
+        });
+    }
+
+    // Shared instances (legacy call sites set .options.text then .showToast()).
+    window.successToast = make('success', 4000);
+    window.failToast = make('error', 5000);   // errors get a beat longer to read
+    window.infoToast = make('info', 4000);
+
+    // Convenience helpers.
+    window.ccToast = {
+        success: function (msg) { successToast.options.text = msg; successToast.showToast(); },
+        error: function (msg) { failToast.options.text = msg; failToast.showToast(); },
+        info: function (msg) { infoToast.options.text = msg; infoToast.showToast(); }
+    };
+})();

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -6,12 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="admin.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script defer src="admin.js"></script>
     <title>Campus Clash</title>

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -15,8 +15,6 @@
     <title>Campus Clash</title>
     <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 </head>
 <body>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -11,6 +11,11 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js" integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<!-- Toasts: library + shared styling/instances (styles live in styles.css), so
+     every page's notifications look identical and the handler below works app-wide. -->
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
+<script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+<script src="/toast.js"></script>
 <!-- Surface otherwise-silent failures (e.g. a failed fetch) instead of leaving the UI quietly broken -->
 <script>
     (function () {
@@ -20,13 +25,7 @@
             var now = Date.now();
             if (now - lastShown < 5000) return; // throttle so one outage isn't a toast storm
             lastShown = now;
-            if (window.Toastify) {
-                window.Toastify({
-                    text: 'Something went wrong loading data. Please try refreshing.',
-                    duration: 4000, close: true, gravity: 'top', position: 'left',
-                    style: { background: '#d27171', color: '#222' }, offset: { y: '40px' }
-                }).showToast();
-            }
+            if (window.ccToast) ccToast.error('Something went wrong loading data. Please try refreshing.');
         });
     })();
 </script>

--- a/views/scoringRules.ejs
+++ b/views/scoringRules.ejs
@@ -6,12 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="scoringRules.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="scoringRules.js"></script>
     <title>Campus Clash</title>


### PR DESCRIPTION
## Why

The toast notifications looked dated — flat pastel green/red blocks with dark text — and each page defined its own. Toastify only loaded on 3 pages, so the global error toast couldn't even appear on the others.

## What

**New look** (dark theme, matches the app):
- Dark surface with a colored **left accent + matching FontAwesome icon** per type — success (green check), error (red exclamation), info (blue info).
- Rounded corners, soft shadow, quiet close button, responsive width.
- Positioned **bottom-right** — clears the sticky navbar and the mobile hamburger.

**Centralized** (one source of truth, works everywhere):
- New `public/toast.js` builds the shared `successToast` / `failToast` / `infoToast` instances plus a `ccToast.{success,error,info}` helper, loaded via the navbar partial so every page has it.
- Removed the duplicate Toastify includes from `admin`/`draftRoom`/`scoringRules`; dropped the local toast definitions from `admin.js`/`draftRoom.js` (now the shared globals). All existing call sites are unchanged.
- The navbar's unhandled-rejection error toast now routes through `ccToast` and works on every page.

## Notes

- Styling uses two-class `.toastify.cc-toast` selectors so it wins regardless of stylesheet load order.
- Bottom-right also sidesteps a Toastify top-gravity offset bug that pushed toasts off-screen on narrow viewports.

## Verification

Live on desktop + mobile: success/error/info render with the new style on pages that previously had no toasts; legacy `successToast.options.text = …; showToast()` still works on admin; bottom-right is in-viewport on mobile; no console errors. Full suite: 14 suites / 104 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)