### PR TITLE
Admin: reconstruct draft history backfill (dry-run → commit)

### DIFF
--- a/modules/draft-history.js
+++ b/modules/draft-history.js
@@ -1,0 +1,106 @@
+// One-time reconstruction of past drafts from user.seasons[].
+//
+// We never stored draft picks, but each manager's `teams` array is saved in the
+// order they were drafted. Combined with a known slot order per league-season
+// and the snake pattern, that's enough to rebuild the exact overall pick number
+// for every team — i.e. the whole draft board.
+//
+// The slot orders below can't be derived from data: 2023 has no prior standings
+// to reverse from, and later years added managers who have no prior finish. So
+// they're recorded here as the source of truth (confirmed from memory / records)
+// and resolved to users at runtime. This table is also the scope lock — the
+// backfill only ever touches these exact league-seasons, never a live draft.
+//
+// Manager keys are "FirstName" or "FirstName Initial" (the initial disambiguates
+// the two Jeffs); they're matched against users within the given league.
+
+const DRAFT_HISTORY = [
+    { league: 'graham-league',  season: 2023, orderMethod: 'manual',    order: ['Treyce', 'Trevor', 'Brock', 'Garrett', 'Michael'] },
+    { league: 'graham-league',  season: 2024, orderMethod: 'standings', order: ['Treyce', 'Garrett', 'Brock', 'Trevor', 'Michael'] },
+    { league: 'graham-league',  season: 2025, orderMethod: 'standings', order: ['Trevor', 'Treyce', 'Garrett', 'Michael', 'Brock', 'Cole'] },
+    { league: 'claunts-league', season: 2023, orderMethod: 'manual',    order: ['Scott', 'Jeff C', 'Jeff D', 'David'] },
+    { league: 'claunts-league', season: 2024, orderMethod: 'standings', order: ['Jeff D', 'Jeff C', 'David', 'Scott'] },
+    { league: 'claunts-league', season: 2025, orderMethod: 'standings', order: ['Scott', 'Joe', 'Jeff D', 'Jeff C', 'Lynn', 'David'] },
+];
+
+function displayName(u) {
+    return `${u.firstName} ${u.lastName ? u.lastName[0] + '.' : ''}`.trim();
+}
+
+function seasonOf(u, season) {
+    return (u.seasons || []).find(s => Number(s.season) === Number(season));
+}
+
+// A key is "First" or "First Initial". Match exact first name (scoped to the
+// league) plus, when given, the last-name initial.
+function matchUsers(users, league, key) {
+    const parts = key.split(' ');
+    const first = parts[0];
+    const initial = parts[1];
+    return users.filter(u =>
+        u.league === league &&
+        u.firstName === first &&
+        (initial == null || (u.lastName || '')[0] === initial));
+}
+
+// Snake overall pick number for a manager at 1-based slot `s`, in 1-based round
+// `r`, with `N` managers.
+function overallPick(r, s, N) {
+    return (r % 2 === 1) ? (r - 1) * N + s : r * N - s + 1;
+}
+
+function reconstructOne(users, cfg) {
+    const res = {
+        league: cfg.league, season: cfg.season, orderMethod: cfg.orderMethod,
+        ok: false, errors: [], order: [], draftOrder: [], picks: [], board: [], integrity: null
+    };
+
+    // Resolve each configured manager key to exactly one user with that season.
+    const resolved = [];
+    for (const key of cfg.order) {
+        const hits = matchUsers(users, cfg.league, key);
+        if (hits.length === 0) { res.errors.push(`No user matched "${key}"`); continue; }
+        if (hits.length > 1) { res.errors.push(`Key "${key}" matched ${hits.length} users`); continue; }
+        if (!seasonOf(hits[0], cfg.season)) { res.errors.push(`"${key}" has no ${cfg.season} season`); continue; }
+        resolved.push(hits[0]);
+    }
+    if (res.errors.length) return res;
+
+    const N = resolved.length;
+    const lengths = resolved.map(u => (seasonOf(u, cfg.season).teams || []).length);
+    const rounds = Math.max(...lengths);
+    if (new Set(lengths).size > 1) {
+        res.errors.push(`Uneven rosters: [${lengths.join(', ')}]`);
+    }
+
+    const board = {};
+    resolved.forEach((u, i) => {
+        const slot = i + 1;
+        res.order.push({ userId: u._id, name: displayName(u), slot });
+        res.draftOrder.push(u._id);
+        const teams = seasonOf(u, cfg.season).teams || [];
+        teams.forEach((team, k) => {
+            const round = k + 1;
+            const overall = overallPick(round, slot, N);
+            if (board[overall]) {
+                res.errors.push(`Collision at overall ${overall}`);
+                return;
+            }
+            board[overall] = { overall, round, name: displayName(u), school: team.school };
+            res.picks.push({ round, overall, userId: u._id, team });
+        });
+    });
+
+    const expected = lengths.reduce((a, b) => a + b, 0);
+    const placed = Object.keys(board).length;
+    res.integrity = { N, rounds, expected, placed, ok: placed === expected && res.errors.length === 0 };
+    res.board = Object.values(board).sort((a, b) => a.overall - b.overall);
+    res.ok = res.integrity.ok;
+    return res;
+}
+
+function reconstructAll(users) {
+    return DRAFT_HISTORY.map(cfg => reconstructOne(users, cfg));
+}
+
+module.exports = { DRAFT_HISTORY, reconstructAll, reconstructOne, overallPick };

--- a/public/admin.css
+++ b/public/admin.css
@@ -541,3 +541,82 @@ select[scoring-config-combine-mode] { width: 100%; }
     max-width: 46ch;
     margin: 0 0 0.75em;
 }
+
+/* --- Draft history backfill (Maintenance) --- */
+.backfill-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6em;
+    margin-bottom: 0.75em;
+}
+.backfill-force {
+    color: #A4A9C2;
+    font-size: 0.85rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    cursor: pointer;
+}
+#backfill-commit:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+.backfill-results {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
+    width: 100%;
+}
+.bf-season {
+    background-color: #101322;
+    border: 1px solid #2A2E42;
+    border-radius: 8px;
+    padding: 0.7em 0.85em;
+    text-align: left;
+}
+.bf-head {
+    font-weight: 600;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4em;
+    margin-bottom: 0.4em;
+}
+.bf-badge {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0.15em 0.5em;
+    border-radius: 999px;
+    background-color: #1A1F33;
+    color: #A4A9C2;
+    border: 1px solid #2A2E42;
+    font-weight: 700;
+}
+.bf-badge.ok { color: #22C37A; border-color: rgba(34, 195, 122, 0.4); }
+.bf-badge.bad { color: #ED5858; border-color: rgba(237, 88, 88, 0.4); }
+.bf-badge.warn { color: #E0B341; border-color: rgba(224, 179, 65, 0.4); }
+.bf-badge.muted { color: #767D99; }
+.bf-errs {
+    color: #ED5858;
+    font-size: 0.8rem;
+    margin: 0.25em 0 0.5em;
+}
+.bf-order {
+    color: #A4A9C2;
+    font-size: 0.8rem;
+    margin-bottom: 0.4em;
+}
+.bf-round {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 0.78rem;
+    color: #F4F6FB;
+    line-height: 1.7;
+}
+.bf-rlabel {
+    color: #ED5858;
+    font-weight: 700;
+    margin-right: 0.3em;
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -712,6 +712,96 @@ if (enrichmentForm) {
     });
 }
 
+// --- Draft history backfill (Maintenance) -----------------------------------
+function displayDraftBackfillContainer() {
+    var c = document.querySelector('[draft-backfill-container]');
+    c.style.display = (c.style.display === 'flex' || c.style.display === '') ? 'none' : 'flex';
+}
+
+(function () {
+    var form = document.getElementById('draft-backfill-form');
+    if (!form) return;
+    var commitBtn = document.getElementById('backfill-commit');
+    var forceBox = document.getElementById('backfill-force');
+    var previewed = false;
+
+    async function run(commit) {
+        block_screen();
+        try {
+            var res = await fetch('/draft/backfill', {
+                method: 'POST',
+                headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+                body: JSON.stringify({ commit: commit, force: forceBox.checked })
+            });
+            var data = await res.json();
+            unblock_screen();
+            if (res.status !== 200) {
+                failToast.options.text = (data && data.message) || (res.status + ' backfill failed');
+                failToast.showToast();
+                return;
+            }
+            renderBackfill(data);
+            if (!commit) {
+                previewed = true;
+                commitBtn.disabled = false;
+                infoToast.options.text = 'Preview ready — review the boards, then Commit.';
+                infoToast.showToast();
+            } else {
+                var n = (data.written || []).length;
+                successToast.options.text = n ? ('Backfilled ' + n + ' draft(s)') : 'Nothing written — see notes below';
+                successToast.showToast();
+                commitBtn.disabled = true;
+                previewed = false;
+            }
+        } catch (err) {
+            unblock_screen();
+            failToast.options.text = 'Backfill failed: ' + err.message;
+            failToast.showToast();
+        }
+    }
+
+    form.addEventListener('submit', function (e) { e.preventDefault(); run(false); });
+    commitBtn.addEventListener('click', function () {
+        if (!previewed) return;
+        if (!window.confirm('Write the reconstructed drafts to the database? This modifies the drafts collection.')) return;
+        run(true);
+    });
+})();
+
+function renderBackfill(data) {
+    var out = document.getElementById('backfill-results');
+    if (!out) return;
+    function esc(s) { var d = document.createElement('div'); d.textContent = String(s == null ? '' : s); return d.innerHTML; }
+
+    out.innerHTML = (data.results || []).map(function (r) {
+        var badges = [];
+        badges.push('<span class="bf-badge ' + (r.ok ? 'ok' : 'bad') + '">' + (r.ok ? 'OK' : 'ERRORS') + '</span>');
+        if (r.integrity) badges.push('<span class="bf-badge">' + r.integrity.placed + '/' + r.integrity.expected + ' picks</span>');
+        if (r.exists) badges.push('<span class="bf-badge warn">exists: ' + esc(r.existingStatus) + '</span>');
+        var writeState = data.dryRun ? r.wouldWrite : r.willWrite;
+        var stateTxt = writeState ? (data.dryRun ? 'will write' : 'written') : (r.skipReason || 'skip');
+        badges.push('<span class="bf-badge ' + (writeState ? 'ok' : 'muted') + '">' + esc(stateTxt) + '</span>');
+
+        var errsHtml = (r.errors && r.errors.length) ? '<div class="bf-errs">' + r.errors.map(esc).join('<br>') + '</div>' : '';
+        var orderHtml = (r.order || []).map(function (o) { return o.slot + '.' + esc(o.name); }).join('  ');
+
+        var byRound = {};
+        (r.board || []).forEach(function (b) { (byRound[b.round] = byRound[b.round] || []).push(b); });
+        var boardHtml = [1, 2].map(function (rd) {
+            if (!byRound[rd]) return '';
+            return '<div class="bf-round"><span class="bf-rlabel">R' + rd + '</span> ' +
+                byRound[rd].map(function (b) { return b.overall + '. ' + esc(b.school) + ' (' + esc(String(b.name).split(' ')[0]) + ')'; }).join('  ·  ') + '</div>';
+        }).join('');
+
+        return '<div class="bf-season">' +
+            '<div class="bf-head">' + esc(r.league) + ' · ' + r.season + ' ' + badges.join(' ') + '</div>' +
+            errsHtml +
+            (orderHtml ? '<div class="bf-order">order: ' + orderHtml + '</div>' : '') +
+            boardHtml +
+            '</div>';
+    }).join('');
+}
+
 const gamesForm = document.getElementById('games-form');
 
 if (gamesForm) {

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -1,6 +1,87 @@
 const express = require('express');
 const router = express.Router();
 const Draft = require('../models/draft');
+const User = require('../models/user');
+const { reconstructAll } = require('../modules/draft-history');
+
+// Trim a reconstruction result down to what the admin UI renders (drops the
+// full team objects on each pick; keeps the human-readable board).
+function previewShape(r) {
+    return {
+        league: r.league, season: r.season, orderMethod: r.orderMethod,
+        ok: r.ok, errors: r.errors, integrity: r.integrity,
+        order: (r.order || []).map(o => ({ name: o.name, slot: o.slot })),
+        board: r.board,
+        exists: r.exists, existingStatus: r.existingStatus,
+        wouldWrite: r.wouldWrite, willWrite: r.willWrite, skipReason: r.skipReason
+    };
+}
+
+// One-time backfill of historical drafts into the `drafts` collection, rebuilt
+// from user.seasons[] (see modules/draft-history.js). Commissioner-gated by the
+// /draft router. Dry-run by default — writes ONLY when commit === true, and only
+// the scope-locked seasons in DRAFT_HISTORY, so it can never touch a live draft.
+router.post('/backfill', async (req, res) => {
+    try {
+        const commit = req.body.commit === true;
+        const force = req.body.force === true;
+
+        const userDocs = await User.find({}, { firstName: 1, lastName: 1, email: 1, league: 1, seasons: 1 }).lean();
+        const results = reconstructAll(userDocs);
+
+        // Annotate each season with whether a draft already exists and whether
+        // this run would write it.
+        for (const r of results) {
+            const existing = await Draft.findOne({ league: r.league, season: r.season });
+            r.exists = !!existing;
+            r.existingStatus = existing ? existing.status : null;
+            r.skipReason = null;
+            if (!r.ok) {
+                r.skipReason = 'reconstruction errors';
+            } else if (existing && existing.status === 'active') {
+                // An in-progress draft is sacrosanct — never overwritten, even with force.
+                r.skipReason = "existing draft is 'active' — refusing to overwrite";
+            } else if (existing && !force) {
+                r.skipReason = `already has a '${existing.status}' draft (check "overwrite" to replace)`;
+            }
+            r.wouldWrite = r.ok && !r.skipReason;   // eligible to write (force already considered)
+            r.willWrite = commit && r.wouldWrite;   // actually writing on this run
+        }
+
+        if (!commit) {
+            return res.json({ dryRun: true, results: results.map(previewShape) });
+        }
+
+        const written = [];
+        for (const r of results) {
+            if (!r.willWrite) continue;
+            await Draft.findOneAndUpdate(
+                { league: r.league, season: r.season },
+                {
+                    $set: {
+                        league: r.league, season: r.season, status: 'complete', snake: true,
+                        totalRounds: r.integrity.rounds, orderMethod: r.orderMethod,
+                        draftOrder: r.draftOrder, picks: r.picks,
+                        currentOverall: r.picks.length + 1, updatedAt: new Date()
+                    },
+                    $setOnInsert: { createdAt: new Date() }
+                },
+                { upsert: true, setDefaultsOnInsert: true }
+            );
+            // Populate the dormant draftPosition on each manager's season.
+            for (const o of r.order) {
+                await User.updateOne(
+                    { _id: o.userId, 'seasons.season': r.season },
+                    { $set: { 'seasons.$.draftPosition': o.slot } }
+                );
+            }
+            written.push({ league: r.league, season: r.season, picks: r.picks.length });
+        }
+        return res.json({ dryRun: false, written, results: results.map(previewShape) });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
 
 // Get the draft for a league + season (returns null if none configured yet).
 router.get('/:league/:season', async (req, res) => {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -225,6 +225,35 @@
     </section>
 
     <section class="admin-group">
+        <div class="group-head"><h2>Maintenance</h2><span class="group-count">1</span></div>
+        <div class="admin-functions">
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayDraftBackfillContainer()">
+                        <i class="fa-solid fa-clock-rotate-left" style="padding-right: 5px;"></i>
+                        Reconstruct Draft History
+                    </button>
+                </div>
+                <div class="sub-container" draft-backfill-container style="display: none">
+                    <p class="function-description">
+                        Rebuilds past drafts into the drafts collection from each manager's saved roster order
+                        (snake + the known draft orders). One-time; run against production. Preview shows every
+                        reconstructed board — nothing is written until you press Commit.
+                    </p>
+                    <form id="draft-backfill-form">
+                        <div class="backfill-controls">
+                            <button type="submit">Preview (dry run)</button>
+                            <button type="button" id="backfill-commit" disabled>Commit backfill</button>
+                            <label class="backfill-force"><input type="checkbox" id="backfill-force"> overwrite existing</label>
+                        </div>
+                    </form>
+                    <div id="backfill-results" class="backfill-results"></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="admin-group">
         <div class="group-head"><h2>League setup</h2><span class="group-count">4</span></div>
         <div class="admin-functions">
             <div class="function-container">


### PR DESCRIPTION
## What

A commissioner-gated admin action that rebuilds the pre-collection drafts (2023–2025, both leagues) into the `drafts` collection — retroactively creating draft-history data we never stored, which unlocks ADP, draft grades, and past-draft views.

We never saved picks, but each manager's `teams[]` is in **draft order**. Combined with the known slot order per league-season and the snake pattern, that yields every team's exact overall pick number.

## How

- **`modules/draft-history.js`** — the source-of-truth order table (can't be derived: 2023 has no prior standings; later years added managers) + the reconstruction (resolve managers → apply snake formula → integrity-check for gaps/collisions).
- **`POST /draft/backfill`** — dry-run by default; writes only when `commit === true`. Scope-locked to the six configured seasons. On commit: upserts a `status:'complete'` `Draft` doc per season and populates the dormant `user.seasons.draftPosition`.
- **Admin UI** — a new "Maintenance" card. **Preview** renders every reconstructed board with integrity + write-eligibility badges; **Commit** enables only after a preview and confirms before writing.

## Safety

- Dry-run first; nothing writes without an explicit Commit.
- Never overwrites an **active** (in-progress) draft. Overwriting any other existing draft (scheduled/pending/complete) requires the explicit **overwrite** checkbox.
- Scope-locked to the six known past seasons — future/live drafts are untouchable.

## ⚠️ Must run against Prod

Local `.env` points at the **test** DB, whose rosters/scores are stale. Run **Preview → eyeball the boards → Commit** on production (the app's own DB context). The `.env` DATABASE_URL is never used by the deployed app.

## Verification

Validated the dry-run flow live: all six seasons reconstruct with 100% integrity, Graham boards match memory, the guard correctly refused a stale `scheduled` test draft, no console errors. Full suite: 14 suites / 104 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)