### PR TITLE
Draft grades: per-league expected-fantasy-points projection

### DIFF
--- a/modules/draft-grades.js
+++ b/modules/draft-grades.js
@@ -1,55 +1,20 @@
-// Post-draft grades — immediate, PRESEASON feedback the moment a draft ends
-// (no games required). Each draft is judged on its OWN MERIT against fixed
-// thresholds (absolute bands), so a manager's grade never depends on how their
-// leaguemates drafted.
+// Post-draft grades — immediate PRESEASON feedback the moment a draft ends.
 //
-// The grade blends three preseason roster-quality signals, chosen to match how
-// THIS league actually scores (wins + ranked wins + deep CFP runs):
-//   * team quality  — average SP+
-//   * projected wins — average expected wins (the win-based core of scoring)
-//   * CFP upside     — reward stacking likely-playoff teams (advancing in the
-//                      12-team CFP is worth the most points). Uses MARKET odds
-//                      when entered (make-CFP probability + a championship-odds
-//                      bonus for deep-run upside), falling back to the SP+ rank
-//                      proxy when a season has no odds.
-//
-// Each signal is normalized against fixed anchors (tunable below) and blended,
-// then mapped to a letter. SP+/wins mirror the draft pool (season value, prior-
-// season fallback). Best-value / biggest-reach picks (shown as highlights, not
-// part of the letter) use projected-wins rank vs. draft slot.
+// The grade is now a per-league EXPECTED-FANTASY-POINTS projection: each drafted
+// team's season is projected and scored through that league's real scoring
+// engine (see modules/draft-projection.js), so Claunts (V1) and Graham (V2)
+// grade the same roster differently, matching how each league actually scores.
+// A manager's roster is graded on ABSOLUTE per-league bands (snake-draft
+// anchors from the team pool) so the letter never depends on how leaguemates
+// drafted.
 
-const { americanToProb } = require('./cfp-odds');
-
-// --- absolute grading anchors + weights (tune here) ---
-const STRENGTH_LOW = -3, STRENGTH_HIGH = 16;   // roster avg SP+  → 0..1
-const WINS_LOW = 6.0, WINS_HIGH = 9.0;         // roster avg expected wins → 0..1
-const CFP_LOW = 0, CFP_HIGH = 3.0;             // roster CFP-upside sum → 0..1
-const W_STRENGTH = 0.35, W_WINS = 0.35, W_CFP = 0.30;
-const CHAMP_WEIGHT = 2;                        // deep-run (title) upside multiplier
+const { resolveConfig } = require('./scoring-defaults');
+const {
+    buildRankingProxy, buildPoolContext, projectTeamPoints, computeLeagueBands,
+    spFor, winsFor
+} = require('./draft-projection');
 
 function clamp01(x) { return Math.max(0, Math.min(1, x)); }
-
-// A season value on a team (SP+ or expected wins), with prior-season fallback.
-function seasonVal(team, season, field) {
-    const seasons = (team && team.seasons) || [];
-    const cur = seasons.find(s => Number(s.season) === season);
-    if (cur && cur[field] != null) return cur[field];
-    const prev = seasons.find(s => Number(s.season) === season - 1);
-    if (prev && prev[field] != null) return prev[field];
-    return null;
-}
-const spFor = (t, s) => seasonVal(t, s, 'spRating');
-const winsFor = (t, s) => seasonVal(t, s, 'expectedWins');
-
-// CFP upside for a team, by its SP+ national rank (1 = best). Top seeds advance
-// further in the 12-team playoff, so they're worth the most.
-function cfpTier(rank) {
-    if (rank == null) return 0;
-    if (rank <= 4) return 1.0;    // bye-caliber — deep run likely
-    if (rank <= 12) return 0.6;   // in the field
-    if (rank <= 25) return 0.25;  // bubble / ranked
-    return 0;
-}
 
 // Letter grade from an absolute 0..1 score (fixed bands).
 function letterFor(score) {
@@ -70,95 +35,93 @@ function displayName(u) {
 function pickView(p) {
     return p ? {
         school: p.school, round: p.round, overall: p.overall,
-        wins: Math.round(p.wins * 10) / 10, value: p.value, logo: p.logo || null
+        points: Math.round(p.points), value: p.value, logo: p.logo || null
     } : null;
 }
 
-// draft: a Draft doc (picks). usersById: { userId: user }. teamsById: { teamId: team (w/ seasons) }.
-function computeGrades(draft, usersById, teamsById) {
-    const season = Number(draft.season);
+// Group season games by the FBS team ids that appear in them (a game with two
+// drafted-pool teams lands under both).
+function groupGamesByTeam(games, teamsById) {
+    const by = {};
+    for (const g of games || []) {
+        const h = String(g.homeId), a = String(g.awayId);
+        if (teamsById[h]) (by[h] = by[h] || []).push(g);
+        if (teamsById[a]) (by[a] = by[a] || []).push(g);
+    }
+    return by;
+}
 
-    // National reference curves for this season.
-    const allTeams = Object.keys(teamsById).map(k => teamsById[k]);
-    // SP+ rank per team id (1 = best).
-    const spRankById = {};
-    allTeams.map(t => ({ id: t.id, sp: spFor(t, season) }))
-        .filter(x => x.sp != null)
-        .sort((a, b) => b.sp - a.sp)
-        .forEach((x, i) => { spRankById[String(x.id)] = i + 1; });
-    // 1. Per pick: SP+, projected wins, and CFP upside.
-    //    CFP upside uses market odds when entered (make-CFP probability + a
-    //    championship-odds bonus for deep-run upside), else the SP+ rank proxy.
+// draft: a Draft doc. usersById: { userId: user }. teamsById: { teamId: team }.
+// opts: { games, config, apPoll } supplied by the route (kept out of here so the
+// projection stays pure/sync and unit-testable).
+function computeGrades(draft, usersById, teamsById, opts = {}) {
+    const season = Number(draft.season);
+    const league = draft.league;
+    const cfg = opts.config || resolveConfig(league, null);
+    const rankings = buildRankingProxy(season, teamsById, opts.apPoll);
+    const poolCtx = buildPoolContext(teamsById, season);
+    const gamesByTeam = groupGamesByTeam(opts.games, teamsById);
+
+    // Project every team in the pool (needed for the absolute bands + reused for
+    // the drafted picks).
+    const projByTeam = {};
+    Object.keys(teamsById).forEach(id => {
+        projByTeam[id] = projectTeamPoints(teamsById[id], gamesByTeam[id], poolCtx, rankings, cfg, season);
+    });
+    const sortedTotals = Object.keys(projByTeam).map(id => projByTeam[id].total).sort((a, b) => b - a);
+    const L = (draft.draftOrder || []).length || Object.keys(usersById).length || 6;
+    const bands = computeLeagueBands(sortedTotals, L, draft.totalRounds || 10);
+    const denom = (bands.eliteAvg - bands.replacementAvg) || 1;
+
+    // Per pick: projected points, wins, make-prob.
     const picks = (draft.picks || []).map(p => {
-        const team = teamsById[String(p.team.id)];
-        const sp = spFor(team, season);
-        const wins = winsFor(team, season);
-        const makeOdds = seasonVal(team, season, 'cfpMakeOdds');
-        const champOdds = seasonVal(team, season, 'cfpChampOdds');
-        const makeProb = makeOdds != null ? americanToProb(makeOdds) : null;
-        const champProb = champOdds != null ? americanToProb(champOdds) : 0;
-        const cfp = makeProb != null
-            ? makeProb + CHAMP_WEIGHT * champProb
-            : cfpTier(spRankById[String(p.team.id)] || null);
+        const proj = projByTeam[String(p.team.id)] || { total: 0, projWins: 0, makeProb: 0 };
         return {
             userId: String(p.userId), overall: p.overall, round: p.round,
             school: p.team.school, logo: (p.team.logos || [])[0],
-            sp: sp == null ? 0 : sp, wins: wins == null ? 0 : wins,
-            spRank: spRankById[String(p.team.id)] || null,
-            makeProb, cfp
+            points: proj.total, wins: proj.projWins, makeProb: proj.makeProb || 0,
+            reg: proj.regular || 0,                                   // regular-season floor
+            post: (proj.cfp || 0) + (proj.confChamp || 0) + (proj.bowl || 0)  // postseason upside
         };
     });
-    const oddsPresent = picks.some(p => p.makeProb != null);
 
-    // Highlight value = how far a pick beat its draft slot on projected wins:
-    // rank all picks by projected wins (1 = most), then value = overall − winsRank.
-    // Big positive = a win-heavy team that fell (steal); big negative = a low-win
-    // team taken early (reach). Elite early picks rank high, so they aren't
-    // penalized. This drives the steal/reach highlights only — not the grade.
-    picks.slice().sort((a, b) => b.wins - a.wins).forEach((p, i) => { p.winsRank = i + 1; });
-    picks.forEach(p => { p.value = p.overall - p.winsRank; });
+    // Steal/reach highlight = how far a pick beat its draft slot on projected
+    // points: rank picks by projected points, value = overall − pointsRank.
+    picks.slice().sort((a, b) => b.points - a.points).forEach((p, i) => { p.pointsRank = i + 1; });
+    picks.forEach(p => { p.value = p.overall - p.pointsRank; });
 
-    // 2. Roll up per manager.
     const byUser = {};
     picks.forEach(p => { (byUser[p.userId] = byUser[p.userId] || []).push(p); });
 
     return Object.keys(byUser).map(uid => {
         const ps = byUser[uid].slice().sort((a, b) => a.overall - b.overall);
-        const strength = ps.reduce((s, p) => s + p.sp, 0) / ps.length;
+        const totalPoints = ps.reduce((s, p) => s + p.points, 0);
+        const avgPoints = totalPoints / ps.length;
         const projWins = ps.reduce((s, p) => s + p.wins, 0) / ps.length;
-        const cfpSum = ps.reduce((s, p) => s + p.cfp, 0);
-        // Display: expected # of CFP teams (sum of make-odds probability) when
-        // odds are in; else a hard count of top-12 SP+ teams.
-        const cfpCount = oddsPresent
-            ? Math.round(ps.reduce((s, p) => s + (p.makeProb || 0), 0) * 10) / 10
-            : ps.filter(p => p.spRank != null && p.spRank <= 12).length;
+        const cfpCount = Math.round(ps.reduce((s, p) => s + (p.makeProb || 0), 0) * 10) / 10;
+        const regPoints = Math.round(ps.reduce((s, p) => s + p.reg, 0));
+        const postPoints = Math.round(ps.reduce((s, p) => s + p.post, 0));
         const best = ps.slice().sort((a, b) => b.value - a.value)[0];
         const worst = ps.slice().sort((a, b) => a.value - b.value)[0];
         const u = usersById[uid] || {};
         const us = (u.seasons || []).find(s => Number(s.season) === season) || {};
-
-        // 3. Absolute blended score → letter (each draft on its own merit).
-        const sStr = clamp01((strength - STRENGTH_LOW) / (STRENGTH_HIGH - STRENGTH_LOW));
-        const sWin = clamp01((projWins - WINS_LOW) / (WINS_HIGH - WINS_LOW));
-        const sCfp = clamp01((cfpSum - CFP_LOW) / (CFP_HIGH - CFP_LOW));
-        const score = W_STRENGTH * sStr + W_WINS * sWin + W_CFP * sCfp;
+        const score = clamp01((avgPoints - bands.replacementAvg) / denom);
 
         return {
             userId: uid, name: displayName(u), franchise: us.franchiseName || null,
             avatarUrl: u.avatarUrl || null,
-            strength: Math.round(strength * 10) / 10,
+            projPoints: Math.round(totalPoints),
+            regPoints, postPoints,
             projWins: Math.round(projWins * 10) / 10,
             cfpCount,
             grade: letterFor(score),
-            // Only surface a steal/reach when it beat (or lagged) its slot by a
-            // few rounds — otherwise there's no notable story to tell.
             bestPick: (best && best.value >= 5) ? pickView(best) : null,
             worstPick: (worst && worst.value <= -5) ? pickView(worst) : null
         };
     }).sort((a, b) => {
         const order = ['A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'D'];
-        return order.indexOf(a.grade) - order.indexOf(b.grade) || b.projWins - a.projWins;
+        return order.indexOf(a.grade) - order.indexOf(b.grade) || b.projPoints - a.projPoints;
     });
 }
 
-module.exports = { computeGrades, spFor, winsFor, cfpTier, letterFor };
+module.exports = { computeGrades, letterFor, spFor, winsFor };

--- a/modules/draft-projection.js
+++ b/modules/draft-projection.js
@@ -1,0 +1,265 @@
+// Expected-fantasy-points projection for the draft grade. For each team we
+// project its season and score it through THAT league's real scoring engine
+// (modules/scoring.js `evaluate`) by synthesizing games and weighting each by
+// its probability — so both leagues, and any commissioner config overrides,
+// fall out automatically. See .claude/plans for the full design + rationale.
+
+const { evaluate } = require('./scoring');
+const { isConferenceChampion } = require('./scoring-detectors');
+const { americanToProb } = require('./cfp-odds');
+const { marginToWinProb, calibrateToExpectedWins, winTotalDistribution, pAtLeast } = require('./win-probability');
+
+// --- tunables ---
+const HFA = 2.5;              // home-field advantage in SP+ points
+const FCS_SP_GAP = 30;        // assumed SP+ deficit of an FCS (non-DB) opponent
+const CONF_T = 9;             // conference-title softmax temperature
+const BOWL_WIN_PROB = 0.5;    // bowls ≈ coin flips (preseason)
+const CFP_FIELD = 12;         // playoff field size (make-prob normalization)
+const ROUND_NOTES = {
+    FR: 'CFP First Round', QF: 'CFP Quarterfinal',
+    SF: 'CFP Semifinal', F: 'CFP National Championship'
+};
+
+// --- season-value helpers (prior-season fallback, like draft-grades) ---
+function seasonVal(team, season, field) {
+    const seasons = (team && team.seasons) || [];
+    const cur = seasons.find(s => Number(s.season) === season);
+    if (cur && cur[field] != null) return cur[field];
+    const prev = seasons.find(s => Number(s.season) === season - 1);
+    if (prev && prev[field] != null) return prev[field];
+    return null;
+}
+const spFor = (t, s) => seasonVal(t, s, 'spRating');
+const winsFor = (t, s) => seasonVal(t, s, 'expectedWins');
+const confFor = (t, s) => seasonVal(t, s, 'conference') || (t && t.conference) || null;
+
+function clamp01(x) { return Math.max(0, Math.min(1, x)); }
+
+// --- ranking proxy -------------------------------------------------------
+// Reuses the real AP poll if one is stored for the season; otherwise builds a
+// synthetic "AP Top 25" from SP+ rank. Poll name is always 'AP Top 25' so the
+// detector's findPoll matches either source (swap to real AP is then free).
+// Ranked entries include each team's alternateNames so the name-join to the
+// Game docs can't silently miss.
+function buildRankingProxy(season, teamsById, apPoll) {
+    if (apPoll && Array.isArray(apPoll.ranks) && apPoll.ranks.length) {
+        return { polls: [{ poll: 'AP Top 25', ranks: apPoll.ranks }] };
+    }
+    const rated = Object.keys(teamsById)
+        .map(id => ({ t: teamsById[id], sp: spFor(teamsById[id], season) }))
+        .filter(x => x.sp != null)
+        .sort((a, b) => b.sp - a.sp)
+        .slice(0, 25);
+    const ranks = [];
+    rated.forEach((x, i) => {
+        const rank = i + 1;
+        ranks.push({ school: x.t.school, rank });
+        (x.t.alternateNames || []).forEach(n => { if (n) ranks.push({ school: n, rank }); });
+    });
+    return { polls: [{ poll: 'AP Top 25', ranks }] };
+}
+
+// --- pool context (built once) ------------------------------------------
+// De-vigs the CFP market across the whole pool (make-probs → Σ≈12, champ → Σ=1),
+// derives a top-4-seed probability, and precomputes SP+ ranks + conference
+// softmax denominators.
+function buildPoolContext(teamsById, season) {
+    const ids = Object.keys(teamsById);
+
+    // De-vig make/champ by pool normalization.
+    let sumMake = 0, sumChamp = 0;
+    const rawMake = {}, rawChamp = {};
+    ids.forEach(id => {
+        const t = teamsById[id];
+        const mo = seasonVal(t, season, 'cfpMakeOdds');
+        const co = seasonVal(t, season, 'cfpChampOdds');
+        if (mo != null) { rawMake[id] = americanToProb(mo); sumMake += rawMake[id]; }
+        if (co != null) { rawChamp[id] = americanToProb(co); sumChamp += rawChamp[id]; }
+    });
+    const makeScale = sumMake > 0 ? CFP_FIELD / sumMake : 0;
+    const champScale = sumChamp > 0 ? 1 / sumChamp : 0;
+
+    const make = {}, champ = {}, seed = {};
+    ids.forEach(id => {
+        make[id] = rawMake[id] != null ? Math.min(0.99, rawMake[id] * makeScale) : null;
+        champ[id] = rawChamp[id] != null ? rawChamp[id] * champScale : null;
+    });
+    // Top-4 seed prob: contenders (by de-vigged champ prob) are likeliest byes;
+    // Σβ ≈ 4. Independents can't win a conference → never a top-4 seed.
+    ids.forEach(id => {
+        const t = teamsById[id];
+        const indep = confFor(t, season) === 'FBS Independents';
+        if (make[id] == null || indep) { seed[id] = 0; return; }
+        seed[id] = Math.min(make[id], 4 * (champ[id] || 0));
+    });
+
+    // SP+ national rank (1 = best) for the odds fallback.
+    const spRankById = {};
+    ids.map(id => ({ id, sp: spFor(teamsById[id], season) }))
+        .filter(x => x.sp != null)
+        .sort((a, b) => b.sp - a.sp)
+        .forEach((x, i) => { spRankById[x.id] = i + 1; });
+
+    // Conference softmax denominators (exclude independents / no-SP+).
+    const confDenom = {};
+    ids.forEach(id => {
+        const t = teamsById[id];
+        const conf = confFor(t, season), sp = spFor(t, season);
+        if (!conf || conf === 'FBS Independents' || sp == null) return;
+        confDenom[conf] = (confDenom[conf] || 0) + Math.exp(sp / CONF_T);
+    });
+
+    return { make, champ, seed, spRankById, confDenom, teamsById, season };
+}
+
+// Rough CFP make-prob when no market odds exist (e.g. historical seasons).
+function makeFallback(rank) {
+    if (rank == null) return 0.02;
+    if (rank <= 4) return 0.85;
+    if (rank <= 12) return 0.5;
+    if (rank <= 25) return 0.15;
+    return 0.03;
+}
+
+// --- synthetic games -----------------------------------------------------
+function synthWin(game, teamId) {
+    const isHome = game.homeId === teamId;
+    return Object.assign({}, game, {
+        homePoints: isHome ? 1 : 0,
+        awayPoints: isHome ? 0 : 1
+    });
+}
+
+function synthResult(base, teamId, teamIsHome, won) {
+    const g = Object.assign({
+        id: -1, season: 0, week: 1, conferenceGame: false,
+        homeId: teamIsHome ? teamId : -999, awayId: teamIsHome ? -999 : teamId,
+        homeTeam: teamIsHome ? 'TEAM' : 'OPP', awayTeam: teamIsHome ? 'OPP' : 'TEAM',
+        homeConference: 'X', awayConference: 'Y'
+    }, base);
+    const teamScored = won ? 1 : 0, oppScored = won ? 0 : 1;
+    g.homePoints = teamIsHome ? teamScored : oppScored;
+    g.awayPoints = teamIsHome ? oppScored : teamScored;
+    return g;
+}
+
+function evalPost(teamId, round, isTop4, won, rankings, cfg) {
+    const g = synthResult({ seasonType: 'postseason', notes: ROUND_NOTES[round], neutralSite: round === 'F' }, teamId, !!isTop4, won);
+    return evaluate(cfg.model, teamId, g, rankings, cfg);
+}
+
+// Solve the single per-round win prob q from c = m·[β·q³ + (1−β)·q⁴].
+function solveQ(m, c, beta) {
+    if (m <= 0) return 0;
+    const cc = Math.min(c, m * 0.999);
+    if (cc <= 0) return 0.001;
+    let lo = 0, hi = 1;
+    for (let i = 0; i < 50; i++) {
+        const q = (lo + hi) / 2;
+        const f = m * (beta * q * q * q + (1 - beta) * q * q * q * q);
+        if (f < cc) lo = q; else hi = q;
+    }
+    return (lo + hi) / 2;
+}
+
+// Expected CFP points: probability-weighted walk of bracket outcomes. Non-bye
+// teams start in the First Round; bye teams start in the QF as a top-4 seed
+// (homeId=team) so Graham's bye bonus fires. Values come from the engine.
+function expectedCfpPoints(teamId, m, beta, q, rankings, cfg) {
+    const E = (round, isTop4) =>
+        q * evalPost(teamId, round, isTop4, true, rankings, cfg)
+        + (1 - q) * evalPost(teamId, round, isTop4, false, rankings, cfg);
+    const wNon = m * (1 - beta), wBye = m * beta;
+    const nonBye = E('FR', false) + q * E('QF', false) + q * q * E('SF', false) + q * q * q * E('F', false);
+    const bye = E('QF', true) + q * E('SF', false) + q * q * E('F', false);
+    return wNon * nonBye + wBye * bye;
+}
+
+// --- per-team projection -------------------------------------------------
+function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season) {
+    const teamId = team.id;
+    const sp = spFor(team, season);
+    const mySp = sp == null ? 0 : sp;
+
+    // 1. Regular season: expected points = Σ P(win) · points-if-win.
+    //    Exclude conference-title games (modeled separately) and any non-regular.
+    const reg = (teamGames || []).filter(g => g.seasonType === 'regular' && !isConferenceChampion(g));
+    const margins = reg.map(g => {
+        const isHome = g.homeId === teamId;
+        const oppId = isHome ? g.awayId : g.homeId;
+        const opp = poolCtx.teamsById[String(oppId)];
+        const oppSp = opp ? spFor(opp, season) : null;           // null → FCS / non-DB
+        const effOpp = oppSp == null ? (mySp - FCS_SP_GAP) : oppSp;
+        const hfa = g.neutralSite ? 0 : (isHome ? HFA : -HFA);
+        return (mySp - effOpp) + hfa;
+    });
+    const { probs } = calibrateToExpectedWins(margins, winsFor(team, season));
+    let regular = 0;
+    reg.forEach((g, i) => { regular += probs[i] * evaluate(cfg.model, teamId, synthWin(g, teamId), rankings, cfg); });
+    const projWins = probs.reduce((a, b) => a + b, 0);
+
+    // 2. CFP (market odds, else SP+-rank fallback).
+    let m = poolCtx.make[String(teamId)];
+    let c = poolCtx.champ[String(teamId)];
+    let beta = poolCtx.seed[String(teamId)] || 0;
+    if (m == null) {
+        const r = poolCtx.spRankById[String(teamId)];
+        m = makeFallback(r); c = m * 0.05; beta = (r != null && r <= 4) ? m * 0.5 : 0;
+    }
+    let cfp = 0;
+    if (m > 0) cfp = expectedCfpPoints(teamId, m, beta, solveQ(m, c, beta), rankings, cfg);
+
+    // 3. Conference title (softmax over conference SP+; independents = 0).
+    let confChamp = 0;
+    const conf = confFor(team, season);
+    if (conf && conf !== 'FBS Independents' && sp != null && poolCtx.confDenom[conf]) {
+        const pConf = Math.exp(sp / CONF_T) / poolCtx.confDenom[conf];
+        const g = synthResult({ seasonType: 'regular', notes: `${conf} Championship`, neutralSite: true, conferenceGame: true, homeConference: conf, awayConference: conf }, teamId, true, true);
+        confChamp = pConf * evaluate(cfg.model, teamId, g, rankings, cfg);
+    }
+
+    // 4. Bowl (non-playoff): P(≥6 wins)·(1 − P(make CFP)) × expected bowl value.
+    const dist = winTotalDistribution(probs);
+    const pBowl = pAtLeast(dist, 6) * (1 - m);
+    const bowlWin = evaluate(cfg.model, teamId, synthResult({ seasonType: 'postseason', notes: 'Bowl', neutralSite: true }, teamId, true, true), rankings, cfg);
+    const bowlLose = evaluate(cfg.model, teamId, synthResult({ seasonType: 'postseason', notes: 'Bowl', neutralSite: true }, teamId, true, false), rankings, cfg);
+    const bowl = pBowl * (BOWL_WIN_PROB * bowlWin + (1 - BOWL_WIN_PROB) * bowlLose);
+
+    const total = regular + cfp + confChamp + bowl;
+    return { regular, cfp, confChamp, bowl, total, projWins, makeProb: m };
+}
+
+// --- absolute per-league bands ------------------------------------------
+// Grades a roster on its PER-TEAM caliber, anchored to the pool:
+//   eliteAvg       = projection at rank R      → "your typical team is top-R caliber"
+//   replacementAvg = projection at rank L·R    → "your typical team is the last one drafted"
+// A roster whose average team sits at top-R caliber earns an A; one made of
+// last-drafted-caliber teams earns a D. Anchors depend only on the team pool +
+// league scoring config + league size/rounds — never on who actually drafted —
+// so the letter is absolute. (Averaging the literal top-R teams was rejected:
+// no single roster can hold them in a snake draft, so it under-grades everyone;
+// snake-slot anchors were also rejected — snake balances total value across
+// seats and collapses the range.) A small window smooths rank cliffs.
+function computeLeagueBands(sortedTotalsDesc, leagueSize, rounds) {
+    const N = sortedTotalsDesc.length;
+    const L = Math.max(2, leagueSize || 6), R = Math.max(1, rounds || 10);
+    const windowAvg = (centerRank) => {
+        const c = Math.min(N, Math.max(1, centerRank));
+        let s = 0, n = 0;
+        for (let rank = c - 2; rank <= c + 2; rank++) {
+            if (rank >= 1 && rank <= N) { s += sortedTotalsDesc[rank - 1]; n++; }
+        }
+        return n ? s / n : 0;
+    };
+    return {
+        eliteAvg: windowAvg(R),
+        replacementAvg: windowAvg(Math.min(N, L * R))
+    };
+}
+
+module.exports = {
+    buildRankingProxy, buildPoolContext, projectTeamPoints, computeLeagueBands,
+    // helpers reused by draft-grades / tests:
+    seasonVal, spFor, winsFor, confFor, makeFallback, solveQ, expectedCfpPoints,
+    HFA, FCS_SP_GAP
+};

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -422,3 +422,10 @@ function evaluate(model, team, game, rankings, cfg) {
     }
     return score;
 }
+
+// Exported for the draft-grade projection (modules/draft-projection.js), which
+// reuses the EXACT engine on synthesized games + a locally-supplied rankings
+// object — so it never triggers the network rankings fetch that
+// calculateScoreV1/V2 do, and stays byte-for-byte consistent with live scoring.
+module.exports.evaluate = evaluate;
+module.exports.normalizeCfg = normalizeCfg;

--- a/modules/win-probability.js
+++ b/modules/win-probability.js
@@ -1,0 +1,89 @@
+// Pure, I/O-free probability helpers for the draft-grade projection
+// (modules/draft-projection.js). Kept separate so they're trivially unit-tested.
+//
+// SP+ is a points-scale rating (expected scoring margin vs. an average team), so
+// the principled win-probability mapping is a normal CDF of the predicted
+// margin. σ ≈ 16.5 is the empirical standard deviation of a college-football
+// game's result vs. its prediction (a 3-pt favorite ≈ 57%, 10-pt ≈ 73%,
+// 17-pt ≈ 85%). HFA in SP+ space is ~2.5 points.
+
+const DEFAULT_SIGMA = 16.5;
+
+// Abramowitz & Stegun 7.1.26 erf approximation (max error ~1.5e-7).
+function erf(x) {
+    const sign = x < 0 ? -1 : 1;
+    const ax = Math.abs(x);
+    const t = 1 / (1 + 0.3275911 * ax);
+    const y = 1 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t * Math.exp(-ax * ax);
+    return sign * y;
+}
+
+// Standard normal CDF.
+function normCdf(z) {
+    return 0.5 * (1 + erf(z / Math.SQRT2));
+}
+
+// P(win) from a predicted point margin (already including HFA). Clamped just
+// inside (0,1) so downstream logs/products never hit exactly 0 or 1.
+function marginToWinProb(margin, sigma = DEFAULT_SIGMA) {
+    if (!isFinite(margin)) return 0.5;
+    const p = normCdf(margin / (sigma || DEFAULT_SIGMA));
+    return Math.min(0.999, Math.max(0.001, p));
+}
+
+// Calibrate a team's per-game win probs to a trusted projected win total by
+// finding the single additive margin shift δ such that Σ Φ((margin_i + δ)/σ)
+// equals `expectedWins`. Additive (not multiplicative) keeps every prob in
+// (0,1) and absorbs systematic rating staleness (e.g. 2025 SP+ used for 2026).
+//
+// margins: array of predicted margins (team − opp + HFA), one per game.
+// Returns { probs, delta }. If expectedWins is null/undefined, returns the raw
+// (δ=0) probs so callers can no-op gracefully.
+function calibrateToExpectedWins(margins, expectedWins, sigma = DEFAULT_SIGMA) {
+    const raw = margins.map(m => marginToWinProb(m, sigma));
+    if (expectedWins == null || !margins.length) return { probs: raw, delta: 0 };
+
+    const target = Math.min(margins.length - 1e-6, Math.max(1e-6, expectedWins));
+    const sumAt = (delta) => margins.reduce((s, m) => s + marginToWinProb(m + delta, sigma), 0);
+
+    // Σ is monotonically increasing in δ; bisect on a wide margin range.
+    let lo = -80, hi = 80;
+    for (let i = 0; i < 60; i++) {
+        const mid = (lo + hi) / 2;
+        if (sumAt(mid) < target) lo = mid; else hi = mid;
+    }
+    const delta = (lo + hi) / 2;
+    return { probs: margins.map(m => marginToWinProb(m + delta, sigma)), delta };
+}
+
+// Poisson-binomial distribution: P(exactly k wins) for k = 0..n given
+// independent per-game win probs. Returns an array of length n+1.
+function winTotalDistribution(probs) {
+    let dist = [1];
+    for (const p of probs) {
+        const next = new Array(dist.length + 1).fill(0);
+        for (let k = 0; k < dist.length; k++) {
+            next[k] += dist[k] * (1 - p);
+            next[k + 1] += dist[k] * p;
+        }
+        dist = next;
+    }
+    return dist;
+}
+
+// P(win total >= k) from a Poisson-binomial distribution.
+function pAtLeast(dist, k) {
+    let s = 0;
+    for (let i = k; i < dist.length; i++) s += dist[i];
+    return s;
+}
+
+module.exports = {
+    DEFAULT_SIGMA,
+    erf,
+    normCdf,
+    marginToWinProb,
+    calibrateToExpectedWins,
+    winTotalDistribution,
+    pAtLeast
+};

--- a/public/admin.js
+++ b/public/admin.js
@@ -827,6 +827,41 @@ if (gamesForm) {
     });
 }
 
+function displayScheduleContainer() {
+    var el = document.querySelector('[schedule-container]');
+    el.style.display = (el.style.display == 'flex' || el.style.display == '') ? 'none' : 'flex';
+}
+
+// Bulk-ingest a season's full FBS regular schedule — the preseason prerequisite
+// for draft grades (the projection reads each team's schedule).
+const scheduleForm = document.getElementById('schedule-form');
+
+if (scheduleForm) {
+    scheduleForm.addEventListener('submit', async function(event) {
+        event.preventDefault();
+        block_screen();
+
+        const season = document.querySelector('[schedule-season]').value;
+        const response = await fetch(`/games/${season}/schedule`, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+        });
+        const data = await response.json();
+        unblock_screen();
+
+        const results = document.getElementById('schedule-results');
+        if (response.status == 201) {
+            successToast.options.text = `Schedule ingested for ${season}: ${data.created} new, ${data.updated} updated`;
+            successToast.showToast();
+            if (results) results.textContent = `${data.total} games (${data.created} new, ${data.updated} updated).`;
+        } else {
+            failToast.options.text = (response.status) + `| Schedule could not be ingested`;
+            failToast.showToast();
+            if (results) results.textContent = (data && data.message) || 'Failed.';
+        }
+    });
+}
+
 const scoresForm = document.getElementById('scores-form');
 
 if (scoresForm) {

--- a/public/draftGrades.css
+++ b/public/draftGrades.css
@@ -99,6 +99,17 @@
 .gg-stat-val { font-size: 1.15rem; font-weight: 700; color: #F4F6FB; font-variant-numeric: tabular-nums; }
 .gg-stat-lbl { color: #A4A9C2; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; }
 
+/* Regular-season vs postseason projected-points split. */
+.gg-split { margin-top: 0.7rem; }
+.gg-split-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; background: #2A2E42; }
+.gg-split-reg { background: #6C9BFF; }
+.gg-split-post { background: #E0B341; }
+.gg-split-legend { display: flex; justify-content: space-between; margin-top: 5px; font-size: 0.68rem; color: #A4A9C2; }
+.gg-split-lg { display: flex; align-items: center; gap: 5px; }
+.gg-split-lg i { width: 8px; height: 8px; border-radius: 2px; display: inline-block; }
+.gg-dot-reg { background: #6C9BFF; }
+.gg-dot-post { background: #E0B341; }
+
 .gg-pick { display: flex; flex-direction: column; gap: 0.15rem; font-size: 0.85rem; }
 .gg-pick-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 700; }
 .gg-steal .gg-pick-label { color: #22C37A; }

--- a/public/draftGrades.js
+++ b/public/draftGrades.js
@@ -27,7 +27,25 @@
         return '<div class="gg-pick ' + cls + '">'
             + '<span class="gg-pick-label">' + label + '</span>'
             + '<span class="gg-pick-team">' + logo(p.logo) + esc(p.school) + '</span>'
-            + '<span class="gg-pick-meta">R' + p.round + ' · ' + p.wins + ' proj W · ' + signed(p.value) + ' slots</span>'
+            + '<span class="gg-pick-meta">R' + p.round + ' · ' + p.points + ' proj pts · ' + signed(p.value) + ' slots</span>'
+            + '</div>';
+    }
+
+    // Thin two-segment bar showing how projected points split between the
+    // regular-season floor and postseason (CFP + conf title + bowl) upside.
+    function splitBar(m) {
+        var reg = m.regPoints || 0, post = m.postPoints || 0, tot = reg + post;
+        if (tot <= 0) return '';
+        var regPct = Math.round(reg / tot * 100);
+        return '<div class="gg-split">'
+            + '<div class="gg-split-bar">'
+            +   '<span class="gg-split-reg" style="width:' + regPct + '%"></span>'
+            +   '<span class="gg-split-post" style="width:' + (100 - regPct) + '%"></span>'
+            + '</div>'
+            + '<div class="gg-split-legend">'
+            +   '<span class="gg-split-lg"><i class="gg-dot-reg"></i>' + reg + ' regular</span>'
+            +   '<span class="gg-split-lg"><i class="gg-dot-post"></i>' + post + ' postseason</span>'
+            + '</div>'
             + '</div>';
     }
 
@@ -44,10 +62,11 @@
             +   '<span class="gg-grade">' + esc(m.grade) + '</span>'
             + '</div>'
             + '<div class="gg-stats">'
+            +   '<div class="gg-stat"><span class="gg-stat-val">' + m.projPoints + '</span><span class="gg-stat-lbl">proj points</span></div>'
             +   '<div class="gg-stat"><span class="gg-stat-val">' + m.projWins + '</span><span class="gg-stat-lbl">proj wins</span></div>'
-            +   '<div class="gg-stat"><span class="gg-stat-val">' + m.strength + '</span><span class="gg-stat-lbl">avg SP+</span></div>'
             +   '<div class="gg-stat"><span class="gg-stat-val">' + m.cfpCount + '</span><span class="gg-stat-lbl">CFP teams</span></div>'
             + '</div>'
+            + splitBar(m)
             + pickLine('best', m.bestPick)
             + pickLine('worst', m.worstPick)
             + '</div>';
@@ -65,6 +84,17 @@
         container.innerHTML = head + note
             + '<div class="grades-grid">'
             + payload.managers.map(function (m) { return card(m, opts.currentUserId); }).join('')
+            + '</div>';
+    };
+
+    // Render just one manager's card (used by the profile chip → expand panel).
+    window.renderDraftGradeCard = function (container, manager, opts) {
+        opts = opts || {};
+        if (!container || !manager) return;
+        var note = opts.note ? '<p class="grades-note">' + esc(opts.note) + '</p>' : '';
+        container.innerHTML = note
+            + '<div class="grades-grid grades-grid-single">'
+            + card(manager, opts.currentUserId)
             + '</div>';
     };
 })();

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -418,7 +418,7 @@ function renderGrades() {
                 renderDraftGrades(el, data, {
                     currentUserId: myUserId,
                     title: 'Draft Grades',
-                    note: 'Instant, preseason grades — a blend of team quality (SP+), projected wins, and CFP upside. Each draft graded on its own merit.'
+                    note: 'Instant, preseason grades — projected fantasy points in this league’s scoring (schedule + SP+ win odds + market CFP odds). Each draft graded on its own merit.'
                 });
             }
         })

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -1,10 +1,23 @@
 @media only screen and (min-width: 0em) {
 
+    /* The body is a centered column flexbox, so a width-less .content shrinks to
+       its table's content width and the card collapses. Stretch it to the
+       viewport at every breakpoint (desktop repeats this in its own query). */
+    .content {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
     .get-users-container {
         width: 95%;
-        max-width: 100vw;
-        /* overflow-x: hidden; */
+        max-width: 900px;
+        margin: 0 auto 1em;
         overflow-x: visible !important;
+        background: #1A1F33;
+        border: 1px solid #2A2E42;
+        border-radius: 14px;
+        padding: 0.25em 1em;
+        box-sizing: border-box;
     }
     
     .header {
@@ -33,14 +46,29 @@
     }
 
     .table-wrapper {
-        overflow-x: scroll;
-        width: 95%;
-
+        overflow-x: auto;
+        overflow-y: hidden;
+        width: 100%;
+        /* styles.css sets margin:10px 20px 20px; with width:100% those side
+           margins push the wrapper past the card edge. Zero them — the card's
+           own padding provides the gutter. */
+        margin: 0;
+        box-shadow: none;
+        /* Round the row backgrounds to echo the card (overflow clips the square
+           corners; overflow-y:hidden + overflow-x:auto keeps horizontal scroll). */
+        border-radius: 10px;
     }
 
+    /* Standings-style: table fills the card; the team column absorbs the slack
+       so the score sits flush right. In-season the weekly columns push the
+       total width past the container and the wrapper scrolls horizontally. */
     .fl-table {
-        width: max-content;
-        min-width: 100%;
+        width: 100%;
+    }
+
+    .fl-table th.sticky-header {
+        width: 100%;
+        text-align: left !important;
     }
 
     .fl-table th {
@@ -81,6 +109,29 @@
     .sticky-header-score {
         padding-left: 1em;
         box-shadow: -8px 0 8px -6px rgba(0, 0, 0, 0.6);
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    /* The mobile ".fl-table .team-header" rule (50px + pre-wrap, meant for the
+       narrow weekly columns) also matches the score header, squishing it and
+       wrapping "Team Score". Outrank it so the score column sizes to its label.
+       That rule also pins padding to "0 0 0 0.5em !important", jamming the score
+       flush to the edge — restore a right gutter (needs !important to win). */
+    .fl-table th.sticky-header-score {
+        width: auto;
+        white-space: nowrap;
+        padding-right: 1.25em !important;
+    }
+
+    /* Matching left gutter so the "Team" header lines up with the team logos.
+       The body cell's <a> carries its own padding-left, so move the inset onto
+       the cell and zero the anchor's — otherwise logos indent past the header. */
+    .fl-table th.sticky-header {
+        padding-left: 1.25em !important;
+    }
+    .fl-table th.sticky-header a {
+        padding-left: 0;
     }
 
     /* Unplayed weeks read as blank (not a scored 0); byes as a muted dash. */
@@ -226,11 +277,14 @@
 
     .get-users-container {
         width: 95%;
-        margin-left: 2.5%;
+        max-width: 900px;
+        margin: 0 auto 1em;
+        padding: 0.25em 1.5em;
     }
 
     .table-wrapper {
-        width: auto;
+        width: 100%;
+        overflow-x: auto;
     }
 
     /* On desktop the table fits without horizontal scroll, so the frozen
@@ -241,15 +295,24 @@
     .sticky-header-score {
         position: static;
         box-shadow: none;
+        text-align: right !important;
+        white-space: nowrap;
     }
 
     .fl-table {
         font-size: 1em;
         line-height: 3em;
-        /* Size to content (not stretched to the wrapper): with the score column
-           no longer sticky on desktop, min-width:100% only padded the table out
-           and pushed the last column off-screen. */
+        /* Fill the container as a standings-style table: the team column grows
+           and pushes the score to the right edge. Weekly columns (in-season)
+           sit between them, scrolling if they overflow. */
+        width: 100%;
         min-width: 0;
+    }
+
+    /* Team column takes the slack so the score sits flush right. */
+    .fl-table th.sticky-header {
+        width: 100%;
+        text-align: left !important;
     }
 
     .hr-subtle {
@@ -348,18 +411,17 @@
     .edit-profile-btn { order: 4; align-self: center; }
 }
 
-/* Desktop layout: center the content column so the hero and the (roughly
-   fixed-width) weekly table sit balanced in the viewport rather than hugging
-   the left with a lonely right gutter. The hero centers via its base margin
-   auto; shrink the table wrapper to the table's width and center it too, so
-   both are symmetric about the middle. Placed after the base rules so it wins
-   on cascade order. */
+/* Desktop layout: the roster is a full-width, standings-style table inside the
+   hero-matching card (team left, score flush right). Fill the wrapper so the
+   columns span the card rather than shrink-wrapping to a lonely centered block.
+   Placed after the base rules so it wins on cascade order. */
 @media only screen and (min-width: 64em) {
     .table-wrapper {
-        width: fit-content;
+        width: 100%;
         max-width: 100%;
         margin-left: auto;
         margin-right: auto;
+        overflow-x: auto;
     }
 }
 
@@ -402,10 +464,45 @@
 .game-card .score-added { white-space: nowrap; padding-left: 0.5em; }
 
 /* Draft grades review section on the profile (cards styled by draftGrades.css). */
-.uh-grades {
-    display: block;
-    width: 92%;
-    max-width: 1100px;
-    margin: 1.5rem auto 0;
+/* Draft-grade chip in the profile hero → expands the detail panel below. */
+.grade-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.85rem;
+    padding: 0.35rem 0.75rem;
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 999px;
+    color: #A4A9C2;
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.18s ease, background 0.18s ease;
 }
-.uh-grades:empty { display: none; }
+.grade-chip:hover { background: #202640; border-color: #3A3F58; }
+.grade-chip-label { text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.72rem; }
+.grade-chip-letter { font-size: 1.05rem; font-weight: 800; color: #6C9BFF; }
+.grade-chip.gg-tier-a { border-color: #22C37A; }
+.grade-chip.gg-tier-a .grade-chip-letter { color: #22C37A; }
+.grade-chip.gg-tier-b { border-color: #6C9BFF; }
+.grade-chip.gg-tier-b .grade-chip-letter { color: #6C9BFF; }
+.grade-chip.gg-tier-c { border-color: #E0B341; }
+.grade-chip.gg-tier-c .grade-chip-letter { color: #E0B341; }
+.grade-chip-caret { font-size: 0.72rem; transition: transform 0.24s ease; }
+.grade-chip[aria-expanded="true"] .grade-chip-caret { transform: rotate(180deg); }
+
+.uh-grades {
+    width: 92%;
+    max-width: 560px;
+    margin: 0 auto;
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.32s ease;
+}
+.uh-grades.is-open { max-height: 900px; margin-top: 1.1rem; }
+.uh-grades .grades-grid-single { grid-template-columns: 1fr; }
+@media (prefers-reduced-motion: reduce) {
+    .uh-grades { transition: none; }
+    .grade-chip-caret { transition: none; }
+}

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -106,27 +106,50 @@ async function getUser() {
     });
 }
 
-// Draft grades review, on the profile: this manager's most-recent season, with
-// the viewing user's card highlighted. Preseason blend of roster strength + draft
-// value (see modules/draft-grades.js).
+// Draft grade on the profile: just THIS manager's own most-recent-season card,
+// surfaced as a color-coded chip in the hero that expands the detail on demand.
+// Preseason blend of roster strength + draft value (see modules/draft-grades.js).
 async function loadHomeGrades(user) {
     const el = document.getElementById('uh-grades');
-    if (!el || !user || !user.league || !(user.seasons || []).length) return;
+    const chip = document.querySelector('[profile-grade-chip]');
+    if (!el || !chip || !user || !user.league || !(user.seasons || []).length) return;
     const season = user.seasons.at(-1).season;
     try {
         const res = await fetch('/draft/grades/' + encodeURIComponent(user.league) + '/' + encodeURIComponent(season), {
             headers: { 'Accept': 'application/json' }
         });
         const data = await res.json();
-        if (!data.managers || !data.managers.length) return;   // no draft for this season — hide section
+        // Show only the profile owner's card; hide the chip entirely if this
+        // manager didn't draft that season.
+        const mine = (data.managers || []).find(m => String(m.userId) === String(user._id));
+        if (!mine) return;   // chip stays hidden
+
+        const tier = (mine.grade || '').charAt(0).toLowerCase();
+        chip.classList.add('gg-tier-' + tier);
+        document.querySelector('[profile-grade-letter]').textContent = mine.grade;
+        chip.hidden = false;
+
+        // "you" tag keys off the logged-in viewer, not the profile owner, so it
+        // only appears when you're looking at your own profile.
         let me;
         try { me = userState.user_metadata.metadata.userId; } catch (e) { /* fall through */ }
         me = me || window.localStorage.getItem('userId') || user._id;
-        if (typeof renderDraftGrades === 'function') {
-            renderDraftGrades(el, data, {
+        if (typeof renderDraftGradeCard === 'function') {
+            renderDraftGradeCard(el, mine, {
                 currentUserId: me,
-                title: 'Draft Grades · ' + season,
-                note: 'Preseason grade — a blend of team quality (SP+), projected wins, and CFP upside. Each draft graded on its own merit.'
+                note: season + ' preseason grade — projected fantasy points in your league’s scoring (schedule + SP+ win odds + market CFP odds). Each draft graded on its own merit.'
+            });
+        }
+        // Reveal the panel but keep it collapsed via CSS max-height, so the
+        // first expand animates (display:none can't transition).
+        el.hidden = false;
+
+        // Chip toggles the detail panel (collapsed by default).
+        if (!chip.dataset.wired) {
+            chip.dataset.wired = '1';
+            chip.addEventListener('click', () => {
+                const open = el.classList.toggle('is-open');
+                chip.setAttribute('aria-expanded', String(open));
             });
         }
     } catch (e) {

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -3,11 +3,16 @@ const router = express.Router();
 const Draft = require('../models/draft');
 const User = require('../models/user');
 const Team = require('../models/team');
+const Game = require('../models/game');
+const Ranking = require('../models/ranking');
+const ScoringConfig = require('../models/scoringConfig');
+const { resolveConfig } = require('../modules/scoring-defaults');
 const { computeGrades } = require('../modules/draft-grades');
 
-// Post-draft grades for a league + season — immediate preseason feedback that
-// blends roster strength (SP+) and draft value (SP+ quality vs. draft slot).
-// Read-only; available as soon as the draft is complete.
+// Post-draft grades for a league + season — immediate preseason feedback. Each
+// roster is projected to EXPECTED FANTASY POINTS under that league's own scoring
+// config (schedule + SP+ win probs + market CFP odds), graded on absolute
+// per-league bands. Read-only; available as soon as the draft is complete.
 router.get('/grades/:league/:season', async (req, res) => {
     try {
         const league = req.params.league;
@@ -21,12 +26,30 @@ router.get('/grades/:league/:season', async (req, res) => {
         const usersById = {};
         users.forEach(u => { usersById[String(u._id)] = u; });
 
-        // SP+ lives on the Team docs (the draft-pick snapshots don't carry it).
-        const teams = await Team.find({}, { id: 1, seasons: 1 }).lean();
+        // SP+ / expected wins / CFP odds / conference live on the Team docs.
+        const teams = await Team.find({}, { id: 1, school: 1, alternateNames: 1, seasons: 1 }).lean();
         const teamsById = {};
         teams.forEach(t => { teamsById[String(t.id)] = t; });
 
-        const managers = computeGrades(draft, usersById, teamsById);
+        // Inputs the projection needs: the season's regular schedule, the
+        // league's resolved scoring config, and a preseason AP poll if ingested
+        // (else the projection synthesizes one from SP+).
+        const games = await Game.find({ season, seasonType: 'regular' },
+            { id: 1, season: 1, seasonType: 1, week: 1, neutralSite: 1, conferenceGame: 1,
+              notes: 1, homeId: 1, homeTeam: 1, homeConference: 1,
+              awayId: 1, awayTeam: 1, awayConference: 1 }).lean();
+
+        const cfgDoc = await ScoringConfig.findOne({ league }).lean();
+        const config = resolveConfig(league, cfgDoc ? {
+            model: cfgDoc.model, values: cfgDoc.values,
+            combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled
+        } : null);
+
+        const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
+        const apPoll = apDoc && Array.isArray(apDoc.polls)
+            ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
+
+        const managers = computeGrades(draft, usersById, teamsById, { games, config, apPoll });
         res.json({ league, season, managers });
     } catch (err) {
         res.status(500).json({ message: err.message });

--- a/routes/games.js
+++ b/routes/games.js
@@ -218,6 +218,43 @@ router.post('/week/mass-create', async (req, res) => {
     }
 });
 
+// Bulk-ingest a full regular-season FBS schedule in one CFBD call. Preseason
+// prerequisite for draft grades (the projection reads each team's schedule).
+// Upserts by game id, so it's safe to re-run and future games (no scores yet)
+// store fine. One shot instead of looping /week/mass-create over 15 weeks.
+router.post('/:season/schedule', async (req, res) => {
+    if (!/^\d{4}$/.test(req.params.season)) {
+        return res.status(400).json({ message: 'Invalid season' });
+    }
+    const season = req.params.season;
+
+    const response = await fetch(`https://api.collegefootballdata.com/games?year=${season}&seasonType=regular&division=fbs`, {
+        method: 'GET',
+        headers: { 'Accept': 'application/json', 'Authorization': process.env.CFBD_API_KEY }
+    });
+    const gameData = await response.json();
+    const responseError = gamesResponseError(response.ok, response.status, gameData);
+    if (responseError) return res.status(400).json({ message: responseError });
+
+    const centralTime = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+    let created = 0, updated = 0;
+    for (const g of gameData) {
+        g.startTimeTbd = g.startTimeTBD;
+        g.lastUpdated = centralTime;
+        const exists = await Game.findOne({ id: g.id });
+        if (!exists) {
+            try { await new Game(g).save(); created++; }
+            catch (err) { console.log('Error saving game', g.id, err.message); }
+        } else {
+            const filter = { id: g.id };
+            delete g.id;
+            try { await Game.findOneAndUpdate(filter, g); updated++; }
+            catch (err) { console.log('Error updating game', filter.id, err.message); }
+        }
+    }
+    return res.status(201).json({ season: Number(season), created, updated, total: gameData.length });
+});
+
 // Populate broadcast info (TV/web outlet) onto existing game docs from CFBD
 // /games/media. One call covers the whole season; matched by game id.
 router.post('/:season/media', async (req, res) => {

--- a/tests/DraftProjection.spec.js
+++ b/tests/DraftProjection.spec.js
@@ -1,0 +1,110 @@
+const {
+    marginToWinProb, calibrateToExpectedWins, winTotalDistribution, pAtLeast
+} = require('../modules/win-probability');
+const {
+    solveQ, expectedCfpPoints, computeLeagueBands
+} = require('../modules/draft-projection');
+const { evaluate } = require('../modules/scoring');
+const { resolveConfig } = require('../modules/scoring-defaults');
+
+// A synthetic "team (home) won" regular-season game against `oppConf`, optionally
+// with the opponent ranked in a supplied poll.
+function winGame(overrides) {
+    return Object.assign({
+        id: 1, season: 2026, week: 1, seasonType: 'regular',
+        neutralSite: false, conferenceGame: false, notes: '',
+        homeId: 1, homeTeam: 'A', homeConference: 'SEC', homePoints: 1,
+        awayId: 2, awayTeam: 'B', awayConference: 'Big Ten', awayPoints: 0
+    }, overrides || {});
+}
+const rankedPoll = (school, rank) => ({ polls: [{ poll: 'AP Top 25', ranks: [{ school, rank }] }] });
+const GRAHAM = resolveConfig('graham-league', null);
+const CLAUNTS = resolveConfig('claunts-league', null);
+
+describe('win-probability', () => {
+    it('maps margin to win prob with sane anchors', () => {
+        expect(marginToWinProb(0)).toBeCloseTo(0.5, 3);
+        expect(marginToWinProb(10)).toBeGreaterThan(0.70);
+        expect(marginToWinProb(10)).toBeLessThan(0.76);
+        expect(marginToWinProb(17)).toBeGreaterThan(0.83);
+        // symmetric
+        expect(marginToWinProb(-8) + marginToWinProb(8)).toBeCloseTo(1, 3);
+    });
+
+    it('calibrates per-game probs to sum to expectedWins (additive shift)', () => {
+        const margins = [20, 10, 5, -3, -15, 2, -8];
+        const { probs, delta } = calibrateToExpectedWins(margins, 4.2);
+        const sum = probs.reduce((a, b) => a + b, 0);
+        expect(sum).toBeCloseTo(4.2, 2);
+        expect(probs.every(p => p > 0 && p < 1)).toBe(true);   // stays in (0,1)
+        expect(typeof delta).toBe('number');
+    });
+
+    it('returns raw probs when expectedWins is null', () => {
+        const margins = [10, -10];
+        const { probs, delta } = calibrateToExpectedWins(margins, null);
+        expect(delta).toBe(0);
+        expect(probs[0]).toBeCloseTo(marginToWinProb(10), 6);
+    });
+
+    it('Poisson-binomial distribution sums to 1 with mean = Σp', () => {
+        const probs = [0.9, 0.5, 0.2, 0.7];
+        const dist = winTotalDistribution(probs);
+        expect(dist).toHaveLength(probs.length + 1);
+        expect(dist.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 6);
+        const mean = dist.reduce((s, p, k) => s + k * p, 0);
+        expect(mean).toBeCloseTo(probs.reduce((a, b) => a + b, 0), 6);
+        expect(pAtLeast(dist, 0)).toBeCloseTo(1, 6);
+    });
+});
+
+describe('evaluate reuse via synthesized win game', () => {
+    it('scores a plain non-conf unranked win = 1 in both leagues', () => {
+        expect(evaluate('graham', 1, winGame(), {}, GRAHAM)).toBe(1);
+        expect(evaluate('claunts', 1, winGame(), {}, CLAUNTS)).toBe(1);
+    });
+
+    it('scores a conference win: Graham base+conf=2, Claunts conf=2', () => {
+        const g = winGame({ conferenceGame: true, awayConference: 'SEC' });
+        expect(evaluate('graham', 1, g, {}, GRAHAM)).toBe(2);
+        expect(evaluate('claunts', 1, g, {}, CLAUNTS)).toBe(2);
+    });
+
+    it('scores a non-conf win vs a top-10 team: Graham 1+2=3, Claunts 3', () => {
+        const g = winGame();
+        const r = rankedPoll('B', 5);
+        expect(evaluate('graham', 1, g, r, GRAHAM)).toBe(3);
+        expect(evaluate('claunts', 1, g, r, CLAUNTS)).toBe(3);
+    });
+
+    it('ranked proxy keyed by opponent NAME drives the bonus', () => {
+        // Wrong name in the poll → no ranked bonus (guards the name-join risk).
+        const g = winGame();
+        expect(evaluate('graham', 1, g, rankedPoll('WRONG', 5), GRAHAM)).toBe(1);
+    });
+});
+
+describe('CFP bracket model', () => {
+    it('solveQ inverts c = m·[β q³ + (1−β) q⁴]', () => {
+        const m = 0.6, c = 0.06, beta = 0.2;
+        const q = solveQ(m, c, beta);
+        expect(q).toBeGreaterThan(0);
+        expect(q).toBeLessThan(1);
+        expect(m * (beta * q ** 3 + (1 - beta) * q ** 4)).toBeCloseTo(c, 4);
+    });
+
+    it('expected CFP points are non-negative and increase with make prob', () => {
+        const low = expectedCfpPoints(9, 0.2, 0.0, solveQ(0.2, 0.01, 0), {}, GRAHAM);
+        const high = expectedCfpPoints(9, 0.9, 0.4, solveQ(0.9, 0.2, 0.4), {}, GRAHAM);
+        expect(low).toBeGreaterThanOrEqual(0);
+        expect(high).toBeGreaterThan(low);
+    });
+});
+
+describe('absolute per-league bands', () => {
+    it('elite average exceeds replacement average', () => {
+        const totals = Array.from({ length: 130 }, (_, i) => 200 - i).sort((a, b) => b - a);
+        const bands = computeLeagueBands(totals, 6, 10);
+        expect(bands.eliteAvg).toBeGreaterThan(bands.replacementAvg);
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -112,7 +112,7 @@
     </section>
 
     <section class="admin-group">
-        <div class="group-head"><h2>Data sync · College Football Data</h2><span class="group-count">7</span></div>
+        <div class="group-head"><h2>Data sync · College Football Data</h2><span class="group-count">8</span></div>
         <div class="admin-functions">
             <div class="function-container">
                 <div class="button-container">
@@ -127,6 +127,21 @@
                         <div><select game-season-type season-type-options></select></div>
                         <div><button type="submit">Retrieve Games</button></div>
                     </form>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayScheduleContainer()">
+                        <i class="fa-solid fa-calendar-days" style="padding-right: 5px;"></i>
+                        Ingest Full Schedule
+                    </button>
+                </div>
+                <div class="sub-container" schedule-container style="display: none">
+                    <form id="schedule-form">
+                        <div><select schedule-season season-options></select></div>
+                        <div><button type="submit">Ingest Full Schedule</button></div>
+                    </form>
+                    <div id="schedule-results" class="cfp-odds-results"></div>
                 </div>
             </div>
             <div class="function-container">

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -37,11 +37,19 @@
             <h1 class="franchise-name" profile-franchise></h1>
             <p class="manager-name" profile-manager></p>
             <div class="profile-stats" profile-stats></div>
+            <button type="button" class="grade-chip" profile-grade-chip hidden
+                    aria-expanded="false" aria-controls="uh-grades">
+                <span class="grade-chip-label">Draft grade</span>
+                <span class="grade-chip-letter" profile-grade-letter></span>
+                <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
+            </button>
         </div>
         <button type="button" class="edit-profile-btn" edit-profile-btn hidden>
             <i class="fa-solid fa-pen"></i> Edit profile
         </button>
     </div>
+
+    <section class="uh-grades" id="uh-grades" hidden></section>
 
     <div class="modal-backdrop" profile-modal hidden>
         <div class="profile-modal-card" role="dialog" aria-modal="true" aria-labelledby="profile-modal-title">
@@ -123,7 +131,6 @@
             </div>
         </div>
     </div>
-    <section class="uh-grades" id="uh-grades"></section>
 
     <footer>
         <a href="https://collegefootballdata.com/" class="cfb-data">Powered by College Football Data</a>


### PR DESCRIPTION
## What

Replaces the league-agnostic heuristic draft grade (SP+/wins/CFP blend) with a **per-league expected-fantasy-points projection**. Each drafted team's season is projected and scored through *that league's own scoring engine*, so Claunts (V1) and Graham (V2) grade the same roster differently — the grade now means "how many points will this roster score in your league."

Also bundles the profile-grade UI work from the same effort (chip + standings-style roster card).

## How it works

For each drafted team, reuse the live scoring engine (`scoring.js` `evaluate()`) on **synthesized games weighted by probability**:
- **Regular season** — per-game `P(win)` from the SP+ gap, calibrated (additive logit shift) so a team's per-game probs sum to its market expected-win total; points-if-win comes from the real per-league rules.
- **CFP** — de-vig the market make/champ odds across the pool, solve a per-round advance prob, and walk the bracket (handles Graham's top-4 bye bonus and Claunts' escalating rounds).
- **Conference title** — SP+ softmax within the conference.
- **Bowls** — `P(≥6 wins)` from a Poisson-binomial win distribution.

Rosters are graded on **absolute per-league bands** anchored to per-team caliber (rank R vs. rank L·R in the pool) — never curved to the actual participants.

## UI

- Profile: tier-colored **grade chip** in the hero that expands the manager's own card (was the full league list).
- Roster table rebuilt as a full-width **standings-style card** matching the hero (rounded, symmetric gutters, in-season sticky/scroll preserved).
- Cards headline **projected points** + proj wins + CFP teams, with a **regular-vs-postseason split bar** and points-based steal/reach.

## New surfaces / data

- `POST /games/:season/schedule` + an **"Ingest Full Schedule"** admin card (preseason prerequisite; the projection reads each team's schedule).
- New modules: `win-probability.js` (pure), `draft-projection.js`. `scoring.js` now exports the pure `evaluate`.

## Verification

- **115/115** tests pass (11 new: win-prob anchors, calibration convergence, Poisson-binomial, `evaluate` reuse, CFP bracket, bands).
- End-to-end in test for both leagues — sensible differentiated spreads (Graham 2026: A- → C; Claunts 2025: B+ → C+), each under its own scoring model.
- Browser-verified profile chip + draft-room panel, desktop + mobile, correct "you" identity, no overflow, split bar; AP-poll swap is automatic.

## Rollout (per season)

Refresh Teams → Expected Wins → CFP Odds → **Ingest Full Schedule** → grades live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)