### PR TITLE
Hall of Fame: league history page (#209)

### DIFF
--- a/public/history.css
+++ b/public/history.css
@@ -1,0 +1,95 @@
+/* Hall of Fame page. Dark theme consistent with the grade cards / profile. */
+.hof {
+    width: 92%;
+    max-width: 1000px;
+    margin: 0.5rem auto 2.5rem;
+    box-sizing: border-box;
+}
+.hof-loading, .hof-empty { color: #A4A9C2; text-align: center; padding: 2.5rem 1rem; }
+
+.hof-section { margin-top: 1.75rem; }
+.hof-h2 {
+    font-size: 1.05rem; font-weight: 700; color: #F4F6FB;
+    margin: 0 0 0.85rem; text-transform: uppercase; letter-spacing: 0.06em;
+}
+
+/* --- shared avatar --- */
+.hof-avatar {
+    width: 44px; height: 44px; border-radius: 50%; overflow: hidden; flex-shrink: 0;
+    display: inline-flex; align-items: center; justify-content: center; background: #101322;
+}
+.hof-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.hof-avatar-initials { font-weight: 700; color: #fff; font-size: 0.95rem; }
+
+/* --- champions strip --- */
+.hof-champs { display: flex; gap: 1rem; overflow-x: auto; padding-bottom: 0.4rem; }
+.hof-champ {
+    flex: 0 0 auto; width: 158px; text-align: center; position: relative;
+    background: #1A1F33; border: 1px solid #2A2E42; border-top: 3px solid #E0B341;
+    border-radius: 14px; padding: 0.9rem;
+}
+.hof-champ-season { color: #A4A9C2; font-weight: 700; letter-spacing: 0.06em; font-size: 0.82rem; }
+.hof-champ-trophy { font-size: 1.35rem; line-height: 1; margin: 0.1rem 0 0.35rem; }
+.hof-champ .hof-avatar { width: 60px; height: 60px; margin: 0 auto 0.5rem; }
+.hof-champ-name { font-weight: 700; color: #F4F6FB; line-height: 1.2; }
+.hof-champ-sub { color: #A4A9C2; font-size: 0.75rem; margin-top: 1px; }
+.hof-champ-score { color: #E0B341; font-weight: 700; margin-top: 0.4rem; font-variant-numeric: tabular-nums; }
+
+/* --- all-time leaderboard (expandable manager cards) --- */
+.hof-board { display: flex; flex-direction: column; gap: 0.6rem; }
+.hof-mgr { background: #1A1F33; border: 1px solid #2A2E42; border-radius: 12px; overflow: hidden; }
+.hof-mgr.hof-you { border-color: #ed5858; box-shadow: inset 0 0 0 1px #ed5858; }
+.hof-mgr-head {
+    display: flex; align-items: center; gap: 0.9rem; width: 100%;
+    padding: 0.7rem 1rem; background: none; border: 0; cursor: pointer;
+    color: inherit; text-align: left; font: inherit;
+}
+.hof-rank { font-weight: 800; color: #A4A9C2; width: 1.4rem; text-align: center; font-variant-numeric: tabular-nums; }
+.hof-mgr-id { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.hof-mgr-nameline { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.hof-mgr-name { font-weight: 600; color: #F4F6FB; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hof-youtag { flex-shrink: 0; }
+.hof-mgr-sub { color: #A4A9C2; font-size: 0.76rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hof-youtag { color: #ed5858; border: 1px solid #ed5858; border-radius: 999px; font-size: 0.58rem; padding: 1px 6px; text-transform: uppercase; letter-spacing: 0.05em; vertical-align: middle; }
+.hof-mgr-titles { min-width: 3rem; text-align: center; font-size: 0.95rem; letter-spacing: -3px; }
+.hof-none { color: #4A4F68; letter-spacing: 0; }
+.hof-stat { display: flex; flex-direction: column; align-items: center; min-width: 3.4rem; }
+.hof-stat b { color: #F4F6FB; font-size: 1.02rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.hof-stat small { color: #A4A9C2; font-size: 0.64rem; text-transform: uppercase; letter-spacing: 0.04em; }
+.hof-chev { color: #A4A9C2; font-size: 0.8rem; transition: transform 0.24s ease; }
+.hof-mgr.is-open .hof-chev { transform: rotate(180deg); }
+
+.hof-mgr-body { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
+.hof-mgr.is-open .hof-mgr-body { max-height: 700px; }
+.hof-mgr-summary {
+    display: flex; flex-wrap: wrap; gap: 0.4rem 1.1rem;
+    padding: 0.55rem 1rem 0.1rem; font-size: 0.76rem; color: #A4A9C2;
+}
+.hof-mgr-summary b { color: #F4F6FB; font-variant-numeric: tabular-nums; }
+.hof-hist-head, .hof-hist {
+    display: grid; grid-template-columns: 3.5rem 6.5rem 1fr auto; gap: 0.6rem;
+    align-items: center; padding: 0.45rem 1rem;
+}
+.hof-hist-head { color: #A4A9C2; text-transform: uppercase; font-size: 0.64rem; letter-spacing: 0.04em; border-top: 1px solid #2A2E42; padding-top: 0.6rem; }
+.hof-hist { border-top: 1px solid #23273b; font-size: 0.82rem; color: #F4F6FB; }
+.hof-hist-season { font-weight: 700; color: #A4A9C2; font-variant-numeric: tabular-nums; }
+.hof-hist-franchise { color: #A4A9C2; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hof-hist-score { text-align: right; font-variant-numeric: tabular-nums; }
+
+@media only screen and (max-width: 560px) {
+    /* Drop the secondary stat + franchise column and tighten everything so the
+       manager name gets enough room not to truncate mid-word. */
+    .hof-mgr-head .hof-stat:last-of-type { display: none; }
+    .hof-mgr-head { gap: 0.55rem; padding: 0.6rem 0.7rem; }
+    .hof-rank { width: 1rem; }
+    .hof-avatar { width: 38px; height: 38px; }
+    .hof-avatar-initials { font-size: 0.8rem; }
+    .hof-mgr-titles { min-width: auto; }
+    .hof-stat { min-width: 2.8rem; }
+    .hof-hist-head, .hof-hist { grid-template-columns: 3rem 1fr auto; }
+    .hof-hist-franchise, .hof-hist-head span:nth-child(3) { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hof-chev, .hof-mgr-body { transition: none; }
+}

--- a/public/history.js
+++ b/public/history.js
@@ -1,0 +1,141 @@
+// Hall of Fame page. Fetches the league history aggregation (GET /history/:league)
+// and renders a champions strip + an all-time leaderboard of expandable manager
+// cards (year-by-year history inside). No new data — see routes/history.js.
+
+(function () {
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+    function ordinal(n) {
+        var s = ['th', 'st', 'nd', 'rd'], v = n % 100;
+        return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+    function avatar(m, size) {
+        if (m.avatarUrl) {
+            var src = m.avatarUrl.indexOf('/upload/') !== -1
+                ? m.avatarUrl.replace('/upload/', '/upload/c_fill,g_face,w_' + size + ',h_' + size + ',q_auto,f_auto/')
+                : m.avatarUrl;
+            return '<span class="hof-avatar"><img src="' + esc(src) + '" alt=""></span>';
+        }
+        var init = m.initials || (m.name || '?').split(' ').map(function (p) { return p[0]; }).join('').slice(0, 2).toUpperCase();
+        return '<span class="hof-avatar hof-avatar-initials" style="background:' + esc(m.color || '#333') + '">' + esc(init) + '</span>';
+    }
+    function currentUserId() {
+        try { return String(userState.user_metadata.metadata.userId); }
+        catch (e) { return window.localStorage.getItem('userId') || null; }
+    }
+    function resolveLeague() {
+        var code = window.localStorage.getItem('leagueCode');
+        if (code && code !== 'undefined') return code;
+        try {
+            code = userState.user_metadata.metadata.league === 'gg' ? 'graham-league' : 'claunts-league';
+            window.localStorage.setItem('leagueCode', code);
+            return code;
+        } catch (e) { return 'claunts-league'; }
+    }
+
+    function championsHtml(seasons) {
+        if (!seasons.length) return '';
+        var cards = seasons.map(function (s) {
+            var c = s.champion;
+            return '<div class="hof-champ">'
+                + '<div class="hof-champ-season">' + s.season + '</div>'
+                + '<div class="hof-champ-trophy">🏆</div>'
+                + avatar(c, 96)
+                + '<div class="hof-champ-name">' + esc(c.franchise || c.name) + '</div>'
+                + (c.franchise ? '<div class="hof-champ-sub">' + esc(c.name) + '</div>' : '')
+                + '<div class="hof-champ-score">' + c.score + ' pts</div>'
+                + '</div>';
+        }).join('');
+        return '<section class="hof-section">'
+            + '<h2 class="hof-h2">Champions</h2>'
+            + '<div class="hof-champs">' + cards + '</div>'
+            + '</section>';
+    }
+
+    function historyRows(m) {
+        return m.history.map(function (h) {
+            return '<div class="hof-hist">'
+                + '<span class="hof-hist-season">' + h.season + '</span>'
+                + '<span class="hof-hist-finish">' + (h.champion ? '🏆 ' : '') + ordinal(h.rank) + ' of ' + h.of + '</span>'
+                + '<span class="hof-hist-franchise">' + esc(h.franchise || '—') + '</span>'
+                + '<span class="hof-hist-score">' + h.score + ' pts</span>'
+                + '</div>';
+        }).join('');
+    }
+
+    function leaderboardHtml(managers, meId) {
+        var cards = managers.map(function (m, i) {
+            var you = meId && String(m.userId) === String(meId);
+            var titles = m.titles > 0 ? '🏆'.repeat(Math.min(m.titles, 5)) : '<span class="hof-none">—</span>';
+            return '<div class="hof-mgr' + (you ? ' hof-you' : '') + '">'
+                + '<button class="hof-mgr-head" type="button" aria-expanded="false">'
+                + '<span class="hof-rank">' + (i + 1) + '</span>'
+                + avatar(m, 72)
+                + '<span class="hof-mgr-id"><span class="hof-mgr-nameline">'
+                + '<span class="hof-mgr-name">' + esc(m.name) + '</span>'
+                + (you ? '<span class="hof-youtag">you</span>' : '') + '</span>'
+                + (m.franchise ? '<span class="hof-mgr-sub">' + esc(m.franchise) + '</span>' : '') + '</span>'
+                + '<span class="hof-mgr-titles" title="Titles">' + titles + '</span>'
+                + '<span class="hof-stat"><b>' + m.totalPoints + '</b><small>total pts</small></span>'
+                + '<span class="hof-stat"><b>' + m.avgFinish + '</b><small>avg finish</small></span>'
+                + '<i class="fa-solid fa-chevron-down hof-chev" aria-hidden="true"></i>'
+                + '</button>'
+                + '<div class="hof-mgr-body">'
+                + '<div class="hof-mgr-summary">'
+                +   '<span>' + m.seasonsPlayed + (m.seasonsPlayed === 1 ? ' season' : ' seasons') + '</span>'
+                +   (m.bestSeason ? '<span>Best <b>' + m.bestSeason.score + '</b> (' + m.bestSeason.season + ')</span>' : '')
+                +   (m.worstSeason ? '<span>Worst <b>' + m.worstSeason.score + '</b> (' + m.worstSeason.season + ')</span>' : '')
+                + '</div>'
+                + '<div class="hof-hist-head">'
+                + '<span>Season</span><span>Finish</span><span>Franchise</span><span>Points</span></div>'
+                + historyRows(m) + '</div>'
+                + '</div>';
+        }).join('');
+        return '<section class="hof-section">'
+            + '<h2 class="hof-h2">All-time</h2>'
+            + '<div class="hof-board">' + cards + '</div>'
+            + '</section>';
+    }
+
+    function render(el, data, meId) {
+        if (!data.managers || !data.managers.length) {
+            el.innerHTML = '<p class="hof-empty">No completed seasons yet — check back once a season wraps.</p>';
+            return;
+        }
+        el.innerHTML = championsHtml(data.seasons) + leaderboardHtml(data.managers, meId);
+        // Expand/collapse manager cards.
+        el.querySelectorAll('.hof-mgr-head').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var card = btn.closest('.hof-mgr');
+                var open = card.classList.toggle('is-open');
+                btn.setAttribute('aria-expanded', String(open));
+            });
+        });
+    }
+
+    window.addEventListener('DOMContentLoaded', async function () {
+        var el = document.getElementById('hof');
+        var league = resolveLeague();
+        try {
+            var res = await fetch('/history/' + encodeURIComponent(league), { headers: { Accept: 'application/json' } });
+            var data = await res.json();
+            render(el, data, currentUserId());
+        } catch (e) {
+            el.innerHTML = '<p class="hof-empty">Couldn’t load league history. Please refresh.</p>';
+        }
+
+        // Admin league switch (mirrors the other pages): reload on selection.
+        if (window.jQuery) {
+            jQuery('[league-selector] a').on('click', function () {
+                var $b = jQuery(this).parents('.dropdown').find('.btn');
+                $b.html(jQuery(this).text()).val(jQuery(this).attr('value'));
+                window.sessionStorage.setItem('league', jQuery('#dropdownMenuButton').text());
+                window.localStorage.setItem('leagueCode', jQuery(this).attr('value'));
+                window.location.reload();
+            });
+        }
+    });
+})();

--- a/routes/history.js
+++ b/routes/history.js
@@ -1,0 +1,91 @@
+const express = require('express');
+const router = express.Router();
+const User = require('../models/user');
+
+// Hall of Fame / league history aggregation. Walks every user's seasons and
+// derives, per league: the champion of each completed season, an all-time
+// manager leaderboard (titles, total points, best/worst, avg finish), and each
+// manager's year-by-year record. Read-only; no new data — cumulativeScore,
+// draftPosition and franchiseName already live on user.seasons.
+//
+// A season counts as "completed" once at least one manager has a
+// cumulativeScore (excludes the in-progress current season, which has none).
+router.get('/:league', async (req, res) => {
+    try {
+        const league = req.params.league;
+        const users = await User.find({ league },
+            { firstName: 1, lastName: 1, avatarUrl: 1, color: 1, seasons: 1 }).lean();
+
+        const fullName = (u) => `${u.firstName || ''} ${u.lastName || ''}`.trim();
+        const initials = (u) => (((u.firstName || '')[0] || '') + ((u.lastName || '')[0] || '')).toUpperCase();
+        // Most recent franchise name the manager used (flavor; may be unset).
+        const latestFranchise = (u) => {
+            const named = (u.seasons || []).filter(s => s.franchiseName)
+                .sort((a, b) => Number(b.season) - Number(a.season));
+            return named.length ? named[0].franchiseName : null;
+        };
+
+        // Group scored (userId, season) entries by season.
+        const bySeason = {};
+        users.forEach(u => {
+            (u.seasons || []).forEach(s => {
+                if (s.cumulativeScore == null) return;      // in-progress / never scored
+                (bySeason[s.season] = bySeason[s.season] || []).push({
+                    userId: String(u._id), name: fullName(u),
+                    franchise: s.franchiseName || null,
+                    avatarUrl: u.avatarUrl || null, initials: initials(u), color: u.color || null,
+                    score: s.cumulativeScore
+                });
+            });
+        });
+
+        // Per-season standings (ranked) + champion. Newest season first.
+        const seasons = Object.keys(bySeason)
+            .map(Number).sort((a, b) => b - a)
+            .map(season => {
+                const ranked = bySeason[season].slice().sort((a, b) => b.score - a.score);
+                const of = ranked.length;
+                ranked.forEach((r, i) => { r.rank = i + 1; r.of = of; });
+                return { season, champion: ranked[0], standings: ranked };
+            });
+
+        // Per-manager all-time rollup.
+        const mgr = {};
+        seasons.forEach(({ season, standings }) => {
+            standings.forEach(r => {
+                const m = mgr[r.userId] || (mgr[r.userId] = {
+                    userId: r.userId, name: r.name, avatarUrl: r.avatarUrl,
+                    initials: r.initials, color: r.color,
+                    titles: 0, titleSeasons: [], totalPoints: 0, seasonsPlayed: 0,
+                    finishes: [], bestSeason: null, worstSeason: null, history: []
+                });
+                m.seasonsPlayed++;
+                m.totalPoints += r.score;
+                m.finishes.push(r.rank);
+                if (r.rank === 1) { m.titles++; m.titleSeasons.push(season); }
+                if (!m.bestSeason || r.score > m.bestSeason.score) m.bestSeason = { season, score: r.score };
+                if (!m.worstSeason || r.score < m.worstSeason.score) m.worstSeason = { season, score: r.score };
+                m.history.push({ season, score: r.score, rank: r.rank, of: r.of, franchise: r.franchise, champion: r.rank === 1 });
+            });
+        });
+
+        const managers = Object.values(mgr).map(m => {
+            const u = users.find(x => String(x._id) === m.userId);
+            return {
+                userId: m.userId, name: m.name, franchise: u ? latestFranchise(u) : null,
+                avatarUrl: m.avatarUrl, initials: m.initials, color: m.color,
+                titles: m.titles, titleSeasons: m.titleSeasons,
+                totalPoints: Math.round(m.totalPoints), seasonsPlayed: m.seasonsPlayed,
+                avgFinish: Math.round((m.finishes.reduce((a, b) => a + b, 0) / m.finishes.length) * 10) / 10,
+                bestSeason: m.bestSeason, worstSeason: m.worstSeason,
+                history: m.history.sort((a, b) => b.season - a.season)
+            };
+        }).sort((a, b) => b.titles - a.titles || b.totalPoints - a.totalPoints);
+
+        res.json({ league, seasons, managers });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -244,6 +244,17 @@ app.get('/team', async function(req, res) {
     }
 });
 
+app.get('/hall-of-fame', async function(req, res) {
+    if (req.oidc.isAuthenticated()) {
+        const user = buildUserContext(req.oidc.user);
+        const userState = safeJson(req.oidc.user);
+
+        res.render('history', {user, userState});
+    } else {
+        res.redirect("/login");
+    }
+});
+
 app.use(express.json());
 app.use(express.static('public'));
 app.use('/images',  express.static('images'));
@@ -298,6 +309,9 @@ app.use('/job-runs', requireAuthOrToken, jobRunsRouter);
 
 const standingsRouter = require('./routes/standings');
 app.use('/standings', requireAuthOrToken, standingsRouter);
+
+const historyRouter = require('./routes/history');
+app.use('/history', requireAuthOrToken, historyRouter);
 
 app.get('/calculate-team-score/:season/:teamId/:teamName', requireCommissioner, async (req, res) => {
     var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="styles.css" rel="stylesheet">
+    <link href="history.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap" rel="stylesheet">
+    <script src="history.js" defer></script>
+    <title>Hall of Fame · Campus Clash</title>
+    <link rel="shortcut icon" type="image/png" href="images/favicon.png" />
+</head>
+
+<body>
+    <%- include('partials/navbar') %>
+    <% if (userState) { %>
+        <script>
+            var userState = <%- userState %>;
+        </script>
+    <% } %>
+
+    <div class="header">
+        <div class="header-title">Hall of Fame</div>
+    </div>
+
+    <main class="hof" id="hof">
+        <p class="hof-loading">Loading league history…</p>
+    </main>
+</body>
+
+</html>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -59,6 +59,7 @@
             </li>
             <% } %>
             <li><a href="./standings">Standings</a></li>
+            <li><a href="./hall-of-fame">Hall of Fame</a></li>
             <li><a href="./rules">Scoring</a></li>
             <li><a href="./draft-room">Draft Room</a></li>
             <% if (user && user.userId) { %>


### PR DESCRIPTION
Closes #209.

## What

A permanent home for the league's past at **/hall-of-fame** ("Hall of Fame" nav link) — turns a yearly game into a multi-year rivalry. Driven entirely by existing data; no new data or ingestion.

## Sections

- **Champions strip** — a gold-topped card per completed season (champion avatar, name/franchise, winning score). Scrolls horizontally.
- **All-time leaderboard** — managers ranked by titles → total points, each showing 🏆 titles, total points, and average finish. The viewer's own row is highlighted.
- **Per-manager year-by-year** — click a card to expand a summary (seasons · best · worst) plus a season-by-season table (finish like "1st of 6" with 🏆 for titles, franchise, points).

## How

- New `GET /history/:league` aggregation (`routes/history.js`) walks every user's seasons and derives champions (top `cumulativeScore` per season), the all-time rollup, and per-manager history. A season counts once at least one manager has a `cumulativeScore`, so the in-progress current season is excluded.
- Page route in `server.js` → `views/history.ejs` + `public/history.{js,css}`; nav link in the shared partial.
- Franchise name is season-scoped (falls back to the manager's name / most-recent franchise); avatars are account-level, so they show everywhere.

## Verification

- Both leagues render from their own data (Graham: Brock ×2, Michael; Claunts: David, Jeff, Scott); champions correct; handles managers who played fewer seasons.
- Desktop + mobile (390px): no overflow, names fit, expand animates, "you" pill intact, photo/initials avatars + franchise ("Acuff Me Up") show.
- 115/115 tests pass; no existing code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)