### PR TITLE
Standings: forward-looking projections + title odds (#210)

### DIFF
--- a/modules/draft-projection.js
+++ b/modules/draft-projection.js
@@ -176,7 +176,11 @@ function expectedCfpPoints(teamId, m, beta, q, rankings, cfg) {
 }
 
 // --- per-team projection -------------------------------------------------
-function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season) {
+// opts.expectedWins: calibration target for the games passed (default: the
+//   team's season expected wins — used for a full-season projection; the
+//   standings projection passes REMAINING expected wins for a remaining subset).
+// opts.perGame: also return perGame [{ winProb, pointsIfWin }] for Monte-Carlo.
+function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season, opts = {}) {
     const teamId = team.id;
     const sp = spFor(team, season);
     const mySp = sp == null ? 0 : sp;
@@ -193,9 +197,15 @@ function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season) {
         const hfa = g.neutralSite ? 0 : (isHome ? HFA : -HFA);
         return (mySp - effOpp) + hfa;
     });
-    const { probs } = calibrateToExpectedWins(margins, winsFor(team, season));
+    const target = opts.expectedWins != null ? opts.expectedWins : winsFor(team, season);
+    const { probs } = calibrateToExpectedWins(margins, target);
     let regular = 0;
-    reg.forEach((g, i) => { regular += probs[i] * evaluate(cfg.model, teamId, synthWin(g, teamId), rankings, cfg); });
+    const perGame = [];
+    reg.forEach((g, i) => {
+        const pts = evaluate(cfg.model, teamId, synthWin(g, teamId), rankings, cfg);
+        regular += probs[i] * pts;
+        if (opts.perGame) perGame.push({ winProb: probs[i], pointsIfWin: pts });
+    });
     const projWins = probs.reduce((a, b) => a + b, 0);
 
     // 2. CFP (market odds, else SP+-rank fallback).
@@ -226,7 +236,7 @@ function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season) {
     const bowl = pBowl * (BOWL_WIN_PROB * bowlWin + (1 - BOWL_WIN_PROB) * bowlLose);
 
     const total = regular + cfp + confChamp + bowl;
-    return { regular, cfp, confChamp, bowl, total, projWins, makeProb: m };
+    return { regular, cfp, confChamp, bowl, total, projWins, makeProb: m, perGame };
 }
 
 // --- absolute per-league bands ------------------------------------------

--- a/modules/standings-projection.js
+++ b/modules/standings-projection.js
@@ -1,0 +1,84 @@
+// Forward-looking standings analytics: projected final points + Monte-Carlo
+// title odds per manager. Reuses the draft-grade projection engine
+// (modules/draft-projection.js), but mid-season: points already banked +
+// expected points from each rostered team's REMAINING schedule + expected
+// postseason. Pure (no I/O) so it's unit-testable; the route feeds it data.
+
+const { projectTeamPoints, spFor, winsFor } = require('./draft-projection');
+
+const nameOf = (u) => `${u.firstName || ''} ${u.lastName ? u.lastName[0] + '.' : ''}`.trim();
+const initialsOf = (u) => (((u.firstName || '')[0] || '') + ((u.lastName || '')[0] || '')).toUpperCase();
+
+// Count a team's wins among its already-completed regular games (for calibrating
+// the remaining schedule to the remaining expected-win total).
+function winsSoFar(teamId, games) {
+    let w = 0;
+    for (const g of games) {
+        if (g.seasonType !== 'regular' || g.completed !== true) continue;
+        if (g.homePoints == null || g.awayPoints == null) continue;
+        const isHome = g.homeId === teamId;
+        if ((isHome && g.homePoints > g.awayPoints) || (!isHome && g.awayPoints > g.homePoints)) w++;
+    }
+    return w;
+}
+
+// Per-manager projection for a season. gamesByTeam: { teamId: [Game] }.
+function buildProjections(users, teamsById, gamesByTeam, cfg, rankings, poolCtx, season) {
+    const out = [];
+    for (const u of users) {
+        const s = (u.seasons || []).find(x => Number(x.season) === season);
+        if (!s || !Array.isArray(s.teams) || !s.teams.length) continue;   // no roster → skip
+        const banked = s.cumulativeScore || 0;
+
+        let expReg = 0, expPost = 0, remainingCount = 0;
+        const perGame = [];
+        for (const rosterTeam of s.teams) {
+            const team = teamsById[String(rosterTeam.id)] || rosterTeam;
+            const all = gamesByTeam[String(rosterTeam.id)] || [];
+            const remaining = all.filter(g => g.seasonType === 'regular' && g.completed !== true);
+            remainingCount += remaining.length;
+            const expWins = winsFor(team, season);
+            const remExpWins = expWins == null ? null : Math.max(0.1, expWins - winsSoFar(rosterTeam.id, all));
+            const proj = projectTeamPoints(team, remaining, poolCtx, rankings, cfg, season,
+                { expectedWins: remExpWins, perGame: true });
+            expReg += proj.regular;
+            expPost += proj.cfp + proj.confChamp + proj.bowl;
+            (proj.perGame || []).forEach(pg => perGame.push(pg));
+        }
+
+        out.push({
+            userId: String(u._id), name: nameOf(u), franchise: s.franchiseName || null,
+            avatarUrl: u.avatarUrl || null, initials: initialsOf(u), color: u.color || null,
+            banked: Math.round(banked),
+            projectedFinal: Math.round(banked + expReg + expPost),
+            postExpected: banked + expPost,   // deterministic part carried into each sim
+            perGame, remainingCount
+        });
+    }
+    return out;
+}
+
+// Light Monte-Carlo: sim the remaining regular games N times (postseason carried
+// as its expected value), count how often each manager finishes 1st. Ties split
+// the championship credit. Returns titleOdds (0..1) keyed by userId.
+function simulateTitleOdds(managers, N) {
+    N = N || 5000;
+    const wins = {};
+    managers.forEach(m => { wins[m.userId] = 0; });
+    for (let s = 0; s < N; s++) {
+        let best = -Infinity, leaders = [];
+        for (const m of managers) {
+            let total = m.postExpected;
+            for (const g of m.perGame) if (Math.random() < g.winProb) total += g.pointsIfWin;
+            if (total > best + 1e-9) { best = total; leaders = [m.userId]; }
+            else if (Math.abs(total - best) <= 1e-9) leaders.push(m.userId);
+        }
+        const share = 1 / leaders.length;
+        leaders.forEach(id => { wins[id] += share; });
+    }
+    const odds = {};
+    managers.forEach(m => { odds[m.userId] = wins[m.userId] / N; });
+    return odds;
+}
+
+module.exports = { buildProjections, simulateTitleOdds, winsSoFar };

--- a/public/standings.css
+++ b/public/standings.css
@@ -599,3 +599,32 @@
     80% { transform: translateY(-4px); }
     100% { transform: translateY(0); }
 }
+
+/* ===== Forward-looking analytics (#210): Projected Finish panel ===== */
+.proj-panel { width: 92%; max-width: 960px; margin: 1.25rem auto 0; box-sizing: border-box; }
+.proj-panel-title { font-size: 1.2rem; font-weight: 700; color: #F4F6FB; margin: 0 0 0.25rem; }
+.proj-panel-note { color: #A4A9C2; font-size: 0.82rem; margin: 0 0 0.9rem; }
+.pp-list { display: flex; flex-direction: column; gap: 0.55rem; }
+.pp-row { display: flex; align-items: center; gap: 0.9rem; background: #1A1F33; border: 1px solid #2A2E42; border-radius: 12px; padding: 0.6rem 1rem; }
+.pp-rank { font-weight: 800; color: #A4A9C2; width: 1.4rem; text-align: center; font-variant-numeric: tabular-nums; }
+.pp-avatar { width: 40px; height: 40px; border-radius: 50%; overflow: hidden; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; background: #101322; }
+.pp-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.pp-avatar-initials { font-weight: 700; color: #fff; font-size: 0.85rem; }
+.pp-id { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.pp-name { font-weight: 600; color: #F4F6FB; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pp-sub { color: #A4A9C2; font-size: 0.76rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pp-points { display: flex; align-items: center; gap: 0.45rem; font-variant-numeric: tabular-nums; }
+.pp-cur { color: #A4A9C2; }
+.pp-arrow { color: #4A4F68; font-size: 0.72rem; }
+.pp-proj { color: #6C9BFF; font-weight: 800; font-size: 1.05rem; }
+.pp-title { display: flex; align-items: center; gap: 0.55rem; min-width: 8.5rem; justify-content: flex-end; }
+.pp-bar { flex: 1; min-width: 54px; max-width: 110px; height: 6px; background: #2A2E42; border-radius: 3px; overflow: hidden; }
+.pp-bar i { display: block; height: 100%; background: #E0B341; }
+.pp-title b { color: #F4F6FB; min-width: 3rem; text-align: right; }
+
+@media only screen and (max-width: 560px) {
+    .pp-row { gap: 0.55rem; padding: 0.55rem 0.7rem; }
+    .pp-sub, .pp-bar { display: none; }   /* keep "0 → 225" + title %; drop the bar */
+    .pp-title { min-width: auto; }
+    .pp-points { gap: 0.3rem; }
+}

--- a/public/standings.js
+++ b/public/standings.js
@@ -127,6 +127,7 @@ async function getUsers() {
             displayHighlights(data);
             maybeCelebrateWeeklyWin(data);
             loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
+            loadProjections(leagueCode, data[0]?.seasons?.[0]?.season);
             displaySchedule(data);
             seedUserIdFromEmail(userMetadata, usersData);
             // Chart is responsive now, so show it on mobile too.
@@ -195,8 +196,62 @@ async function loadAdvancedHighlights(league, season) {
 }
 
 function displayHighlights(users) {
+    const cards = buildHighlights(users);
     const container = document.querySelector('.highlights-container');
-    if (container) container.innerHTML = buildHighlightsHtml(buildHighlights(users));
+    const header = document.querySelector('.highlights-header');
+    // Hide the whole section (header + its leading divider) when there's nothing
+    // to show yet — e.g. preseason, before any games are scored — so we don't
+    // leave a bare "League Highlights" heading over empty space.
+    if (!cards.length) {
+        if (header) header.style.display = 'none';
+        if (container) container.style.display = 'none';
+        const hr = header && header.previousElementSibling;
+        if (hr && hr.classList && hr.classList.contains('hr-subtle')) hr.style.display = 'none';
+        return;
+    }
+    if (header) header.style.display = '';
+    if (container) { container.style.display = ''; container.innerHTML = buildHighlightsHtml(cards); }
+}
+
+// Forward-looking analytics (#210): projected final points + title odds, in a
+// dedicated "Projected Finish" panel below the standings. Server-computed (needs
+// schedule/SP+/odds); the route returns nothing when a season has no games left.
+async function loadProjections(league, season) {
+    if (!league || season == null) return;
+    let managers = [];
+    try {
+        const res = await fetch(`/standings/projections/${league}/${season}`, { headers: { Accept: 'application/json' } });
+        const data = await res.json();
+        managers = (data && data.managers) || [];
+    } catch (e) { return; }
+    if (!managers.length) return;
+    renderProjPanel(managers);
+}
+
+function projAvatarHtml(m) {
+    if (m.avatarUrl) {
+        const src = m.avatarUrl.indexOf('/upload/') !== -1
+            ? m.avatarUrl.replace('/upload/', '/upload/c_fill,g_face,w_48,h_48,q_auto,f_auto/') : m.avatarUrl;
+        return `<span class="pp-avatar"><img src="${src}" alt=""></span>`;
+    }
+    return `<span class="pp-avatar pp-avatar-initials" style="background:${m.color || '#333'}">${escapeHtml(m.initials || '?')}</span>`;
+}
+
+function renderProjPanel(managers) {
+    const el = document.getElementById('proj-panel');
+    if (!el) return;
+    const rows = managers.map((m, i) => `
+        <div class="pp-row">
+            <span class="pp-rank">${i + 1}</span>
+            ${projAvatarHtml(m)}
+            <span class="pp-id"><span class="pp-name">${escapeHtml(m.franchise || m.name)}</span>${m.franchise ? `<span class="pp-sub">${escapeHtml(m.name)}</span>` : ''}</span>
+            <span class="pp-points"><span class="pp-cur">${m.banked}</span><i class="fa-solid fa-arrow-right pp-arrow"></i><span class="pp-proj">${m.projectedFinal}</span></span>
+            <span class="pp-title"><span class="pp-bar"><i style="width:${Math.min(100, m.titleOdds)}%"></i></span><b>${m.titleOdds}%</b></span>
+        </div>`).join('');
+    el.innerHTML = `<h2 class="proj-panel-title">🔮 Projected Finish</h2>
+        <p class="proj-panel-note">Projected final points and title odds — banked points plus expected points from each roster's remaining schedule.</p>
+        <div class="pp-list">${rows}</div>`;
+    el.hidden = false;
 }
 
 // Reserved celebration: if the logged-in manager posted the top score in the

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -6,6 +6,11 @@ const Record = require('../models/record');
 const Game = require('../models/game');
 const Betting = require('../models/bettingLine');
 const Draft = require('../models/draft');
+const Ranking = require('../models/ranking');
+const ScoringConfig = require('../models/scoringConfig');
+const { resolveConfig } = require('../modules/scoring-defaults');
+const { buildRankingProxy, buildPoolContext } = require('../modules/draft-projection');
+const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 
 // Advanced league highlights that need data the Standings payload doesn't carry
@@ -81,6 +86,68 @@ router.get('/highlights/:league/:season', async (req, res) => {
         });
 
         res.json(buildAdvancedHighlights({ records, metaById, picks, scoreById, games, spreadByGameId, draftedNames, metaByName, fantasyByGameId }));
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Forward-looking analytics: projected final points + Monte-Carlo title odds
+// per manager for a league + season. Reuses the draft-grade projection engine
+// on each rostered team's REMAINING schedule. Read-only.
+router.get('/projections/:league/:season', async (req, res) => {
+    try {
+        const league = req.params.league;
+        const season = Number(req.params.season);
+
+        const users = await User.find(
+            { league, 'seasons.season': season },
+            { firstName: 1, lastName: 1, avatarUrl: 1, color: 1, seasons: { $elemMatch: { season } } }
+        ).lean();
+        if (!users.length) return res.json({ league, season, managers: [] });
+
+        const teams = await Team.find({}, { id: 1, school: 1, alternateNames: 1, seasons: 1 }).lean();
+        const teamsById = {};
+        teams.forEach(t => { teamsById[String(t.id)] = t; });
+
+        const games = await Game.find({ season, seasonType: 'regular' },
+            { id: 1, season: 1, seasonType: 1, week: 1, neutralSite: 1, conferenceGame: 1, notes: 1,
+              completed: 1, homeId: 1, homeTeam: 1, homeConference: 1, homePoints: 1,
+              awayId: 1, awayTeam: 1, awayConference: 1, awayPoints: 1 }).lean();
+        const gamesByTeam = {};
+        games.forEach(g => {
+            const h = String(g.homeId), a = String(g.awayId);
+            if (teamsById[h]) (gamesByTeam[h] = gamesByTeam[h] || []).push(g);
+            if (teamsById[a]) (gamesByTeam[a] = gamesByTeam[a] || []).push(g);
+        });
+
+        const cfgDoc = await ScoringConfig.findOne({ league }).lean();
+        const cfg = resolveConfig(league, cfgDoc ? {
+            model: cfgDoc.model, values: cfgDoc.values, combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled
+        } : null);
+        const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
+        const apPoll = apDoc && Array.isArray(apDoc.polls) ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
+
+        const rankings = buildRankingProxy(season, teamsById, apPoll);
+        const poolCtx = buildPoolContext(teamsById, season);
+        const managers = buildProjections(users, teamsById, gamesByTeam, cfg, rankings, poolCtx, season);
+        // Forward-looking only: if the regular season has no games left (season
+        // complete / not yet scheduled), the "projection" would just be actuals
+        // plus a stray postseason term — hide it. Client renders nothing.
+        if (!managers.length || !managers.some(m => m.remainingCount > 0)) {
+            return res.json({ league, season, managers: [] });
+        }
+
+        const odds = simulateTitleOdds(managers, 5000);
+        const ranked = managers.slice().sort((a, b) => b.projectedFinal - a.projectedFinal);
+        const payload = ranked.map((m, i) => ({
+            userId: m.userId, name: m.name, franchise: m.franchise,
+            avatarUrl: m.avatarUrl, initials: m.initials, color: m.color,
+            banked: m.banked, projectedFinal: m.projectedFinal,
+            titleOdds: Math.round(odds[m.userId] * 1000) / 10,   // percent, 0.1 precision
+            projectedRank: i + 1
+        }));
+
+        res.json({ league, season, managers: payload });
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/tests/StandingsProjection.spec.js
+++ b/tests/StandingsProjection.spec.js
@@ -1,0 +1,76 @@
+const { buildProjections, simulateTitleOdds, winsSoFar } = require('../modules/standings-projection');
+const { buildPoolContext, buildRankingProxy } = require('../modules/draft-projection');
+const { resolveConfig } = require('../modules/scoring-defaults');
+
+describe('winsSoFar', () => {
+    const games = [
+        { seasonType: 'regular', completed: true, homeId: 1, awayId: 2, homePoints: 28, awayPoints: 10 }, // 1 won (home)
+        { seasonType: 'regular', completed: true, homeId: 3, awayId: 1, homePoints: 14, awayPoints: 21 }, // 1 won (away)
+        { seasonType: 'regular', completed: true, homeId: 1, awayId: 4, homePoints: 7, awayPoints: 35 },  // 1 lost
+        { seasonType: 'regular', completed: false, homeId: 1, awayId: 5 },                                 // not played
+        { seasonType: 'postseason', completed: true, homeId: 1, awayId: 6, homePoints: 30, awayPoints: 3 } // not regular
+    ];
+    it('counts only completed regular wins for the team', () => {
+        expect(winsSoFar(1, games)).toBe(2);
+    });
+});
+
+describe('simulateTitleOdds', () => {
+    it('odds sum to ~1 across managers', () => {
+        const managers = [
+            { userId: 'a', postExpected: 100, perGame: [{ winProb: 0.6, pointsIfWin: 3 }, { winProb: 0.4, pointsIfWin: 2 }] },
+            { userId: 'b', postExpected: 90, perGame: [{ winProb: 0.5, pointsIfWin: 3 }] },
+            { userId: 'c', postExpected: 110, perGame: [] }
+        ];
+        const odds = simulateTitleOdds(managers, 3000);
+        const sum = Object.values(odds).reduce((s, v) => s + v, 0);
+        expect(sum).toBeCloseTo(1, 5);
+    });
+
+    it('a strictly dominant manager wins every sim', () => {
+        const odds = simulateTitleOdds([
+            { userId: 'x', postExpected: 1000, perGame: [] },
+            { userId: 'y', postExpected: 0, perGame: [] }
+        ], 500);
+        expect(odds.x).toBe(1);
+        expect(odds.y).toBe(0);
+    });
+
+    it('splits credit on an exact tie', () => {
+        const odds = simulateTitleOdds([
+            { userId: 'x', postExpected: 100, perGame: [] },
+            { userId: 'y', postExpected: 100, perGame: [] }
+        ], 500);
+        expect(odds.x).toBeCloseTo(0.5, 5);
+        expect(odds.y).toBeCloseTo(0.5, 5);
+    });
+});
+
+describe('buildProjections', () => {
+    const season = 2026;
+    const teamsById = {
+        '1': { id: 1, school: 'A', seasons: [{ season, spRating: 12, expectedWins: 9, conference: 'SEC' }] },
+        '2': { id: 2, school: 'B', seasons: [{ season, spRating: -6, expectedWins: 4, conference: 'SEC' }] }
+    };
+    const cfg = resolveConfig('graham-league', null);
+    const rankings = buildRankingProxy(season, teamsById, null);
+    const poolCtx = buildPoolContext(teamsById, season);
+    const mkGame = (id) => ({ id, season, seasonType: 'regular', completed: false, conferenceGame: false, neutralSite: false, homeId: 1, awayId: 2, homeTeam: 'A', awayTeam: 'B', homeConference: 'SEC', awayConference: 'Big Ten' });
+    const gamesByTeam = { '1': [mkGame(101), mkGame(102)] };
+
+    it('projects a manager: banked + expected, with per-game data', () => {
+        const users = [{ _id: 'u1', firstName: 'Test', lastName: 'User', seasons: [{ season, cumulativeScore: 10, teams: [{ id: 1, school: 'A' }] }] }];
+        const out = buildProjections(users, teamsById, gamesByTeam, cfg, rankings, poolCtx, season);
+        expect(out).toHaveLength(1);
+        expect(out[0].banked).toBe(10);
+        expect(out[0].remainingCount).toBe(2);
+        expect(out[0].projectedFinal).toBeGreaterThan(10);   // banked + positive expected
+        expect(out[0].perGame).toHaveLength(2);
+        expect(out[0].perGame[0].winProb).toBeGreaterThan(0.5); // strong team favored
+    });
+
+    it('skips users with no roster for the season', () => {
+        const users = [{ _id: 'u2', firstName: 'No', lastName: 'Roster', seasons: [] }];
+        expect(buildProjections(users, teamsById, gamesByTeam, cfg, rankings, poolCtx, season)).toHaveLength(0);
+    });
+});

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -74,6 +74,12 @@
             </table>
         </div>
     </div>
+
+    <!-- Forward-looking analytics (#210): projected finish + title odds.
+         Rendered by standings.js loadProjections(); hidden when a season has no
+         remaining games. -->
+    <section class="proj-panel" id="proj-panel" hidden></section>
+
     <hr class="hr-subtle">
     <h2 class="highlights-header">🌟 League Highlights</h2>
     <!-- Cards are rendered from data by standings.js (buildHighlights). -->


### PR DESCRIPTION
Closes #210.

## What

Adds a **"🔮 Projected Finish" panel** below the standings that answers *"where am I headed?"* — each manager's **projected final points** and **title odds**, not just where they currently stand. Keeps the middle of the table engaged late in a season.

## How

- Reuses the draft-grade projection engine (`modules/draft-projection.js` `projectTeamPoints`, generalized with `opts.expectedWins` / `opts.perGame` — backward-compatible) on each rostered team's **remaining** schedule.
  - Projected final = **banked points + expected points from remaining games + expected postseason**; remaining games are calibrated to *remaining* expected wins (season expected wins − wins so far).
- New `modules/standings-projection.js`: `buildProjections` (played/remaining split) + `simulateTitleOdds` (5,000-sim Monte-Carlo; each sim flips the remaining games by win probability and counts championships; ties split).
- New `GET /standings/projections/:league/:season` — reads **only Mongo** (schedule / SP+ / odds / scoring config); **no CFBD calls**, computed on demand per standings load.
- UI: a dedicated panel (`0 → 225` with a title-odds bar + %), chosen over inline table columns after mocking up both (columns scrolled off-screen on mobile).

## Behavior / edge cases

- **Forward-looking only:** the panel **hides** when a season has no games left (completed/not-yet-scheduled), so it never shows actuals-plus-a-stray-postseason term.
- Also hides the empty **League Highlights** header in the preseason state (no cards yet).
- Preseason: banked 0, all games remaining → projected ≈ the draft-grade projection (verified: Garrett 225, matching his draft grade); title odds sum to 100%.
- FCS opponents / missing SP+ / odds already handled by the shared projection engine.

## Verification

- **121/121** tests pass (6 new: `winsSoFar`, title-odds sum/dominance/tie-split, `buildProjections`).
- End-to-end both leagues; browser-verified desktop + mobile (390px), no page overflow; confirmed the panel hides on the completed 2025 season while League Highlights still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)