### PR TITLE
Fix Retrieve Rankings: bulk by-year, non-destructive upsert

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -508,51 +508,30 @@ if (calculateAllForm) {
 
 const rankingsForm = document.getElementById('rankings-form');
 
+// Pull a whole season's rankings in one shot (all weeks, regular + postseason)
+// and upsert them — non-destructive, safe to re-run.
 if (rankingsForm) {
     rankingsForm.addEventListener('submit', async function(event) {
         event.preventDefault();
+        block_screen();
 
         const season = document.querySelector('[rankings-season]').value;
-        const seasonType = document.querySelector('[season-type-options]').value.toLowerCase();
-        const week = document.querySelector('[week-options]').value;
-
-        var response = await fetch(`/rankings/${season}/${week}/${seasonType}`, {
-            method: 'GET',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            }
+        const response = await fetch(`/rankings/${season}/refresh`, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
         });
-    
-        var rankings = await response;
+        const data = await response.json();
+        unblock_screen();
 
-        if (rankings.status == 200) {
-            successToast.options.text = `Rankings already in system for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`;
+        const results = document.getElementById('rankings-results');
+        if (response.status == 201) {
+            successToast.options.text = `Rankings synced for ${season}: ${data.weeks} weeks (${data.created} new, ${data.updated} updated)`;
             successToast.showToast();
+            if (results) results.textContent = `${data.weeks} weeks — ${data.created} new, ${data.updated} updated.`;
         } else {
-            const response = await fetch("/rankings/retrieveRankings", {
-                method: 'POST',
-                headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-                },
-                body: `{
-                "season": "${season}",
-                "seasonType": "${seasonType}",
-                "week": "${week}"
-                }`,
-            });
-
-            response.json().then(data => {
-                if (response.status == 201) {
-                    console.log("New Rankings", data);
-                    successToast.options.text = `New rankings retrieved for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`;
-                    successToast.showToast();
-                } else {
-                    failToast.options.text = response.status + " Rankings could not be retrieved";
-                    failToast.showToast();
-                }
-            });
+            failToast.options.text = (response.status) + ` | Rankings could not be retrieved`;
+            failToast.showToast();
+            if (results) results.textContent = (data && data.message) || 'Failed.';
         }
     });
 }

--- a/routes/rankings.js
+++ b/routes/rankings.js
@@ -116,4 +116,38 @@ router.get('/:week/:seasonType/poll/:pollName', async (req, res) => {
     }
 });
 
+// Bulk-pull a whole season's rankings in one CFBD call and upsert each week's
+// doc. Non-destructive: matches on (season, seasonType, week), updates existing
+// and inserts new, never deletes — so it's safe to re-run and covers regular +
+// postseason weeks at once. Replaces the fragile per-week form.
+router.post('/:season/refresh', async (req, res) => {
+    if (!/^\d{4}$/.test(req.params.season)) {
+        return res.status(400).json({ message: 'Invalid season' });
+    }
+    const season = Number(req.params.season);
+    try {
+        const response = await fetch(`https://api.collegefootballdata.com/rankings?year=${season}`, {
+            method: 'GET',
+            headers: { 'Accept': 'application/json', 'Authorization': process.env.CFBD_API_KEY }
+        });
+        const data = await response.json();
+        if (!response.ok || !Array.isArray(data)) {
+            return res.status(400).json({ message: (data && data.message) || `CFBD request failed (${response.status})` });
+        }
+
+        let created = 0, updated = 0;
+        for (const wk of data) {
+            if (wk.week == null || !wk.seasonType) continue;
+            const filter = { season: wk.season, seasonType: wk.seasonType, week: wk.week };
+            const doc = { season: wk.season, seasonType: wk.seasonType, week: wk.week, polls: wk.polls || [] };
+            const existing = await Ranking.findOne(filter);
+            if (existing) { await Ranking.findOneAndUpdate(filter, doc); updated++; }
+            else { await new Ranking(doc).save(); created++; }
+        }
+        return res.status(201).json({ season, weeks: data.length, created, updated });
+    } catch (err) {
+        return res.status(500).json({ message: err.message });
+    }
+});
+
 module.exports = router;

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -154,10 +154,9 @@
                 <div class="sub-container" rankings-container style="display: none">
                     <form id="rankings-form">
                         <div><select rankings-season season-options></select></div>
-                        <div><select season-type-options></select></div>
-                        <div><select week-options></select></div>
                         <div><button type="submit">Retrieve Rankings</button></div>
                     </form>
+                    <div id="rankings-results" class="cfp-odds-results"></div>
                 </div>
             </div>
             <div class="function-container">


### PR DESCRIPTION
## Problem

The **Retrieve Rankings** admin action was broken. The handler read the season type and week via `document.querySelector('[season-type-options]')` / `'[week-options]'`, but those attributes aren't unique — the **Retrieve Games** form carries the same attributes and appears first in the DOM, so `querySelector` returned *its* (empty) selects. Result: it POSTed `{ season, seasonType: "", week: "" }` and failed.

## Fix

Replace the fragile per-week flow with a single **by-year** pull (your suggestion):

- **New `POST /rankings/:season/refresh`** — one CFBD `/rankings?year=` call returns every week (regular + postseason, 17 for 2025); upsert each by `(season, seasonType, week)`. **Non-destructive**: updates existing docs, inserts new ones, never deletes — safe to re-run, idempotent.
- **Simplified admin form** to a season picker + button (+ a results line), which also removes the selector collision entirely.

The per-week `POST /rankings/retrieveRankings` route is **kept** — the automated weekly scoring job (`modules/score-update.js`) still relies on it to ensure the current week's rankings exist before scoring.

## Verification

- Hit the real endpoint (logged in) for 2025 → `{ weeks: 17, created: 1, updated: 16 }` — 16 existing weeks updated in place, 1 new, nothing dropped. Re-running just updates (idempotent).
- Admin form now renders a single season select; syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)