### PR TITLE
Admin: robust screen-block + football loading overlay

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -575,3 +575,59 @@ select[scoring-config-combine-mode] { width: 100%; }
 }
 .cfp-odds-table .cfp-num { font-variant-numeric: tabular-nums; text-align: right; }
 .cfp-odds-table tbody tr:hover { background-color: #171B31; }
+
+/* -------------------------------------------------------------------------
+   Admin "working" overlay loader (markup injected by block_screen in
+   admin.js). A tumbling football + animated "Working…" caption; centered so
+   it works on desktop and mobile, and it honors reduced-motion.
+   ------------------------------------------------------------------------- */
+.admin-loader {
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    gap: 0.9rem;
+    color: #F4F6FB;
+    text-align: center;
+    padding: 1rem;
+}
+.admin-loader-ball {
+    display: inline-flex;
+    filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.45));
+    animation: cc-ball-tumble 1.1s ease-in-out infinite;
+}
+.admin-loader-ball svg { display: block; }
+.admin-loader-text {
+    font-family: 'Poppins', sans-serif;
+    font-weight: 600;
+    font-size: 1.05rem;
+    letter-spacing: 0.04em;
+}
+.admin-loader-dots i {
+    font-style: normal;
+    animation: cc-loader-dot 1.2s ease-in-out infinite both;
+}
+.admin-loader-dots i:nth-child(2) { animation-delay: 0.2s; }
+.admin-loader-dots i:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes cc-ball-tumble {
+    0%   { transform: rotate(0deg)   translateY(0); }
+    50%  { transform: rotate(180deg) translateY(-9px); }
+    100% { transform: rotate(360deg) translateY(0); }
+}
+@keyframes cc-loader-dot {
+    0%, 80%, 100% { opacity: 0.25; }
+    40%           { opacity: 1; }
+}
+
+@media (max-width: 480px) {
+    .admin-loader-text { font-size: 0.95rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .admin-loader-ball { animation: cc-ball-pulse 1.5s ease-in-out infinite; }
+    .admin-loader-dots i { animation: none; opacity: 0.7; }
+}
+@keyframes cc-ball-pulse {
+    0%, 100% { opacity: 0.55; }
+    50%      { opacity: 1; }
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -601,6 +601,7 @@ if (recruitRankingsForm) {
                 } else {
                     failToast.options.text = response.status + " Recruiting Rankings could not be retrieved";
                     failToast.showToast();
+                    unblock_screen();
                 }
             });
         }
@@ -637,6 +638,7 @@ if (teamRecordsForm) {
             } else {
                 failToast.options.text = response.status + " Team Records could not be retrieved";
                 failToast.showToast();
+                unblock_screen();
             }
         });
     });
@@ -672,6 +674,7 @@ if (refreshTeamsForm) {
             } else {
                 failToast.options.text = response.status + " Teams could not be refreshed";
                 failToast.showToast();
+                unblock_screen();
             }
         });
     });
@@ -822,7 +825,9 @@ if (gamesForm) {
                 unblock_screen();
             } else {
                 failToast.options.text = response.status + "| Games could not be retrieved";
-                failToast.showToast();            }
+                failToast.showToast();
+                unblock_screen();
+            }
         });
     });
 }
@@ -894,7 +899,9 @@ if (scoresForm) {
                 unblock_screen();
             } else {
                 failToast.options.text = response.status + "| Scores could not be updated";
-                failToast.showToast();            }
+                failToast.showToast();
+                unblock_screen();
+            }
         });
     });
 }
@@ -929,6 +936,7 @@ if (bettingLinesForm) {
             } else {
                 failToast.options.text = response.status + " Betting Records could not be retrieved";
                 failToast.showToast();
+                unblock_screen();
             }
         });
     });
@@ -964,6 +972,7 @@ if (expectedWinsForm) {
             } else {
                 failToast.options.text = response.status + " Team expected wins could not be updated";
                 failToast.showToast();
+                unblock_screen();
             }
         });
     });
@@ -995,6 +1004,7 @@ if (apiCallsForm) {
             } else {
                 failToast.options.text = response.status + " API calls remaining could not be retrieved";
                 failToast.showToast();
+                unblock_screen();
             }
         });
     });
@@ -1130,17 +1140,62 @@ function displayApiCallsContainer() {
     }
 }
 
+// Full-screen "working" overlay shown while an admin request runs. It carries a
+// football loader (desktop + mobile friendly, respects reduced-motion) and, most
+// importantly, is engineered so it can NEVER stay stuck:
+//   1. block_screen is idempotent — repeated calls reuse one overlay.
+//   2. A watchdog auto-clears it if a handler ever forgets to unblock.
+//   3. A global unhandledrejection listener (registered below) clears it the
+//      instant a request throws/rejects.
+// Individual handlers also unblock in both their success and error branches.
 function block_screen() {
-    $('<div id="screenBlock"></div>').appendTo('body');
-    $('#screenBlock').css( { opacity: 0, width: $(document).width(), height: $(document).height() } );
-    $('#screenBlock').addClass('blockDiv');
-    $('#screenBlock').animate({opacity: 0.7}, 200);
+    let el = document.getElementById('screenBlock');
+    if (!el) {
+        el = document.createElement('div');
+        el.id = 'screenBlock';
+        el.className = 'blockDiv';
+        el.setAttribute('role', 'status');
+        el.setAttribute('aria-live', 'polite');
+        el.setAttribute('aria-label', 'Working');
+        var ball = (typeof window !== 'undefined' && window.ccIcon)
+            ? window.ccIcon('football', { size: 46 })
+            : '🏈';
+        el.innerHTML =
+            '<div class="admin-loader">' +
+              '<span class="admin-loader-ball" aria-hidden="true">' + ball + '</span>' +
+              '<div class="admin-loader-text">Working<span class="admin-loader-dots"><i>.</i><i>.</i><i>.</i></span></div>' +
+            '</div>';
+        document.body.appendChild(el);
+    }
+    // Fade in on the next frame so the CSS transition actually runs.
+    requestAnimationFrame(function () { el.classList.add('is-visible'); });
+    // Safety net: never leave the overlay up longer than the slowest admin op
+    // (score updates cap out near 100s), even if a handler forgets to unblock.
+    clearTimeout(block_screen._watchdog);
+    block_screen._watchdog = setTimeout(unblock_screen, 150000);
 }
 
 function unblock_screen() {
-$('#screenBlock').animate({opacity: 0}, 200, function() {
-    $('#screenBlock').remove();
-});
+    clearTimeout(block_screen._watchdog);
+    var el = document.getElementById('screenBlock');
+    if (!el) return;
+    el.classList.remove('is-visible');
+    // Remove after the fade, with a hard-removal fallback so a missed
+    // transitionend (reduced-motion, backgrounded tab) can't orphan the node.
+    var removed = false;
+    var done = function () {
+        if (removed) return;
+        removed = true;
+        if (el.parentNode) el.parentNode.removeChild(el);
+    };
+    el.addEventListener('transitionend', done, { once: true });
+    setTimeout(done, 400);
+}
+
+// Belt-and-suspenders: if any admin request rejects (network error, aborted
+// fetch, JSON parse failure) the overlay clears immediately instead of hanging.
+if (typeof window !== 'undefined') {
+    window.addEventListener('unhandledrejection', function () { unblock_screen(); });
 }
 
 if ($("[league-selector]")) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -392,13 +392,25 @@ footer {
 }
 
 .blockDiv {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    background-color: #FFF;
-    width: 0px;
-    height: 0px;
-    z-index: 10;
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(16, 20, 34, 0.78);
+    -webkit-backdrop-filter: blur(3px);
+    backdrop-filter: blur(3px);
+    z-index: 3000;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.blockDiv.is-visible {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 /* Table Styles */


### PR DESCRIPTION
## What

The admin "working" overlay could get stuck up on the page, and it was just a plain white dim with no sign anything was happening. This fixes both.

### The stuck-overlay bug
Most admin handlers called `unblock_screen()` **only** in their success branch. So:
- a non-2xx response (e.g. the rankings 400s we hit earlier) → overlay stays up, and
- a thrown/aborted/network-failed fetch → overlay stays up.

Fixed with layered guarantees so it can never hang:
1. **Global `unhandledrejection` listener** clears the overlay the instant a request throws/rejects.
2. **`unblock_screen()` added to every handler's error branch** so a non-2xx status clears it immediately.
3. **150s watchdog** in `block_screen` as a final backstop (longer than the slowest admin op — score updates cap near 100s).
4. `block_screen` is now **idempotent** (repeated calls reuse one overlay instead of stacking duplicate `#screenBlock` nodes), and removal has a hard-removal fallback so a missed `transitionend` can't orphan the node.

### The loading animation
Replaces the white dim with a dark, blurred scrim and an on-brand **tumbling football + animated "Working…"** loader (uses the `ccIcon` football). Centered for desktop and mobile; honors `prefers-reduced-motion` (gentle pulse instead of tumble).

## Verification
Verified live on `/admin`:
- Overlay renders correctly on desktop and mobile (375px) — centered scrim + football + "Working…".
- A rejected request clears the overlay via the global net (confirmed `#screenBlock` removed).
- Idempotent: 3× `block_screen()` → 1 overlay node.
- No console errors (aside from the deliberate test rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)