### PR TITLE
Admin: one-click full-season scoring + faster team scoring

### DIFF
--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -41,7 +41,8 @@ module.exports= {
         }
     },
 
-    updateScores: async function(season, week) {
+    updateScores: async function(season, week, cache) {
+        var rankingCache = cache || new Map();
         var response = await internalFetch(`${process.env.URL}/users/season/${process.env.YEAR}`, {
             method: 'GET',
             headers: {
@@ -81,9 +82,9 @@ module.exports= {
                         // values + disabled) so commissioner structure changes
                         // are honored, not just point values.
                         if (cfg.model == "claunts") {
-                            teamScore = await module.exports.calculateScoreV1(team.id, game, week, process.env.YEAR, cfg);
+                            teamScore = await module.exports.calculateScoreV1(team.id, game, week, process.env.YEAR, cfg, rankingCache);
                         } else if (cfg.model == "graham") {
-                            teamScore = await module.exports.calculateScoreV2(team.id, game, week, process.env.YEAR, cfg);
+                            teamScore = await module.exports.calculateScoreV2(team.id, game, week, process.env.YEAR, cfg, rankingCache);
                         }
 
                         score += teamScore;
@@ -146,7 +147,8 @@ module.exports= {
         }
     },
 
-    calculateTeamScores: async function (season, teamId, teamName) {
+    calculateTeamScores: async function (season, teamId, teamName, cache) {
+        var rankingCache = cache || new Map();
 
         var cumulativeScoreV1 = 0;
         var cumulativeScoreV2 = 0;
@@ -171,8 +173,8 @@ module.exports= {
                 var gameScoreV1 = 0;
                 var gameScoreV2 = 0;
 
-                gameScoreV1 = await module.exports.calculateScoreV1(teamId, game, game.week, season, clauntsCfg);
-                gameScoreV2 = await module.exports.calculateScoreV2(teamId, game, game.week, season, grahamCfg);
+                gameScoreV1 = await module.exports.calculateScoreV1(teamId, game, game.week, season, clauntsCfg, rankingCache);
+                gameScoreV2 = await module.exports.calculateScoreV2(teamId, game, game.week, season, grahamCfg, rankingCache);
 
                 cumulativeScoreV1 += gameScoreV1;
                 cumulativeScoreV2 += gameScoreV2;
@@ -208,14 +210,14 @@ module.exports= {
     // Scoring for the Claunts league (claunts model). `cfg` may be a flat point-
     // values object (back-compat with callers/tests that only tune values) or a
     // fully-resolved config { model, combineMode, values, disabled }.
-    calculateScoreV1: async function (team, data, week, season = process.env.YEAR, cfg = MODELS.claunts.defaults) {
-        var rankings = await getRankingsForGame(data, week, season);
+    calculateScoreV1: async function (team, data, week, season = process.env.YEAR, cfg = MODELS.claunts.defaults, cache) {
+        var rankings = await getRankingsForGame(data, week, season, cache);
         return evaluate('claunts', team, data, rankings, normalizeCfg('claunts', cfg));
     },
 
     // Scoring for the Graham league (graham model). See calculateScoreV1 re: cfg.
-    calculateScoreV2: async function (team, data, week, season = process.env.YEAR, cfg = MODELS.graham.defaults) {
-        var rankings = await getRankingsForGame(data, week, season);
+    calculateScoreV2: async function (team, data, week, season = process.env.YEAR, cfg = MODELS.graham.defaults, cache) {
+        var rankings = await getRankingsForGame(data, week, season, cache);
         return evaluate('graham', team, data, rankings, normalizeCfg('graham', cfg));
     },
 
@@ -348,7 +350,18 @@ async function getScoringConfig(league) {
 }
 
 // Builds the rankings-fetch URL for a game and returns the parsed rankings.
-async function getRankingsForGame(game, week, season) {
+// Fetches the ranking doc for a game's week from the internal /rankings
+// endpoint (a Mongo read). The same (season, week, seasonType) doc is needed by
+// every game in a week and by both league models, so callers that score many
+// games in one run (updateScores / calculateTeamScores) pass a `cache` Map to
+// reuse it instead of re-reading it per game. Without a cache it always fetches
+// — so direct callers stay stateless and correct even if rankings change.
+async function getRankingsForGame(game, week, season, cache) {
+    var key = (game.seasonType == "postseason")
+        ? `${season}|1|regular`
+        : `${season}|${week}|${game.seasonType}`;
+    if (cache && cache.has(key)) return cache.get(key);
+
     var url = (game.seasonType == "postseason")
         ? `${process.env.URL}/rankings/${season}/1/regular`
         : `${process.env.URL}/rankings/${season}/${week}/${game.seasonType}`;
@@ -356,7 +369,9 @@ async function getRankingsForGame(game, week, season) {
         method: 'GET',
         headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
     });
-    return response.json();
+    var data = await response.json();
+    if (cache) cache.set(key, data);
+    return data;
 }
 
 // --- unified scoring engine ---------------------------------------------

--- a/public/admin.css
+++ b/public/admin.css
@@ -631,3 +631,12 @@ select[scoring-config-combine-mode] { width: 100%; }
     0%, 100% { opacity: 0.55; }
     50%      { opacity: 1; }
 }
+
+/* Caption under the "Score All Weeks" button explaining what it runs. */
+.all-weeks-note {
+    font-size: 0.72rem;
+    color: #A4A9C2;
+    line-height: 1.4;
+    margin-top: 0.4em;
+    max-width: 22em;
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -468,41 +468,58 @@ if (calculateForm) {
     });
 }
 
+// Score every team's team-doc in one server-side request (rankings cached
+// across the run) instead of firing ~136 parallel requests + ~136 toasts.
 const calculateAllForm = document.getElementById('all-score-form')
 if (calculateAllForm) {
     calculateAllForm.addEventListener('submit', async function(event) {
         event.preventDefault();
 
         const season = document.querySelector('[team-score-season]').value;
+        if (!season) {
+            failToast.options.text = 'Pick a season first';
+            failToast.showToast();
+            return;
+        }
 
-        await fetch('/teams', {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json'
+        try {
+            const { status, data } = await runLongBlockingRequest(`/scores/calculate-all/${season}`, 'Calculating team scores…');
+            if (status === 200) {
+                successToast.options.text = `Calculated ${data.scored} teams${data.failed ? ` (${data.failed} failed)` : ''} for ${season}`;
+                successToast.showToast();
+            } else {
+                failToast.options.text = status + ' | Team scores could not be calculated' + (data && data.message ? `: ${data.message}` : '');
+                failToast.showToast();
             }
-        }).then(res => res.json()).then(data => {
-            console.log("Number of teams: " + data.length)
-            data.forEach(async (team) => {
-                var response = await fetch(`/calculate-team-score/${season}/${team.id}/${team.school}`, {
-                    method: 'GET',
-                    headers: {
-                    'Accept': 'application/json'
-                    }
-                });
+        } catch (err) {
+            failToast.options.text = 'Team scores failed: ' + err.message;
+            failToast.showToast();
+        }
+    });
+}
 
-                response.json().then(data => {
-                    if (response.status == 200) {
-                        console.log(data);
-                        successToast.options.text = "Score successfully calculated for " + data.school;
-                        successToast.showToast();
-                    } else {
-                        failToast.options.text = response.status + " Team score could not be calculated";
-                        failToast.showToast();
-                    }
-                });
-            })
-        });
+// Score the whole season in one click: user weekly scores for every week +
+// postseason, all team-doc scores, then cumulative totals — the finished-season
+// backfill (replaces 17× Update Scores + Calculate Scores for all teams).
+const scoresAllForm = document.getElementById('scores-all-form');
+if (scoresAllForm) {
+    scoresAllForm.addEventListener('submit', async function(event) {
+        event.preventDefault();
+        if (!window.confirm('Recompute ALL user + team scores for the whole season? This can take several minutes.')) return;
+
+        try {
+            const { status, data } = await runLongBlockingRequest('/scores/update-all', 'Scoring the full season — this can take several minutes…');
+            if (status === 200) {
+                successToast.options.text = `Scored ${data.weeksScored} weeks + ${data.teamsScored} teams${data.teamsFailed ? ` (${data.teamsFailed} failed)` : ''}`;
+                successToast.showToast();
+            } else {
+                failToast.options.text = status + ' | Season score failed' + (data && data.message ? `: ${data.message}` : '');
+                failToast.showToast();
+            }
+        } catch (err) {
+            failToast.options.text = 'Season score failed: ' + err.message;
+            failToast.showToast();
+        }
     });
 }
 
@@ -1169,6 +1186,33 @@ function unblock_screen() {
     };
     el.addEventListener('transitionend', done, { once: true });
     setTimeout(done, 400);
+}
+
+// Update the loading overlay's caption (status for long-running admin ops).
+function setBlockMessage(msg) {
+    var t = document.querySelector('#screenBlock .admin-loader-text');
+    if (t) t.textContent = msg;
+}
+
+// Run a long admin POST behind the overlay. The overlay's safety watchdog is
+// 150s, so for multi-minute operations we re-arm it on a heartbeat; the overlay
+// always clears on success OR failure (finally). Returns { status, data }.
+async function runLongBlockingRequest(url, message) {
+    block_screen();
+    setBlockMessage(message);
+    var heartbeat = setInterval(block_screen, 60000); // keep the watchdog from firing mid-run
+    try {
+        var res = await fetch(url, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            signal: AbortSignal.timeout(1200000) // 20-minute ceiling
+        });
+        var data = await res.json().catch(function () { return {}; });
+        return { status: res.status, data: data };
+    } finally {
+        clearInterval(heartbeat);
+        unblock_screen();
+    }
 }
 
 // Belt-and-suspenders: if any admin request rejects (network error, aborted

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -4,6 +4,7 @@ const scoringModule = require('../modules/scoring.js');
 const User = require('../models/user');
 const Game = require('../models/game');
 const { computeAdminStatus } = require('../modules/admin-status');
+const { internalFetch } = require('../modules/internal-api');
 
 // Read-only status summary for the admin console: how far scoring/games have
 // progressed and whether any completed results are still unscored. Derived from
@@ -36,5 +37,70 @@ router.post('/update', async (req, res) => {
         res.status(500).json({message: err.message});
     }
 });
+
+// Full-season recompute in one request: user weekly scores for every regular
+// week + postseason, then every team's team-doc scores, then cumulative totals
+// once at the end. Reuses the exact per-week / per-team engine, so it's just an
+// orchestration of existing logic (and idempotent — safe to re-run). This is
+// what backfills a whole season after ingestion, replacing 17 clicks of Update
+// Scores + Calculate Scores for all teams. One ranking cache is shared across
+// the whole run, so each week's poll is read once, not once per game per team.
+router.post('/update-all', async (req, res) => {
+    try {
+        const season = process.env.YEAR;
+        const cache = new Map();
+
+        // 1. User weekly scores: each regular week, then postseason.
+        let weeksScored = 0;
+        for (let w = 1; w <= 16; w++) {
+            await scoringModule.updateScores('regular', String(w), cache);
+            weeksScored++;
+        }
+        await scoringModule.updateScores('postseason', '1', cache);
+        weeksScored++;
+
+        // 2. Team-doc scores for every team.
+        const { scored, failed } = await calculateAllTeams(season, cache);
+
+        // 3. Cumulative totals once, after everything is scored.
+        await scoringModule.updateCumulativeScores();
+
+        res.status(200).json({ season, weeksScored, teamsScored: scored, teamsFailed: failed });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Score every team's team-doc in one request (server-side loop) — replaces the
+// browser firing one request per team. Rankings are cached across the whole run.
+router.post('/calculate-all/:season', async (req, res) => {
+    try {
+        const { scored, failed } = await calculateAllTeams(req.params.season, new Map());
+        res.status(200).json({ season: req.params.season, scored, failed });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Loop every team through the team-doc scorer, sharing one ranking cache across
+// all teams. Never throws for a single team — a bad team is counted and skipped
+// so one failure can't abort a whole-season run.
+async function calculateAllTeams(season, cache) {
+    const teamsRes = await internalFetch(`${process.env.URL}/teams`, {
+        method: 'GET',
+        headers: { 'Accept': 'application/json' }
+    });
+    const teams = await teamsRes.json();
+    let scored = 0, failed = 0;
+    for (const team of (Array.isArray(teams) ? teams : [])) {
+        try {
+            await scoringModule.calculateTeamScores(season, team.id, team.school, cache);
+            scored++;
+        } catch (e) {
+            failed++;
+        }
+    }
+    return { scored, failed };
+}
 
 module.exports = router;

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -69,6 +69,10 @@
                         <div><select score-season-type season-type-options></select></div>
                         <div><button type="submit">Update Scores</button></div>
                     </form>
+                    <form id="scores-all-form">
+                        <div><button type="submit">Score All Weeks (users + teams)</button></div>
+                        <div class="all-weeks-note">Every regular week + postseason, all team scores, then cumulative totals. Takes a few minutes.</div>
+                    </form>
                 </div>
             </div>
             <div class="function-container">


### PR DESCRIPTION
## What

Two related admin-scoring improvements.

### 1. New: "Score All Weeks (users + teams)"
A single button that recomputes the **whole season** in one click — the finished-season backfill, replacing ~17 clicks of Update Scores plus Calculate Scores for all teams.

- **`POST /scores/update-all`** — runs Update Scores for every regular week + postseason (user standings), then every team's team-doc scores, then cumulative totals once. Orchestration of the existing engine; idempotent, safe to re-run.
- Button lives in the **Update Scores** tool, behind the loading overlay with a progress caption ("Scoring the full season…") and a heartbeat that keeps the overlay's 150s safety watchdog armed across the multi-minute run.

### 2. Efficiency
Answering "is Calculate Scores for all teams efficient?" — it made **no CFBD API calls** (all internal Mongo reads), but it was wasteful:

- **Ranking cache (opt-in, passed through).** The same `(season, week, seasonType)` poll was re-read once *per model per game* (~2× per game in `calculateTeamScores`). It's now read **once per run** via a cache threaded through `updateScores`/`calculateTeamScores` → `calculateScoreV1/V2` → `getRankingsForGame`. No hidden global state — direct `calculateScore` callers (and tests) pass no cache and fetch every time, so scoring stays stateless and correct.
- **"Calculate Scores for all teams" is now one request.** It posts to **`POST /scores/calculate-all/:season`**, which loops teams server-side sharing one ranking cache, instead of the browser firing ~136 parallel requests and popping ~136 toasts. One summary toast now.

## Correctness
Scores are **identical** to before — the cache only avoids redundant reads. Verified end-to-end against the test DB:
- Full `/update-all` run: **17 weeks + 138 teams, 0 failures, ~4 min**.
- Re-audited every regular-season game score vs the scoring rules + real poll docs: **0 mismatches** in both leagues.
- **All 121 tests pass** (`npx jest`).

## Notes
- The multi-minute run is expected (it re-scores the entire season). The overlay shows a progress caption throughout.
- `/scores/update-all` obsoletes the one-off rescore script from the earlier data-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)