### PR TITLE
Fix full-season scoring 503 on Heroku (30s request timeout)

### DIFF
--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -41,8 +41,10 @@ module.exports= {
         }
     },
 
-    updateScores: async function(season, week, cache) {
-        var rankingCache = cache || new Map();
+    updateScores: async function(season, week) {
+        // One ranking cache per call: every game in the week shares its poll doc
+        // instead of re-reading it from Mongo per game.
+        var rankingCache = new Map();
         var response = await internalFetch(`${process.env.URL}/users/season/${process.env.YEAR}`, {
             method: 'GET',
             headers: {
@@ -147,8 +149,10 @@ module.exports= {
         }
     },
 
-    calculateTeamScores: async function (season, teamId, teamName, cache) {
-        var rankingCache = cache || new Map();
+    calculateTeamScores: async function (season, teamId, teamName) {
+        // One ranking cache per call: both league models + same-week games share
+        // each poll doc instead of re-reading it from Mongo per game per model.
+        var rankingCache = new Map();
 
         var cumulativeScoreV1 = 0;
         var cumulativeScoreV2 = 0;

--- a/public/admin.js
+++ b/public/admin.js
@@ -468,8 +468,10 @@ if (calculateForm) {
     });
 }
 
-// Score every team's team-doc in one server-side request (rankings cached
-// across the run) instead of firing ~136 parallel requests + ~136 toasts.
+// Score every team's team-doc by looping the existing per-team endpoint in
+// small concurrent batches (single summary toast) instead of firing ~136
+// parallel requests + ~136 toasts. Each request is short — this is driven from
+// the browser precisely so no single request trips Heroku's 30s router timeout.
 const calculateAllForm = document.getElementById('all-score-form')
 if (calculateAllForm) {
     calculateAllForm.addEventListener('submit', async function(event) {
@@ -482,16 +484,14 @@ if (calculateAllForm) {
             return;
         }
 
+        block_screen();
         try {
-            const { status, data } = await runLongBlockingRequest(`/scores/calculate-all/${season}`, 'Calculating team scores…');
-            if (status === 200) {
-                successToast.options.text = `Calculated ${data.scored} teams${data.failed ? ` (${data.failed} failed)` : ''} for ${season}`;
-                successToast.showToast();
-            } else {
-                failToast.options.text = status + ' | Team scores could not be calculated' + (data && data.message ? `: ${data.message}` : '');
-                failToast.showToast();
-            }
+            const { total, failed } = await calcAllTeams(season);
+            unblock_screen();
+            successToast.options.text = `Calculated ${total - failed}/${total} teams for ${season}` + (failed ? ` (${failed} failed)` : '');
+            successToast.showToast();
         } catch (err) {
+            unblock_screen();
             failToast.options.text = 'Team scores failed: ' + err.message;
             failToast.showToast();
         }
@@ -499,24 +499,46 @@ if (calculateAllForm) {
 }
 
 // Score the whole season in one click: user weekly scores for every week +
-// postseason, all team-doc scores, then cumulative totals — the finished-season
-// backfill (replaces 17× Update Scores + Calculate Scores for all teams).
+// postseason, then all team-doc scores — the finished-season backfill (replaces
+// 17× Update Scores + Calculate Scores for all teams). Orchestrated from the
+// browser as many short requests: a single server request doing the whole
+// season would exceed Heroku's 30s router timeout (H12) and 503.
 const scoresAllForm = document.getElementById('scores-all-form');
 if (scoresAllForm) {
     scoresAllForm.addEventListener('submit', async function(event) {
         event.preventDefault();
         if (!window.confirm('Recompute ALL user + team scores for the whole season? This can take several minutes.')) return;
 
+        const season = window.APP_YEAR || String(new Date().getFullYear());
+        const weeks = [];
+        for (let w = 1; w <= 16; w++) weeks.push(['regular', w]);
+        weeks.push(['postseason', 1]);
+
+        block_screen();
+        const failedWeeks = [];
         try {
-            const { status, data } = await runLongBlockingRequest('/scores/update-all', 'Scoring the full season — this can take several minutes…');
-            if (status === 200) {
-                successToast.options.text = `Scored ${data.weeksScored} weeks + ${data.teamsScored} teams${data.teamsFailed ? ` (${data.teamsFailed} failed)` : ''}`;
-                successToast.showToast();
-            } else {
-                failToast.options.text = status + ' | Season score failed' + (data && data.message ? `: ${data.message}` : '');
-                failToast.showToast();
+            // 1. User weekly scores — one short request per week (each also
+            //    recomputes cumulative totals, so the last call leaves them current).
+            for (let i = 0; i < weeks.length; i++) {
+                block_screen(); // re-arm the overlay watchdog between steps
+                setBlockMessage(`Scoring week ${i + 1} of ${weeks.length}…`);
+                try {
+                    await updateWeek(weeks[i][0], weeks[i][1]);
+                } catch (e) {
+                    failedWeeks.push(weeks[i][0] === 'postseason' ? 'postseason' : `wk${weeks[i][1]}`);
+                }
             }
+            // 2. Team-doc scores.
+            const { total, failed } = await calcAllTeams(season);
+            unblock_screen();
+
+            const notes = [];
+            if (failedWeeks.length) notes.push(`${failedWeeks.length} week(s) failed`);
+            if (failed) notes.push(`${failed} team(s) failed`);
+            successToast.options.text = `Season scored: ${weeks.length} weeks + ${total} teams` + (notes.length ? ` (${notes.join(', ')})` : '');
+            successToast.showToast();
         } catch (err) {
+            unblock_screen();
             failToast.options.text = 'Season score failed: ' + err.message;
             failToast.showToast();
         }
@@ -1194,25 +1216,41 @@ function setBlockMessage(msg) {
     if (t) t.textContent = msg;
 }
 
-// Run a long admin POST behind the overlay. The overlay's safety watchdog is
-// 150s, so for multi-minute operations we re-arm it on a heartbeat; the overlay
-// always clears on success OR failure (finally). Returns { status, data }.
-async function runLongBlockingRequest(url, message) {
-    block_screen();
-    setBlockMessage(message);
-    var heartbeat = setInterval(block_screen, 60000); // keep the watchdog from firing mid-run
-    try {
-        var res = await fetch(url, {
-            method: 'POST',
-            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-            signal: AbortSignal.timeout(1200000) // 20-minute ceiling
-        });
-        var data = await res.json().catch(function () { return {}; });
-        return { status: res.status, data: data };
-    } finally {
-        clearInterval(heartbeat);
-        unblock_screen();
+// Score one week's user scores (existing per-week endpoint; stays well under
+// Heroku's 30s request limit). Throws on a non-OK response.
+async function updateWeek(seasonType, week) {
+    var res = await fetch('/scores/update', {
+        method: 'POST',
+        headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seasonType: seasonType, week: String(week) })
+    });
+    if (!res.ok) throw new Error(seasonType + ' week ' + week + ': ' + res.status);
+}
+
+// Score every team's team-doc by looping the per-team endpoint in small
+// concurrent batches, updating the overlay caption. Each request is short, so
+// no single request can trip Heroku's 30s router timeout. Returns
+// { total, failed }; a failed team is counted and skipped, never fatal.
+async function calcAllTeams(season) {
+    var teams = await fetch('/teams', { headers: { 'Accept': 'application/json' } }).then(function (r) { return r.json(); });
+    var list = Array.isArray(teams) ? teams : [];
+    var done = 0, failed = 0;
+    var CONCURRENCY = 5;
+    for (var i = 0; i < list.length; i += CONCURRENCY) {
+        var chunk = list.slice(i, i + CONCURRENCY);
+        await Promise.all(chunk.map(async function (t) {
+            try {
+                var res = await fetch('/calculate-team-score/' + season + '/' + t.id + '/' + encodeURIComponent(t.school), { headers: { 'Accept': 'application/json' } });
+                if (!res.ok) failed++;
+            } catch (e) {
+                failed++;
+            }
+            done++;
+        }));
+        block_screen(); // re-arm the overlay watchdog between batches
+        setBlockMessage('Calculating team scores ' + done + ' of ' + list.length + '…');
     }
+    return { total: list.length, failed: failed };
 }
 
 // Belt-and-suspenders: if any admin request rejects (network error, aborted

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -4,7 +4,6 @@ const scoringModule = require('../modules/scoring.js');
 const User = require('../models/user');
 const Game = require('../models/game');
 const { computeAdminStatus } = require('../modules/admin-status');
-const { internalFetch } = require('../modules/internal-api');
 
 // Read-only status summary for the admin console: how far scoring/games have
 // progressed and whether any completed results are still unscored. Derived from
@@ -37,70 +36,4 @@ router.post('/update', async (req, res) => {
         res.status(500).json({message: err.message});
     }
 });
-
-// Full-season recompute in one request: user weekly scores for every regular
-// week + postseason, then every team's team-doc scores, then cumulative totals
-// once at the end. Reuses the exact per-week / per-team engine, so it's just an
-// orchestration of existing logic (and idempotent — safe to re-run). This is
-// what backfills a whole season after ingestion, replacing 17 clicks of Update
-// Scores + Calculate Scores for all teams. One ranking cache is shared across
-// the whole run, so each week's poll is read once, not once per game per team.
-router.post('/update-all', async (req, res) => {
-    try {
-        const season = process.env.YEAR;
-        const cache = new Map();
-
-        // 1. User weekly scores: each regular week, then postseason.
-        let weeksScored = 0;
-        for (let w = 1; w <= 16; w++) {
-            await scoringModule.updateScores('regular', String(w), cache);
-            weeksScored++;
-        }
-        await scoringModule.updateScores('postseason', '1', cache);
-        weeksScored++;
-
-        // 2. Team-doc scores for every team.
-        const { scored, failed } = await calculateAllTeams(season, cache);
-
-        // 3. Cumulative totals once, after everything is scored.
-        await scoringModule.updateCumulativeScores();
-
-        res.status(200).json({ season, weeksScored, teamsScored: scored, teamsFailed: failed });
-    } catch (err) {
-        res.status(500).json({ message: err.message });
-    }
-});
-
-// Score every team's team-doc in one request (server-side loop) — replaces the
-// browser firing one request per team. Rankings are cached across the whole run.
-router.post('/calculate-all/:season', async (req, res) => {
-    try {
-        const { scored, failed } = await calculateAllTeams(req.params.season, new Map());
-        res.status(200).json({ season: req.params.season, scored, failed });
-    } catch (err) {
-        res.status(500).json({ message: err.message });
-    }
-});
-
-// Loop every team through the team-doc scorer, sharing one ranking cache across
-// all teams. Never throws for a single team — a bad team is counted and skipped
-// so one failure can't abort a whole-season run.
-async function calculateAllTeams(season, cache) {
-    const teamsRes = await internalFetch(`${process.env.URL}/teams`, {
-        method: 'GET',
-        headers: { 'Accept': 'application/json' }
-    });
-    const teams = await teamsRes.json();
-    let scored = 0, failed = 0;
-    for (const team of (Array.isArray(teams) ? teams : [])) {
-        try {
-            await scoringModule.calculateTeamScores(season, team.id, team.school, cache);
-            scored++;
-        } catch (e) {
-            failed++;
-        }
-    }
-    return { scored, failed };
-}
-
 module.exports = router;


### PR DESCRIPTION
## Problem

"Score All Weeks" 503'd in production. Root cause: **Heroku's H12 request timeout** — the router kills any HTTP request that doesn't respond within **30 seconds**. PR #220's `/scores/update-all` (and the single-request `/scores/calculate-all`) did the whole season's work — ~4 minutes — inside one request, so the router returned the generic Application Error page at 30s. It only worked locally because there's no router in front of localhost.

(The earlier `userData is not iterable` was a separate, now-fixed issue: `INTERNAL_API_TOKEN` was missing in the Prod config.)

## Fix

Drive the work from the browser as **many short requests**, each well under 30s — the same shape as the existing per-week "Update Scores" and per-team "Calculate Team Score" that already run fine in prod.

- **Removed** `POST /scores/update-all` and `POST /scores/calculate-all` (and the server-side team loop). A single request doing the whole season can't return within Heroku's window.
- **"Score All Weeks"** now loops the existing `POST /scores/update` (one short request per week — ~12s each — which also refreshes cumulative totals), then scores every team via the existing per-team endpoint in small concurrent batches. The overlay caption shows progress ("Scoring week 3 of 17…", "Calculating team scores 40 of 138…"); a failed week/team is counted and reported, not fatal.
- **"Calculate Scores for all teams"** likewise loops the per-team endpoint in batches with one summary toast (still no ~136 parallel requests / toast storm).
- Ranking cache is now created **per** `updateScores` / `calculateTeamScores` call (dropped the now-unused shared-cache param), keeping the within-request win — a week's poll is read once, not once per game per model.

## Verification (local)
- Both removed routes now return **404**.
- `POST /scores/update` (one week) → **200 in ~12s** (well under 30s).
- Per-team endpoint → **200** across a batch; `encodeURIComponent` handles team names.
- `window.APP_YEAR` supplies the authoritative season to team scoring.
- Full re-audit after scoring: **0 mismatches** in both leagues; **all 121 tests pass**.

Scoring output is identical — same endpoints, same engine, just orchestrated client-side.

## Note
Each request goes through Heroku's router individually, so the whole-season run takes a few minutes with the overlay up — expected. The per-week and per-team endpoints were already the production-proven path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)