### PR TITLE
Fix profile roster striping + standings head-to-head display bugs

### DIFF
--- a/public/standings.js
+++ b/public/standings.js
@@ -610,7 +610,7 @@ async function displaySchedule(data) {
 
                     var topData = '';
                     var bottomData = '';
-                    var scoreAdded = '<strong style="color: white;">+0<strong>';
+                    var scoreAdded = ''; // no badge unless this user's own team earned points
                     var awayTeam = '';
                     var homeTeam = '';
                     var isAway = false;
@@ -656,37 +656,42 @@ async function displaySchedule(data) {
                             shouldReplace = true;
                             // Each team's own points (the old code showed one team's
                             // score for both), found safely by (teamId, gameId).
-                            var awayScoreAdded = '<strong style="color: #F2A93B;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
-                            var homeScoreAdded = '<strong style="color: #F2A93B;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
+                            // Only the current user's own team earns points on this card; the
+                            // opponent's team lives in another user's data and resolves to 0 here,
+                            // so gate on >0 to avoid a spurious "+0" badge on the opponent's row.
+                            var awayPts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id);
+                            var homePts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id);
+                            var awayScoreAdded = awayPts > 0 ? '<strong style="color: #F2A93B;">+' + awayPts + '</strong>' : '';
+                            var homeScoreAdded = homePts > 0 ? '<strong style="color: #F2A93B;">+' + homePts + '</strong>' : '';
 
                             if (game.awayPoints > game.homePoints) {
-                                topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';
-                                bottomData = (game.homePoints || '-') + '<td class="score-added">' + homeScoreAdded + '</td>';
+                                topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';
+                                bottomData = (game.homePoints != null ? game.homePoints : '-') + '<td class="score-added">' + homeScoreAdded + '</td>';
                             } else {
-                                topData = (game.awayPoints || '-') + '<td class="score-added">' + awayScoreAdded + '</td>';
-                                bottomData = (game.homePoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + homeScoreAdded + '</td>';
+                                topData = (game.awayPoints != null ? game.awayPoints : '-') + '<td class="score-added">' + awayScoreAdded + '</td>';
+                                bottomData = (game.homePoints != null ? game.homePoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + homeScoreAdded + '</td>';
                             }
 
                         } else if ( game.awayPoints > game.homePoints ) {
                             if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
                                 scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                             }
-                            topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
-                            bottomData = (game.homePoints || '-');
+                            topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
+                            bottomData = (game.homePoints != null ? game.homePoints : '-');
                         } else if (game.homePoints > game.awayPoints) {
 
                             if(!isAway) {
                                 scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
                             }
 
-                            topData = (game.awayPoints || '-');
-                            bottomData = (game.homePoints || '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
+                            topData = (game.awayPoints != null ? game.awayPoints : '-');
+                            bottomData = (game.homePoints != null ? game.homePoints : '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                         } else {
                             if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
                                 scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                             }
-                            topData = (game.awayPoints || '-');
-                            bottomData = (game.homePoints || '-');
+                            topData = (game.awayPoints != null ? game.awayPoints : '-');
+                            bottomData = (game.homePoints != null ? game.homePoints : '-');
                         }
                     } else {
         
@@ -783,8 +788,8 @@ async function displaySchedule(data) {
                                     shouldReplace = true;
                                     scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
                                 }
-                                topData = (game.awayPoints || '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
-                                bottomData = (game.homePoints || '-');
+                                topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
+                                bottomData = (game.homePoints != null ? game.homePoints : '-');
                             } else {
 
                                 if(game.homeId == userData.seasons.at(-1).teams[iterNum].id) {
@@ -792,8 +797,8 @@ async function displaySchedule(data) {
                                     scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
                                 }
 
-                                topData = (game.awayPoints || '-');
-                                bottomData = (game.homePoints || '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
+                                topData = (game.awayPoints != null ? game.awayPoints : '-');
+                                bottomData = (game.homePoints != null ? game.homePoints : '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             }
                         }
                         

--- a/public/standings.js
+++ b/public/standings.js
@@ -661,8 +661,8 @@ async function displaySchedule(data) {
                             // so gate on >0 to avoid a spurious "+0" badge on the opponent's row.
                             var awayPts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id);
                             var homePts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id);
-                            var awayScoreAdded = awayPts > 0 ? '<strong style="color: #F2A93B;">+' + awayPts + '</strong>' : '';
-                            var homeScoreAdded = homePts > 0 ? '<strong style="color: #F2A93B;">+' + homePts + '</strong>' : '';
+                            var awayScoreAdded = awayPts > 0 ? '<strong style="color: #22C37A;">+' + awayPts + '</strong>' : '';
+                            var homeScoreAdded = homePts > 0 ? '<strong style="color: #22C37A;">+' + homePts + '</strong>' : '';
 
                             if (game.awayPoints > game.homePoints) {
                                 topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -506,3 +506,11 @@
     .uh-grades { transition: none; }
     .grade-chip-caret { transition: none; }
 }
+
+/* Roster table zebra fix. Odd rows carry no background of their own, so the
+   frozen Team / Team Score columns show #101322 while the middle cells let the
+   lighter profile card (#1A1F33) bleed through — a two-tone, inconsistent row.
+   Give odd rows the same solid base as the frozen columns for a clean stripe
+   (even rows are #171b31 from styles.css). Applies at all widths and outranks
+   the mobile `background: none` rule since userHome.css loads last. */
+.fl-table tbody tr:nth-child(odd) { background: #101322; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -514,3 +514,8 @@
    (even rows are #171b31 from styles.css). Applies at all widths and outranks
    the mobile `background: none` rule since userHome.css loads last. */
 .fl-table tbody tr:nth-child(odd) { background: #101322; }
+
+/* Same fix for the header row: only the frozen Team / Team Score cells carried a
+   background, so the middle header cells let the lighter card show through. Give
+   every header cell the solid base + a divider so the header reads as one bar. */
+.fl-table thead th { background-color: #101322; border-bottom: 1px solid #2A2E42; }


### PR DESCRIPTION
Three small display fixes.

## 1. Profile roster table — inconsistent row coloring
Odd rows carried no background of their own, so the frozen **Team** / **Team Score** columns showed `#101322` while the middle cells let the lighter profile card (`#1A1F33`) bleed through — a two-tone, uneven stripe. Odd rows now get the same solid base as the frozen columns for a clean zebra. Scoped to `userHome.css`, so the shared standings table is untouched.

## 2. Standings head-to-head — a real `0` showed as `-`
Score cells used `game.awayPoints || '-'`; since `0` is falsy in JS, a team that was shut out (e.g. **Texas Tech 0** vs Oregon) rendered a dash. Fixed with an explicit `!= null` check.

## 3. Standings head-to-head — `+6` **and** `+0` at once
Each game card belongs to one manager's team and should badge only that team. But the **playoff branch** badged *both* teams from the current user's `weeklyScore`, so the opponent (whose points live in another user's data) resolved to a spurious **`+0`**. The default badge was also a white `+0` stamped on the winner row when the card's owner wasn't the scorer. Now a badge renders only for the owner's own team, and only when it actually earned points (`> 0`) — matching the profile convention (no `+0` badges).

## Verification (in-browser, graham league)
- Profile roster rows alternate cleanly (odd `#101322` / even `#171b31`), no card bleed-through.
- Postseason head-to-head: **Oregon 23 / Texas Tech 0** (was `-`).
- Every postseason card badges only the winner's real points (`+6`, `+10` for the title game) — **no stray `+0`** anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)