### PR TITLE
Fix betting refresh timeout (H12) crashing the nightly scoring job

### DIFF
--- a/modules/betting.js
+++ b/modules/betting.js
@@ -1,23 +1,29 @@
 const { internalFetch } = require('./internal-api');
 module.exports = {
+    // Betting is the last, non-critical step of the nightly update. Never let it
+    // throw: a non-2xx (or a non-JSON body — e.g. an upstream timeout page) is
+    // logged and swallowed so it can't fail the whole scoring job.
     updateAllBettingLines: async function() {
-        const response = await internalFetch(`${process.env.URL}/betting/new/${process.env.YEAR}`, {
-            method: 'POST',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: `{
-            "season": "${process.env.YEAR}"
-            }`,
-        });
+        try {
+            const response = await internalFetch(`${process.env.URL}/betting/new/${process.env.YEAR}`, {
+                method: 'POST',
+                headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+                },
+                body: `{
+                "season": "${process.env.YEAR}"
+                }`,
+            });
 
-        response.json().then(data => {
             if (response.status == 201) {
                 console.log("✅ Betting lines successfully updated");
             } else {
-                console.log("❌ Betting lines could not be refreshed" + " | " + response.status);
+                const text = await response.text().catch(() => '');
+                console.log("❌ Betting lines could not be refreshed | " + response.status + (text ? ' | ' + text.slice(0, 140) : ''));
             }
-        });
+        } catch (err) {
+            console.log("❌ Betting lines update failed: " + err.message);
+        }
     }
 };

--- a/routes/betting.js
+++ b/routes/betting.js
@@ -39,57 +39,46 @@ router.post('/new/:year', async (req, res) => {
             }
         });
 
-        var allBettingLines = await response.json();
-
-        var refreshedLines = [];
-        var newLines = [];
-        for (const bettingLine of allBettingLines) {
-            var existingBettingLine = await Betting.findOne({id: bettingLine.id, year: bettingLine.year});
-
-            if (existingBettingLine != null) {
-                
-                existingBettingLine.season = bettingLine.season;
-                existingBettingLine.seasonType = bettingLine.seasonType;
-                existingBettingLine.week = bettingLine.week;
-                existingBettingLine.startDate = bettingLine.startDate;
-                existingBettingLine.homeTeam = bettingLine.homeTeam;
-                existingBettingLine.homeConference = bettingLine.homeConference;
-                existingBettingLine.homeClassification = bettingLine.homeClassification;
-                existingBettingLine.homeScore = bettingLine.homeScore;
-                existingBettingLine.awayTeam = bettingLine.awayTeam;
-                existingBettingLine.awayConference = bettingLine.awayConference;
-                existingBettingLine.awayClassification = bettingLine.awayClassification;
-                existingBettingLine.awayScore = bettingLine.awayScore;
-                existingBettingLine.lines = bettingLine.lines;
-
-                var filter = {id: bettingLine.id, year: bettingLine.year};
-                try {
-                    var updatedBettingLine = await Betting.findOneAndUpdate(filter, existingBettingLine, {new: true});
-                    refreshedLines.push(updatedBettingLine);
-                } catch (err) {
-                    console.log("Error updating record with id:", existingBettingLine.id);
-                    console.log("Update error:", err.message);
-                } 
-
-            } else {
-                newLines.push(bettingLine);
-            }
+        const allBettingLines = await response.json();
+        if (!Array.isArray(allBettingLines)) {
+            return res.status(400).json({ message: 'CFBD lines response was not a list' });
         }
 
-        try {
-            console.log("Refreshing " + refreshedLines.length + " records and adding " + newLines.length + " new records");
-            const newCreatedBettingLines = await Betting.insertMany(newLines);
+        // Upsert every line in one bulk write, keyed on the CFBD line id (unique
+        // per game). The old code did a findOne + findOneAndUpdate PER line —
+        // ~1,600 sequential round-trips for a full season, which blew past
+        // Heroku's 30s request limit (H12) and killed the nightly scoring job.
+        const ops = allBettingLines
+            .filter(bl => bl && bl.id != null)
+            .map(bl => ({
+                updateOne: {
+                    filter: { id: bl.id },
+                    update: { $set: {
+                        id: bl.id,
+                        season: bl.season,
+                        seasonType: bl.seasonType,
+                        week: bl.week,
+                        startDate: bl.startDate,
+                        homeTeam: bl.homeTeam,
+                        homeConference: bl.homeConference,
+                        homeClassification: bl.homeClassification,
+                        homeScore: bl.homeScore,
+                        awayTeam: bl.awayTeam,
+                        awayConference: bl.awayConference,
+                        awayClassification: bl.awayClassification,
+                        awayScore: bl.awayScore,
+                        lines: bl.lines
+                    } },
+                    upsert: true
+                }
+            }));
 
-            var returnedBettingLines = {
-                newLines: newCreatedBettingLines,
-                refreshedLines: refreshedLines
-            };
-
-            return res.status(201).json(returnedBettingLines);
-        } catch (err) {
-            console.log("Error refreshing teams: " + err.message);
-            res.status(400).json({message: err.message});
-        }
+        const result = ops.length
+            ? await Betting.bulkWrite(ops, { ordered: false })
+            : { upsertedCount: 0, modifiedCount: 0 };
+        const created = result.upsertedCount || 0;
+        console.log(`Betting lines for ${req.body.season}: ${ops.length} total, ${created} new, ${result.modifiedCount || 0} updated`);
+        return res.status(201).json({ total: ops.length, created, updated: result.modifiedCount || 0 });
     } catch (err) {
         res.status(400).json({message: err.message});
     }


### PR DESCRIPTION
## What surfaced this
Manually triggering the `daily-scores` job in prod (to verify the scheduled-job path after the `INTERNAL_API_TOKEN` fix) showed it scoring every team and updating records fine, then **crashing on the betting step**:
```
SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```
The internal `POST /betting/new/2025` came back as Heroku's **HTML error page**, and `response.json()` threw.

## Root cause
`POST /betting/new/:year` did a `findOne` + `findOneAndUpdate` **per betting line** — ~1,600 sequential DB round-trips for a full season — which blows past Heroku's **30s request limit (H12)**. The router then returns its HTML error page. (Both of the route's own error handlers return JSON, so the HTML can only be coming from the router, not the app.) This means the **nightly `daily-scores` job has been failing at the betting step every run in prod** — it just wasn't visible until we triggered it.

## Fix
- **`routes/betting.js`** — replace the per-line loop with a single `Betting.bulkWrite` of upserts keyed on the CFBD line `id`. Same effective dedup as before (the model has no `year` field, so the old `{id, year}` filter matched on `id` alone). Also guards a non-array CFBD response.
- **`modules/betting.js`** — never throw. Betting is the last, non-critical step of the nightly update, so a non-2xx or non-JSON body is now logged and swallowed instead of failing the whole scoring job.

## Verification (test DB)
`POST /betting/new/2025` → **201 in ~7.4s** (was an H12 timeout), upserting **1,597** lines with **0 duplicates created** (all matched existing docs by `id` → dedup preserved). All **121 tests pass**.

## After merge
Deploy, then re-run `heroku run node update-daily-scores-job.js -a fantasy-cfb` — the betting step should now complete and the job should log a `daily-scores` · **success** entry in `/job-runs` and send the completion email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)