### PR TITLE
Admin: function descriptions + smooth accordion + control polish

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -640,3 +640,116 @@ select[scoring-config-combine-mode] { width: 100%; }
     margin-top: 0.4em;
     max-width: 22em;
 }
+
+/* =========================================================================
+   Admin UI refresh: accordion animation + button/field polish
+   ========================================================================= */
+
+/* --- Accordion: smooth height + fade. Collapsed by default; toggleSub() in
+   admin.js sets max-height to the measured content height to animate open. --- */
+.sub-container {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    transition: max-height 0.3s ease, opacity 0.22s ease;
+}
+.sub-container.open {
+    opacity: 1;
+}
+
+/* --- Accordion header buttons: clean list-row look with a rotating caret,
+   replacing the chunky double box-shadow. --- */
+.button-container button {
+    display: flex;
+    align-items: center;
+    gap: 0.55em;
+    text-align: left;
+    background-color: #1A1F33;
+    color: #F4F6FB;
+    border: 1px solid #2A2E42;
+    border-radius: 10px;
+    box-shadow: none;
+    padding: 0.7em 0.95em;
+    font-size: 0.92rem;
+    font-weight: 600;
+    transition: background-color 0.18s ease, border-color 0.18s ease;
+}
+.button-container button:hover {
+    background-color: #212843;
+    border-color: #3a4162;
+}
+/* Caret chevron on the right, rotates down when the panel is open. */
+.button-container button::after {
+    content: "";
+    margin-left: auto;
+    flex: 0 0 auto;
+    width: 0.5em;
+    height: 0.5em;
+    border-right: 2px solid #767D9C;
+    border-bottom: 2px solid #767D9C;
+    transform: rotate(-45deg);
+    transition: transform 0.25s ease, border-color 0.18s ease;
+}
+.function-container.is-open .button-container button {
+    background-color: #212843;
+    border-color: #3a4162;
+}
+.function-container.is-open .button-container button::after {
+    transform: rotate(45deg);
+    border-color: #F4F6FB;
+}
+
+/* Keep the "unscored results" highlight working with the new flat button. */
+.function-container.attn .button-container button {
+    box-shadow: inset 3px 0 0 #F2C14E;
+    border-color: #F2C14E66;
+}
+
+/* --- Action (submit) buttons inside a panel --- */
+.sub-container button {
+    background-color: #ed5858;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    padding: 0.6em 1em;
+    font-size: 0.9rem;
+    font-weight: 600;
+    transition: background-color 0.18s ease, transform 0.08s ease;
+}
+.sub-container button:hover { background-color: #d94a4a; }
+.sub-container button:active { transform: translateY(1px); }
+
+/* --- Fields & dropdowns in the generic panels (config forms keep their own
+   .draft-config-form styling, which this :not() leaves untouched). --- */
+.sub-container form:not(.draft-config-form) select,
+.sub-container form:not(.draft-config-form) input[type="text"],
+.sub-container form:not(.draft-config-form) input[type="number"] {
+    background-color: #101322;
+    color: #F4F6FB;
+    border: 1px solid #2A2E42;
+    border-radius: 8px;
+    padding: 0.5em 0.65em;
+    font-size: 0.88rem;
+    margin-bottom: 0.4em;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.sub-container form:not(.draft-config-form) select:focus,
+.sub-container form:not(.draft-config-form) input:focus {
+    outline: none;
+    border-color: #6C9BFF;
+    box-shadow: 0 0 0 2px rgba(108, 155, 255, 0.25);
+}
+
+/* Slightly smaller, tighter one-line description. */
+.function-description {
+    font-size: 0.8rem;
+    margin: 0 0 0.7em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sub-container { transition: opacity 0.2s ease; }
+    .button-container button::after { transition: border-color 0.18s ease; }
+}

--- a/public/admin.css
+++ b/public/admin.css
@@ -717,10 +717,21 @@ select[scoring-config-combine-mode] { width: 100%; }
     padding: 0.6em 1em;
     font-size: 0.9rem;
     font-weight: 600;
+    box-sizing: border-box;
     transition: background-color 0.18s ease, transform 0.08s ease;
 }
 .sub-container button:hover { background-color: #d94a4a; }
 .sub-container button:active { transform: translateY(1px); }
+
+/* Full-width form with no horizontal margin — the base rules give it
+   width:100% AND margin:0.5em, so its right margin overflowed the panel and got
+   clipped by the accordion's overflow:hidden (chopping the controls' right
+   edge). Keep only the vertical gap. */
+.sub-container form:not(.draft-config-form) {
+    width: 100%;
+    margin: 0.5em 0;
+    box-sizing: border-box;
+}
 
 /* --- Fields & dropdowns in the generic panels (config forms keep their own
    .draft-config-form styling, which this :not() leaves untouched). --- */
@@ -734,6 +745,8 @@ select[scoring-config-combine-mode] { width: 100%; }
     padding: 0.5em 0.65em;
     font-size: 0.88rem;
     margin-bottom: 0.4em;
+    width: 100%;
+    box-sizing: border-box;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .sub-container form:not(.draft-config-form) select:focus,

--- a/public/admin.js
+++ b/public/admin.js
@@ -311,7 +311,7 @@ function renderAdminStatus(el, s, api, year, jobs) {
     var fix = el.querySelector('[data-fix-scores]');
     if (fix) fix.addEventListener('click', function () {
         var c = document.querySelector('[scores-container]');
-        if (c && c.style.display === 'none') displayScoresContainer();
+        if (c && !c.classList.contains('open')) displayScoresContainer();
         if (tool) tool.scrollIntoView({ behavior: 'smooth', block: 'center' });
     });
 }
@@ -734,10 +734,7 @@ if (enrichmentForm) {
 }
 
 // --- CFP odds ingestion (Market odds) ---------------------------------------
-function displayCfpOddsContainer() {
-    var c = document.querySelector('[cfp-odds-container]');
-    c.style.display = (c.style.display === 'flex' || c.style.display === '') ? 'none' : 'flex';
-}
+function displayCfpOddsContainer() { toggleSub('cfp-odds-container'); }
 
 (function () {
     var form = document.getElementById('cfp-odds-form');
@@ -850,10 +847,7 @@ if (gamesForm) {
     });
 }
 
-function displayScheduleContainer() {
-    var el = document.querySelector('[schedule-container]');
-    el.style.display = (el.style.display == 'flex' || el.style.display == '') ? 'none' : 'flex';
-}
+function displayScheduleContainer() { toggleSub('schedule-container'); }
 
 // Bulk-ingest a season's full FBS regular schedule — the preseason prerequisite
 // for draft grades (the projection reads each team's schedule).
@@ -1028,135 +1022,73 @@ if (apiCallsForm) {
     });
 }
 
-function displayCreateUserContainer() {
-    var createUserContainer = document.querySelector('[create-user-container]');
-
-    if (createUserContainer.style.display == 'flex' || createUserContainer.style.display=='') {
-        createUserContainer.style.display = 'none';
-    } else {
-        createUserContainer.style.display = 'flex';
-    }
+// --- Accordion (admin function panels) -----------------------------------
+// Panels collapse via a CSS max-height:0 state; on open we set max-height to the
+// measured content height so it animates smoothly, then release the cap so
+// lazy-loaded content (draft/scoring config) can still grow. The inline
+// display:none is dropped once so the collapsed CSS state can take over.
+function initAccordion() {
+    document.querySelectorAll('.sub-container').forEach(function (sc) {
+        sc.style.display = '';
+    });
+}
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAccordion);
+} else {
+    initAccordion();
 }
 
-function displayRemoveUserContainer() {
-    var removeUserContainer = document.querySelector('[remove-user-container]');
+// Toggle a panel open/closed by its container attribute. Returns the new open
+// state so callers that lazy-load on expand (draft/scoring config) can react.
+function toggleSub(attr) {
+    var el = document.querySelector('[' + attr + ']');
+    if (!el) return false;
+    var open = !el.classList.contains('open');
 
-    if (removeUserContainer.style.display == 'flex' || removeUserContainer.style.display=='') {
-        removeUserContainer.style.display = 'none';
+    clearTimeout(el._mhTimer);
+    if (open) {
+        el.classList.add('open');
+        el.style.maxHeight = el.scrollHeight + 'px';
+        // After the open animation, drop the cap so async-loaded content
+        // (draft/scoring config) can still grow the panel. Guarded + timer-based
+        // so it survives rapid re-toggles and reduced-motion (no transitionend).
+        el._mhTimer = setTimeout(function () {
+            if (el.classList.contains('open')) el.style.maxHeight = 'none';
+        }, 340);
     } else {
-        removeUserContainer.style.display = 'flex';
+        // Pin the current height, then collapse to 0 so it can transition.
+        el.style.maxHeight = el.scrollHeight + 'px';
+        void el.offsetHeight; // reflow
+        el.classList.remove('open');
+        el.style.maxHeight = '0';
     }
+
+    var fc = el.closest('.function-container');
+    if (fc) {
+        fc.classList.toggle('is-open', open);
+        var btn = fc.querySelector('.button-container button');
+        if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    return open;
 }
 
-function displayTeamContainer() {
-    var teamScoreContainer = document.querySelector('[calculate-team-score-container]');
+function displayCreateUserContainer() { toggleSub('create-user-container'); }
 
-    if (teamScoreContainer.style.display == 'flex' || teamScoreContainer.style.display=='') {
-        teamScoreContainer.style.display = 'none';
-    } else {
-        teamScoreContainer.style.display = 'flex';
-    }
-}
+function displayRemoveUserContainer() { toggleSub('remove-user-container'); }
 
-function displayRankingsContainer() {
-    var rankingsContainer = document.querySelector('[rankings-container]');
+function displayTeamContainer() { toggleSub('calculate-team-score-container'); }
 
-    if (rankingsContainer.style.display == 'flex' || rankingsContainer.style.display=='') {
-        rankingsContainer.style.display = 'none';
-    } else {
-        rankingsContainer.style.display = 'flex';
-    }
-}
+function displayRankingsContainer() { toggleSub('rankings-container'); }
 
-function displayRecruitRankingsContainer() {
-    var recruitRankingsContainer = document.querySelector('[recruit-rankings-container]');
-
-    if (recruitRankingsContainer.style.display == 'flex' || recruitRankingsContainer.style.display=='') {
-        recruitRankingsContainer.style.display = 'none';
-    } else {
-        recruitRankingsContainer.style.display = 'flex';
-    }
-}
-
-function displayTeamRecordsContainer() {
-    var teamRecordsContainer = document.querySelector('[team-records-container]');
-
-    if (teamRecordsContainer.style.display == 'flex' || teamRecordsContainer.style.display=='') {
-        teamRecordsContainer.style.display = 'none';
-    } else {
-        teamRecordsContainer.style.display = 'flex';
-    }
-}
-
-function displayRefreshTeamsContainer() {
-    var refreshTeamsContainer = document.querySelector('[refresh-teams-container]');
-
-    if (refreshTeamsContainer.style.display == 'flex' || refreshTeamsContainer.style.display=='') {
-        refreshTeamsContainer.style.display = 'none';
-    } else {
-        refreshTeamsContainer.style.display = 'flex';
-    }
-}
-
-function displayGamesContainer() {
-    var gamesContainer = document.querySelector('[games-container]');
-
-    if (gamesContainer.style.display == 'flex' || gamesContainer.style.display=='') {
-        gamesContainer.style.display = 'none';
-    } else {
-        gamesContainer.style.display = 'flex';
-    }
-}
-
-function displayScoresContainer() {
-    var scoresContainer = document.querySelector('[scores-container]');
-
-    if (scoresContainer.style.display == 'flex' || scoresContainer.style.display=='') {
-        scoresContainer.style.display = 'none';
-    } else {
-        scoresContainer.style.display = 'flex';
-    }
-}
-
-function displayBettingLinesContainer() {
-    var bettingContainer = document.querySelector('[betting-lines-container]');
-
-    if (bettingContainer.style.display == 'flex' || bettingContainer.style.display=='') {
-        bettingContainer.style.display = 'none';
-    } else {
-        bettingContainer.style.display = 'flex';
-    }
-}
-
-function displayExpectedWinsContainer() {
-    var expectedWinsContainer = document.querySelector('[expected-wins-container]');
-
-    if (expectedWinsContainer.style.display == 'flex' || expectedWinsContainer.style.display=='') {
-        expectedWinsContainer.style.display = 'none';
-    } else {
-        expectedWinsContainer.style.display = 'flex';
-    }
-}
-
-function displayEnrichmentContainer() {
-    var enrichmentContainer = document.querySelector('[enrichment-container]');
-
-    if (enrichmentContainer.style.display == 'flex' || enrichmentContainer.style.display=='') {
-        enrichmentContainer.style.display = 'none';
-    } else {
-        enrichmentContainer.style.display = 'flex';
-    }
-}
-
-function displayApiCallsContainer() {
-    var apiCallsContainer = document.querySelector('[api-calls-container]');
-
-    if (apiCallsContainer.style.display == 'flex' || apiCallsContainer.style.display=='') {
-        apiCallsContainer.style.display = 'none';
-    } else {
-        apiCallsContainer.style.display = 'flex';
-    }
-}
+function displayRecruitRankingsContainer() { toggleSub('recruit-rankings-container'); }
+function displayTeamRecordsContainer() { toggleSub('team-records-container'); }
+function displayRefreshTeamsContainer() { toggleSub('refresh-teams-container'); }
+function displayGamesContainer() { toggleSub('games-container'); }
+function displayScoresContainer() { toggleSub('scores-container'); }
+function displayBettingLinesContainer() { toggleSub('betting-lines-container'); }
+function displayExpectedWinsContainer() { toggleSub('expected-wins-container'); }
+function displayEnrichmentContainer() { toggleSub('enrichment-container'); }
+function displayApiCallsContainer() { toggleSub('api-calls-container'); }
 
 // Full-screen "working" overlay shown while an admin request runs. It carries a
 // football loader (desktop + mobile friendly, respects reduced-motion) and, most
@@ -1308,13 +1240,7 @@ function populateDraftSeasonOptions() {
 }
 
 async function displayDraftConfigContainer() {
-    var container = document.querySelector('[draft-config-container]');
-    if (container.style.display == 'flex' || container.style.display == '') {
-        container.style.display = 'none';
-    } else {
-        container.style.display = 'flex';
-        await loadDraftConfig();
-    }
+    if (toggleSub('draft-config-container')) await loadDraftConfig();
 }
 
 async function loadDraftConfig() {
@@ -1532,13 +1458,7 @@ if (document.querySelector('[draft-season]')) {
 var scoringConfigData = null;
 
 async function displayScoringConfigContainer() {
-    var c = document.querySelector('[scoring-config-container]');
-    if (c.style.display == 'flex' || c.style.display == '') {
-        c.style.display = 'none';
-    } else {
-        c.style.display = 'flex';
-        await loadScoringConfig();
-    }
+    if (toggleSub('scoring-config-container')) await loadScoringConfig();
 }
 
 async function loadScoringConfig() {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -64,6 +64,7 @@
                 </div>
                 <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · nightly + Saturday/Sunday jobs</div>
                 <div class="sub-container" scores-container style="display: none">
+                    <p class="function-description">Recalculate managers' fantasy points for one week — or the whole season — from the games already stored.</p>
                     <form id="scores-form">
                         <div><select score-week week-options></select></div>
                         <div><select score-season-type season-type-options></select></div>
@@ -84,6 +85,7 @@
                 </div>
                 <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · with the scores jobs</div>
                 <div class="sub-container" calculate-team-score-container style="display: none">
+                    <p class="function-description">Recompute a team's per-game fantasy points — one team or all — for a season.</p>
                     <form id="score-form">
                         <div class="team-picker-container" team-picker-container>
                             <select class="calculate-team-picker" id="calculate-team-picker" calculate-team-options>
@@ -106,6 +108,7 @@
                 </div>
                 <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · expected-wins job</div>
                 <div class="sub-container" expected-wins-container style="display: none">
+                    <p class="function-description">Recompute each team's projected win total for the season from current SP+ ratings.</p>
                     <form id="expected-wins-form">
                         <div><select expected-wins-season season-options></select></div>
                         <div><button type="submit">Refresh Expected Wins</button></div>
@@ -126,6 +129,7 @@
                     </button>
                 </div>
                 <div class="sub-container" games-container style="display: none">
+                    <p class="function-description">Pull one week's games and results from CollegeFootballData.</p>
                     <form id="games-form">
                         <div><select game-week week-options></select></div>
                         <div><select game-season-type season-type-options></select></div>
@@ -141,6 +145,7 @@
                     </button>
                 </div>
                 <div class="sub-container" schedule-container style="display: none">
+                    <p class="function-description">Pull a full season's regular-season schedule in one pass (the prerequisite for draft grades).</p>
                     <form id="schedule-form">
                         <div><select schedule-season season-options></select></div>
                         <div><button type="submit">Ingest Full Schedule</button></div>
@@ -156,6 +161,7 @@
                     </button>
                 </div>
                 <div class="sub-container" rankings-container style="display: none">
+                    <p class="function-description">Pull every poll for a season (AP + CFP, all weeks) and upsert it — safe to re-run.</p>
                     <form id="rankings-form">
                         <div><select rankings-season season-options></select></div>
                         <div><button type="submit">Retrieve Rankings</button></div>
@@ -171,6 +177,7 @@
                     </button>
                 </div>
                 <div class="sub-container" recruit-rankings-container style="display: none">
+                    <p class="function-description">Pull the 247Sports team recruiting rankings for a season.</p>
                     <form id="recruit-rankings-form">
                         <div><select recruiting-season season-options></select></div>
                         <div><button type="submit">Retrieve Recruiting Rankings</button></div>
@@ -185,6 +192,7 @@
                     </button>
                 </div>
                 <div class="sub-container" team-records-container style="display: none">
+                    <p class="function-description">Pull each team's win/loss record for a season.</p>
                     <form id="team-records-form">
                         <div><select record-season season-options></select></div>
                         <div><button type="submit">Retrieve Team Records</button></div>
@@ -199,6 +207,7 @@
                     </button>
                 </div>
                 <div class="sub-container" betting-lines-container style="display: none">
+                    <p class="function-description">Pull sportsbook spreads and totals for every game in a season.</p>
                     <form id="betting-lines-form">
                         <div><select betting-season season-options></select></div>
                         <div><button type="submit">Retrieve Betting Lines</button></div>
@@ -213,6 +222,7 @@
                     </button>
                 </div>
                 <div class="sub-container" refresh-teams-container style="display: none">
+                    <p class="function-description">Re-pull the FBS team list — names, logos, and conferences — for a season.</p>
                     <form id="refresh-teams-form">
                         <div><select refresh-season season-options></select></div>
                         <div><button type="submit">Refresh Teams</button></div>
@@ -228,11 +238,7 @@
                 </div>
                 <div class="job-tag"><i class="fa-solid fa-bolt"></i> Automated · weekly enrichment job (Tue)</div>
                 <div class="sub-container" enrichment-container style="display: none">
-                    <p class="function-description">
-                        Pulls SP+ &amp; FPI ratings, 247 talent, returning production and head coaches onto every
-                        team, plus TV/broadcast outlets onto games. Powers the team-page Outlook block and the
-                        draft board's SP+ column. Uses ~6 CFBD calls.
-                    </p>
+                    <p class="function-description">Pull SP+/FPI ratings, talent, returning production and coaches onto teams, plus TV outlets onto games (~6 CFBD calls).</p>
                     <form id="enrichment-form">
                         <div><select enrichment-season season-options></select></div>
                         <div><button type="submit">Run Enrichment</button></div>
@@ -253,11 +259,7 @@
                     </button>
                 </div>
                 <div class="sub-container" cfp-odds-container style="display: none">
-                    <p class="function-description">
-                        Paste a sportsbook's futures board (team + American odds) to feed the draft-grade
-                        CFP factor. Pick the market, paste, then <strong>Preview</strong> to check the team
-                        matches — nothing is saved until you <strong>Commit</strong>.
-                    </p>
+                    <p class="function-description">Paste a sportsbook futures board to feed the draft-grade CFP factor — Preview to check matches, then Commit to save.</p>
                     <form id="cfp-odds-form">
                         <div><select cfp-odds-market>
                             <option value="make">Odds to make the CFP</option>
@@ -291,6 +293,7 @@
                     </button>
                 </div>
                 <div class="sub-container" draft-config-container style="display: none">
+                    <p class="function-description">Set a season's draft date, rounds, format, and pick order.</p>
                     <form id="draft-config-form" class="draft-config-form">
                         <div class="draft-status-row">
                             Status: <span draft-status class="draft-status-badge">—</span>
@@ -341,6 +344,7 @@
                     </button>
                 </div>
                 <div class="sub-container" scoring-config-container style="display: none">
+                    <p class="function-description">Tune this league's point values, bonus-stacking mode, and postseason events.</p>
                     <form id="scoring-config-form" class="draft-config-form">
                         <div class="draft-status-row">League: <span scoring-config-model></span></div>
                         <div class="draft-field">
@@ -369,6 +373,7 @@
                     </button>
                 </div>
                 <div class="sub-container" create-user-container style="display: none">
+                    <p class="function-description">Add a manager to this league with a display color and starting roster.</p>
                     <form id="create-form">
                         <input type="text" class="first-name" first-name placeholder="First Name">
                         <input type="text" class="last-name" last-name placeholder="Last Name">
@@ -393,6 +398,7 @@
                     </button>
                 </div>
                 <div class="sub-container" remove-user-container style="display: none">
+                    <p class="function-description">Remove a manager from this league.</p>
                     <form id="remove-form">
                         <div class="user-container" user-container>
                             <select class="user-picker" id="user-picker" user-options>
@@ -416,6 +422,7 @@
                     </button>
                 </div>
                 <div class="sub-container" api-calls-container style="display: none">
+                    <p class="function-description">Check how many CollegeFootballData API calls remain this month.</p>
                     <form id="api-calls-form">
                         <div><button type="submit">View API calls remaining</button></div>
                         <div class="api-info"><p class="api-info" api-calls-remaining></p></div>


### PR DESCRIPTION
Three UI improvements to the Admin console.

## 1. One-sentence descriptions
Every admin function now shows a short description when expanded — like the enrichment ("Refresh Ratings & Broadcasts") panel already did, but tightened to a single sentence (the two existing multi-sentence ones were trimmed to match). 17 panels total.

## 2. Smooth accordion animation
Panels now expand/collapse with a smooth height + fade instead of snapping open. The 17 per-function `display*Container()` toggles were collapsed into one shared, class-based helper (`toggleSub`) that animates a JS-measured `max-height` and releases the cap afterward (so the draft/scoring config panels can still lazy-load and grow). Header buttons get a caret that rotates when the panel is open.

## 3. Control polish
- **Header buttons:** flat card-style rows with an icon + chevron, dropping the chunky double `box-shadow`.
- **Action buttons:** cleaner rounded red buttons with a subtle shadow + hover/active states.
- **Fields & dropdowns:** filled, rounded inputs/selects with a focus ring, scoped with `:not(.draft-config-form)` so the bespoke draft/scoring config forms are untouched.

## Verification
In-browser (admin page): all 17 panels wrap and collapse correctly; descriptions render; open/close **end-states are correct** (open = full height + opacity 1, closed = 0 height + opacity 0); the "unscored results → open Update Scores" affordance still works; no console errors; **121 tests pass**.

Note: the embedded preview pane doesn't advance CSS transitions (an inline `opacity:1 !important` computed to 0 while a plain background change applied — classic frozen-transition behavior), so I validated the animation by asserting its start/end states rather than capturing the in-between frames. It'll animate normally in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)