### PR TITLE
League management: Admin vs League Manager split + editable league name + dev role-spoof

### DIFF
--- a/models/league.js
+++ b/models/league.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+// A league is otherwise identified only by its code (graham-league /
+// claunts-league) with a hardcoded display name; this makes the name editable
+// by a commissioner. Codes still come from scoring-defaults LEAGUES — this doc
+// just overrides the display name.
+const leagueSchema = new mongoose.Schema({
+    code: { type: String, required: true, unique: true },
+    name: { type: String, required: true }
+}, { timestamps: true });
+
+module.exports = mongoose.model('League', leagueSchema);

--- a/modules/dev-role.js
+++ b/modules/dev-role.js
@@ -1,0 +1,65 @@
+// Dev-only role spoofing. Lets a real Admin, in a non-production environment,
+// view the app as a "League Manager" or a regular member to test permissions.
+// It only ever DE-escalates (the real user must already be Admin), so it can't
+// grant access — and it's a hard no-op in production. Everything that gates on
+// roles or builds the view context reads the "effective" user/roles here, so
+// the spoof is consistent across the server gates and the client UI.
+
+const DEV = process.env.NODE_ENV !== 'production';
+const SPOOF_COOKIE = 'cc_spoof';
+
+function realRoles(oidcUser) {
+    return (oidcUser && oidcUser.user_metadata && oidcUser.user_metadata.roles) || [];
+}
+
+// Only a real (Auth0) Admin may spoof — never a spoofed identity.
+function isRealAdmin(req) {
+    return !!(req && req.oidc && req.oidc.isAuthenticated() && realRoles(req.oidc.user).includes('Admin'));
+}
+
+function getCookie(req, name) {
+    const header = (req && req.headers && req.headers.cookie) || '';
+    const hit = header.split(';').map(s => s.trim()).find(s => s.startsWith(name + '='));
+    return hit ? decodeURIComponent(hit.slice(name.length + 1)) : null;
+}
+
+// Active spoof payload { roles: [...], league?: code } or null. Gated to
+// dev + a real Admin so it can never take effect in prod or for anyone else.
+function readSpoof(req) {
+    if (!DEV || !isRealAdmin(req)) return null;
+    const raw = getCookie(req, SPOOF_COOKIE);
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw);
+        return (parsed && Array.isArray(parsed.roles)) ? parsed : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function isSpoofing(req) {
+    return readSpoof(req) !== null;
+}
+
+function effectiveRoles(req) {
+    const s = readSpoof(req);
+    return s ? s.roles : realRoles(req && req.oidc && req.oidc.user);
+}
+
+// A shallow clone of the OIDC user with roles/league overridden when spoofing,
+// so buildUserContext / userState reflect the spoof. Returns the real user
+// untouched when not spoofing.
+function effectiveUser(req) {
+    const u = req && req.oidc && req.oidc.user;
+    const s = readSpoof(req);
+    if (!s || !u) return u;
+    const um = u.user_metadata || {};
+    return Object.assign({}, u, {
+        user_metadata: Object.assign({}, um, {
+            roles: s.roles,
+            metadata: Object.assign({}, um.metadata || {}, s.league ? { league: s.league } : {})
+        })
+    });
+}
+
+module.exports = { DEV, SPOOF_COOKIE, realRoles, isRealAdmin, readSpoof, isSpoofing, effectiveRoles, effectiveUser };

--- a/modules/draft-socket.js
+++ b/modules/draft-socket.js
@@ -11,6 +11,15 @@ function isCommissioner(user) {
     return user && (user.role === 'Admin' || user.role === 'League Manager');
 }
 
+// Commissioner control is scoped by league: an Admin controls any league's
+// draft; a League Manager only their own (the league is baked into their
+// signed draft token).
+function isCommissionerOf(user, league) {
+    if (!user) return false;
+    if (user.role === 'Admin') return true;
+    return user.role === 'League Manager' && user.league === league;
+}
+
 // The shape broadcast to clients — the draft plus a derived "on the clock".
 function publicState(draft) {
     const d = draft.toObject ? draft.toObject() : draft;
@@ -84,7 +93,7 @@ module.exports = function registerDraftSockets(io) {
 
         socket.on('start-draft', async ({ league, season }) => {
             try {
-                if (!isCommissioner(socket.user)) {
+                if (!isCommissionerOf(socket.user, league)) {
                     return socket.emit('draft-error', { message: 'Only the commissioner can start the draft' });
                 }
                 const draft = await Draft.findOne({ league, season });
@@ -105,7 +114,7 @@ module.exports = function registerDraftSockets(io) {
 
         socket.on('undo-pick', async ({ league, season }) => {
             try {
-                if (!isCommissioner(socket.user)) {
+                if (!isCommissionerOf(socket.user, league)) {
                     return socket.emit('draft-error', { message: 'Only the commissioner can undo a pick' });
                 }
                 const draft = await Draft.findOne({ league, season });
@@ -138,7 +147,7 @@ module.exports = function registerDraftSockets(io) {
                 const turn = engine.whoseTurn(draft);
                 if (!turn) return socket.emit('draft-error', { message: 'Draft is complete' });
 
-                const commish = isCommissioner(socket.user);
+                const commish = isCommissionerOf(socket.user, league);
                 // A member may only pick on their own turn; a commissioner may
                 // pick for whoever is on the clock (absent member).
                 if (String(socket.user.userId) !== turn.userId && !commish) {

--- a/modules/league-access.js
+++ b/modules/league-access.js
@@ -1,0 +1,31 @@
+const crypto = require('crypto');
+const { effectiveRoles, effectiveUser } = require('./dev-role');
+
+// The league a user belongs to, from their Auth0 inner metadata flag
+// ('gg' -> graham-league, anything else -> claunts-league).
+function leagueCodeFor(oidcUser) {
+    const inner = (oidcUser && oidcUser.user_metadata && oidcUser.user_metadata.metadata) || {};
+    return inner.league === 'gg' ? 'graham-league' : 'claunts-league';
+}
+
+function tokenOk(req) {
+    const configured = process.env.INTERNAL_API_TOKEN;
+    const provided = req && req.get && req.get('X-Internal-Token');
+    if (!configured || !provided) return false;
+    const a = Buffer.from(String(provided));
+    const b = Buffer.from(String(configured));
+    return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+// May the caller manage this league? Trusted server-to-server calls (internal
+// token) and Admins: any league. League Managers: only their own. Uses
+// effective roles/user so it honors a dev role-spoof.
+function canManageLeague(req, league) {
+    if (tokenOk(req)) return true;
+    const roles = effectiveRoles(req);
+    if (roles.includes('Admin')) return true;
+    if (roles.includes('League Manager')) return leagueCodeFor(effectiveUser(req)) === league;
+    return false;
+}
+
+module.exports = { leagueCodeFor, canManageLeague };

--- a/modules/require-admin.js
+++ b/modules/require-admin.js
@@ -1,0 +1,27 @@
+const crypto = require('crypto');
+const { effectiveRoles } = require('./dev-role');
+
+function safeEqual(a, b) {
+    const bufA = Buffer.from(String(a));
+    const bufB = Buffer.from(String(b));
+    if (bufA.length !== bufB.length) return false;
+    return crypto.timingSafeEqual(bufA, bufB);
+}
+
+// Platform-wide / cross-league operations (global data sync, scoring runs,
+// market odds). Allowed only for:
+//   1. server-to-server calls carrying the internal token (scheduled jobs), OR
+//   2. an authenticated Admin session.
+// A League Manager is NOT sufficient here — those are league-scoped and use
+// requireCommissioner instead. Everything else gets 403.
+module.exports = function requireAdmin(req, res, next) {
+    const configured = process.env.INTERNAL_API_TOKEN;
+    const provided = req.get('X-Internal-Token');
+    if (configured && provided && safeEqual(provided, configured)) {
+        return next();
+    }
+    if (req.oidc && req.oidc.isAuthenticated() && effectiveRoles(req).includes('Admin')) {
+        return next();
+    }
+    return res.status(403).json({ message: 'Forbidden' });
+};

--- a/modules/require-commissioner.js
+++ b/modules/require-commissioner.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { effectiveRoles } = require('./dev-role');
 
 function safeEqual(a, b) {
     const bufA = Buffer.from(String(a));
@@ -24,7 +25,7 @@ module.exports = function requireCommissioner(req, res, next) {
     }
 
     if (req.oidc && req.oidc.isAuthenticated()) {
-        const roles = (req.oidc.user && req.oidc.user.user_metadata && req.oidc.user.user_metadata.roles) || [];
+        const roles = effectiveRoles(req);
         if (roles.includes('Admin') || roles.includes('League Manager')) {
             return next();
         }

--- a/public/admin.css
+++ b/public/admin.css
@@ -210,7 +210,16 @@
     border: 1px solid #2A2E42;
     border-radius: 4px;
     padding: 6px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
 }
+/* Let flex children (fields, labels) shrink instead of overflowing the panel,
+   which the accordion clips with overflow:hidden. */
+.draft-config-form .draft-field,
+.draft-config-form .scoring-field,
+.draft-config-form .scoring-field label { min-width: 0; }
 
 .draft-status-row {
     font-size: 0.95em;
@@ -726,8 +735,8 @@ select[scoring-config-combine-mode] { width: 100%; }
 /* Full-width form with no horizontal margin — the base rules give it
    width:100% AND margin:0.5em, so its right margin overflowed the panel and got
    clipped by the accordion's overflow:hidden (chopping the controls' right
-   edge). Keep only the vertical gap. */
-.sub-container form:not(.draft-config-form) {
+   edge). Applies to every panel form, including the draft/scoring config. */
+.sub-container form {
     width: 100%;
     margin: 0.5em 0;
     box-sizing: border-box;

--- a/public/admin.js
+++ b/public/admin.js
@@ -62,9 +62,12 @@ function setTeamOptions(data) {
     teamOptionList.forEach(selector => {
         selector.innerHTML = str;
     });
-    calculateTeamOption.innerHTML = str;
+    // The calculate-team picker lives in the Admin-only Scoring group, so it's
+    // absent for a League Manager — guard it (and the team-container clone).
+    if (calculateTeamOption) calculateTeamOption.innerHTML = str;
 
-    multiplyNode(document.querySelector('.team-container'), 10, true);
+    var teamContainer = document.querySelector('.team-container');
+    if (teamContainer) multiplyNode(teamContainer, 10, true);
 }
 
 function setSeasonOptions() {

--- a/public/admin.js
+++ b/public/admin.js
@@ -327,6 +327,39 @@ window.onload = async function() {
     loadAdminStatus();
 };
 
+// League name: rename the active league (own-league enforced server-side).
+const leagueNameForm = document.getElementById('league-name-form');
+if (leagueNameForm) {
+    leagueNameForm.addEventListener('submit', async function (event) {
+        event.preventDefault();
+        const code = getDraftLeagueCode();
+        const name = (document.querySelector('[league-name-input]').value || '').trim();
+        if (!name) {
+            failToast.options.text = 'Enter a league name';
+            failToast.showToast();
+            return;
+        }
+        try {
+            const res = await fetch('/leagues/' + code, {
+                method: 'PATCH',
+                headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.status === 200) {
+                successToast.options.text = `League renamed to "${data.name}"`;
+                successToast.showToast();
+            } else {
+                failToast.options.text = (data && data.message) || ('League name could not be saved | ' + res.status);
+                failToast.showToast();
+            }
+        } catch (err) {
+            failToast.options.text = 'League name save failed: ' + err.message;
+            failToast.showToast();
+        }
+    });
+}
+
 const createForm = document.getElementById('create-form')
 
 if (createForm) {
@@ -1089,6 +1122,18 @@ function displayBettingLinesContainer() { toggleSub('betting-lines-container'); 
 function displayExpectedWinsContainer() { toggleSub('expected-wins-container'); }
 function displayEnrichmentContainer() { toggleSub('enrichment-container'); }
 function displayApiCallsContainer() { toggleSub('api-calls-container'); }
+function displayLeagueNameContainer() { if (toggleSub('league-name-container')) loadLeagueName(); }
+
+// Prefill the league-name field with the current name for the active league.
+async function loadLeagueName() {
+    try {
+        var code = getDraftLeagueCode();
+        var list = await fetch('/leagues', { headers: { 'Accept': 'application/json' } }).then(function (r) { return r.json(); });
+        var lg = (list || []).find(function (l) { return l.code === code; });
+        var input = document.querySelector('[league-name-input]');
+        if (input && lg) input.value = lg.name;
+    } catch (e) { /* leave the field as-is */ }
+}
 
 // Full-screen "working" overlay shown while an admin request runs. It carries a
 // football loader (desktop + mobile friendly, respects reduced-motion) and, most

--- a/public/scoringRules.css
+++ b/public/scoringRules.css
@@ -83,3 +83,14 @@
         font-size: 1.2rem;
     }
 }
+
+/* Heading icons scale with the heading font (they were a fixed 20–26px, which
+   read as too small next to the large Scoring Rules headings). Scoped to
+   .rules-container so this wins over the generic injected .cc-icon sizing. */
+.rules-container .header-title .cc-icon,
+.rules-container .rule-header .cc-icon {
+    width: 1em;
+    height: 1em;
+    vertical-align: -0.12em;
+    margin-right: 0.3em;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -681,3 +681,13 @@ footer {
 @keyframes brand-draw {
     to { clip-path: inset(0 0 0 0); }
 }
+/* Dev-only role-spoof switcher in the navbar (rendered only in non-production
+   for a real Admin). Amber signals "development tool". */
+.dev-spoof { display: flex; align-items: center; gap: 4px; }
+.dev-spoof-label { font-size: 0.68rem; color: #E0B341; text-transform: uppercase; letter-spacing: 0.04em; }
+.dev-spoof button {
+    font-size: 0.72rem; padding: 3px 8px; border-radius: 6px;
+    border: 1px solid rgba(224,179,65,0.4); background: transparent; color: #E0B341; cursor: pointer;
+}
+.dev-spoof button.active { background: #E0B341; color: #101322; font-weight: 700; }
+.dev-spoof button:hover { background: rgba(224,179,65,0.18); }

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -8,6 +8,7 @@ const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
 const { resolveConfig } = require('../modules/scoring-defaults');
 const { computeGrades } = require('../modules/draft-grades');
+const { canManageLeague } = require('../modules/league-access');
 
 // Post-draft grades for a league + season — immediate preseason feedback. Each
 // roster is projected to EXPECTED FANTASY POINTS under that league's own scoring
@@ -74,6 +75,9 @@ router.post('/', async (req, res) => {
         if (!league || season == null) {
             return res.status(400).json({ message: 'league and season are required' });
         }
+        if (!canManageLeague(req, league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
 
         const existing = await Draft.findOne({ league, season });
         if (existing && (existing.status === 'active' || existing.status === 'complete')) {
@@ -113,6 +117,9 @@ router.post('/:id/start', async (req, res) => {
         if (draft == null) {
             return res.status(404).json({ message: 'Draft not found' });
         }
+        if (!canManageLeague(req, draft.league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
         if (draft.status === 'complete') {
             return res.status(409).json({ message: 'Draft is already complete' });
         }
@@ -135,14 +142,18 @@ router.post('/:id/start', async (req, res) => {
 // or wipe a mistaken start.
 router.post('/:id/reset', async (req, res) => {
     try {
+        const existing = await Draft.findById(req.params.id);
+        if (existing == null) {
+            return res.status(404).json({ message: 'Draft not found' });
+        }
+        if (!canManageLeague(req, existing.league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
         const draft = await Draft.findByIdAndUpdate(
             req.params.id,
             { $set: { status: 'pending', picks: [], currentOverall: 1, updatedAt: new Date() } },
             { new: true }
         );
-        if (draft == null) {
-            return res.status(404).json({ message: 'Draft not found' });
-        }
         res.json(draft);
     } catch (err) {
         res.status(500).json({ message: err.message });

--- a/routes/leagues.js
+++ b/routes/leagues.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const router = express.Router();
+const League = require('../models/league');
+const { LEAGUES } = require('../modules/scoring-defaults');
+const { canManageLeague } = require('../modules/league-access');
+
+// List leagues with their (editable) display names, falling back to the
+// hardcoded defaults for any league without a saved name.
+router.get('/', async (req, res) => {
+    try {
+        const docs = await League.find({}, { code: 1, name: 1, _id: 0 }).lean();
+        const byCode = {};
+        docs.forEach(d => { byCode[d.code] = d.name; });
+        const list = LEAGUES.map(l => ({ code: l.code, name: byCode[l.code] || l.name }));
+        res.json(list);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Rename a league. Commissioner-gated upstream (server.js); here we enforce
+// that a League Manager can only rename their OWN league (Admins: any).
+router.patch('/:code', async (req, res) => {
+    try {
+        const code = req.params.code;
+        if (!LEAGUES.some(l => l.code === code)) {
+            return res.status(404).json({ message: 'Unknown league' });
+        }
+        if (!canManageLeague(req, code)) {
+            return res.status(403).json({ message: 'Forbidden' });
+        }
+        const name = ((req.body && req.body.name) || '').trim();
+        if (!name) return res.status(400).json({ message: 'Name is required' });
+        if (name.length > 40) return res.status(400).json({ message: 'Name too long (40 characters max)' });
+
+        const doc = await League.findOneAndUpdate(
+            { code },
+            { code, name },
+            { new: true, upsert: true }
+        );
+        res.json({ code: doc.code, name: doc.name });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const ScoringConfig = require('../models/scoringConfig');
 const { resolveConfig, fieldsForModel } = require('../modules/scoring-defaults');
+const { canManageLeague } = require('../modules/league-access');
 
 // Attaches the ordered field metadata (for the admin form + rules page) to a
 // resolved config. `fields` reflect the resolved `disabled` set via each
@@ -33,6 +34,9 @@ router.post('/', async (req, res) => {
         const { league, model, values, combineMode, disabled } = req.body;
         if (!league) {
             return res.status(400).json({ message: 'league is required' });
+        }
+        if (!canManageLeague(req, league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
         }
         const resolved = resolveConfig(league, { model, values, combineMode, disabled });
         const doc = await ScoringConfig.findOneAndUpdate(

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const User = require('../models/user');
 const scoring = require('../modules/scoring');
 const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
+const { canManageLeague } = require('../modules/league-access');
 
 // Self-service profile edit: a signed-in user updates THEIR OWN franchise name
 // / avatar / onboarding flag. The identity comes from the Auth0 session (never
@@ -140,6 +141,11 @@ router.get('/:id/season', async (req, res) => {
 //Creating One
 router.post('/', async (req, res) => {
 
+    // A League Manager may only add players to their own league (Admins: any).
+    if (!canManageLeague(req, req.body.league)) {
+        return res.status(403).json({ message: 'Forbidden: not your league' });
+    }
+
     var date = new Date();
     var centralTime = date.toLocaleString("en-US", {timeZone: "America/Chicago"});
 
@@ -219,6 +225,10 @@ router.patch('/draft/:id', getUserNewSeason, async (req, res) => {
 
 //Deleting One
 router.delete('/:id', getUser, async (req, res) => {
+    // A League Manager may only remove players from their own league.
+    if (!canManageLeague(req, res.user.league)) {
+        return res.status(403).json({ message: 'Forbidden: not your league' });
+    }
     try {
         await res.user.deleteOne();
         res.json({message: 'Deleted User'});

--- a/server.js
+++ b/server.js
@@ -12,8 +12,12 @@ const schedule = require('node-schedule');
 const { auth } = require('express-openid-connect');
 const requireAuthOrToken = require('./modules/require-auth');
 const requireCommissioner = require('./modules/require-commissioner');
+const requireAdmin = require('./modules/require-admin');
+const devRole = require('./modules/dev-role');
+const { leagueCodeFor } = require('./modules/league-access');
 const ScoringConfig = require('./models/scoringConfig');
 const User = require('./models/user');
+const League = require('./models/league');
 const { resolveConfig, fieldsForModel, LEAGUES } = require('./modules/scoring-defaults');
 const draftToken = require('./modules/draft-token');
 const registerDraftSockets = require('./modules/draft-socket');
@@ -65,6 +69,35 @@ app.locals.leagues = LEAGUES;
 // auth router attaches /login, /logout, and /callback routes to the baseURL
 app.use(auth(config));
 
+// Dev role-spoof + view context. Resolves the effective user (honors an Admin's
+// active role spoof in non-production; a no-op in prod / for non-Admins) and
+// exposes dev flags to every view. The render routes and the role gates all
+// read this, so a spoof is consistent across server checks and the client UI.
+app.use((req, res, next) => {
+    req.effUser = devRole.effectiveUser(req);
+    res.locals.devMode = devRole.DEV;
+    res.locals.canSpoof = devRole.DEV && devRole.isRealAdmin(req);
+    res.locals.spoof = devRole.readSpoof(req); // {roles, league} | null, for the dev widget
+    next();
+});
+
+// Per-request league display names (editable via /leagues) for the navbar
+// switcher — HTML GETs only, falling back to the hardcoded defaults.
+app.use(async (req, res, next) => {
+    res.locals.leagues = LEAGUES;
+    try {
+        if (req.method === 'GET' && (req.headers.accept || '').includes('text/html')) {
+            const docs = await League.find({}, { code: 1, name: 1, _id: 0 }).lean();
+            if (docs.length) {
+                const byCode = {};
+                docs.forEach(d => { byCode[d.code] = d.name; });
+                res.locals.leagues = LEAGUES.map(l => ({ code: l.code, name: byCode[l.code] || l.name }));
+            }
+        }
+    } catch (e) { /* fall back to defaults */ }
+    next();
+});
+
 // Make the logged-in member's avatar available to every rendered view, so the
 // navbar can show their profile photo instead of a generic icon. One indexed
 // lookup per page navigation (guarded to HTML GETs so it never fires for static
@@ -101,9 +134,9 @@ app.get('/profile', requiresAuth(), (req, res) => {
 // Mint a short-lived signed token the browser uses to authenticate its draft
 // socket connection. Requires a real Auth0 session so the identity is trusted.
 app.get('/draft-token', requiresAuth(), (req, res) => {
-  const ctx = buildUserContext(req.oidc.user);
+  const ctx = buildUserContext(req.effUser);
   const token = draftToken.sign(
-    { userId: ctx.userId, role: ctx.role, name: ctx.firstName },
+    { userId: ctx.userId, role: ctx.role, name: ctx.firstName, league: leagueCodeFor(req.effUser) },
     process.env.AUTH_SECRET
   );
   res.json({ token });
@@ -133,9 +166,9 @@ db.on('open', () => console.log('Connected to Database'));
 // req.isAuthenticated is provided from the auth router
 app.get('/', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
+        const user = buildUserContext(req.effUser);
 
-        const userState = safeJson(req.oidc.user);
+        const userState = safeJson(req.effUser);
 
         res.render('standings', {user, userState});
     } else {
@@ -149,8 +182,8 @@ app.get('/valentine', (req, res) => {
 
 app.get('/standings', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
-        const userState = safeJson(req.oidc.user);
+        const user = buildUserContext(req.effUser);
+        const userState = safeJson(req.effUser);
 
         res.render('standings', {user, userState});
     } else {
@@ -160,8 +193,8 @@ app.get('/standings', (req, res) => {
 
 app.get('/rules', async (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
-        const userState = safeJson(req.oidc.user);
+        const user = buildUserContext(req.effUser);
+        const userState = safeJson(req.effUser);
 
         // Render the rules from the league's scoring config so the page can
         // never drift from the engine.
@@ -185,9 +218,9 @@ app.get('/rules', async (req, res) => {
 
 app.get('/draft-room', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
+        const user = buildUserContext(req.effUser);
         user.isDraft = false;
-        const userState = safeJson(req.oidc.user);
+        const userState = safeJson(req.effUser);
 
         res.render('draftRoom', {user, userState});
     } else {
@@ -197,15 +230,17 @@ app.get('/draft-room', (req, res) => {
 
 app.get('/admin', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
+        const user = buildUserContext(req.effUser);
         // Only commissioners get the admin page; other members go home.
-        const roles = (req.oidc.user && req.oidc.user.user_metadata && req.oidc.user.user_metadata.roles) || [];
+        // Effective roles so a dev role-spoof is honored.
+        const roles = devRole.effectiveRoles(req);
         if (!roles.includes('Admin') && !roles.includes('League Manager')) {
             return res.redirect('/');
         }
-        const userState = safeJson(req.oidc.user);
+        const userState = safeJson(req.effUser);
+        const isAdmin = roles.includes('Admin');
 
-        res.render('admin', {user, userState, year: process.env.YEAR});
+        res.render('admin', {user, userState, year: process.env.YEAR, isAdmin});
     } else {
         res.redirect("/login");
     }
@@ -213,8 +248,8 @@ app.get('/admin', (req, res) => {
 
 app.get('/index', (req, res) => {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
-        const userState = safeJson(req.oidc.user);
+        const user = buildUserContext(req.effUser);
+        const userState = safeJson(req.effUser);
 
         res.render('standings', {user, userState});
     } else {
@@ -224,8 +259,8 @@ app.get('/index', (req, res) => {
 
 app.get('/userHome', async function(req, res) {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
-        const userState = safeJson(req.oidc.user);
+        const user = buildUserContext(req.effUser);
+        const userState = safeJson(req.effUser);
 
         res.render('userHome', {user, userState, cloudinary: cloudinaryConfig()});
     } else {
@@ -235,8 +270,8 @@ app.get('/userHome', async function(req, res) {
 
 app.get('/team', async function(req, res) {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
-        const userState = safeJson(req.oidc.user);
+        const user = buildUserContext(req.effUser);
+        const userState = safeJson(req.effUser);
 
         res.render('team', {user, userState});
     } else {
@@ -246,8 +281,8 @@ app.get('/team', async function(req, res) {
 
 app.get('/hall-of-fame', async function(req, res) {
     if (req.oidc.isAuthenticated()) {
-        const user = buildUserContext(req.oidc.user);
-        const userState = safeJson(req.oidc.user);
+        const user = buildUserContext(req.effUser);
+        const userState = safeJson(req.effUser);
 
         res.render('history', {user, userState});
     } else {
@@ -259,14 +294,24 @@ app.use(express.json());
 app.use(express.static('public'));
 app.use('/images',  express.static('images'));
 
-// Authorization: state-changing (non-GET) API calls require a commissioner
-// session or the internal token. Reads stay open to any authenticated member.
-// /teams/teamLogos is a POST but a member-safe read, so it's exempted.
+// Authorization for state-changing (non-GET) API calls, in two tiers:
+//   - Platform-wide data sync, scoring runs, and market odds -> Admin only
+//     (requireAdmin).
+//   - League-scoped setup (roster, draft, scoring config, league name) -> any
+//     commissioner (requireCommissioner); the handlers additionally enforce
+//     that a League Manager can only touch their OWN league.
+// GET reads stay open to any authenticated member, and the internal token
+// passes both tiers so scheduled jobs keep working. /teams/teamLogos is a
+// member-safe POST read, so it's exempted.
 app.use('/teams', (req, res, next) => {
     if (req.method === 'GET' || (req.method === 'POST' && req.path === '/teamLogos')) return next();
-    return requireCommissioner(req, res, next);
+    return requireAdmin(req, res, next);
 });
-app.use(['/users', '/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/draft', '/scoring-config', '/job-runs'], (req, res, next) => {
+app.use(['/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/job-runs'], (req, res, next) => {
+    if (req.method === 'GET') return next();
+    return requireAdmin(req, res, next);
+});
+app.use(['/users', '/draft', '/scoring-config', '/leagues'], (req, res, next) => {
     if (req.method === 'GET') return next();
     // Self-service profile edit is scoped to the caller's own record (identity
     // comes from the session in the handler), so it doesn't need commissioner.
@@ -304,6 +349,27 @@ app.use('/draft', requireAuthOrToken, draftRouter);
 const scoringConfigRouter = require('./routes/scoringConfig');
 app.use('/scoring-config', requireAuthOrToken, scoringConfigRouter);
 
+const leaguesRouter = require('./routes/leagues');
+app.use('/leagues', requireAuthOrToken, leaguesRouter);
+
+// Dev-only role spoofing: a real Admin (non-production only) can view the app
+// as a League Manager or a regular member to test permissions. Sets/clears the
+// cookie the effective-roles resolver reads. Returns 404 in production or for
+// anyone who isn't a real Admin, so it can never be an escalation path.
+app.post('/dev/spoof', (req, res) => {
+    if (!devRole.DEV || !devRole.isRealAdmin(req)) return res.status(404).end();
+    const role = (req.body && req.body.role) || '';   // 'Admin' | 'League Manager' | 'member'
+    const league = (req.body && req.body.league) || undefined;
+    const roles = role === 'member' ? [] : (role ? [role] : []);
+    res.cookie(devRole.SPOOF_COOKIE, JSON.stringify({ roles, league }), { sameSite: 'lax', httpOnly: true });
+    res.json({ ok: true, roles, league: league || null });
+});
+app.post('/dev/spoof/reset', (req, res) => {
+    if (!devRole.DEV || !devRole.isRealAdmin(req)) return res.status(404).end();
+    res.clearCookie(devRole.SPOOF_COOKIE);
+    res.json({ ok: true });
+});
+
 const jobRunsRouter = require('./routes/jobRuns');
 app.use('/job-runs', requireAuthOrToken, jobRunsRouter);
 
@@ -313,7 +379,7 @@ app.use('/standings', requireAuthOrToken, standingsRouter);
 const historyRouter = require('./routes/history');
 app.use('/history', requireAuthOrToken, historyRouter);
 
-app.get('/calculate-team-score/:season/:teamId/:teamName', requireCommissioner, async (req, res) => {
+app.get('/calculate-team-score/:season/:teamId/:teamName', requireAdmin, async (req, res) => {
     var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);
 
     if (response.status == 200) {

--- a/tests/Permissions.spec.js
+++ b/tests/Permissions.spec.js
@@ -1,0 +1,96 @@
+process.env.INTERNAL_API_TOKEN = 'test-internal-token';
+
+const requireAdmin = require('../modules/require-admin');
+const requireCommissioner = require('../modules/require-commissioner');
+const { canManageLeague } = require('../modules/league-access');
+const { effectiveRoles } = require('../modules/dev-role');
+
+function mkReq({ roles = [], authed = true, token = null, cookie = '', innerLeague = null } = {}) {
+    return {
+        get: (h) => (h === 'X-Internal-Token' ? token : undefined),
+        headers: { cookie },
+        oidc: {
+            isAuthenticated: () => authed,
+            user: authed ? { user_metadata: { roles, metadata: innerLeague ? { league: innerLeague } : {} } } : null
+        }
+    };
+}
+function mkRes() {
+    return { statusCode: 200, body: null, status(c) { this.statusCode = c; return this; }, json(b) { this.body = b; return this; } };
+}
+function run(mw, req) {
+    const res = mkRes();
+    let nexted = false;
+    mw(req, res, () => { nexted = true; });
+    return { nexted, status: res.statusCode, body: res.body };
+}
+
+describe('requireAdmin', () => {
+    test('valid internal token passes (jobs)', () => {
+        expect(run(requireAdmin, mkReq({ authed: false, token: 'test-internal-token' })).nexted).toBe(true);
+    });
+    test('Admin session passes', () => {
+        expect(run(requireAdmin, mkReq({ roles: ['Admin'] })).nexted).toBe(true);
+    });
+    test('League Manager is forbidden', () => {
+        const r = run(requireAdmin, mkReq({ roles: ['League Manager'] }));
+        expect(r.nexted).toBe(false);
+        expect(r.status).toBe(403);
+    });
+    test('regular member is forbidden', () => {
+        expect(run(requireAdmin, mkReq({ roles: [] })).status).toBe(403);
+    });
+});
+
+describe('requireCommissioner', () => {
+    test('Admin and League Manager both pass', () => {
+        expect(run(requireCommissioner, mkReq({ roles: ['Admin'] })).nexted).toBe(true);
+        expect(run(requireCommissioner, mkReq({ roles: ['League Manager'] })).nexted).toBe(true);
+    });
+    test('regular member is forbidden', () => {
+        expect(run(requireCommissioner, mkReq({ roles: [] })).status).toBe(403);
+    });
+    test('internal token passes', () => {
+        expect(run(requireCommissioner, mkReq({ authed: false, token: 'test-internal-token' })).nexted).toBe(true);
+    });
+});
+
+describe('canManageLeague (own-league)', () => {
+    test('internal token can manage any league', () => {
+        expect(canManageLeague(mkReq({ authed: false, token: 'test-internal-token' }), 'claunts-league')).toBe(true);
+    });
+    test('Admin can manage any league', () => {
+        expect(canManageLeague(mkReq({ roles: ['Admin'], innerLeague: 'gg' }), 'claunts-league')).toBe(true);
+    });
+    test('League Manager can manage their own league only', () => {
+        const graham = mkReq({ roles: ['League Manager'], innerLeague: 'gg' });
+        expect(canManageLeague(graham, 'graham-league')).toBe(true);
+        expect(canManageLeague(graham, 'claunts-league')).toBe(false);
+        const claunts = mkReq({ roles: ['League Manager'], innerLeague: 'cl' });
+        expect(canManageLeague(claunts, 'claunts-league')).toBe(true);
+        expect(canManageLeague(claunts, 'graham-league')).toBe(false);
+    });
+    test('regular member cannot manage any league', () => {
+        expect(canManageLeague(mkReq({ roles: [] }), 'graham-league')).toBe(false);
+    });
+});
+
+describe('dev role spoof (effectiveRoles)', () => {
+    const spoofCookie = (obj) => 'cc_spoof=' + encodeURIComponent(JSON.stringify(obj));
+
+    test('a real Admin with a spoof cookie takes on the spoofed roles', () => {
+        const req = mkReq({ roles: ['Admin'], cookie: spoofCookie({ roles: ['League Manager'] }) });
+        expect(effectiveRoles(req)).toEqual(['League Manager']);
+    });
+    test('spoofing "member" (empty roles) de-escalates the Admin', () => {
+        const req = mkReq({ roles: ['Admin'], cookie: spoofCookie({ roles: [] }) });
+        expect(effectiveRoles(req)).toEqual([]);
+    });
+    test('a non-Admin cannot spoof (cookie ignored)', () => {
+        const req = mkReq({ roles: ['League Manager'], cookie: spoofCookie({ roles: ['Admin'] }) });
+        expect(effectiveRoles(req)).toEqual(['League Manager']);
+    });
+    test('no cookie returns the real roles', () => {
+        expect(effectiveRoles(mkReq({ roles: ['Admin'] }))).toEqual(['Admin']);
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -31,7 +31,7 @@
 
     <div class="header">
         <div class="header-title">
-            Admin
+            <%= isAdmin ? 'Admin' : 'League Management' %>
         </div>
     </div>
 

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -52,6 +52,8 @@
 
     <div class="admin-status" admin-status hidden></div>
 
+    <% /* Platform-wide groups: Admins only. League Managers see just League setup. */ %>
+    <% if (isAdmin) { %>
     <section class="admin-group">
         <div class="group-head"><h2>Scoring — force a run</h2><span class="group-count">3</span></div>
         <div class="admin-functions">
@@ -282,9 +284,26 @@
         </div>
     </section>
 
+    <% } %>
+
     <section class="admin-group">
-        <div class="group-head"><h2>League setup</h2><span class="group-count">4</span></div>
+        <div class="group-head"><h2>League setup</h2><span class="group-count">5</span></div>
         <div class="admin-functions">
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayLeagueNameContainer()">
+                        <i class="fa-solid fa-pen" style="padding-right: 5px;"></i>
+                        League Name
+                    </button>
+                </div>
+                <div class="sub-container" league-name-container style="display: none">
+                    <p class="function-description">Set the display name shown in the league switcher and page headers.</p>
+                    <form id="league-name-form">
+                        <div><input type="text" league-name-input maxlength="40" placeholder="League name"></div>
+                        <div><button type="submit">Save Name</button></div>
+                    </form>
+                </div>
+            </div>
             <div class="function-container">
                 <div class="button-container">
                     <button onclick="displayDraftConfigContainer()">
@@ -411,6 +430,7 @@
         </div>
     </section>
 
+    <% if (isAdmin) { %>
     <section class="admin-group">
         <div class="group-head"><h2>Monitoring</h2><span class="group-count">1</span></div>
         <div class="admin-functions">
@@ -431,6 +451,7 @@
             </div>
         </div>
     </section>
+    <% } %>
 
     <footer>
         <a href="https://collegefootballdata.com/" class="cfb-data">Powered by College Football Data</a>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -45,8 +45,11 @@
     </button>
     <div class="navbar-links" id="navbar-links">
         <ul>
-            <% if (user && user.role == "Admin") { %>
-            <li><a admin-page href="./admin">Admin</a></li>
+            <% var _role = (user && user.role) || ''; %>
+            <% if (_role === 'Admin' || _role === 'League Manager') { %>
+            <li><a admin-page href="./admin"><%= _role === 'Admin' ? 'Admin' : 'League Management' %></a></li>
+            <% } %>
+            <% if (_role === 'Admin') { %>
             <li league-selector>
                 <div class="dropdown dropdown-nav">
                     <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -77,6 +80,18 @@
                 <% } %>
                 <span class="nav-label">My Team</span>
             </a></li>
+            <% } %>
+            <% if (typeof canSpoof !== 'undefined' && canSpoof) {
+                 var _sp = (typeof spoof !== 'undefined' && spoof) ? spoof : null;
+                 var _cur = !_sp ? 'Admin'
+                     : ((_sp.roles || []).indexOf('League Manager') >= 0 ? 'League Manager'
+                     : ((_sp.roles || []).indexOf('Admin') >= 0 ? 'Admin' : 'member')); %>
+            <li class="dev-spoof" aria-label="Dev role spoof">
+                <span class="dev-spoof-label">Dev · view as</span>
+                <button type="button" data-spoof="Admin" class="<%= _cur === 'Admin' ? 'active' : '' %>">Admin</button>
+                <button type="button" data-spoof="League Manager" class="<%= _cur === 'League Manager' ? 'active' : '' %>">League&nbsp;Mgr</button>
+                <button type="button" data-spoof="member" class="<%= _cur === 'member' ? 'active' : '' %>">Member</button>
+            </li>
             <% } %>
             <li><a href="./logout">Logout</a></li>
         </ul>
@@ -144,6 +159,18 @@
                 a.classList.add('active');
                 a.setAttribute('aria-current', 'page');
             }
+        });
+
+        // --- Dev-only role spoof buttons (rendered only when canSpoof). ---
+        nav.querySelectorAll('.dev-spoof [data-spoof]').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var role = btn.getAttribute('data-spoof');
+                fetch('/dev/spoof', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ role: role })
+                }).then(function () { location.reload(); });
+            });
         });
     })();
 </script>


### PR DESCRIPTION
Turns **League Manager** into a real, scoped role, and adds two supporting capabilities. One combined PR as requested.

## 1. Permissions split (enforced server-side)
Previously League Manager == Admin at the API layer, with the differences only hidden in the UI. Now:

- **New `requireAdmin`** (Admin session *or* internal token) gates every **platform-wide write**: `/scores` runs, `/games`, `/rankings`, `/recruiting`, `/records`, `/betting`, `/teams` refresh·enrich·CFP-odds, `/calculate-team-score`.
- **`requireCommissioner`** (Admin *or* League Manager) stays on **league-scoped writes** (`/users`, `/draft`, `/scoring-config`, `/leagues`), and each handler now enforces an **own-league guard** (`canManageLeague`) — a League Manager can only touch *their own* league. The internal token still passes both tiers so scheduled jobs keep working.
- **Draft socket** control is scoped too: a League Manager can only run their own league's draft (the league is baked into the signed draft token).
- **Navbar** shows the console to League Managers, labelled **"League Management"** (Admins: **"Admin"**); the cross-league switcher stays Admin-only.
- **Admin page** renders the global groups only for Admins; a League Manager sees just **League setup**.

## 2. Editable league name
New `League` model `{ code, name }` + `GET`/`PATCH /leagues` (own-league on PATCH), falling back to the hardcoded defaults. A **"League Name"** function in the League-setup group; the navbar switcher reads names per request.

## 3. Dev role-spoof (non-production only)
A real Admin can **view as** a League Manager or a regular member to test permissions. Effective roles resolve from a spoof cookie that's honored **only in dev for a real Admin**, so server gates and client UI stay consistent. It only ever **de-escalates**, and `/dev/spoof` 404s in production — never an escalation path.

## Verification
- **136 tests pass**, incl. a new `Permissions` spec: `requireAdmin` (Admin/token pass, LM/member 403), `canManageLeague` (own-league only), and the spoof resolver (real Admin can spoof, non-Admin can't).
- **EJS renders** for both roles: Admin → all 5 groups; League Manager → League setup only; spoofer + League Name present; navbar label + spoof active-state correct.

### ⚠️ Not click-tested
The browser session expired mid-build and I can't re-authenticate (credentials are off-limits), so I could **not** exercise the live flows: the spoof buttons actually switching role, the member redirect off `/admin`, and the league-name save round-trip. The underlying logic is covered by the unit tests and template renders, but please click through these after pulling — the spoofer makes it quick (View as → League Manager / Member).

🤖 Generated with [Claude Code](https://claude.com/claude-code)