### PR TITLE
Weekly Recap: per-user recap card + story popup (#212)

### DIFF
--- a/modules/weekly-recap.js
+++ b/modules/weekly-recap.js
@@ -1,0 +1,355 @@
+// Pure, DB-free per-manager weekly recap — a personal "here's your week" card.
+// It's the same math the League Highlights use (public/standings-insights.js),
+// scoped to ONE manager and ONE week: weekly score, league rank + movement,
+// margin vs the league average, the roster's MVP team, and a one-line
+// narrative. routes/standings.js gathers the league's per-season data (and an
+// optional upset index) and hands it here. Kept DB-free so it's unit-testable
+// AND so a future weekly-recap EMAIL job can reuse it verbatim — no rework.
+
+function ordinal(n) {
+    const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+const round = (v) => Math.round((v || 0) * 10) / 10;
+
+// Effective week number so a postseason entry always sorts after Week 16.
+// weeklyScore[].season is overloaded as a type tag ('postseason'); some data
+// also just uses week > 16.
+function effWeek(entry) {
+    if (!entry) return 0;
+    if (entry.season === 'postseason' || entry.week > 16) return 17;
+    return entry.week;
+}
+function weekLabel(entry) {
+    if (!entry) return '';
+    return effWeek(entry) === 17 ? 'Postseason' : 'Week ' + entry.week;
+}
+function seasonOf(user, season) {
+    return (user && user.seasons || []).find(s => String(s.season) === String(season)) || null;
+}
+// Cumulative points through effective-week W (inclusive) — matches how the
+// season total is summed, but bounded by week.
+function cumThrough(weekly, W) {
+    return (weekly || []).reduce((sum, e) => effWeek(e) <= W ? sum + (e.score || 0) : sum, 0);
+}
+// Rank (1 = best) of userId among the league by cumulative-through-W. Null if
+// the user isn't in the set.
+// Standard competition ranking (1 + managers strictly ahead) so ties SHARE a
+// rank instead of getting arbitrary DB-order placements. Returns { rank, tie }
+// (tie = another manager holds the exact same total), or null if not found.
+function rankAt(leagueSeasons, W, userId) {
+    const mine = leagueSeasons.find(ls => String(ls.userId) === String(userId));
+    if (!mine) return null;
+    const myCum = cumThrough(mine.weekly, W);
+    let ahead = 0, shared = 0;
+    leagueSeasons.forEach(ls => {
+        const c = cumThrough(ls.weekly, W);
+        if (c > myCum) ahead += 1;
+        else if (c === myCum && String(ls.userId) !== String(userId)) shared += 1;
+    });
+    return { rank: ahead + 1, tie: shared > 0 };
+}
+
+// Index completed regular-season games to underdog-winner info, keyed by
+// gameId, for the layered "upset" narrative. spreadByGameId is the home
+// spread (CFBD convention: a POSITIVE home spread means the home team was the
+// underdog by that many points). Only games the underdog actually won land in
+// the index. rankByWeek (optional) is { [week]: { [school]: apRank } } — the AP
+// poll the loser held entering that week, so the narrative can read "upset of
+// #3 Georgia". Mirrors modules/standings-highlights.js biggestUpsetCard.
+function indexUpsets(games, spreadByGameId, rankByWeek) {
+    const out = {};
+    (games || []).forEach(g => {
+        if (!g.completed) return;
+        const homeWon = g.homePoints > g.awayPoints;
+        const awayWon = g.awayPoints > g.homePoints;
+        if (!homeWon && !awayWon) return;
+        const spread = spreadByGameId ? spreadByGameId[g.id] : undefined;
+        if (spread == null) return;
+        const margin = homeWon ? (spread > 0 ? spread : null) : (spread < 0 ? -spread : null);
+        if (margin == null || margin <= 0) return;
+        const loser = homeWon ? g.awayTeam : g.homeTeam;
+        const wk = rankByWeek && g.week != null ? rankByWeek[g.week] : null;
+        out[g.id] = {
+            winner: homeWon ? g.homeTeam : g.awayTeam,
+            loser,
+            loserRank: (wk && wk[loser] != null) ? wk[loser] : null,
+            margin: round(margin),
+            winScore: homeWon ? g.homePoints : g.awayPoints,
+            loseScore: homeWon ? g.awayPoints : g.homePoints
+        };
+    });
+    return out;
+}
+
+// The one-line story. Deterministic and rule-based (the reliable base); when a
+// rostered team won as a betting underdog that week, the upset flavor takes
+// over ("Oregon's upset over Georgia as a 10.5-pt underdog powered your week").
+function narrate({ score, rank, rankDelta, rankTie, vsLeagueAvg, mvp, upset }) {
+    const place = rank != null ? (rankTie ? 'T-' : '') + ordinal(rank) : null;
+    const move = rankDelta == null ? null
+        : rankDelta > 0 ? `climbed ${rankDelta} spot${rankDelta > 1 ? 's' : ''}`
+        : rankDelta < 0 ? `slipped ${-rankDelta} spot${-rankDelta > 1 ? 's' : ''}`
+        : 'held steady';
+    const moved = move && rankDelta; // truthy only on an actual climb/slip
+
+    if (score <= 0 && (!mvp || mvp.score <= 0)) return 'Quiet week — no points banked.';
+
+    // Layered: an underdog win on your roster is the story worth telling.
+    if (upset) {
+        const foe = upset.loser ? `${upset.loserRank ? '#' + upset.loserRank + ' ' : ''}${upset.loser}` : '';
+        const beat = foe ? ` over ${foe}` : '';
+        const dog = upset.margin ? ` as a ${upset.margin}-pt underdog` : '';
+        const tail = place ? (moved ? `, ${move} to ${place}` : `, good for ${place}`) : '';
+        return `${upset.team}'s upset${beat}${dog} powered your ${score}-pt week${tail}.`;
+    }
+
+    const avg = vsLeagueAvg == null ? ''
+        : vsLeagueAvg > 0 ? `, ${vsLeagueAvg} above the league average`
+        : vsLeagueAvg < 0 ? `, ${-vsLeagueAvg} below the league average`
+        : ', right on the league average';
+    const lead = mvp && mvp.score > 0 ? `${mvp.school}'s ${mvp.score} pts led the way` : `${score} pts`;
+    if (moved) return `${lead} as you ${move} to ${place}${avg}.`;
+    return `${lead}${avg}${place ? ` — holding at ${place}` : ''}.`;
+}
+
+// Build one recap object per week the manager has played, oldest → newest.
+//   user         — the profile user's full doc (all seasons)
+//   leagueUsers  — every user in the league (full docs) for rank + average
+//   season       — the season to recap (number or string)
+//   upsetByGameId — optional output of indexUpsets(), for the upset narrative
+function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
+    const mySeason = seasonOf(user, season);
+    const result = { userId: String(user && user._id), season: Number(season), recaps: [] };
+    if (!mySeason || !(mySeason.weeklyScore || []).length) return result;
+
+    const leagueSeasons = (leagueUsers || [])
+        .map(u => { const s = seasonOf(u, season); return s ? { userId: String(u._id), weekly: s.weeklyScore || [] } : null; })
+        .filter(Boolean);
+
+    // Roster meta by school name (scoreByTeam[].team is the school string).
+    const metaBySchool = {};
+    (mySeason.teams || []).forEach(t => { metaBySchool[t.school] = t; });
+    const logoFor = (school) => {
+        const m = metaBySchool[school];
+        return m && m.logos && m.logos.length ? m.logos[m.logos.length - 1] : null;
+    };
+
+    // Distinct effective weeks across the whole league, ascending — so "the
+    // previous week" for rank movement is the real prior week, not W-1 (which
+    // may not exist).
+    const weekSet = new Set();
+    leagueSeasons.forEach(ls => ls.weekly.forEach(e => weekSet.add(effWeek(e))));
+    const weeksAsc = [...weekSet].sort((a, b) => a - b);
+
+    // Per-week league stats (average / high / low) so slides can call out
+    // "top score of the week", the margin vs average, streaks, etc.
+    const weekStats = {};
+    weeksAsc.forEach(W => {
+        const arr = [];
+        leagueSeasons.forEach(ls => {
+            // One sample PER MANAGER (summed across any games/entries that week),
+            // so a manager with multiple entries in a week isn't double-counted.
+            let sum = 0, played = false;
+            ls.weekly.forEach(e => { if (effWeek(e) === W) { sum += (e.score || 0); played = true; } });
+            if (played) arr.push(sum);
+        });
+        weekStats[W] = {
+            avg: arr.length ? round(arr.reduce((s, v) => s + v, 0) / arr.length) : null,
+            max: arr.length ? round(Math.max(...arr)) : null,
+            min: arr.length ? round(Math.min(...arr)) : null,
+            count: arr.length
+        };
+    });
+
+    // Fold entries that share an effective week (e.g. multiple postseason rounds
+    // both tagged 'postseason') into one, so each week yields exactly one recap.
+    const byEff = new Map();
+    (mySeason.weeklyScore || []).forEach(e => {
+        const W = effWeek(e);
+        if (!byEff.has(W)) byEff.set(W, { week: e.week, season: e.season, score: 0, scoreByTeam: [] });
+        const agg = byEff.get(W);
+        agg.score += (e.score || 0);
+        (e.scoreByTeam || []).forEach(st => agg.scoreByTeam.push(st));
+    });
+    const myWeekly = [...byEff.values()].sort((a, b) => effWeek(a) - effWeek(b));
+    // Running state for the "momentum" slide (season high, streaks, milestones).
+    let runningMax = -Infinity, runningTotal = 0, aboveStreak = 0, belowStreak = 0, regularWeeksSeen = 0;
+
+    result.recaps = myWeekly.map(entry => {
+        const W = effWeek(entry);
+        const wi = weeksAsc.indexOf(W);
+        const prevW = wi > 0 ? weeksAsc[wi - 1] : null;
+        const score = round(entry.score || 0);
+        const stats = weekStats[W] || {};
+
+        const rankInfo = rankAt(leagueSeasons, W, user._id);
+        const rank = rankInfo ? rankInfo.rank : null;
+        const rankTie = rankInfo ? rankInfo.tie : false;
+        const prevInfo = prevW != null ? rankAt(leagueSeasons, prevW, user._id) : null;
+        const prevRank = prevInfo ? prevInfo.rank : null;
+        const rankDelta = (rank != null && prevRank != null) ? (prevRank - rank) : null; // + = climbed
+
+        const leagueAvg = stats.avg;
+        const vsLeagueAvg = leagueAvg != null ? round(score - leagueAvg) : null;
+        // stats.max/min are rounded to match `score`; small epsilon guards floats.
+        const weekHigh = stats.count > 1 && stats.max != null && score >= stats.max - 0.05 && score > 0;
+        const weekLow = stats.count > 1 && stats.min != null && score <= stats.min + 0.05;
+
+        // MVP + dud among this week's roster teams. Sum per team first — a team
+        // can appear multiple times in one entry (e.g. several postseason games),
+        // so the MVP is a team's total for the week, not a single game.
+        const teamAgg = {};
+        (entry.scoreByTeam || []).forEach(st => {
+            const t = teamAgg[st.team] || (teamAgg[st.team] = { school: st.team, score: 0, logo: logoFor(st.team) });
+            t.score = round(t.score + (st.score || 0));
+        });
+        const teams = Object.values(teamAgg);
+        let mvp = null, dud = null;
+        teams.forEach(t => {
+            if (!mvp || t.score > mvp.score) mvp = t;
+            if (!dud || t.score < dud.score) dud = t;
+        });
+        const teamCount = teams.length;
+        // All teams tied for the week's best (so co-MVPs surface together).
+        const mvpTeams = mvp ? teams.filter(t => t.score === mvp.score) : [];
+        const mvpShare = (mvp && score > 0) ? Math.round((mvp.score / score) * 100) : null;
+        // Only call out a "dud" when there's real spread on the roster.
+        const dudTeam = (dud && teamCount > 1 && mvp && dud.score < mvp.score) ? dud : null;
+
+        // Upset flavor: the biggest-underdog win among this week's roster games.
+        let upset = null;
+        if (upsetByGameId) {
+            (entry.scoreByTeam || []).forEach(st => {
+                const u = st.gameId != null ? upsetByGameId[st.gameId] : null;
+                if (u && u.winner === st.team && (!upset || u.margin > upset.margin)) {
+                    upset = { team: st.team, loser: u.loser, loserRank: u.loserRank, margin: u.margin, fantasy: round(st.score || 0), logo: logoFor(st.team) };
+                }
+            });
+        }
+
+        // Momentum. "Season high" compares REGULAR-season weeks only — the
+        // postseason is expected to be the biggest week (bonuses stack across
+        // several games), so calling it a new high isn't real news. The finale
+        // gets its own season-wrap beat instead (see buildSlides).
+        runningTotal += score;
+        const isRegularWeek = W <= 16;
+        // "New high" only when the manager has a PRIOR regular week of their own
+        // to beat — gate on their own played-week count, not the league index wi
+        // (a manager whose first scored week isn't the league's earliest would
+        // otherwise get a bogus season-high on week one).
+        const isSeasonHigh = isRegularWeek && regularWeeksSeen > 0 && score > 0 && score > runningMax;
+        if (isRegularWeek) { runningMax = Math.max(runningMax, score); regularWeeksSeen += 1; }
+        if (vsLeagueAvg != null && vsLeagueAvg > 0) { aboveStreak += 1; belowStreak = 0; }
+        else if (vsLeagueAvg != null && vsLeagueAvg < 0) { belowStreak += 1; aboveStreak = 0; }
+        else { aboveStreak = 0; belowStreak = 0; }
+        const prevTotal = runningTotal - score;                           // largest ×50 crossed this week
+        const topMultiple = Math.floor(runningTotal / 50) * 50;
+        const milestone = (topMultiple >= 50 && topMultiple > prevTotal) ? topMultiple : null;
+
+        const recap = {
+            week: entry.week, effWeek: W, label: weekLabel(entry),
+            score, rank, rankDelta, rankTie, leagueAvg, vsLeagueAvg, weekHigh, weekLow,
+            mvpTeam: mvp, mvpTeams, mvpShare, dudTeam, isUpset: !!upset, upset,
+            isSeasonHigh, aboveAvgStreak: aboveStreak, belowAvgStreak: belowStreak,
+            cumTotal: round(runningTotal), milestone,
+            narrative: narrate({ score, rank, rankDelta, rankTie, vsLeagueAvg, mvp, upset })
+        };
+        recap.slides = buildSlides(recap);
+        return recap;
+    });
+
+    return result;
+}
+
+// Turn one enriched recap into an ordered deck of one-idea-per-slide "story"
+// beats for the popup carousel. Slides only appear when they have something to
+// say (like the League Highlights cards), so a quiet week stays short. Shape
+// per slide: { id, icon, kicker, title, big?, logo?, text?, sub?, tone, cta? }.
+function buildSlides(r) {
+    const slides = [];
+    const place = r.rank != null ? (r.rankTie ? 'T-' : '') + ordinal(r.rank) : null;
+
+    // Hook — the week + headline score.
+    slides.push({ id: 'hook', icon: 'flame', kicker: 'Weekly Recap', title: r.label, big: String(r.score), sub: 'points banked', tone: 'neutral' });
+
+    // Rank + movement.
+    if (r.rank != null) {
+        const moveSub = r.rankDelta == null ? 'your first week on the board'
+            : r.rankDelta > 0 ? `up ${r.rankDelta} spot${r.rankDelta > 1 ? 's' : ''} from last week`
+            : r.rankDelta < 0 ? `down ${-r.rankDelta} spot${-r.rankDelta > 1 ? 's' : ''} from last week`
+            : 'held your ground';
+        slides.push({ id: 'rank', icon: r.rankDelta > 0 ? 'riser' : 'chart', kicker: 'Where you stand', title: 'League rank', big: place, sub: moveSub, tone: r.rankDelta > 0 ? 'good' : (r.rankDelta < 0 ? 'bad' : 'neutral') });
+    }
+
+    // Top / bottom of the week (league-wide bragging rights or humbling).
+    if (r.weekHigh) slides.push({ id: 'weekhigh', icon: 'trophy', kicker: 'Bragging rights', title: 'Top score of the week', big: String(r.score), sub: 'nobody in the league scored more', tone: 'good' });
+    else if (r.weekLow) slides.push({ id: 'weeklow', icon: 'heartbreak', kicker: 'Oof', title: 'Low score of the week', big: String(r.score), sub: 'league-low this week — it happens', tone: 'bad' });
+
+    // Margin vs the field.
+    if (r.vsLeagueAvg != null) {
+        slides.push({ id: 'vsavg', icon: 'target', kicker: 'vs the field', title: 'League average', big: (r.vsLeagueAvg > 0 ? '+' : '') + r.vsLeagueAvg, sub: `you ${r.score} · league avg ${r.leagueAvg}`, tone: r.vsLeagueAvg > 0 ? 'good' : (r.vsLeagueAvg < 0 ? 'bad' : 'neutral') });
+    }
+
+    // MVP spotlight (co-MVPs when teams tie for the week's best).
+    if (r.mvpTeam && r.mvpTeam.score > 0) {
+        const tied = (r.mvpTeams && r.mvpTeams.length) ? r.mvpTeams : [r.mvpTeam];
+        const isTie = tied.length > 1;
+        slides.push({
+            id: 'mvp', icon: 'medal',
+            kicker: isTie ? 'Co-MVPs' : 'Your MVP',
+            title: tied.map(t => t.school).join(' & '),
+            big: String(r.mvpTeam.score),
+            logos: tied.map(t => t.logo).filter(Boolean),
+            sub: isTie ? `${r.mvpTeam.score} pts each` : (r.mvpShare != null ? `${r.mvpShare}% of your points` : 'top team this week'),
+            tone: 'good'
+        });
+    }
+
+    // The dud.
+    if (r.dudTeam) {
+        slides.push({ id: 'dud', icon: 'snowflake', kicker: 'The dud', title: r.dudTeam.school, big: String(r.dudTeam.score), logo: r.dudTeam.logo, sub: 'quietest team on your roster', tone: 'bad' });
+    }
+
+    // The upset (with AP rank when the loser was ranked).
+    if (r.upset) {
+        const foe = `${r.upset.loserRank ? '#' + r.upset.loserRank + ' ' : ''}${r.upset.loser}`;
+        slides.push({ id: 'upset', icon: 'upset', kicker: 'Upset alert', title: r.upset.team, big: 'UPSET', logo: r.upset.logo, sub: `beat ${foe} as a ${r.upset.margin}-pt underdog`, tone: 'good' });
+    }
+
+    // Momentum — a single beat. On the finale, wrap the season (the postseason
+    // being your biggest week is expected, not a "new high"). Otherwise:
+    // season high › milestone › hot streak › cold streak.
+    if (r.effWeek === 17) slides.push({ id: 'seasonwrap', icon: 'star', kicker: 'Season in the books', title: 'Season total', big: String(r.cumTotal), sub: place ? `${place} place — that's a wrap` : "that's a wrap on the season", tone: 'good' });
+    else if (r.isSeasonHigh) slides.push({ id: 'seasonhigh', icon: 'burst', kicker: 'Personal best', title: 'New season high!', big: String(r.score), sub: 'your biggest week yet', tone: 'good' });
+    else if (r.milestone) slides.push({ id: 'milestone', icon: 'star', kicker: 'Milestone', title: `${r.milestone} points`, big: String(r.cumTotal), sub: 'season total and climbing', tone: 'good' });
+    else if (r.aboveAvgStreak >= 2) slides.push({ id: 'streak', icon: 'flame', kicker: 'On a heater', title: `${r.aboveAvgStreak} weeks hot`, big: '🔥', sub: `${r.aboveAvgStreak} straight weeks above the league average`, tone: 'good' });
+    else if (r.belowAvgStreak >= 2) slides.push({ id: 'coldstreak', icon: 'snowflake', kicker: 'Cold stretch', title: `${r.belowAvgStreak} weeks cold`, big: '❄️', sub: `${r.belowAvgStreak} straight weeks below average — bounce-back time`, tone: 'bad' });
+
+    // Closing — the one-line story + the CTA.
+    slides.push({ id: 'closing', icon: 'checkered', kicker: 'The story', title: 'Your week', text: r.narrative, tone: 'neutral', cta: true });
+
+    return slides;
+}
+
+// ---- Weekly-popup gating (mirrored in public/weekly-recap.js) --------------
+// The recap popup fires once per "recap week", which opens each Monday 07:00
+// local — by then the weekend's scoring jobs have finalized the week. The key
+// is the ISO date of that Monday-07:00 boundary; the client stores the last
+// key it showed and only pops when the current key differs.
+function recapWindowKey(date) {
+    const d = new Date(date.getTime());
+    const sinceMonday = (d.getDay() + 6) % 7;       // 0 = Mon … 6 = Sun
+    const boundary = new Date(d.getFullYear(), d.getMonth(), d.getDate() - sinceMonday, 7, 0, 0, 0);
+    if (d < boundary) boundary.setDate(boundary.getDate() - 7);   // before Mon 7am → last week's
+    const y = boundary.getFullYear(), m = String(boundary.getMonth() + 1).padStart(2, '0'), day = String(boundary.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+// Only nudge during the CFB season window (Aug–Jan) so the popup doesn't nag
+// through the offseason; the recap stays available on My Team year-round.
+function isRecapSeason(date) {
+    const m = date.getMonth() + 1;
+    return m >= 8 || m === 1;
+}
+
+module.exports = { buildWeeklyRecaps, buildSlides, indexUpsets, narrate, effWeek, weekLabel, cumThrough, rankAt, recapWindowKey, isRecapSeason };

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -507,6 +507,7 @@
     .grade-chip-caret { transition: none; }
 }
 
+
 /* Roster table zebra fix. Odd rows carry no background of their own, so the
    frozen Team / Team Score columns show #101322 while the middle cells let the
    lighter profile card (#1A1F33) bleed through — a two-tone, inconsistent row.

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -103,7 +103,48 @@ async function getUser() {
         ensureWeekSelected(data[0]);
         displaySchedule(data[0]);
         loadHomeGrades(data[0]);
+        renderRecap(data[0]);
     });
+}
+
+// Weekly Recap on the profile: a "here's your week" card tucked behind a hero
+// pill (like the Draft grade chip). Rendering + the app-wide weekly popup live
+// in public/weekly-recap.js (window.ccRecap); here we just fetch, mount the
+// collapsed card, and wire the pill to expand it.
+async function renderRecap(user) {
+    const el = document.getElementById('uh-recap');
+    const chip = document.querySelector('[recap-chip]');
+    if (!el || !chip || !window.ccRecap || !user || !user.league || !(user.seasons || []).length) return;
+
+    // Recap the latest season that actually has weekly scores, so the pill is
+    // useful in the offseason too (shows last season's finish).
+    const played = (user.seasons || [])
+        .filter(s => (s.weeklyScore || []).length > 0)
+        .sort((a, b) => Number(b.season) - Number(a.season));
+    if (!played.length) return;
+
+    try {
+        const data = await window.ccRecap.fetchRecap(user.league, played[0].season, user._id);
+        if (!data || !(data.recaps || []).length) return;
+        const latest = window.ccRecap.mountInline(el, data);
+
+        // Teaser on the pill: latest week + rank + movement arrow.
+        const teaser = document.querySelector('[recap-chip-teaser]');
+        if (teaser && latest) {
+            const place = latest.rank != null ? escapeHtml(ordinal(latest.rank)) : '';
+            teaser.innerHTML = `${escapeHtml(latest.label)} · ${place} ${window.ccRecap.movement(latest.rankDelta)}`;
+        }
+        chip.hidden = false;
+        if (!chip.dataset.wired) {
+            chip.dataset.wired = '1';
+            chip.addEventListener('click', () => {
+                const open = el.classList.toggle('is-open');
+                chip.setAttribute('aria-expanded', String(open));
+            });
+        }
+    } catch (e) {
+        console.error('weekly recap failed:', e);
+    }
 }
 
 // Draft grade on the profile: just THIS manager's own most-recent-season card,

--- a/public/weekly-recap.css
+++ b/public/weekly-recap.css
@@ -1,0 +1,341 @@
+/* Weekly Recap — shared styles for the My Team card, the hero pill, and the
+   once-a-week popup. Loaded app-wide via the navbar partial so the popup can
+   render on any page. Palette matches the app's dark theme. */
+
+/* ---------- Hero pill + collapsible card (My Team) ---------- */
+.profile-chips { display: flex; flex-wrap: wrap; gap: 0.6em; }
+
+.recap-chip-teaser {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #F4F6FB;
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.uh-recap {
+    width: 92%;
+    max-width: 720px;
+    margin: 0 auto;
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.32s ease;
+}
+.uh-recap.is-open { max-height: 1200px; margin-top: 1.1rem; }
+
+.recap-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1em 1.5em;
+    flex-wrap: wrap;
+    margin-bottom: 0.75rem;
+}
+/* The card header is a section label, not a page title — override the global
+   .header-title (48px) so it doesn't dwarf the card and blow out the spacing. */
+.recap-head .header-title {
+    margin: 0;
+    padding: 0;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    font-weight: 700;
+}
+.recap-week-picker { display: flex; flex-direction: column; gap: 3px; }
+.recap-week-caption {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #767D9C;
+}
+.recap-week-picker select {
+    background: #101322;
+    border: 1px solid #3A3F58;
+    border-radius: 8px;
+    color: #F4F6FB;
+    font: inherit;
+    font-size: 0.85rem;
+    padding: 6px 10px;
+    cursor: pointer;
+}
+
+/* ---------- The recap card (shared by My Team + popup) ---------- */
+.recap-card {
+    background: #1A1F33;
+    border: 1px solid #2A2E42;
+    border-radius: 14px;
+    padding: 1.1em 1.25em;
+}
+.recap-narrative {
+    margin: 0 0 1em;
+    font-size: 1.02rem;
+    line-height: 1.5;
+    color: #F4F6FB;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5em;
+}
+.recap-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #5BD08D;
+    background: rgba(91, 208, 141, 0.12);
+    border: 1px solid rgba(91, 208, 141, 0.35);
+    border-radius: 20px;
+    padding: 2px 8px;
+}
+.recap-badge svg { width: 0.9em; height: 0.9em; }
+.recap-stats { display: flex; flex-wrap: wrap; gap: 1.75em; }
+.recap-stats .stat { display: flex; flex-direction: column; }
+.recap-stats .stat .stat-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #F4F6FB;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.recap-stats .stat .stat-value img { height: 1.2rem; width: auto; }
+.recap-stats .stat .stat-label {
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #767D9C;
+    margin-top: 2px;
+}
+.recap-move { font-size: 0.9rem; font-weight: 700; }
+.recap-move.up { color: #5BD08D; }
+.recap-move.down { color: #ED5858; }
+.recap-move.flat { color: #767D9C; }
+
+/* ---------- Weekly popup ---------- */
+.recap-popup-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1em;
+    background: rgba(8, 10, 20, 0);
+    -webkit-backdrop-filter: blur(0px);
+    backdrop-filter: blur(0px);
+    transition: background 0.28s ease, backdrop-filter 0.28s ease;
+}
+.recap-popup-backdrop.is-in {
+    background: rgba(8, 10, 20, 0.6);
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+}
+.recap-popup {
+    position: relative;
+    width: 100%;
+    max-width: 460px;
+    background: #171B2E;
+    border: 1px solid #2A2E42;
+    border-radius: 18px;
+    padding: 1.5em 1.5em 1.35em;
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    transform: translateY(22px) scale(0.94);
+    transition: opacity 0.34s ease, transform 0.42s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.recap-popup-backdrop.is-in .recap-popup { opacity: 1; transform: translateY(0) scale(1); }
+.recap-popup-close {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    background: transparent;
+    border: none;
+    color: #A4A9C2;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 8px;
+}
+.recap-popup-close { z-index: 3; }
+.recap-popup-close:hover { color: #F4F6FB; background: #2A2E42; }
+.recap-popup-link {
+    display: inline-block;
+    margin-top: 1.1em;
+    color: #8E8CF0;
+    font-weight: 600;
+    font-size: 0.92rem;
+    text-decoration: none;
+    position: relative;
+    z-index: 3;
+}
+.recap-popup-link:hover { text-decoration: underline; }
+
+/* ---------- Story carousel ---------- */
+.recap-story { max-width: 420px; padding: 2.4em 1.4em 1.5em; overflow: hidden; }
+
+/* Segmented progress bars, Instagram/Wrapped style. */
+.recap-progress {
+    position: absolute;
+    top: 12px;
+    left: 16px;
+    right: 46px;
+    display: flex;
+    gap: 5px;
+    z-index: 3;
+}
+.recap-progress span {
+    flex: 1;
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.16);
+    transition: background 0.3s ease;
+}
+.recap-progress span.filled { background: #8E8CF0; }
+
+.recap-story-viewport { overflow: hidden; cursor: pointer; }
+.recap-story-track {
+    display: flex;
+    transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.recap-slide {
+    flex: 0 0 100%;
+    min-height: 268px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 0.45em;
+    /* Generous side padding so titles/numbers never underlap the ‹ › nav
+       buttons (which sit ~46px in from the popup edge). */
+    padding: 0.4em 1.7rem;
+}
+/* Screen-reader-only live region announcing "Slide X of N". */
+.recap-sr {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0 0 0 0);
+    white-space: nowrap; border: 0;
+}
+.recap-slide-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #8E8CF0;
+}
+.recap-slide-kicker svg { width: 1em; height: 1em; }
+.recap-slide-logo { width: 66px; height: 66px; object-fit: contain; margin: 0.1em 0; }
+.recap-slide-logos { display: flex; gap: 0.7em; align-items: center; justify-content: center; flex-wrap: wrap; }
+.recap-slide-logos .recap-slide-logo { width: 54px; height: 54px; }
+.recap-slide-title { font-size: 1.35rem; font-weight: 700; color: #F4F6FB; line-height: 1.2; }
+.recap-slide-big { font-size: 3.1rem; font-weight: 800; line-height: 1; letter-spacing: -0.01em; }
+.recap-slide-big.good { color: #5BD08D; }
+.recap-slide-big.bad { color: #ED5858; }
+.recap-slide-big.neutral { color: #F4F6FB; }
+.recap-slide-text { margin: 0.2em 0 0; font-size: 1.08rem; line-height: 1.5; color: #F4F6FB; max-width: 320px; }
+.recap-slide-sub { font-size: 0.82rem; color: #A4A9C2; max-width: 300px; }
+
+/* Faint tap-affordance chevrons (visual only). */
+.recap-nav-hint {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 56px;
+    font-size: 1.7rem;
+    line-height: 1;
+    color: rgba(244, 246, 251, 0.4);
+    background: transparent;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    z-index: 5;
+    -webkit-tap-highlight-color: transparent;
+    transition: color 0.15s ease, background 0.15s ease;
+}
+.recap-nav-hint:hover { color: #F4F6FB; background: rgba(255, 255, 255, 0.06); }
+.recap-nav-hint:focus-visible { outline: 2px solid #8E8CF0; outline-offset: 2px; }
+.recap-nav-hint.left { left: 6px; }
+.recap-nav-hint.right { right: 6px; }
+
+/* Per-slide entrance choreography — each element starts hidden and is animated
+   in when its slide becomes .is-active. showSlide() re-arms the class on every
+   navigation, so the beats replay each time you land on a slide. */
+.recap-slide-kicker,
+.recap-slide .recap-slide-logo,
+.recap-slide-title,
+.recap-slide-big,
+.recap-slide-text,
+.recap-slide-sub,
+.recap-slide .recap-popup-link { opacity: 0; }
+
+.recap-slide.is-active .recap-slide-kicker { animation: recap-fade-up 0.45s ease both 0.02s; }
+.recap-slide.is-active .recap-slide-logo { animation: recap-pop-in 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both 0.12s; }
+.recap-slide.is-active .recap-slide-logos .recap-slide-logo:nth-child(2) { animation-delay: 0.22s; }
+.recap-slide.is-active .recap-slide-logos .recap-slide-logo:nth-child(3) { animation-delay: 0.32s; }
+.recap-slide.is-active .recap-slide-logos .recap-slide-logo:nth-child(4) { animation-delay: 0.42s; }
+.recap-slide.is-active .recap-slide-title { animation: recap-fade-up 0.45s ease both 0.18s; }
+.recap-slide.is-active .recap-slide-big { animation: recap-pop 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both 0.26s; }
+.recap-slide.is-active .recap-slide-text { animation: recap-fade-up 0.5s ease both 0.2s; }
+.recap-slide.is-active .recap-slide-sub { animation: recap-fade-up 0.45s ease both 0.36s; }
+.recap-slide.is-active .recap-popup-link { animation: recap-fade-up 0.45s ease both 0.46s; }
+
+/* The upset "UPSET" lands like a stamp, tilted for swagger. */
+.recap-slide[data-slide-id="upset"].is-active .recap-slide-big { animation: recap-stamp 0.5s cubic-bezier(0.2, 1.4, 0.3, 1) both 0.26s; }
+
+@keyframes recap-fade-up {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes recap-pop {
+    0%   { opacity: 0; transform: scale(0.6); }
+    60%  { opacity: 1; transform: scale(1.08); }
+    100% { opacity: 1; transform: scale(1); }
+}
+@keyframes recap-pop-in {
+    0%   { opacity: 0; transform: scale(0.3) rotate(-8deg); }
+    70%  { opacity: 1; transform: scale(1.1) rotate(3deg); }
+    100% { opacity: 1; transform: scale(1) rotate(0); }
+}
+@keyframes recap-stamp {
+    0%   { opacity: 0; transform: scale(2) rotate(-12deg); }
+    60%  { opacity: 1; transform: scale(0.92) rotate(3deg); }
+    100% { opacity: 1; transform: scale(1) rotate(-4deg); }
+}
+
+@media (max-width: 600px) {
+    .recap-stats { gap: 1.25em; }
+    .recap-narrative { font-size: 0.95rem; }
+    .recap-slide-big { font-size: 2.6rem; }
+    .recap-slide-title { font-size: 1.2rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .uh-recap,
+    .recap-popup-backdrop,
+    .recap-popup,
+    .recap-story-track,
+    .recap-progress span { transition: none; }
+    /* Keep every slide element visible with no motion. */
+    .recap-slide-kicker,
+    .recap-slide .recap-slide-logo,
+    .recap-slide-title,
+    .recap-slide-big,
+    .recap-slide-text,
+    .recap-slide-sub,
+    .recap-slide .recap-popup-link { opacity: 1; animation: none !important; }
+}

--- a/public/weekly-recap.js
+++ b/public/weekly-recap.js
@@ -1,0 +1,275 @@
+// Shared Weekly Recap client: rendering + the app-wide weekly popup. Loaded on
+// every page via the navbar partial, so both the My Team card and the popup
+// draw from one place. The popup fires once per "recap week" (opens Monday
+// 07:00 local), the same window the server module documents. Exposes
+// window.ccRecap for userHome.js to mount the inline card.
+(function () {
+    'use strict';
+
+    function escapeHtml(v) {
+        return String(v == null ? '' : v)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+    function ordinal(n) {
+        const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
+        return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+    // Movement chip: ▲ climbed / ▼ slipped / – held.
+    function movement(delta) {
+        if (delta == null || delta === 0) return '<span class="recap-move flat">–</span>';
+        if (delta > 0) return `<span class="recap-move up">▲${delta}</span>`;
+        return `<span class="recap-move down">▼${-delta}</span>`;
+    }
+    function statTile(valueHtml, label) {
+        return `<div class="stat"><span class="stat-value">${valueHtml}</span><span class="stat-label">${escapeHtml(label)}</span></div>`;
+    }
+
+    // One week's recap card body (narrative + optional UPSET badge + tiles).
+    function cardHtml(r) {
+        if (!r) return '';
+        const tiles = [];
+        tiles.push(statTile(String(r.score), 'Points this week'));
+        if (r.rank != null) tiles.push(statTile(`${escapeHtml(ordinal(r.rank))} ${movement(r.rankDelta)}`, 'League rank'));
+        if (r.vsLeagueAvg != null) {
+            const tone = r.vsLeagueAvg > 0 ? 'up' : (r.vsLeagueAvg < 0 ? 'down' : 'flat');
+            const txt = r.vsLeagueAvg > 0 ? `+${r.vsLeagueAvg}` : String(r.vsLeagueAvg);
+            tiles.push(statTile(`<span class="recap-move ${tone}">${txt}</span>`, 'vs league avg'));
+        }
+        if (r.mvpTeam && r.mvpTeam.score > 0) {
+            const tied = (r.mvpTeams && r.mvpTeams.length) ? r.mvpTeams : [r.mvpTeam];
+            const logos = tied.map(t => t.logo ? `<img src="${escapeHtml(t.logo)}" alt="">` : '').join('');
+            tiles.push(statTile(`${logos}${r.mvpTeam.score}`, `MVP: ${tied.map(t => t.school).join(' & ')}`));
+        }
+        const badge = r.isUpset ? `<span class="recap-badge">${window.ccIcon ? window.ccIcon('upset', { size: 16 }) : ''} Upset</span>` : '';
+        return `
+            <p class="recap-narrative">${escapeHtml(r.narrative)}${badge}</p>
+            <div class="recap-stats">${tiles.join('')}</div>`;
+    }
+
+    function selectorHtml(recaps) {
+        return recaps.map(r => `<option value="${r.effWeek}">${escapeHtml(r.label)}</option>`).join('');
+    }
+
+    async function fetchRecap(league, season, userId) {
+        const res = await fetch(
+            `/standings/recap/${encodeURIComponent(league)}/${encodeURIComponent(season)}/${encodeURIComponent(userId)}`,
+            { headers: { 'Accept': 'application/json' } });
+        if (!res.ok) return null;
+        return res.json();
+    }
+
+    // Mount the full "Your Week" card (header + week selector + body) into `el`,
+    // defaulting to the latest week. Returns the latest recap so the caller can
+    // build a teaser (used by the My Team pill). Does not reveal `el` itself —
+    // the caller controls that (collapsed behind the pill).
+    function mountInline(el, data) {
+        const recaps = (data && data.recaps) || [];
+        if (!recaps.length) return null;
+        el.innerHTML = `
+            <div class="recap-head">
+                <div class="header-title">Your Week</div>
+                <label class="recap-week-picker">
+                    <span class="recap-week-caption">Recap week</span>
+                    <select recap-week aria-label="Recap week">${selectorHtml(recaps)}</select>
+                </label>
+            </div>
+            <div class="recap-card" recap-body></div>`;
+        const sel = el.querySelector('[recap-week]');
+        const body = el.querySelector('[recap-body]');
+        const paint = () => {
+            const r = recaps.find(x => String(x.effWeek) === sel.value) || recaps[recaps.length - 1];
+            body.innerHTML = cardHtml(r);
+            if (window.ccHydrateIcons) window.ccHydrateIcons(body);
+        };
+        sel.addEventListener('change', paint);
+        sel.value = String(recaps[recaps.length - 1].effWeek);
+        paint();
+        return recaps[recaps.length - 1];
+    }
+
+    // ---- Weekly popup: a swipe/tap "story" carousel -------------------------
+
+    let openEl = null, lastFocused = null, prevBodyOverflow = '';
+    function closePopup() {
+        if (!openEl) return;
+        const el = openEl; openEl = null;
+        el.classList.remove('is-in');
+        document.removeEventListener('keydown', onKey);
+        document.body.style.overflow = prevBodyOverflow;   // release scroll lock
+        const done = () => el.remove();
+        el.addEventListener('transitionend', done, { once: true });
+        setTimeout(done, 450);   // fallback if transitions don't fire
+        // Return focus to whatever opened the popup (a11y).
+        if (lastFocused && typeof lastFocused.focus === 'function') { try { lastFocused.focus(); } catch (e) { /* gone */ } }
+        lastFocused = null;
+    }
+    function onKey(e) {
+        if (!openEl) return;
+        if (e.key === 'Escape') closePopup();
+        else if (e.key === 'ArrowRight') openEl._next();
+        else if (e.key === 'ArrowLeft') openEl._prev();
+    }
+
+    // One story beat. Big number/emoji, optional team logo, or a narrative line.
+    function slideHtml(s, ctaHref) {
+        const logo = (Array.isArray(s.logos) && s.logos.length)
+            ? `<div class="recap-slide-logos">${s.logos.map(u => `<img class="recap-slide-logo" src="${escapeHtml(u)}" alt="">`).join('')}</div>`
+            : (s.logo ? `<img class="recap-slide-logo" src="${escapeHtml(s.logo)}" alt="">` : '');
+        const big = s.big != null ? `<div class="recap-slide-big ${s.tone || 'neutral'}">${escapeHtml(s.big)}</div>` : '';
+        const text = s.text ? `<p class="recap-slide-text">${escapeHtml(s.text)}</p>` : '';
+        const sub = s.sub ? `<div class="recap-slide-sub">${escapeHtml(s.sub)}</div>` : '';
+        const cta = (s.cta && ctaHref) ? `<a class="recap-popup-link" href="${ctaHref}">See all weeks →</a>` : '';
+        return `<div class="recap-slide tone-${s.tone || 'neutral'}" data-slide-id="${s.id || ''}">
+            <div class="recap-slide-kicker">${window.ccIcon ? window.ccIcon(s.icon, { size: 15 }) : ''} ${escapeHtml(s.kicker || '')}</div>
+            ${logo}
+            <div class="recap-slide-title">${escapeHtml(s.title || '')}</div>
+            ${big}${text}${sub}${cta}
+        </div>`;
+    }
+
+    function showPopup(data, userId) {
+        if (openEl) { openEl.remove(); document.removeEventListener('keydown', onKey); openEl = null; }   // never stack
+        const recaps = (data && data.recaps) || [];
+        if (!recaps.length) return;
+        lastFocused = document.activeElement;   // to restore on close
+        const latest = recaps[recaps.length - 1];
+        const slides = (latest.slides && latest.slides.length) ? latest.slides
+            : [{ id: 'only', icon: 'flame', kicker: 'Weekly Recap', title: latest.label, text: latest.narrative, tone: 'neutral', cta: true }];
+        const ctaHref = userId ? `/userHome?user=${encodeURIComponent(userId)}` : null;
+
+        const el = document.createElement('div');
+        el.className = 'recap-popup-backdrop';
+        el.innerHTML = `
+            <div class="recap-popup recap-story" role="dialog" aria-modal="true" aria-label="Weekly recap">
+                <div class="recap-progress" aria-hidden="true">${slides.map(() => '<span></span>').join('')}</div>
+                <span class="recap-sr" aria-live="polite"></span>
+                <button type="button" class="recap-popup-close" aria-label="Close">&times;</button>
+                <div class="recap-story-viewport">
+                    <div class="recap-story-track">${slides.map(s => slideHtml(s, ctaHref)).join('')}</div>
+                </div>
+                <button type="button" class="recap-nav-hint left" aria-label="Previous">‹</button>
+                <button type="button" class="recap-nav-hint right" aria-label="Next">›</button>
+            </div>`;
+
+        const track = el.querySelector('.recap-story-track');
+        const bars = el.querySelectorAll('.recap-progress span');
+        const slideEls = Array.from(track.children);
+        const prevBtn = el.querySelector('.recap-nav-hint.left');
+        const nextBtn = el.querySelector('.recap-nav-hint.right');
+        const sr = el.querySelector('.recap-sr');
+        let idx = 0;
+        const showSlide = (i) => {
+            idx = Math.max(0, Math.min(slides.length - 1, i));
+            track.style.transform = `translateX(${-idx * 100}%)`;
+            bars.forEach((b, n) => b.classList.toggle('filled', n <= idx));
+            if (sr) sr.textContent = `Slide ${idx + 1} of ${slides.length}`;
+            // Nothing to go back to on the first beat.
+            if (prevBtn) prevBtn.style.visibility = idx === 0 ? 'hidden' : 'visible';
+            // Replay the current slide's content animation each time it's shown:
+            // drop the class off everyone, force a reflow, re-arm the active one.
+            slideEls.forEach(s => s.classList.remove('is-active'));
+            void slideEls[idx].offsetWidth;
+            slideEls[idx].classList.add('is-active');
+        };
+        el._next = () => { if (idx < slides.length - 1) showSlide(idx + 1); else closePopup(); };
+        el._prev = () => { if (idx > 0) showSlide(idx - 1); };
+        if (prevBtn) prevBtn.addEventListener('click', (e) => { e.stopPropagation(); el._prev(); });
+        if (nextBtn) nextBtn.addEventListener('click', (e) => { e.stopPropagation(); el._next(); });
+
+        // Tap left third / right two-thirds to page; leave links + the close
+        // button to their own handlers. Measure against the VIEWPORT (fixed) —
+        // the track's own rect shifts with its translateX and would mis-zone.
+        const viewport = el.querySelector('.recap-story-viewport');
+        let swiped = false;   // set by a swipe so the synthesized click doesn't double-advance
+        viewport.addEventListener('click', (e) => {
+            if (swiped) { swiped = false; return; }
+            if (e.target.closest('a')) return;
+            const r = viewport.getBoundingClientRect();
+            (e.clientX - r.left) < r.width * 0.33 ? el._prev() : el._next();
+        });
+        // Swipe on touch.
+        let sx = null;
+        el.addEventListener('touchstart', (e) => { sx = e.touches[0].clientX; }, { passive: true });
+        el.addEventListener('touchend', (e) => {
+            if (sx == null) return;
+            const dx = e.changedTouches[0].clientX - sx; sx = null;
+            if (Math.abs(dx) > 40) { swiped = true; (dx < 0 ? el._next() : el._prev()); }
+        });
+        el.addEventListener('click', (e) => {
+            if (e.target === el || e.target.closest('.recap-popup-close')) closePopup();
+        });
+        // Focus trap: keep Tab inside the dialog while it's open.
+        el.addEventListener('keydown', (e) => {
+            if (e.key !== 'Tab') return;
+            const f = Array.from(el.querySelectorAll('button:not([disabled]), a[href]'))
+                .filter(x => x.offsetParent !== null);
+            if (!f.length) return;
+            const first = f[0], last = f[f.length - 1];
+            if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+            else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+        });
+
+        prevBodyOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';   // lock background scroll
+        document.body.appendChild(el);
+        if (window.ccHydrateIcons) window.ccHydrateIcons(el);
+        openEl = el;
+        document.addEventListener('keydown', onKey);
+        showSlide(0);
+        void el.offsetWidth;             // reflow so the entrance transition runs
+        el.classList.add('is-in');
+        const closeBtn = el.querySelector('.recap-popup-close');
+        if (closeBtn) closeBtn.focus();   // move focus into the dialog
+    }
+
+    // ---- Gating (mirror of modules/weekly-recap.js) -------------------------
+    function recapWindowKey(date) {
+        const d = new Date(date.getTime());
+        const sinceMonday = (d.getDay() + 6) % 7;
+        const b = new Date(d.getFullYear(), d.getMonth(), d.getDate() - sinceMonday, 7, 0, 0, 0);
+        if (d < b) b.setDate(b.getDate() - 7);
+        const y = b.getFullYear(), m = String(b.getMonth() + 1).padStart(2, '0'), day = String(b.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    }
+    function isRecapSeason(date) { const m = date.getMonth() + 1; return m >= 8 || m === 1; }
+
+    const SEEN_KEY = 'ccRecapPopupSeen';
+
+    // Decide + show the popup once per recap week. `force` (?recapPopup=1)
+    // bypasses the gate for testing.
+    async function maybeShowPopup(opts) {
+        opts = opts || {};
+        const now = new Date();
+        const here = (location.pathname || '').replace(/\/+$/, '');
+        if (!opts.force) {
+            if (!isRecapSeason(now)) return;
+            if (here === '/userHome') return;                 // already visible there
+            if (localStorage.getItem(SEEN_KEY) === recapWindowKey(now)) return;
+        }
+        const data = await fetchRecap(opts.league, 'latest', opts.userId);
+        if (!data || !(data.recaps || []).length) return;     // nothing to show yet — don't burn the key
+        showPopup(data, opts.userId);
+        if (!opts.force) localStorage.setItem(SEEN_KEY, recapWindowKey(now));
+    }
+
+    window.ccRecap = { cardHtml, selectorHtml, fetchRecap, mountInline, showPopup, closePopup, maybeShowPopup, recapWindowKey, isRecapSeason, movement, ordinal };
+
+    // App-wide auto-run: after the page's userState is in scope, offer the
+    // weekly popup to the logged-in viewer (their own recap, not the profile
+    // being viewed).
+    if (typeof document !== 'undefined') {
+        document.addEventListener('DOMContentLoaded', function () {
+            try {
+                const meta = window.userState && window.userState.user_metadata && window.userState.user_metadata.metadata;
+                if (!meta || !meta.userId) return;
+                const league = meta.league === 'gg' ? 'graham-league' : 'claunts-league';
+                const force = new URLSearchParams(location.search).get('recapPopup') === '1';
+                window.ccRecap.maybeShowPopup({ league: league, userId: meta.userId, force: force });
+            } catch (e) { /* non-fatal */ }
+        });
+    }
+
+    // Allow node/jest to exercise the pure gating helpers.
+    if (typeof module !== 'undefined' && module.exports) module.exports = { recapWindowKey, isRecapSeason };
+})();

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -12,6 +12,7 @@ const { resolveConfig } = require('../modules/scoring-defaults');
 const { buildRankingProxy, buildPoolContext } = require('../modules/draft-projection');
 const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
+const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
 
 // Advanced league highlights that need data the Standings payload doesn't carry
 // (records/xWins, games+rankings, draft order). Read-only; returns cards in the
@@ -148,6 +149,81 @@ router.get('/projections/:league/:season', async (req, res) => {
         }));
 
         res.json({ league, season, managers: payload });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Per-manager Weekly Recap: one "here's your week" card per played week for a
+// single manager — score, rank + movement, vs league average, MVP team, and a
+// one-line narrative. Same math as League Highlights, scoped to one user, plus
+// a layered upset narrative when a rostered team won as a betting underdog.
+// Read-only. The compute lives in modules/weekly-recap.js so a future recap
+// EMAIL can reuse it unchanged.
+router.get('/recap/:league/:season/:userId', async (req, res) => {
+    try {
+        const league = req.params.league;
+        const userId = req.params.userId;
+
+        // `latest` (used by the weekly popup) resolves to the most recent season
+        // the manager actually has weekly scores for — so the popup works during
+        // the season and shows last season's finish in the offseason.
+        let season = req.params.season;
+        if (season === 'latest') {
+            const target = await User.findById(userId);
+            const played = ((target && target.seasons) || [])
+                .filter(s => (s.weeklyScore || []).length > 0)
+                .sort((a, b) => Number(b.season) - Number(a.season));
+            if (!played.length) return res.json({ league, season: null, userId, recaps: [] });
+            season = String(played[0].season);
+        }
+        const seasonNum = Number(season);
+
+        // Whole league for the target season (need nested teams + weeklyScore
+        // for rank/average, so no projection).
+        const users = await User.find({ league: league, 'seasons.season': season });
+        const user = users.find(u => String(u._id) === String(userId));
+        if (!user) return res.json({ league, season: seasonNum, userId, recaps: [] });
+
+        // Upset index: drafted teams' completed regular-season games + spreads,
+        // so a rostered underdog win can flavor that week's narrative.
+        const draftedIds = new Set();
+        users.forEach(u => {
+            const s = (u.seasons || []).find(x => String(x.season) === String(season));
+            ((s && s.teams) || []).forEach(t => draftedIds.add(Number(t.id)));
+        });
+        const idList = [...draftedIds];
+        let upsetByGameId = {};
+        if (idList.length) {
+            const games = await Game.find(
+                { season: seasonNum, seasonType: 'regular', completed: true, $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
+                { id: 1, week: 1, homeTeam: 1, awayTeam: 1, homePoints: 1, awayPoints: 1, completed: 1, _id: 0 }
+            );
+            const betting = await Betting.find({ season: seasonNum, seasonType: 'regular' }, { id: 1, lines: 1, _id: 0 });
+            const spreadByGameId = {};
+            betting.forEach(b => {
+                const lines = b.lines || [];
+                const line = lines.find(l => l.provider === 'DraftKings') || lines[0];
+                if (line && typeof line.spread === 'number') spreadByGameId[b.id] = line.spread;
+            });
+
+            // AP Top 25 by week, so the upset narrative can name the beaten
+            // team's rank ("upset of #3 Georgia"). Each Ranking doc is one week.
+            const rankByWeek = {};
+            const rankings = await Ranking.find({ season: seasonNum, seasonType: 'regular' }, { week: 1, polls: 1, _id: 0 });
+            rankings.forEach(rk => {
+                const ap = (rk.polls || []).find(p => p.poll === 'AP Top 25');
+                if (!ap) return;
+                const byTeam = (rankByWeek[rk.week] = rankByWeek[rk.week] || {});
+                (ap.ranks || []).forEach(r => { if (r.school != null && r.rank != null) byTeam[r.school] = r.rank; });
+            });
+
+            upsetByGameId = indexUpsets(games, spreadByGameId, rankByWeek);
+        }
+
+        const recap = buildWeeklyRecaps({ user, leagueUsers: users, season, upsetByGameId });
+        const name = `${user.firstName || ''} ${user.lastName ? user.lastName[0] + '.' : ''}`.trim();
+        res.json({ league, ...recap, name });
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/tests/WeeklyRecap.spec.js
+++ b/tests/WeeklyRecap.spec.js
@@ -1,0 +1,298 @@
+const { buildWeeklyRecaps, buildSlides, indexUpsets, narrate, recapWindowKey, isRecapSeason } = require('../modules/weekly-recap');
+
+// Two managers, one league, season 2025. Manager A trails after week 1 then
+// overtakes in week 2 on a big Oregon week.
+function fixture() {
+    const teamsA = [
+        { id: 1, school: 'Oregon', mascot: 'Ducks', logos: ['o1.png', 'o2.png'] },
+        { id: 2, school: 'Duke', mascot: 'Blue Devils', logos: ['d.png'] }
+    ];
+    const teamsB = [{ id: 3, school: 'Iowa', mascot: 'Hawkeyes', logos: ['i.png'] }];
+    const A = {
+        _id: 'a', firstName: 'Ann', lastName: 'Adams', league: 'graham-league',
+        seasons: [{
+            season: 2025, teams: teamsA, cumulativeScore: 80,
+            weeklyScore: [
+                { week: 1, score: 30, scoreByTeam: [{ team: 'Oregon', teamId: 1, gameId: 100, score: 20 }, { team: 'Duke', teamId: 2, gameId: 101, score: 10 }] },
+                { week: 2, score: 50, scoreByTeam: [{ team: 'Oregon', teamId: 1, gameId: 102, score: 35 }, { team: 'Duke', teamId: 2, gameId: 103, score: 15 }] }
+            ]
+        }]
+    };
+    const B = {
+        _id: 'b', firstName: 'Bob', lastName: 'Barns', league: 'graham-league',
+        seasons: [{
+            season: 2025, teams: teamsB, cumulativeScore: 60,
+            weeklyScore: [
+                { week: 1, score: 40, scoreByTeam: [{ team: 'Iowa', teamId: 3, gameId: 200, score: 40 }] },
+                { week: 2, score: 20, scoreByTeam: [{ team: 'Iowa', teamId: 3, gameId: 201, score: 20 }] }
+            ]
+        }]
+    };
+    return { A, B, users: [A, B] };
+}
+
+describe('buildWeeklyRecaps', () => {
+    test('produces one recap per played week, oldest first', () => {
+        const { A, users } = fixture();
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2025 });
+        expect(recaps.map(r => r.week)).toEqual([1, 2]);
+    });
+
+    test('rank, movement, and vs-league-average are computed per week', () => {
+        const { A, users } = fixture();
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2025 });
+        const [w1, w2] = recaps;
+        // Week 1: A (30) trails B (40) → 2nd, no prior week so no movement.
+        expect(w1.rank).toBe(2);
+        expect(w1.rankDelta).toBeNull();
+        expect(w1.leagueAvg).toBe(35);       // (30 + 40) / 2
+        expect(w1.vsLeagueAvg).toBe(-5);
+        // Week 2: A cum 80 vs B cum 60 → 1st, climbed one spot from 2nd.
+        expect(w2.rank).toBe(1);
+        expect(w2.rankDelta).toBe(1);
+        expect(w2.leagueAvg).toBe(35);       // (50 + 20) / 2
+        expect(w2.vsLeagueAvg).toBe(15);
+    });
+
+    test('MVP team is the roster team that scored most that week', () => {
+        const { A, users } = fixture();
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2025 });
+        expect(recaps[0].mvpTeam.school).toBe('Oregon');
+        expect(recaps[0].mvpTeam.score).toBe(20);
+        expect(recaps[0].mvpTeam.logo).toBe('o2.png');    // logos.at(-1)
+        expect(recaps[1].mvpTeam.score).toBe(35);
+    });
+
+    test('base narrative (no upset context) reads cleanly and flags the climb', () => {
+        const { A, users } = fixture();
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2025 });
+        expect(recaps[1].isUpset).toBe(false);
+        expect(recaps[1].narrative).toContain('climbed 1 spot to 1st');
+        expect(recaps[1].narrative).toContain('Oregon');
+    });
+
+    test('MVP/dud sum per team when a team appears in multiple games (postseason)', () => {
+        const u = {
+            _id: 'p', firstName: 'Post', lastName: 'Season', league: 'graham-league',
+            seasons: [{
+                season: 2025, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }, { id: 2, school: 'Duke', logos: ['d.png'] }],
+                weeklyScore: [{
+                    week: 1, season: 'postseason', score: 24, scoreByTeam: [
+                        { team: 'Oregon', score: 6 }, { team: 'Oregon', score: 6 }, { team: 'Oregon', score: 6 },
+                        { team: 'Duke', score: 6 }
+                    ]
+                }]
+            }]
+        };
+        const { recaps } = buildWeeklyRecaps({ user: u, leagueUsers: [u], season: 2025 });
+        expect(recaps[0].label).toBe('Postseason');
+        expect(recaps[0].mvpTeam).toMatchObject({ school: 'Oregon', score: 18 });   // 3×6, not 6
+        expect(recaps[0].dudTeam).toMatchObject({ school: 'Duke', score: 6 });
+    });
+
+    test('co-MVPs: teams tied for the week best surface together', () => {
+        const u = {
+            _id: 'q', firstName: 'Tie', lastName: 'Guy', league: 'graham-league',
+            seasons: [{
+                season: 2025, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }, { id: 2, school: 'Ole Miss', logos: ['om.png'] }, { id: 3, school: 'Duke', logos: ['d.png'] }],
+                weeklyScore: [{
+                    week: 1, season: 'postseason', score: 42, scoreByTeam: [
+                        { team: 'Oregon', score: 6 }, { team: 'Oregon', score: 6 }, { team: 'Oregon', score: 6 },  // 18
+                        { team: 'Ole Miss', score: 9 }, { team: 'Ole Miss', score: 9 },                            // 18
+                        { team: 'Duke', score: 6 }
+                    ]
+                }]
+            }]
+        };
+        const { recaps } = buildWeeklyRecaps({ user: u, leagueUsers: [u], season: 2025 });
+        const r = recaps[0];
+        expect(r.mvpTeams.map(t => t.school).sort()).toEqual(['Ole Miss', 'Oregon']);
+        expect(r.mvpTeams.every(t => t.score === 18)).toBe(true);
+        const mvp = r.slides.find(s => s.id === 'mvp');
+        expect(mvp.kicker).toBe('Co-MVPs');
+        expect(mvp.title).toBe('Oregon & Ole Miss');
+        expect(mvp.sub).toBe('18 pts each');
+        expect(mvp.logos).toEqual(['o.png', 'om.png']);
+    });
+
+    test('postseason does not claim a "new season high"; it gets a season-wrap beat', () => {
+        const u = {
+            _id: 'w', firstName: 'Wrap', lastName: 'Up', league: 'graham-league',
+            seasons: [{
+                season: 2025, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }],
+                weeklyScore: [
+                    { week: 1, score: 10, scoreByTeam: [{ team: 'Oregon', score: 10 }] },
+                    { week: 2, score: 20, scoreByTeam: [{ team: 'Oregon', score: 20 }] }, // regular-season high
+                    { week: 1, season: 'postseason', score: 60, scoreByTeam: [{ team: 'Oregon', score: 60 }] } // biggest week overall
+                ]
+            }]
+        };
+        const { recaps } = buildWeeklyRecaps({ user: u, leagueUsers: [u], season: 2025 });
+        const wk2 = recaps.find(r => r.effWeek === 2);
+        const post = recaps.find(r => r.effWeek === 17);
+        expect(wk2.isSeasonHigh).toBe(true);                       // regular-season high still fires
+        expect(post.isSeasonHigh).toBe(false);                     // postseason does NOT
+        expect(post.slides.some(s => s.id === 'seasonhigh')).toBe(false);
+        expect(post.slides.some(s => s.id === 'seasonwrap')).toBe(true);
+    });
+
+    test('rank ties share a placement and are flagged (T-1st)', () => {
+        const mk = (id, fn, s1, s2) => ({
+            _id: id, firstName: fn, lastName: 'X', league: 'graham-league',
+            seasons: [{ season: 2025, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }],
+                weeklyScore: [
+                    { week: 1, score: s1, scoreByTeam: [{ team: 'Oregon', score: s1 }] },
+                    { week: 2, score: s2, scoreByTeam: [{ team: 'Oregon', score: s2 }] }
+                ] }]
+        });
+        // Through week 2: A=30, B=30 (tie for 1st), C=10.
+        const A = mk('a', 'Al', 10, 20), B = mk('b', 'Bo', 20, 10), C = mk('c', 'Cy', 5, 5);
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: [A, B, C], season: 2025 });
+        const w2 = recaps.find(r => r.effWeek === 2);
+        expect(w2.rank).toBe(1);
+        expect(w2.rankTie).toBe(true);
+        expect(w2.slides.find(s => s.id === 'rank').big).toBe('T-1st');
+    });
+
+    test('a manager who debuts after week 1 gets no bogus season-high on their first week', () => {
+        const other = { _id: 'o', firstName: 'Op', lastName: 'O', league: 'graham-league',
+            seasons: [{ season: 2025, teams: [{ id: 9, school: 'X', logos: ['x.png'] }],
+                weeklyScore: [
+                    { week: 1, score: 10, scoreByTeam: [{ team: 'X', score: 10 }] },
+                    { week: 2, score: 10, scoreByTeam: [{ team: 'X', score: 10 }] }
+                ] }] };
+        const late = { _id: 'l', firstName: 'La', lastName: 'L', league: 'graham-league',
+            seasons: [{ season: 2025, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }],
+                weeklyScore: [
+                    { week: 2, score: 25, scoreByTeam: [{ team: 'Oregon', score: 25 }] },
+                    { week: 3, score: 40, scoreByTeam: [{ team: 'Oregon', score: 40 }] }
+                ] }] };
+        const { recaps } = buildWeeklyRecaps({ user: late, leagueUsers: [other, late], season: 2025 });
+        expect(recaps.find(r => r.effWeek === 2).isSeasonHigh).toBe(false);  // no prior week of their own
+        expect(recaps.find(r => r.effWeek === 3).isSeasonHigh).toBe(true);   // 40 > 25
+    });
+
+    test('multiple entries sharing an effective week fold into one recap', () => {
+        const u = { _id: 'm', firstName: 'Mu', lastName: 'M', league: 'graham-league',
+            seasons: [{ season: 2025, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }],
+                weeklyScore: [
+                    { week: 1, season: 'postseason', score: 20, scoreByTeam: [{ team: 'Oregon', score: 20 }] },
+                    { week: 2, season: 'postseason', score: 14, scoreByTeam: [{ team: 'Oregon', score: 14 }] }
+                ] }] };
+        const { recaps } = buildWeeklyRecaps({ user: u, leagueUsers: [u], season: 2025 });
+        const post = recaps.filter(r => r.effWeek === 17);
+        expect(post.length).toBe(1);            // folded, not two "Postseason" recaps
+        expect(post[0].score).toBe(34);         // 20 + 14
+        expect(post[0].mvpTeam.score).toBe(34); // Oregon summed across both entries
+    });
+
+    test('empty when the manager has no weeks that season', () => {
+        const { A, users } = fixture();
+        const out = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2099 });
+        expect(out.recaps).toEqual([]);
+    });
+});
+
+describe('indexUpsets + layered narrative', () => {
+    // Oregon (away) beats favored Georgia; home spread -7 means Georgia was a
+    // 7-pt favorite, so Oregon won as a 7-pt underdog.
+    const games = [
+        { id: 102, week: 2, homeTeam: 'Georgia', awayTeam: 'Oregon', homePoints: 24, awayPoints: 27, completed: true },
+        { id: 103, week: 2, homeTeam: 'Duke', awayTeam: 'Wake', homePoints: 31, awayPoints: 10, completed: true }
+    ];
+    const spreads = { 102: -7, 103: -14 };   // both home teams favored
+    const rankByWeek = { 2: { Georgia: 3 } }; // Georgia was AP #3 entering week 2
+
+    test('indexes only underdog wins, with margin, loser, and AP rank', () => {
+        const idx = indexUpsets(games, spreads, rankByWeek);
+        expect(idx[102]).toMatchObject({ winner: 'Oregon', loser: 'Georgia', margin: 7, loserRank: 3 });
+        expect(idx[103]).toBeUndefined();     // Duke won as a favorite — not an upset
+    });
+
+    test('a rostered underdog win takes over that week’s narrative, naming the AP rank', () => {
+        const { A, users } = fixture();
+        const upsetByGameId = indexUpsets(games, spreads, rankByWeek);
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2025, upsetByGameId });
+        const w2 = recaps[1];
+        expect(w2.isUpset).toBe(true);
+        expect(w2.upset).toMatchObject({ team: 'Oregon', loser: 'Georgia', margin: 7, loserRank: 3 });
+        expect(w2.narrative).toContain("Oregon's upset over #3 Georgia");
+        expect(w2.narrative).toContain('7-pt underdog');
+    });
+
+    test('unranked loser omits the # prefix', () => {
+        const idx = indexUpsets(games, spreads);   // no rankByWeek
+        expect(idx[102].loserRank).toBeNull();
+        const s = narrate({ score: 20, rank: 1, rankDelta: 1, vsLeagueAvg: 5, mvp: null, upset: idx[102] });
+        expect(s).toContain('over Georgia');
+        expect(s).not.toContain('#');
+    });
+});
+
+describe('buildSlides (story deck)', () => {
+    test('a big week assembles the full conditional deck, in order', () => {
+        const r = {
+            label: 'Week 8', score: 16, rank: 5, rankDelta: 1, leagueAvg: 11.5, vsLeagueAvg: 4.5,
+            weekHigh: true, weekLow: false,
+            mvpTeam: { school: 'Louisville', score: 9, logo: 'l.png' }, mvpShare: 56,
+            dudTeam: { school: 'Duke', score: 1, logo: 'd.png' },
+            isUpset: true, upset: { team: 'Louisville', loser: 'Miami', loserRank: 2, margin: 10.5 },
+            isSeasonHigh: true, aboveAvgStreak: 1, belowAvgStreak: 0, cumTotal: 120, milestone: null,
+            narrative: 'x'
+        };
+        const slides = buildSlides(r);
+        expect(slides.map(s => s.id)).toEqual(
+            ['hook', 'rank', 'weekhigh', 'vsavg', 'mvp', 'dud', 'upset', 'seasonhigh', 'closing']);
+        expect(slides.find(s => s.id === 'upset').sub).toContain('#2 Miami');
+        expect(slides.find(s => s.id === 'mvp').sub).toBe('56% of your points');
+        expect(slides.find(s => s.id === 'closing').cta).toBe(true);
+    });
+
+    test('a quiet week stays short (no mvp/dud/upset/momentum)', () => {
+        const r = {
+            label: 'Week 3', score: 0, rank: 6, rankDelta: 0, leagueAvg: 5, vsLeagueAvg: -5,
+            weekHigh: false, weekLow: true, mvpTeam: null, dudTeam: null,
+            isUpset: false, isSeasonHigh: false, aboveAvgStreak: 0, belowAvgStreak: 1,
+            narrative: 'Quiet week.'
+        };
+        expect(buildSlides(r).map(s => s.id)).toEqual(['hook', 'rank', 'weeklow', 'vsavg', 'closing']);
+    });
+
+    test('buildWeeklyRecaps attaches a slide deck to each week', () => {
+        const { A, users } = fixture();
+        const { recaps } = buildWeeklyRecaps({ user: A, leagueUsers: users, season: 2025 });
+        expect(Array.isArray(recaps[0].slides)).toBe(true);
+        expect(recaps[0].slides[0].id).toBe('hook');
+    });
+});
+
+describe('weekly popup gating', () => {
+    test('recapWindowKey returns the most recent Monday 07:00 boundary', () => {
+        // Wed 2025-09-10 → that week's Monday is 2025-09-08.
+        expect(recapWindowKey(new Date(2025, 8, 10, 12, 0))).toBe('2025-09-08');
+        // Monday 2025-09-08 06:59 (before 7am) → previous Monday 2025-09-01.
+        expect(recapWindowKey(new Date(2025, 8, 8, 6, 59))).toBe('2025-09-01');
+        // Monday 2025-09-08 07:00 exactly → that Monday.
+        expect(recapWindowKey(new Date(2025, 8, 8, 7, 0))).toBe('2025-09-08');
+        // Sunday 2025-09-14 23:00 → still the 2025-09-08 window.
+        expect(recapWindowKey(new Date(2025, 8, 14, 23, 0))).toBe('2025-09-08');
+    });
+
+    test('isRecapSeason covers Aug–Jan only', () => {
+        expect(isRecapSeason(new Date(2025, 8, 1))).toBe(true);   // September
+        expect(isRecapSeason(new Date(2026, 0, 5))).toBe(true);   // January
+        expect(isRecapSeason(new Date(2026, 6, 27))).toBe(false); // July (offseason)
+    });
+});
+
+describe('narrate (pure)', () => {
+    test('quiet week when nothing was banked', () => {
+        expect(narrate({ score: 0, rank: 4, rankDelta: 0, vsLeagueAvg: 0, mvp: null, upset: null }))
+            .toBe('Quiet week — no points banked.');
+    });
+    test('slip is phrased as a slip', () => {
+        const s = narrate({ score: 22, rank: 5, rankDelta: -2, vsLeagueAvg: -8, mvp: { school: 'Duke', score: 12 }, upset: null });
+        expect(s).toContain('slipped 2 spots to 5th');
+        expect(s).toContain('below the league average');
+    });
+});

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -18,6 +18,10 @@
 <script src="/toast.js"></script>
 <!-- Custom icon suite (ccIcon + [data-icon] hydration), emitted once app-wide. -->
 <script src="/icons.js"></script>
+<!-- Weekly Recap: shared card rendering + the once-a-week popup, app-wide so the
+     popup can greet the logged-in viewer on whatever page they land on. -->
+<link rel="stylesheet" type="text/css" href="/weekly-recap.css">
+<script src="/weekly-recap.js"></script>
 <!-- Surface otherwise-silent failures (e.g. a failed fetch) instead of leaving the UI quietly broken -->
 <script>
     (function () {

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -37,12 +37,20 @@
             <h1 class="franchise-name" profile-franchise></h1>
             <p class="manager-name" profile-manager></p>
             <div class="profile-stats" profile-stats></div>
-            <button type="button" class="grade-chip" profile-grade-chip hidden
-                    aria-expanded="false" aria-controls="uh-grades">
-                <span class="grade-chip-label">Draft grade</span>
-                <span class="grade-chip-letter" profile-grade-letter></span>
-                <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
-            </button>
+            <div class="profile-chips">
+                <button type="button" class="grade-chip" profile-grade-chip hidden
+                        aria-expanded="false" aria-controls="uh-grades">
+                    <span class="grade-chip-label">Draft grade</span>
+                    <span class="grade-chip-letter" profile-grade-letter></span>
+                    <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
+                </button>
+                <button type="button" class="grade-chip recap-chip" recap-chip hidden
+                        aria-expanded="false" aria-controls="uh-recap">
+                    <span class="grade-chip-label"><i class="fa-regular fa-calendar-check" aria-hidden="true"></i> Weekly recap</span>
+                    <span class="recap-chip-teaser" recap-chip-teaser></span>
+                    <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
+                </button>
+            </div>
         </div>
         <button type="button" class="edit-profile-btn" edit-profile-btn hidden>
             <i class="fa-solid fa-pen"></i> Edit profile
@@ -50,6 +58,8 @@
     </div>
 
     <section class="uh-grades" id="uh-grades" hidden></section>
+
+    <section class="uh-recap" id="uh-recap"></section>
 
     <div class="modal-backdrop" profile-modal hidden>
         <div class="profile-modal-card" role="dialog" aria-modal="true" aria-labelledby="profile-modal-title">


### PR DESCRIPTION
Closes #212.

A personal **"here's your week"** recap for each manager — a reason to open the app every week, not just draft night.

## What it shows
Weekly score, league rank + movement, margin vs the league average, MVP team, and a one-line narrative. Same math as the League Highlights, scoped to one manager. Computed in a **pure, DB-free module** so a future recap **email** can reuse it verbatim.

## Surfaces
- **My Team** — a hero pill (`Weekly Recap · Wk N · rank ▲`) that expands a card with a week selector.
- **App-wide story popup** — Instagram/Wrapped style, fires the first visit after **Monday 07:00 local**, in-season only (Aug–Jan), skipped on My Team where it's already visible.

## Story deck (one idea per slide, only when meaningful)
Hook → rank + movement → top/bottom of the week → vs league average → **MVP** (co-MVPs on a tie, all logos) → the dud → **the upset** (names the beaten team's AP rank) → a momentum beat → a **postseason season-wrap** capstone. Tap / click / swipe / arrow-keys to page, segmented progress bars, per-slide entrance animations, `prefers-reduced-motion` safe.

## Server
- `modules/weekly-recap.js` (pure): `buildWeeklyRecaps`, `buildSlides`, `indexUpsets`, `narrate`, gating helpers.
  - **Per-team aggregation** — a team can have multiple games in one week (postseason, or a Week 0 game the source tags Week 1), so MVP/dud sum per team.
  - **Competition ranking** — ties share a place (`T-5th`), no fabricated movement.
  - **Effective-week folding** — entries sharing a week collapse into one recap; each manager counts once toward the league average.
- `GET /standings/recap/:league/:season/:userId` — `season=latest` resolves to the manager's most recent played season; loads games + betting spreads + AP poll for the upset narrative.

## Accessibility
Dialog focus trap + focus return, background scroll-lock, live "Slide X of N" announcement, escaped interpolation.

## Testing
`tests/WeeklyRecap.spec.js` — rank/movement, league average, MVP aggregation, co-MVP ties, layered + AP-rank upset narrative, postseason wrap, debut-week guard, effective-week folding, Monday-07:00 gating. **157 tests pass.** Verified live across desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)