### PR TITLE
My Team redesign + per-season game modes (bring #232 to main)

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -14,14 +14,22 @@ const scoringConfigSchema = new mongoose.Schema({
     combineMode: { type: String, enum: ['first', 'sum'] },
     disabled: { type: [String], default: [] },
     // Optional weekly-engagement layer (GitHub #230), per-league opt-in.
-    // Head-to-head win bonus + weekly Captain multiplier. Off by default so
-    // existing leagues are unaffected until a commissioner enables them.
+    // DEPRECATED / legacy: a single league-wide engagement blob. Superseded by
+    // engagementBySeason (below) so a league can run the game modes in one
+    // season without altering another. Kept for rollback + reference; the
+    // resolver no longer reads it.
     engagement: {
         h2hEnabled: { type: Boolean, default: false },
         h2hWinBonus: { type: Number, default: 3 },
         captainEnabled: { type: Boolean, default: false },
         captainMultiplier: { type: Number, default: 2 }
     },
+    // Per-season engagement settings, keyed by season (string year), e.g.
+    // { "2026": { h2hEnabled, h2hWinBonus, captainEnabled, captainMultiplier } }.
+    // A season with no entry is fully OFF — enabling a mode for one season never
+    // affects another, and a rescore of a season without an entry adds no
+    // captain/H2H bonus. Stored as Mixed so seasons can be added freely.
+    engagementBySeason: { type: mongoose.Schema.Types.Mixed, default: {} },
     updatedAt: { type: Date, default: Date.now }
 });
 

--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -139,22 +139,45 @@ function resolveConfig(league, overrides) {
         ? overrides.combineMode
         : modelDef.structure.combineMode;
     const disabled = (overrides && Array.isArray(overrides.disabled)) ? overrides.disabled.slice() : [];
-    const eng = (overrides && overrides.engagement) || {};
     return {
         model,
         combineMode,
         values: Object.assign({}, modelDef.defaults, (overrides && overrides.values) || {}),
         disabled,
-        engagement: {
-            h2hEnabled: !!eng.h2hEnabled,
-            h2hWinBonus: typeof eng.h2hWinBonus === 'number' ? eng.h2hWinBonus : 3,
-            captainEnabled: !!eng.captainEnabled,
-            captainMultiplier: typeof eng.captainMultiplier === 'number' ? eng.captainMultiplier : 2
-        }
+        // Legacy flat engagement (deprecated — see engagementBySeason). Kept in
+        // the resolved shape for back-compat with any old reader.
+        engagement: normalizeEngagement((overrides && overrides.engagement) || {}),
+        // Raw per-season map, passed through untouched for engagementForSeason().
+        engagementBySeason: (overrides && overrides.engagementBySeason) || {}
     };
+}
+
+// Engagement (game modes) defaults: everything off, with the standard bonus /
+// multiplier values used when a mode is turned on.
+const ENGAGEMENT_DEFAULTS = { h2hEnabled: false, h2hWinBonus: 3, captainEnabled: false, captainMultiplier: 2 };
+
+// Coerce a stored/partial engagement object into a complete, well-typed one.
+function normalizeEngagement(e) {
+    e = e || {};
+    return {
+        h2hEnabled: !!e.h2hEnabled,
+        h2hWinBonus: typeof e.h2hWinBonus === 'number' ? e.h2hWinBonus : ENGAGEMENT_DEFAULTS.h2hWinBonus,
+        captainEnabled: !!e.captainEnabled,
+        captainMultiplier: typeof e.captainMultiplier === 'number' ? e.captainMultiplier : ENGAGEMENT_DEFAULTS.captainMultiplier
+    };
+}
+
+// Resolve the engagement (game-mode) settings for ONE season from a per-season
+// map. A season with no explicit entry is fully OFF — this is what keeps each
+// season independent: turning a mode on for 2026 leaves 2025 (no entry) off, so
+// even a rescore of 2025 adds no captain/H2H bonus.
+function engagementForSeason(bySeason, season) {
+    const entry = bySeason && (bySeason[String(season)] || bySeason[Number(season)]);
+    return normalizeEngagement(entry || {});
 }
 
 module.exports = {
     CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, STRUCTURES, MODELS, LEAGUES,
-    modelForLeague, fieldsForModel, resolveConfig
+    modelForLeague, fieldsForModel, resolveConfig,
+    ENGAGEMENT_DEFAULTS, normalizeEngagement, engagementForSeason
 };

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -1,5 +1,5 @@
 const { internalFetch } = require('./internal-api');
-const { resolveConfig, MODELS } = require('./scoring-defaults');
+const { resolveConfig, MODELS, engagementForSeason } = require('./scoring-defaults');
 const { CONDITIONS, buildContext } = require('./scoring-detectors');
 const { resolveCaptain, captainWeeklyBonus } = require('./captain');
 // Configure API key authorization: ApiKeyAuth
@@ -107,15 +107,18 @@ module.exports= {
             }
 
             // Captain (weekly N×) for opted-in leagues — regular season only
-            // (the postseason self-selects your teams). The captained team's
-            // points get the multiplier; existing leagues (engagement off) skip
-            // this entirely, so their scoring is unchanged.
+            // (the postseason self-selects your teams). Resolved PER SEASON: a
+            // season with no engagement entry is off, so scoring/rescoring a
+            // season the mode was never enabled for adds nothing (and enabling
+            // it for one season never touches another). Existing classic leagues
+            // are likewise unchanged.
+            var seasonEng = engagementForSeason(cfg.engagementBySeason, process.env.YEAR);
             var captainTeamId = null, captainBonus = 0;
-            if (cfg.engagement && cfg.engagement.captainEnabled && season !== "postseason") {
+            if (seasonEng.captainEnabled && season !== "postseason") {
                 var priorWeekly = (user.seasons[0].weeklyScore || [])
                     .filter(e => e.season !== "postseason" && parseInt(e.week) < parseInt(week));
                 captainTeamId = resolveCaptain(user.seasons[0].captains, week, user.seasons[0].teams, priorWeekly);
-                captainBonus = captainWeeklyBonus(teamScores, captainTeamId, cfg.engagement.captainMultiplier);
+                captainBonus = captainWeeklyBonus(teamScores, captainTeamId, seasonEng.captainMultiplier);
                 score += captainBonus;
             }
 
@@ -366,7 +369,8 @@ async function getScoringConfig(league) {
             values: data.values,
             combineMode: data.combineMode,
             disabled: data.disabled,
-            engagement: data.engagement
+            engagement: data.engagement,
+            engagementBySeason: data.engagementBySeason
         });
     } catch (e) { /* fall through to defaults */ }
     return resolveConfig(league, null);

--- a/public/admin.js
+++ b/public/admin.js
@@ -1127,13 +1127,30 @@ function displayEnrichmentContainer() { toggleSub('enrichment-container'); }
 function displayApiCallsContainer() { toggleSub('api-calls-container'); }
 function displayLeagueNameContainer() { if (toggleSub('league-name-container')) loadLeagueName(); }
 
-function displayEngagementContainer() { if (toggleSub('engagement-container')) loadEngagement(); }
+function displayEngagementContainer() { if (toggleSub('engagement-container')) { setEngagementSeasonOptions(); loadEngagement(); } }
 
-// Prefill the engagement toggles from the active league's saved config.
+// Populate the engagement season selector once (next season down a few years),
+// defaulting to the current year. Reloads the toggles when the season changes,
+// since each season has its own settings.
+function setEngagementSeasonOptions() {
+    var sel = document.querySelector('[eng-season]');
+    if (!sel || sel.dataset.ready) return;
+    var y = new Date().getFullYear();
+    var str = '';
+    for (var yr = y + 1; yr >= y - 3; yr--) str += '<option value="' + yr + '"' + (yr === y ? ' selected' : '') + '>' + yr + '</option>';
+    sel.innerHTML = str;
+    sel.dataset.ready = '1';
+    sel.addEventListener('change', loadEngagement);
+}
+
+// Prefill the engagement toggles from the active league's saved config for the
+// selected season.
 async function loadEngagement() {
     try {
         var code = getDraftLeagueCode();
-        var cfg = await fetch('/scoring-config/' + encodeURIComponent(code), { headers: { 'Accept': 'application/json' } }).then(function (r) { return r.json(); });
+        var seasonSel = document.querySelector('[eng-season]');
+        var season = (seasonSel && seasonSel.value) || new Date().getFullYear();
+        var cfg = await fetch('/scoring-config/' + encodeURIComponent(code) + '?season=' + encodeURIComponent(season), { headers: { 'Accept': 'application/json' } }).then(function (r) { return r.json(); });
         var e = (cfg && cfg.engagement) || {};
         var h2h = document.querySelector('[eng-h2h-enabled]');
         var bonus = document.querySelector('[eng-h2h-bonus]');
@@ -1151,7 +1168,9 @@ if (engagementForm) {
     engagementForm.addEventListener('submit', async function (event) {
         event.preventDefault();
         const code = getDraftLeagueCode();
+        const seasonSel = document.querySelector('[eng-season]');
         const body = {
+            season: (seasonSel && seasonSel.value) || String(new Date().getFullYear()),
             h2hEnabled: document.querySelector('[eng-h2h-enabled]').checked,
             h2hWinBonus: Number(document.querySelector('[eng-h2h-bonus]').value),
             captainEnabled: document.querySelector('[eng-captain-enabled]').checked,
@@ -1165,7 +1184,7 @@ if (engagementForm) {
             });
             const data = await res.json().catch(() => ({}));
             if (res.status === 200) {
-                successToast.options.text = 'Game modes saved'
+                successToast.options.text = `Game modes saved · ${data.season || body.season}`
                     + (data.h2hEnabled ? ` · H2H +${data.h2hWinBonus}` : ' · H2H off')
                     + (data.captainEnabled ? ` · Captain ${data.captainMultiplier}×` : ' · Captain off');
                 successToast.showToast();

--- a/public/h2h-card.css
+++ b/public/h2h-card.css
@@ -34,7 +34,11 @@
 .h2h-tlogo { width: 20px; height: 20px; object-fit: contain; flex-shrink: 0; }
 .h2h-tid { flex: 1; min-width: 0; display: flex; flex-direction: column; line-height: 1.25; }
 .h2h-mdcol.right .h2h-tid { align-items: flex-end; }
-.h2h-tnm { min-width: 0; max-width: 100%; font-size: 0.74rem; color: #C9CEE6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.h2h-tnmline { display: flex; align-items: center; gap: 4px; min-width: 0; max-width: 100%; }
+.h2h-mdcol.right .h2h-tnmline { justify-content: flex-end; }
+.h2h-tnm { min-width: 0; font-size: 0.74rem; color: #C9CEE6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* Captain marker — this team's points are doubled into the matchup total. */
+.h2h-capx { flex: none; font-size: 0.5rem; font-weight: 800; letter-spacing: .02em; color: #E0B341; border: 1px solid rgba(224,179,65,.45); border-radius: 99px; padding: 0 4px; line-height: 1.5; }
 .h2h-tsub { min-width: 0; max-width: 100%; font-size: 0.6rem; color: #767D9C; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .h2h-mdcol.right .h2h-tnm, .h2h-mdcol.right .h2h-tsub { text-align: right; }
 /* Full school name on desktop; team abbreviation on mobile (tight columns). */

--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -38,7 +38,9 @@
     // scores hug the center divider, like a Sleeper matchup.
     function teamRow(t, right) {
         var img = '<img class="h2h-tlogo" src="' + esc(t.logo) + '" alt="">';
-        var nm = '<span class="h2h-tnm"><span class="tnm-full">' + esc(t.school) + '</span><span class="tnm-abbr">' + esc(t.abbr || t.school) + '</span></span>';
+        // Captain doubles this team's points — mark it so the inflated score reads.
+        var cap = t.captain ? '<span class="h2h-capx" title="Captain — points doubled">★2×</span>' : '';
+        var nm = '<span class="h2h-tnmline"><span class="h2h-tnm"><span class="tnm-full">' + esc(t.school) + '</span><span class="tnm-abbr">' + esc(t.abbr || t.school) + '</span></span>' + cap + '</span>';
         var sub = t.opp
             ? '<span class="h2h-tsub">' + esc(t.ha) + ' ' + esc(t.opp) + (t.status === 'final' && t.gameScore ? ' · ' + esc(t.gameScore) : '') + '</span>'
             : '';

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -593,3 +593,17 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-drawer-close:hover { color: #F4F6FB; border-color: #3A3F58; }
 .uh-drawer-body { padding: 18px; overflow-y: auto; }
 @media (prefers-reduced-motion: reduce) { .uh-scrim, .uh-drawer, button.uh-tile { transition: none; } }
+
+/* Bento tile glances + drawer content (#230 redesign) */
+.uh-mu-glance { display: flex; align-items: center; gap: 6px; font-size: 15px; color: #F4F6FB; font-weight: 700; min-width: 0; }
+.uh-mu-glance .num { font-variant-numeric: tabular-nums; }
+.uh-mu-dash { color: #767D9C; }
+.uh-mu-opp { color: #C9CEE6; font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.uh-res { font-size: 10px; font-weight: 800; letter-spacing: 0.03em; border-radius: 99px; padding: 1px 7px; flex: none; }
+.uh-res.r-W { color: #5BD08D; background: rgba(34,195,122,0.12); }
+.uh-res.r-L { color: #ED5858; background: rgba(237,88,88,0.12); }
+.uh-res.r-T { color: #A4A9C2; background: rgba(164,169,194,0.12); }
+.uh-res.r-LIVE { color: #ED5858; background: rgba(237,88,88,0.12); }
+.uh-drawer-lead { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: #767D9C; font-weight: 700; margin-bottom: 10px; }
+.uh-drawer-cap { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: #767D9C; font-weight: 700; margin: 18px 0 10px; }
+.uh-drawer-body .uh-h2h-log { display: flex; flex-direction: column; gap: 8px; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -386,6 +386,8 @@
 .field span { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.06em; color: #A4A9C2; }
 .field input { background: #101322; border: 1px solid #3A3F58; border-radius: 8px; padding: 10px 12px; color: #F4F6FB; font: inherit; }
 .field input:focus { outline: none; border-color: #8E8CF0; }
+.field input:disabled { opacity: 0.5; cursor: not-allowed; }
+.field .field-note { text-transform: none; letter-spacing: 0; font-size: 0.72rem; color: #767D9C; }
 .avatar-edit { display: flex; align-items: center; gap: 1em; margin-bottom: 1em; }
 .avatar-edit-controls { display: flex; flex-direction: column; gap: 6px; }
 .upload-status { font-size: 0.75rem; color: #767D9C; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -684,3 +684,14 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-seg-btn { flex: 1; padding: 8px; border: 0; background: transparent; color: #8A90A8; font: inherit; font-size: 13px; font-weight: 700; border-radius: 7px; cursor: pointer; }
 .uh-seg-btn.active { background: #1A1F33; color: #F4F6FB; }
 .uh-seg-btn:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 1px; }
+
+/* Games tile glance + card sizing inside the drawer (#230 polish 3) */
+.uh-games-logos { display: flex; flex-wrap: wrap; gap: 6px; }
+.uh-games-logos img { width: 24px; height: 24px; object-fit: contain; }
+.uh-games-wk { display: block; margin-top: 8px; }
+.uh-games-pick { display: block; margin-bottom: 14px; }
+.uh-games-pick select { background: #12162A; border: 1px solid #2A2E42; border-radius: 8px; color: #F4F6FB; font: inherit; padding: 8px 10px; }
+/* In the drawer the grid is a vertical column, so the card's flex-basis (340px)
+   must not become its height — size cards to content, full width. */
+.uh-drawer-body .schedule-grid { display: flex; flex-direction: column; gap: 10px; padding: 0; }
+.uh-drawer-body .game-card { flex: 0 0 auto; width: 100%; max-width: 100%; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -664,3 +664,23 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-rg-pts { font-weight: 800; color: #F4F6FB; font-variant-numeric: tabular-nums; flex: none; }
 
 .uh-cap-sub { display: block; color: #767D9C; font-size: 12px; margin-top: 6px; }
+
+/* Trajectory / Draft / Schedule glances + roster toggle (#230 polish 2) */
+.uh-traj-g { display: flex; align-items: baseline; gap: 8px; }
+.uh-traj-num { font-size: 28px; font-weight: 800; color: #F4F6FB; }
+.uh-traj-spark { display: block; margin-top: 10px; }
+
+.uh-draft-g { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.uh-draft-stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.uh-ds { display: flex; flex-direction: column; font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: #767D9C; }
+.uh-ds b { font-size: 15px; font-weight: 800; color: #F4F6FB; letter-spacing: 0; text-transform: none; }
+
+.uh-sched-lbl { display: block; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: #6C9BFF; font-weight: 800; margin-bottom: 7px; }
+.uh-sched-row { display: flex; align-items: center; }
+.uh-sched-opp { color: #F4F6FB; font-weight: 600; }
+.uh-sched-pct { margin-left: auto; color: #6C9BFF; font-weight: 800; }
+
+.uh-seg { display: flex; gap: 4px; background: #12162A; border: 1px solid #2A2E42; border-radius: 10px; padding: 4px; margin-bottom: 14px; }
+.uh-seg-btn { flex: 1; padding: 8px; border: 0; background: transparent; color: #8A90A8; font: inherit; font-size: 13px; font-weight: 700; border-radius: 7px; cursor: pointer; }
+.uh-seg-btn.active { background: #1A1F33; color: #F4F6FB; }
+.uh-seg-btn:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 1px; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -619,3 +619,16 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-cap-glance img { width: 22px; height: 22px; object-fit: contain; flex: none; }
 .uh-cap-2x { font-size: 10px; font-weight: 800; color: #E0B341; border: 1px solid rgba(224,179,65,0.4); border-radius: 99px; padding: 1px 6px; flex: none; }
 #uh-glance-recap { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; line-height: 1.4; }
+
+/* Roster + Trajectory drawer content (#230 redesign) */
+.uh-roster-cards { display: flex; flex-direction: column; gap: 8px; }
+.uh-rc { display: flex; align-items: center; gap: 11px; background: #12162A; border: 1px solid #2A2E42; border-radius: 11px; padding: 10px; text-decoration: none; }
+.uh-rc:hover { border-color: #3A3F58; }
+.uh-rc img { width: 28px; height: 28px; object-fit: contain; flex: none; }
+.uh-rc-meta { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.uh-rc-nm { color: #F4F6FB; font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.uh-rc-bar { height: 4px; border-radius: 99px; background: #0c1022; overflow: hidden; }
+.uh-rc-bar i { display: block; height: 100%; background: #5BD08D; }
+.uh-rc-pts { font-weight: 800; color: #F4F6FB; font-variant-numeric: tabular-nums; flex: none; }
+.uh-drawer-body .table-wrapper { overflow-x: auto; margin: 0; }
+.uh-drawer-body .profile-chart-wrap { height: 220px; position: relative; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -632,3 +632,8 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-rc-pts { font-weight: 800; color: #F4F6FB; font-variant-numeric: tabular-nums; flex: none; }
 .uh-drawer-body .table-wrapper { overflow-x: auto; margin: 0; }
 .uh-drawer-body .profile-chart-wrap { height: 220px; position: relative; }
+
+/* Games drawer (#230 redesign) */
+.uh-games-pick { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; font-size: 11px; color: #767D9C; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; }
+.uh-games-pick select { background: #12162A; border: 1px solid #2A2E42; border-radius: 8px; color: #F4F6FB; font: inherit; padding: 6px 8px; text-transform: none; letter-spacing: 0; }
+.uh-drawer-body .schedule-grid { display: flex; flex-direction: column; gap: 10px; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -637,3 +637,30 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-games-pick { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; font-size: 11px; color: #767D9C; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; }
 .uh-games-pick select { background: #12162A; border: 1px solid #2A2E42; border-radius: 8px; color: #F4F6FB; font: inherit; padding: 6px 8px; text-transform: none; letter-spacing: 0; }
 .uh-drawer-body .schedule-grid { display: flex; flex-direction: column; gap: 10px; }
+
+/* Enriched tile glances (#230 redesign polish) */
+.uh-mug { display: flex; align-items: center; gap: 8px; }
+.uh-mug-side { display: flex; align-items: center; gap: 7px; flex: 1; min-width: 0; }
+.uh-mug-side.r { justify-content: flex-end; }
+.uh-mug .h2h-av { width: 26px; height: 26px; }
+.uh-mug-nm { font-size: 13px; color: #C9CEE6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.uh-mug-sc { font-size: 20px; font-weight: 800; color: #A4A9C2; flex: none; font-variant-numeric: tabular-nums; }
+.uh-mug-sc.win { color: #5BD08D; }
+.uh-mug-vs { font-size: 10px; font-weight: 800; letter-spacing: 0.04em; color: #767D9C; flex: none; }
+.uh-mug-bar { display: flex; align-items: center; gap: 8px; margin-top: 12px; }
+.uh-mug-track { flex: 1; display: flex; height: 6px; border-radius: 99px; overflow: hidden; background: #0c1022; }
+.uh-mug-track i { height: 100%; }
+.uh-mug-track i.fav { background: #22C37A; } .uh-mug-track i.dog { background: #B0454F; } .uh-mug-track i.even { background: #5A6080; }
+.uh-mug-track i:not(.r) { border-radius: 99px 0 0 99px; } .uh-mug-track i.r { border-radius: 0 99px 99px 0; }
+.uh-mug-pct { font-size: 11px; font-weight: 700; color: #A4A9C2; min-width: 2rem; flex: none; font-variant-numeric: tabular-nums; }
+.uh-mug-pct:last-child { text-align: right; }
+.uh-mug-pct.fav { color: #5BD08D; } .uh-mug-pct.dog { color: #8A90A8; }
+
+.uh-rg { display: flex; flex-direction: column; gap: 8px; }
+.uh-rg-row { display: flex; align-items: center; gap: 9px; }
+.uh-rg-row img { width: 22px; height: 22px; object-fit: contain; flex: none; }
+.uh-rg-nm { flex: 1; min-width: 0; color: #C9CEE6; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.uh-rg-star { color: #E0B341; font-size: 11px; }
+.uh-rg-pts { font-weight: 800; color: #F4F6FB; font-variant-numeric: tabular-nums; flex: none; }
+
+.uh-cap-sub { display: block; color: #767D9C; font-size: 12px; margin-top: 6px; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -695,3 +695,7 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
    must not become its height — size cards to content, full width. */
 .uh-drawer-body .schedule-grid { display: flex; flex-direction: column; gap: 10px; padding: 0; }
 .uh-drawer-body .game-card { flex: 0 0 auto; width: 100%; max-width: 100%; }
+
+/* Draft-grade card in the drawer: plain page-style border (no tier left-accent
+   or "you" highlight — it's always your own grade on My Team). */
+.uh-drawer-body .gg-card { border-left: 1px solid #2A2E42; box-shadow: none; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -551,3 +551,45 @@
 .uh-h2h { width: 92%; max-width: 720px; margin: 1.5rem auto 0; }
 .uh-h2h-log { display: flex; flex-direction: column; gap: 0.5rem; }
 .uh-h2h-empty { color: #767D9C; font-size: 0.85rem; }
+
+/* ---------- My Team bento (#230 redesign, feat/my-team-redesign) ---------- */
+.uh-bento { width: 92%; max-width: 1000px; margin: 1.5em auto; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+@media (max-width: 640px) { .uh-bento { grid-template-columns: 1fr; } }
+.uh-tile { background: #1A1F33; border: 1px solid #2A2E42; border-radius: 14px; padding: 16px; text-align: left; color: inherit; font: inherit; min-width: 0; }
+button.uh-tile { display: flex; flex-direction: column; cursor: pointer; transition: border-color 0.15s ease, transform 0.12s ease; }
+button.uh-tile:hover { border-color: #3A3F58; }
+button.uh-tile:active { transform: scale(0.992); }
+button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; }
+.uh-tile.span2 { grid-column: 1 / -1; }
+.uh-tlabel { display: flex; align-items: center; font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: #767D9C; font-weight: 700; margin-bottom: 10px; }
+.uh-chev { margin-left: auto; color: #767D9C; }
+.uh-glance { color: #C9CEE6; font-size: 14px; }
+.uh-stub { color: #767D9C; font-size: 14px; line-height: 1.5; }
+
+.uh-hero { display: flex; align-items: center; gap: 16px; }
+.uh-hero-av { width: 56px; height: 56px; flex: none; }
+.uh-hero-meta { min-width: 0; flex: 1; }
+.uh-hero-name { font-size: 20px; font-weight: 800; color: #F4F6FB; line-height: 1.1; }
+.uh-hero-sub { font-size: 13px; color: #767D9C; margin-top: 2px; }
+.uh-hero-stats { display: flex; gap: 18px; margin-top: 10px; flex-wrap: wrap; }
+.uh-hero-stats .stat { display: flex; flex-direction: column; }
+.uh-hero-stats .stat-value { font-size: 1.15rem; font-weight: 800; color: #F4F6FB; display: flex; align-items: center; gap: 6px; }
+.uh-hero-stats .stat-value img { height: 1.1rem; width: auto; }
+.uh-hero-stats .stat-label { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: #767D9C; margin-top: 2px; }
+.uh-edit { margin-left: auto; align-self: flex-start; width: 36px; height: 36px; border-radius: 10px; border: 1px solid #2A2E42; background: transparent; color: #C9CEE6; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+.uh-edit:hover { border-color: #3A3F58; color: #F4F6FB; }
+.uh-edit:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; }
+
+.uh-scrim { position: fixed; inset: 0; background: rgba(4,6,14,0.6); opacity: 0; pointer-events: none; transition: opacity 0.25s ease; z-index: 1200; }
+.uh-scrim.open { opacity: 1; pointer-events: auto; }
+.uh-drawer { position: fixed; z-index: 1201; background: #1A1F33; border: 1px solid #2A2E42; display: flex; flex-direction: column; top: 0; right: 0; height: 100vh; width: min(440px, 92vw); border-radius: 18px 0 0 18px; transform: translateX(102%); transition: transform 0.3s cubic-bezier(0.2,0.8,0.2,1); overscroll-behavior: contain; }
+.uh-drawer.open { transform: translateX(0); }
+@media (max-width: 640px) { .uh-drawer { top: auto; left: 0; right: 0; bottom: 0; width: auto; height: auto; max-height: 86vh; border-radius: 20px 20px 0 0; transform: translateY(102%); } .uh-drawer.open { transform: translateY(0); } }
+.uh-drawer-grab { display: none; }
+@media (max-width: 640px) { .uh-drawer-grab { display: block; width: 38px; height: 4px; border-radius: 99px; background: #3A3F58; margin: 8px auto 0; } }
+.uh-drawer-head { display: flex; align-items: center; gap: 10px; padding: 18px 18px 14px; border-bottom: 1px solid #2A2E42; flex: none; }
+.uh-drawer-title { font-size: 16px; font-weight: 800; color: #F4F6FB; }
+.uh-drawer-close { margin-left: auto; width: 32px; height: 32px; border-radius: 9px; border: 1px solid #2A2E42; background: transparent; color: #C9CEE6; cursor: pointer; font-size: 16px; }
+.uh-drawer-close:hover { color: #F4F6FB; border-color: #3A3F58; }
+.uh-drawer-body { padding: 18px; overflow-y: auto; }
+@media (prefers-reduced-motion: reduce) { .uh-scrim, .uh-drawer, button.uh-tile { transition: none; } }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -607,3 +607,15 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-drawer-lead { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: #767D9C; font-weight: 700; margin-bottom: 10px; }
 .uh-drawer-cap { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: #767D9C; font-weight: 700; margin: 18px 0 10px; }
 .uh-drawer-body .uh-h2h-log { display: flex; flex-direction: column; gap: 8px; }
+
+/* Draft / Captain / Recap tile glances (#230 redesign) */
+.uh-grade { font-size: 26px; font-weight: 800; color: #C9CEE6; line-height: 1; }
+.uh-grade.gg-tier-a { color: #22C37A; }
+.uh-grade.gg-tier-b { color: #6C9BFF; }
+.uh-grade.gg-tier-c { color: #E0B341; }
+.uh-grade.gg-tier-d, .uh-grade.gg-tier-f { color: #ED5858; }
+.uh-glance-sub { color: #767D9C; font-size: 12px; margin-left: 8px; }
+.uh-cap-glance { display: flex; align-items: center; gap: 8px; font-size: 14px; color: #F4F6FB; font-weight: 600; }
+.uh-cap-glance img { width: 22px; height: 22px; object-fit: contain; flex: none; }
+.uh-cap-2x { font-size: 10px; font-weight: 800; color: #E0B341; border: 1px solid rgba(224,179,65,0.4); border-radius: 99px; padding: 1px 6px; flex: none; }
+#uh-glance-recap { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; line-height: 1.4; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -592,6 +592,13 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-drawer-close { margin-left: auto; width: 32px; height: 32px; border-radius: 9px; border: 1px solid #2A2E42; background: transparent; color: #C9CEE6; cursor: pointer; font-size: 16px; }
 .uh-drawer-close:hover { color: #F4F6FB; border-color: #3A3F58; }
 .uh-drawer-body { padding: 18px; overflow-y: auto; }
+/* Lock the background from scrolling behind the open drawer. */
+body.uh-drawer-open { overflow: hidden; }
+/* Trajectory drawer summary row (total / best week / finish / gap). */
+.uh-drawer-stats { display: flex; gap: 18px; flex-wrap: wrap; margin-bottom: 16px; }
+.uh-drawer-stats .stat { display: flex; flex-direction: column; }
+.uh-drawer-stats .stat-value { font-size: 1.15rem; font-weight: 800; color: #F4F6FB; font-variant-numeric: tabular-nums; }
+.uh-drawer-stats .stat-label { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: #767D9C; margin-top: 2px; }
 @media (prefers-reduced-motion: reduce) { .uh-scrim, .uh-drawer, button.uh-tile { transition: none; } }
 
 /* Bento tile glances + drawer content (#230 redesign) */

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -576,6 +576,14 @@ button.uh-tile:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; 
 .uh-hero-stats .stat-value { font-size: 1.15rem; font-weight: 800; color: #F4F6FB; display: flex; align-items: center; gap: 6px; }
 .uh-hero-stats .stat-value img { height: 1.1rem; width: auto; }
 .uh-hero-stats .stat-label { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: #767D9C; margin-top: 2px; }
+/* Preseason / undrafted-window empty state (active season not yet drafted). */
+.uh-preseason-pill { display: inline-block; font-size: 0.62rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; color: #E0B341; border: 1px solid rgba(224,179,65,0.4); border-radius: 99px; padding: 3px 10px; }
+.uh-preseason { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 8px; padding: 40px 24px; }
+.uh-preseason-icon { display: inline-flex; opacity: 0.85; margin-bottom: 4px; }
+.uh-preseason-h { font-size: 18px; font-weight: 800; color: #F4F6FB; margin: 0; text-wrap: balance; }
+.uh-preseason-p { font-size: 14px; color: #A4A9C2; line-height: 1.5; margin: 0; max-width: 34ch; }
+.uh-preseason-last { margin-top: 10px; font-size: 12px; color: #767D9C; }
+.uh-preseason-last b { color: #C9CEE6; font-weight: 700; }
 .uh-edit { margin-left: auto; align-self: flex-start; width: 36px; height: 36px; border-radius: 10px; border: 1px solid #2A2E42; background: transparent; color: #C9CEE6; cursor: pointer; display: flex; align-items: center; justify-content: center; }
 .uh-edit:hover { border-color: #3A3F58; color: #F4F6FB; }
 .uh-edit:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -156,6 +156,7 @@ async function renderBento(data) {
     hydrateDraft(data);
     hydrateRoster(data);
     hydrateTrajectory(data);
+    hydrateGames(data);
 }
 
 // Roster → Roster tile. Glance shows your top performer; drawer lists all teams
@@ -207,6 +208,42 @@ function hydrateTrajectory(user) {
         renderProfileChart(user);
         const section = body.querySelector('[profile-chart-section]');
         if (section && section.hidden) { const e = body.querySelector('#uh-traj-empty'); if (e) e.hidden = false; }
+    };
+}
+
+// Games → Games tile. Glance names the selected week; drawer hosts a week picker
+// + this week's game cards for your rostered teams (reused displaySchedule).
+function hydrateGames(user) {
+    const tile = document.getElementById('uh-tile-games');
+    const season = (user.seasons || []).at(-1) || {};
+    if (!(season.teams || []).length) { if (tile) tile.hidden = true; return; }
+    ensureWeekSelected(user);
+
+    const g = document.getElementById('uh-glance-games');
+    if (g) g.textContent = `${window.localStorage.getItem('week') || 'This week'} · your teams`;
+
+    uhDrawer.games = (body) => {
+        const weeks = [];
+        for (let w = 1; w <= 16; w++) weeks.push(['week-' + w, 'Week ' + w]);
+        weeks.push(['week-17', 'Postseason']);
+        const cur = window.localStorage.getItem('weekCode') || 'week-1';
+        body.innerHTML = `<label class="uh-games-pick"><span>Week</span><select uh-games-week>${weeks.map(([v, l]) => `<option value="${v}"${v === cur ? ' selected' : ''}>${l}</option>`).join('')}</select></label>
+            <div class="football-loader" style="display:none"><div class="football-icon">🏈</div><p class="loading-text">Scouting for games...</p></div>
+            <div class="schedule-grid" schedule-body><div id="no-games-container"></div></div>`;
+        const sel = body.querySelector('[uh-games-week]');
+        const run = () => {
+            const loader = body.querySelector('.football-loader'); if (loader) loader.style.display = 'flex';
+            const sb = body.querySelector('[schedule-body]'); if (sb) sb.style.display = 'none';
+            displaySchedule(user);
+        };
+        sel.addEventListener('change', () => {
+            const label = sel.options[sel.selectedIndex].text;
+            window.localStorage.setItem('weekCode', sel.value);
+            window.localStorage.setItem('week', label);
+            if (g) g.textContent = `${label} · your teams`;
+            run();
+        });
+        run();
     };
 }
 

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -124,6 +124,44 @@ async function renderBento(data) {
     document.title = `${franchise || manager} · Campus Clash`;
     const own = currentUserId() && String(currentUserId()) === String(data._id);
     const pencil = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
+
+    // Preseason / undrafted window: the active season (APP_YEAR) hasn't been
+    // drafted for this manager yet — there's no season entry to key tiles off,
+    // so uhSeasonFor is only giving us a prior-season fallback. Rather than mix
+    // last season's data into a half-empty grid, show a dedicated empty state.
+    const hasActiveSeason = (data.seasons || []).some(s => String(s.season) === String(activeYear));
+    if (!hasActiveSeason) {
+        const prior = (data.seasons || [])
+            .filter(s => (s.weeklyScore || []).length)
+            .sort((a, b) => Number(b.season) - Number(a.season))[0];
+        let lastLine = '';
+        if (prior) {
+            const bt = bestTeam(prior);
+            lastLine = `<div class="uh-preseason-last">Last season · <b>${escapeHtml(prior.season)}</b> · ${prior.cumulativeScore || 0} pts`
+                + (bt && bt.total > 0 ? ` · best <b>${escapeHtml(bt.team.school)}</b> (${bt.total})` : '') + `</div>`;
+        }
+        const ball = window.ccIcon ? window.ccIcon('football', { size: 44 }) : '🏈';
+        bento.innerHTML =
+            `<div class="uh-tile span2 uh-hero">
+                <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
+                <div class="uh-hero-meta">
+                    <div class="uh-hero-name">${escapeHtml(franchise)}</div>
+                    <div class="uh-hero-sub">${escapeHtml(franchise ? ('Managed by ' + manager) : manager)}</div>
+                    <div class="uh-hero-stats"><span class="uh-preseason-pill">${escapeHtml(activeYear)} preseason</span></div>
+                </div>
+                ${own ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
+            </div>`
+            + `<div class="uh-tile span2 uh-preseason">
+                    <span class="uh-preseason-icon">${ball}</span>
+                    <h2 class="uh-preseason-h">The ${escapeHtml(activeYear)} season hasn’t kicked off yet</h2>
+                    <p class="uh-preseason-p">Your roster, matchups, and weekly recaps land here once your league’s draft is complete.</p>
+                    ${lastLine}
+                </div>`;
+        renderAvatar(document.getElementById('uh-hero-av'), data);
+        if (own) setupEditModal(data, season);
+        return;
+    }
+
     const tile = (k, label, glance, span, affordance) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" id="uh-tile-${k}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">${affordance || '›'}</span></span><span class="uh-glance" id="uh-glance-${k}">${glance}</span></button>`;
 
     bento.innerHTML =

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -231,11 +231,38 @@ function hydrateTrajectory(user, activeYear) {
         g.innerHTML = `<span class="uh-traj-g"><b class="uh-traj-num num">${season.cumulativeScore || 0}</b><span class="uh-glance-sub">total points</span></span>${series.length >= 2 ? `<span class="uh-traj-spark">${uhSpark(series, 260, 34, '#5BD08D')}</span>` : ''}`;
     }
 
-    uhDrawer.trajectory = (body) => {
-        body.innerHTML = `<div class="profile-chart-section" profile-chart-section hidden><div class="profile-chart-wrap"><canvas id="profile-chart"></canvas></div></div><p class="uh-stub" id="uh-traj-empty" hidden>Not enough scored weeks yet to chart a trend.</p>`;
+    uhDrawer.trajectory = async (body) => {
+        body.innerHTML = `<div class="uh-drawer-stats" id="uh-traj-stats"></div>
+            <div class="profile-chart-section" profile-chart-section hidden><div class="profile-chart-wrap"><canvas id="profile-chart"></canvas></div></div>
+            <p class="uh-stub" id="uh-traj-empty" hidden>Not enough scored weeks yet to chart a trend.</p>`;
         renderProfileChart(user);
         const section = body.querySelector('[profile-chart-section]');
         if (section && section.hidden) { const e = body.querySelector('#uh-traj-empty'); if (e) e.hidden = false; }
+
+        // Summary row: total points, best single week, finish + gap to the
+        // rest of the league (fetched from the same league standings the hero
+        // rank uses, so it stays scoped to the active season).
+        const statsEl = body.querySelector('#uh-traj-stats');
+        if (!statsEl) return;
+        let bestWk = 0;
+        (season.weeklyScore || []).forEach(w => { if ((w.score || 0) > bestWk) bestWk = w.score || 0; });
+        let html = statTile(String(season.cumulativeScore || 0), 'Total points');
+        if (bestWk > 0) html += statTile(String(bestWk), 'Best week');
+        try {
+            const res = await fetch(`/users/league/${encodeURIComponent(user.league)}`, { headers: { Accept: 'application/json' } });
+            if (res.ok) {
+                const ranked = (await res.json())
+                    .map(u => ({ id: u._id, score: (u.seasons && u.seasons[0] && u.seasons[0].cumulativeScore) || 0 }))
+                    .sort((a, b) => b.score - a.score);
+                const idx = ranked.findIndex(r => r.id === user._id);
+                if (idx >= 0) {
+                    html += statTile(`${escapeHtml(ordinal(idx + 1))} of ${ranked.length}`, 'Finish');
+                    if (idx === 0 && ranked[1]) html += statTile(`+${ranked[0].score - ranked[1].score}`, 'Lead over 2nd');
+                    else if (idx > 0) html += statTile(`−${ranked[0].score - ranked[idx].score}`, 'Behind leader');
+                }
+            }
+        } catch (e) { /* stats degrade to points-only */ }
+        statsEl.innerHTML = html;
     };
 }
 
@@ -324,9 +351,12 @@ function uhSpark(pts, w, h, color) {
     const ex = w.toFixed(1), ey = (h - ((pts[pts.length - 1] - min) / rng) * h).toFixed(1);
     return `<svg width="100%" height="${h}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" style="display:block"><path d="${d}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="${ex}" cy="${ey}" r="2.6" fill="${color}"/></svg>`;
 }
+// The tile that opened the drawer, so focus can return to it on close.
+var uhDrawerOpener = null;
 function openDrawer(key) {
     const title = UH_DRAWERS[key];
     if (title == null) return;
+    uhDrawerOpener = document.getElementById('uh-tile-' + key) || document.activeElement;
     document.getElementById('uh-drawer-title').textContent = title;
     const body = document.getElementById('uh-drawer-body');
     if (uhDrawer[key]) { body.innerHTML = ''; uhDrawer[key](body); }
@@ -334,15 +364,20 @@ function openDrawer(key) {
     const d = document.getElementById('uh-drawer');
     d.hidden = false;
     document.getElementById('uh-scrim').classList.add('open');
+    document.body.classList.add('uh-drawer-open');   // lock background scroll
     requestAnimationFrame(() => d.classList.add('open'));
     document.getElementById('uh-drawer-close').focus();
 }
 function closeDrawer() {
     const d = document.getElementById('uh-drawer');
-    if (!d) return;
+    if (!d || d.hidden) return;
     d.classList.remove('open');
     document.getElementById('uh-scrim').classList.remove('open');
+    document.body.classList.remove('uh-drawer-open');
     setTimeout(() => { d.hidden = true; }, 300);
+    // Return focus to the tile that opened it (accessibility).
+    if (uhDrawerOpener && typeof uhDrawerOpener.focus === 'function') uhDrawerOpener.focus();
+    uhDrawerOpener = null;
 }
 function setupDrawer() {
     const scrim = document.getElementById('uh-scrim'), close = document.getElementById('uh-drawer-close');

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -151,6 +151,9 @@ async function renderBento(data) {
 
     // Hydrate each tile's glance + drawer from real data.
     hydrateH2H(data);
+    hydrateCaptain(data);
+    hydrateRecap(data);
+    hydrateDraft(data);
 }
 
 var UH_DRAWERS = {
@@ -273,11 +276,14 @@ async function hydrateH2H(user) {
 // for the current regular-season week. Behind a hero chip that expands a team
 // grid. Only shown for your own profile, and only when the league has opted in
 // (or ?captain=1 to preview). Weeks already scored are locked.
-async function renderCaptain(user) {
-    const chip = document.querySelector('[captain-chip]');
-    const panel = document.getElementById('uh-captain');
-    if (!chip || !panel || !user || !user.league || !(user.seasons || []).length) return;
-    if (String(currentUserId()) !== String(user._id)) return;   // own profile only
+// Captain (#230) → Captain tile. Own profile only, and only when the league has
+// Captain on (or ?captain=1). Glance shows the current pick; drawer is the team
+// picker (set/clear a 2× team for the current open week).
+async function hydrateCaptain(user) {
+    const tile = document.getElementById('uh-tile-captain');
+    const hide = () => { if (tile) tile.hidden = true; };
+    if (!user || !user.league || !(user.seasons || []).length) return hide();
+    if (String(currentUserId()) !== String(user._id)) return hide();   // own profile only
 
     const preview = new URLSearchParams(location.search).get('captain') === '1';
     let enabled = false;
@@ -285,12 +291,10 @@ async function renderCaptain(user) {
         const r = await fetch('/scoring-config/' + encodeURIComponent(user.league), { headers: { Accept: 'application/json' } });
         if (r.ok) { const c = await r.json(); enabled = !!(c.engagement && c.engagement.captainEnabled); }
     } catch (e) { /* fall through to preview gate */ }
-    if (!enabled && !preview) return;
+    if (!enabled && !preview) return hide();
 
-    // Captain is set for the CURRENT season's first unplayed week. In the
-    // offseason (no current-season roster, or every week already scored) there's
-    // nothing to set, so the picker stays hidden — except in preview mode, which
-    // falls back to the latest season that still has an open week.
+    // Current season's first unplayed week (preview falls back to the latest
+    // season with an open week).
     const firstOpenWeek = (s) => {
         const scored = new Set((s.weeklyScore || []).filter(e => e.season !== 'postseason' && e.week <= 16).map(e => Number(e.week)));
         for (let w = 1; w <= 16; w++) if (!scored.has(w)) return w;
@@ -303,30 +307,28 @@ async function renderCaptain(user) {
         const cand = (user.seasons || []).slice().reverse().find(s => (s.teams || []).length && firstOpenWeek(s) != null);
         if (cand) { season = cand; week = firstOpenWeek(cand); }
     }
-    if (!season || week == null) return;
+    if (!season || week == null) return hide();
 
     let pick = ((season.captains || []).find(c => Number(c.week) === week) || {}).teamId;
-
     const teamById = {};
     (season.teams || []).forEach(t => { teamById[t.id] = t; });
-    const teaser = document.querySelector('[captain-chip-teaser]');
-    const setTeaser = () => {
+    if (tile) tile.hidden = false;
+
+    const g = document.getElementById('uh-glance-captain');
+    const setGlance = () => {
+        if (!g) return;
         const t = pick != null ? teamById[pick] : null;
-        teaser.innerHTML = t
-            ? `<img src="${t.logos.at(-1)}" alt=""> ${escapeHtml(t.school)}`
+        g.innerHTML = t
+            ? `<span class="uh-cap-glance"><img src="${t.logos.at(-1)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></span>`
             : `<span class="captain-unset">Set for Wk ${week}</span>`;
     };
-    const paint = () => {
-        panel.innerHTML = `
-            <div class="recap-head"><div class="header-title">Captain · Week ${week}</div></div>
-            <div class="recap-card">
-                <p class="captain-note">Pick one team to score <b>2×</b> this week. Locks at kickoff.</p>
-                <div class="captain-grid">${(season.teams || []).map(t => `
-                    <button type="button" class="captain-team${Number(pick) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(pick) === Number(t.id)}">
-                        <img src="${t.logos.at(-1)}" alt=""><span>${escapeHtml(t.school)}</span>
-                    </button>`).join('')}</div>
-            </div>`;
-        panel.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {
+    const paint = (container) => {
+        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${week}. Tap the current pick to clear. Locks at kickoff.</p>
+            <div class="captain-grid">${(season.teams || []).map(t => `
+                <button type="button" class="captain-team${Number(pick) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(pick) === Number(t.id)}">
+                    <img src="${t.logos.at(-1)}" alt=""><span>${escapeHtml(t.school)}</span>
+                </button>`).join('')}</div>`;
+        container.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {
             const teamId = Number(btn.getAttribute('data-team'));
             const next = Number(pick) === teamId ? null : teamId;   // click current to clear
             try {
@@ -337,112 +339,80 @@ async function renderCaptain(user) {
                 const data = await res.json();
                 if (!res.ok) throw new Error(data.message || 'Could not set captain');
                 pick = next;
-                setTeaser(); paint();
+                setGlance(); paint(container);
                 if (window.ccToast) ccToast.success(next ? `Captain set: ${teamById[next].school}` : 'Captain cleared');
             } catch (e) { if (window.ccToast) ccToast.error(e.message); }
         }));
     };
 
-    setTeaser();
-    paint();
-    chip.hidden = false;
-    if (!chip.dataset.wired) {
-        chip.dataset.wired = '1';
-        chip.addEventListener('click', () => {
-            const open = panel.classList.toggle('is-open');
-            chip.setAttribute('aria-expanded', String(open));
-        });
-    }
+    setGlance();
+    uhDrawer.captain = (body) => paint(body);
 }
 
-// Weekly Recap on the profile: a "here's your week" card tucked behind a hero
-// pill (like the Draft grade chip). Rendering + the app-wide weekly popup live
-// in public/weekly-recap.js (window.ccRecap); here we just fetch, mount the
-// collapsed card, and wire the pill to expand it.
-async function renderRecap(user) {
-    const el = document.getElementById('uh-recap');
-    const chip = document.querySelector('[recap-chip]');
-    if (!el || !chip || !window.ccRecap || !user || !user.league || !(user.seasons || []).length) return;
+// Weekly Recap (#212) → Your Week tile. Glance shows the latest week's narrative;
+// drawer mounts the full "Your Week" card (week selector + story) via ccRecap.
+async function hydrateRecap(user) {
+    const tile = document.getElementById('uh-tile-recap');
+    const hide = () => { if (tile) tile.hidden = true; };
+    if (!window.ccRecap || !user || !user.league || !(user.seasons || []).length) return hide();
 
-    // Recap the latest season that actually has weekly scores, so the pill is
-    // useful in the offseason too (shows last season's finish).
     const played = (user.seasons || [])
         .filter(s => (s.weeklyScore || []).length > 0)
         .sort((a, b) => Number(b.season) - Number(a.season));
-    if (!played.length) return;
+    if (!played.length) return hide();
 
     try {
         const data = await window.ccRecap.fetchRecap(user.league, played[0].season, user._id);
-        if (!data || !(data.recaps || []).length) return;
-        const latest = window.ccRecap.mountInline(el, data);
+        if (!data || !(data.recaps || []).length) return hide();
+        if (tile) tile.hidden = false;
 
-        // Teaser on the pill: latest week + rank + movement arrow.
-        const teaser = document.querySelector('[recap-chip-teaser]');
-        if (teaser && latest) {
-            const place = latest.rank != null ? escapeHtml(ordinal(latest.rank)) : '';
-            teaser.innerHTML = `${escapeHtml(latest.label)} · ${place} ${window.ccRecap.movement(latest.rankDelta)}`;
+        const latest = data.recaps[data.recaps.length - 1];
+        const g = document.getElementById('uh-glance-recap');
+        if (g && latest) {
+            const place = latest.rank != null ? ` · ${escapeHtml(ordinal(latest.rank))} ${window.ccRecap.movement(latest.rankDelta)}` : '';
+            g.innerHTML = latest.narrative ? escapeHtml(latest.narrative) : `${escapeHtml(latest.label)}${place}`;
         }
-        chip.hidden = false;
-        if (!chip.dataset.wired) {
-            chip.dataset.wired = '1';
-            chip.addEventListener('click', () => {
-                const open = el.classList.toggle('is-open');
-                chip.setAttribute('aria-expanded', String(open));
-            });
-        }
+        uhDrawer.recap = (body) => { window.ccRecap.mountInline(body, data); };
     } catch (e) {
         console.error('weekly recap failed:', e);
+        hide();
     }
 }
 
-// Draft grade on the profile: just THIS manager's own most-recent-season card,
-// surfaced as a color-coded chip in the hero that expands the detail on demand.
-// Preseason blend of roster strength + draft value (see modules/draft-grades.js).
-async function loadHomeGrades(user) {
-    const el = document.getElementById('uh-grades');
-    const chip = document.querySelector('[profile-grade-chip]');
-    if (!el || !chip || !user || !user.league || !(user.seasons || []).length) return;
+// Draft grade → Draft grade tile. Glance shows the color-coded letter; drawer
+// renders this manager's full draft-grade card (reused from draftGrades.js).
+async function hydrateDraft(user) {
+    const tile = document.getElementById('uh-tile-draft');
+    const hide = () => { if (tile) tile.hidden = true; };
+    if (!user || !user.league || !(user.seasons || []).length) return hide();
     const season = user.seasons.at(-1).season;
     try {
         const res = await fetch('/draft/grades/' + encodeURIComponent(user.league) + '/' + encodeURIComponent(season), {
             headers: { 'Accept': 'application/json' }
         });
         const data = await res.json();
-        // Show only the profile owner's card; hide the chip entirely if this
-        // manager didn't draft that season.
         const mine = (data.managers || []).find(m => String(m.userId) === String(user._id));
-        if (!mine) return;   // chip stays hidden
+        if (!mine) return hide();   // didn't draft that season
+        if (tile) tile.hidden = false;
 
         const tier = (mine.grade || '').charAt(0).toLowerCase();
-        chip.classList.add('gg-tier-' + tier);
-        document.querySelector('[profile-grade-letter]').textContent = mine.grade;
-        chip.hidden = false;
+        const g = document.getElementById('uh-glance-draft');
+        if (g) g.innerHTML = `<span class="uh-grade gg-tier-${tier}">${escapeHtml(mine.grade)}</span><span class="uh-glance-sub">preseason projection</span>`;
 
-        // "you" tag keys off the logged-in viewer, not the profile owner, so it
-        // only appears when you're looking at your own profile.
         let me;
         try { me = userState.user_metadata.metadata.userId; } catch (e) { /* fall through */ }
         me = me || window.localStorage.getItem('userId') || user._id;
-        if (typeof renderDraftGradeCard === 'function') {
-            renderDraftGradeCard(el, mine, {
-                currentUserId: me,
-                note: season + ' preseason grade — projected fantasy points in your league’s scoring (schedule + SP+ win odds + market CFP odds). Each draft graded on its own merit.'
-            });
-        }
-        // Reveal the panel but keep it collapsed via CSS max-height, so the
-        // first expand animates (display:none can't transition).
-        el.hidden = false;
-
-        // Chip toggles the detail panel (collapsed by default).
-        if (!chip.dataset.wired) {
-            chip.dataset.wired = '1';
-            chip.addEventListener('click', () => {
-                const open = el.classList.toggle('is-open');
-                chip.setAttribute('aria-expanded', String(open));
-            });
-        }
+        uhDrawer.draft = (body) => {
+            if (typeof renderDraftGradeCard === 'function') {
+                renderDraftGradeCard(body, mine, {
+                    currentUserId: me,
+                    note: season + ' preseason grade — projected fantasy points in your league’s scoring (schedule + SP+ win odds + market CFP odds). Each draft graded on its own merit.'
+                });
+            }
+        };
     } catch (e) {
-        console.error('home grades failed:', e);
+        console.error('draft grade failed:', e);
+        hide();
     }
 }
 

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -405,20 +405,18 @@ async function hydrateCaptain(user) {
     } catch (e) { /* fall through to preview gate */ }
     if (!enabled && !preview) return hide();
 
-    // Current season's first unplayed week (preview falls back to the latest
-    // season with an open week).
+    // Captain is set for the active season's next unplayed regular week. Use the
+    // latest season that has a roster AND an open week (consistent with every
+    // other tile, which keys off seasons.at(-1) — not the wall-clock year, which
+    // is ahead of the data in the offseason). No open week (finished season) →
+    // nothing to set → hide.
     const firstOpenWeek = (s) => {
         const scored = new Set((s.weeklyScore || []).filter(e => e.season !== 'postseason' && e.week <= 16).map(e => Number(e.week)));
         for (let w = 1; w <= 16; w++) if (!scored.has(w)) return w;
         return null;
     };
-    const year = new Date().getFullYear();
-    let season = (user.seasons || []).find(s => Number(s.season) === year && (s.teams || []).length);
-    let week = season ? firstOpenWeek(season) : null;
-    if ((!season || week == null) && preview) {
-        const cand = (user.seasons || []).slice().reverse().find(s => (s.teams || []).length && firstOpenWeek(s) != null);
-        if (cand) { season = cand; week = firstOpenWeek(cand); }
-    }
+    const season = (user.seasons || []).slice().reverse().find(s => (s.teams || []).length && firstOpenWeek(s) != null);
+    const week = season ? firstOpenWeek(season) : null;
     if (!season || week == null) return hide();
 
     let pick = ((season.captains || []).find(c => Number(c.week) === week) || {}).teamId;

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -101,14 +101,24 @@ async function getUser() {
     });
 }
 
+// The active season for the whole page: the user's entry matching the server's
+// current season (window.APP_YEAR = process.env.YEAR), else the latest season on
+// the doc. Every tile keys off this ONE value so they never show different
+// seasons at a flip.
+function uhSeasonFor(user, year) {
+    const seasons = (user && user.seasons) || [];
+    return seasons.find(s => String(s.season) === String(year)) || seasons[seasons.length - 1] || {};
+}
+
 // ---------- My Team bento (#230 redesign, feat/my-team-redesign) ----------
-// Renders the tile grid; each tile opens the slide-over drawer. STAGE 2 (shell):
-// the hero tile shows real identity + edit; the other tiles open placeholder
-// drawers that the next stage wires to the real renderers.
+// Renders the tile grid; each tile is a glance that opens a slide-over drawer,
+// all keyed off the one active season (uhSeasonFor).
 async function renderBento(data) {
     const bento = document.getElementById('uh-bento');
     if (!bento || !data) return;
-    const season = data.seasons.at(-1) || {};
+    const activeYear = (window.APP_YEAR && String(window.APP_YEAR))
+        || (data.seasons && data.seasons.length ? String(data.seasons[data.seasons.length - 1].season) : String(new Date().getFullYear()));
+    const season = uhSeasonFor(data, activeYear);
     const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
     const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
     document.title = `${franchise || manager} · Campus Clash`;
@@ -138,7 +148,10 @@ async function renderBento(data) {
     renderAvatar(document.getElementById('uh-hero-av'), data);
     const statsEl = document.getElementById('uh-hero-stats');
     let sh = '';
-    try { const rank = await computeRank(data); if (rank) sh += statTile(escapeHtml(ordinal(rank.rank)), `of ${rank.total} teams`); } catch (e) { /* rank optional */ }
+    // Rank only once the active season has scores (preseason ties everyone at 0).
+    if ((season.weeklyScore || []).length) {
+        try { const rank = await computeRank(data); if (rank) sh += statTile(escapeHtml(ordinal(rank.rank)), `of ${rank.total} teams`); } catch (e) { /* rank optional */ }
+    }
     sh += statTile(String(season.cumulativeScore || 0), 'Total points');
     const bt = bestTeam(season);
     if (bt && bt.total > 0) sh += statTile(`<img src="${bt.team.logos.at(-1)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
@@ -149,22 +162,22 @@ async function renderBento(data) {
     bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
     setupDrawer();
 
-    // Hydrate each tile's glance + drawer from real data.
-    hydrateH2H(data);
-    hydrateCaptain(data);
-    hydrateRecap(data);
-    hydrateDraft(data);
-    hydrateRoster(data);
-    hydrateTrajectory(data);
-    hydrateGames(data);
+    // Hydrate each tile's glance + drawer from the one active season.
+    hydrateH2H(data, activeYear);
+    hydrateCaptain(data, activeYear);
+    hydrateRecap(data, activeYear);
+    hydrateDraft(data, activeYear);
+    hydrateRoster(data, activeYear);
+    hydrateTrajectory(data, activeYear);
+    hydrateGames(data, activeYear);
 }
 
 // Roster → Roster tile. Glance shows your top performer; drawer lists all teams
 // as cards (points + share bar) then the full week-by-week grid (reused
 // displayTeams). Sums per-team points from this season's weekly scoreByTeam.
-function hydrateRoster(user) {
+function hydrateRoster(user, activeYear) {
     const tile = document.getElementById('uh-tile-roster');
-    const season = (user.seasons || []).at(-1) || {};
+    const season = uhSeasonFor(user, activeYear);
     const teams = season.teams || [];
     if (!teams.length) { if (tile) tile.hidden = true; return; }
 
@@ -206,9 +219,9 @@ function hydrateRoster(user) {
 
 // Trajectory → Trajectory tile. Glance shows total points; drawer hosts the
 // cumulative-points line chart (reused renderProfileChart).
-function hydrateTrajectory(user) {
+function hydrateTrajectory(user, activeYear) {
     const tile = document.getElementById('uh-tile-trajectory');
-    const season = (user.seasons || []).at(-1) || {};
+    const season = uhSeasonFor(user, activeYear);
     if (!(season.weeklyScore || []).length) { if (tile) tile.hidden = true; return; }
 
     const g = document.getElementById('uh-glance-trajectory');
@@ -228,10 +241,17 @@ function hydrateTrajectory(user) {
 
 // Games → Games tile. Glance names the selected week; drawer hosts a week picker
 // + this week's game cards for your rostered teams (reused displaySchedule).
-async function hydrateGames(user) {
+async function hydrateGames(user, activeYear) {
     const tile = document.getElementById('uh-tile-games');
-    const season = (user.seasons || []).at(-1) || {};
+    const season = uhSeasonFor(user, activeYear);
     if (!(season.teams || []).length) { if (tile) tile.hidden = true; return; }
+    // weekCode isn't season-scoped — reset it when the active season changes so a
+    // new season doesn't inherit last season's selected week (e.g. Postseason).
+    if (window.localStorage.getItem('weekSeason') !== String(activeYear)) {
+        window.localStorage.removeItem('weekCode');
+        window.localStorage.removeItem('week');
+        window.localStorage.setItem('weekSeason', String(activeYear));
+    }
     ensureWeekSelected(user);
 
     // Resting state: only the logos of your teams that actually play this week.
@@ -339,15 +359,13 @@ function setupDrawer() {
 //  - Schedule: up-next (in-season) + the full week-by-week schedule; tap a week
 //    to expand its detail.
 // Both tiles hide when the league doesn't have H2H on (and ?h2h=1 isn't set).
-async function hydrateH2H(user) {
+async function hydrateH2H(user, activeYear) {
     const mTile = document.getElementById('uh-tile-matchup');
     const sTile = document.getElementById('uh-tile-schedule');
     const hide = () => { if (mTile) mTile.hidden = true; if (sTile) sTile.hidden = true; };
     if (!user || !user.league || !(user.seasons || []).length || !window.ccH2H) return hide();
 
-    const played = (user.seasons || []).filter(s => (s.weeklyScore || []).length > 0).sort((a, b) => Number(b.season) - Number(a.season));
-    if (!played.length) return hide();
-    const season = played[0].season;
+    const season = activeYear;
 
     let enabled = false;
     try {
@@ -446,7 +464,7 @@ async function hydrateH2H(user) {
 // Captain (#230) → Captain tile. Own profile only, and only when the league has
 // Captain on (or ?captain=1). Glance shows the current pick; drawer is the team
 // picker (set/clear a 2× team for the current open week).
-async function hydrateCaptain(user) {
+async function hydrateCaptain(user, activeYear) {
     const tile = document.getElementById('uh-tile-captain');
     const hide = () => { if (tile) tile.hidden = true; };
     if (!user || !user.league || !(user.seasons || []).length) return hide();
@@ -460,19 +478,18 @@ async function hydrateCaptain(user) {
     } catch (e) { /* fall through to preview gate */ }
     if (!enabled && !preview) return hide();
 
-    // Captain is set for the active season's next unplayed regular week. Use the
-    // latest season that has a roster AND an open week (consistent with every
-    // other tile, which keys off seasons.at(-1) — not the wall-clock year, which
-    // is ahead of the data in the offseason). No open week (finished season) →
-    // nothing to set → hide.
+    // Captain is set for the active season's next unplayed regular week. The
+    // active season is the server's authoritative YEAR (window.APP_YEAR), the
+    // same season every other tile keys off. No roster or no open week
+    // (finished season) → nothing to set → hide.
     const firstOpenWeek = (s) => {
         const scored = new Set((s.weeklyScore || []).filter(e => e.season !== 'postseason' && e.week <= 16).map(e => Number(e.week)));
         for (let w = 1; w <= 16; w++) if (!scored.has(w)) return w;
         return null;
     };
-    const season = (user.seasons || []).slice().reverse().find(s => (s.teams || []).length && firstOpenWeek(s) != null);
-    const week = season ? firstOpenWeek(season) : null;
-    if (!season || week == null) return hide();
+    const season = uhSeasonFor(user, activeYear);
+    const week = (season.teams || []).length ? firstOpenWeek(season) : null;
+    if (!(season.teams || []).length || week == null) return hide();
 
     let pick = ((season.captains || []).find(c => Number(c.week) === week) || {}).teamId;
     const teamById = {};
@@ -517,18 +534,13 @@ async function hydrateCaptain(user) {
 
 // Weekly Recap (#212) → Your Week tile. Glance shows the latest week's narrative;
 // drawer mounts the full "Your Week" card (week selector + story) via ccRecap.
-async function hydrateRecap(user) {
+async function hydrateRecap(user, activeYear) {
     const tile = document.getElementById('uh-tile-recap');
     const hide = () => { if (tile) tile.hidden = true; };
     if (!window.ccRecap || !user || !user.league || !(user.seasons || []).length) return hide();
 
-    const played = (user.seasons || [])
-        .filter(s => (s.weeklyScore || []).length > 0)
-        .sort((a, b) => Number(b.season) - Number(a.season));
-    if (!played.length) return hide();
-
     try {
-        const data = await window.ccRecap.fetchRecap(user.league, played[0].season, user._id);
+        const data = await window.ccRecap.fetchRecap(user.league, activeYear, user._id);
         if (!data || !(data.recaps || []).length) return hide();
         if (tile) tile.hidden = false;
 
@@ -547,11 +559,11 @@ async function hydrateRecap(user) {
 
 // Draft grade → Draft grade tile. Glance shows the color-coded letter; drawer
 // renders this manager's full draft-grade card (reused from draftGrades.js).
-async function hydrateDraft(user) {
+async function hydrateDraft(user, activeYear) {
     const tile = document.getElementById('uh-tile-draft');
     const hide = () => { if (tile) tile.hidden = true; };
     if (!user || !user.league || !(user.seasons || []).length) return hide();
-    const season = user.seasons.at(-1).season;
+    const season = activeYear;
     try {
         const res = await fetch('/draft/grades/' + encodeURIComponent(user.league) + '/' + encodeURIComponent(season), {
             headers: { 'Accept': 'application/json' }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -1,6 +1,11 @@
 var weekCode;
 var userData;
 var isMobile;
+// The one active season (process.env.YEAR via window.APP_YEAR), set by
+// renderBento. Reused renderers (displayTeams/renderProfileChart/
+// displaySchedule/ensureWeekSelected) read it instead of guessing with
+// seasons.at(-1), so every part of the page keys off the same season.
+var uhActiveYear;
 
 // Escapes HTML special chars before interpolating values into innerHTML.
 function escapeHtml(value) {
@@ -118,6 +123,7 @@ async function renderBento(data) {
     if (!bento || !data) return;
     const activeYear = (window.APP_YEAR && String(window.APP_YEAR))
         || (data.seasons && data.seasons.length ? String(data.seasons[data.seasons.length - 1].season) : String(new Date().getFullYear()));
+    uhActiveYear = activeYear;   // reused renderers read this (see var decl)
     const season = uhSeasonFor(data, activeYear);
     const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
     const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
@@ -674,7 +680,7 @@ async function hydrateDraft(user, activeYear) {
 // displaySchedule never reads a null weekCode) on a fresh visit.
 function ensureWeekSelected(data) {
     if (window.localStorage.getItem('weekCode') && window.localStorage.getItem('week')) return;
-    const weekly = (data.seasons.at(-1) || {}).weeklyScore || [];
+    const weekly = uhSeasonFor(data, uhActiveYear).weeklyScore || [];
     let maxWeek = 0, hasPost = false;
     weekly.forEach(w => {
         if (w.season === 'postseason' || w.week > 16) hasPost = true;
@@ -938,7 +944,7 @@ function columnTeamScore(entry, teamSchool) {
 function displayTeams(data) {
     const head = document.querySelector('[user-table-head]');
     const body = document.querySelector('[user-table-body]');
-    const season = data.seasons.at(-1) || {};
+    const season = uhSeasonFor(data, uhActiveYear);
     const teams = season.teams || [];
     const columns = weeklyColumns(season);
 
@@ -999,7 +1005,7 @@ function renderProfileChart(data) {
     const canvas = document.getElementById('profile-chart');
     if (!section || !canvas || typeof Chart === 'undefined') return;
 
-    const season = data.seasons.at(-1) || {};
+    const season = uhSeasonFor(data, uhActiveYear);
     const cols = weeklyColumns(season);
     let cum = 0;
     const labels = [], points = [];
@@ -1252,7 +1258,7 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
     // A rostered team's points for this game -> a green badge cell, or '' at 0.
     const badgeCell = (id, rostered) => {
         if (!rostered) return '';
-        const pts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, id, game.id);
+        const pts = teamGameScoreById(uhSeasonFor(userData, uhActiveYear).weeklyScore, id, game.id);
         return pts > 0 ? `<td class="score-added"><strong style="color: #22C37A;">+${pts}</strong></td>` : '';
     };
     const caret = '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i>';
@@ -1283,7 +1289,7 @@ async function displaySchedule(data) {
     let week = window.localStorage.getItem('weekCode').substring(5);
     let seasonType = 'regular';
     let rankingsInfo;
-    const seasonYear = data.seasons.at(-1).season;
+    const seasonYear = uhSeasonFor(data, uhActiveYear).season;
 
     if (week == '17') {
         rankingsInfo = await getRankings((week - 1), seasonType, seasonYear);
@@ -1296,7 +1302,7 @@ async function displaySchedule(data) {
     const allBettingLines = await getAllBettingLines(seasonYear) || [];
 
     // Fetch each roster team's games in parallel, then all logos in one request.
-    const teamsList = data.seasons.at(-1).teams;
+    const teamsList = uhSeasonFor(data, uhActiveYear).teams || [];
     const rosteredIds = new Set(teamsList.map(t => t.id));
     const gamesPerTeam = await Promise.all(teamsList.map(t => getGame(seasonType, week, t)));
 

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -228,18 +228,31 @@ function hydrateTrajectory(user) {
 
 // Games → Games tile. Glance names the selected week; drawer hosts a week picker
 // + this week's game cards for your rostered teams (reused displaySchedule).
-function hydrateGames(user) {
+async function hydrateGames(user) {
     const tile = document.getElementById('uh-tile-games');
     const season = (user.seasons || []).at(-1) || {};
     if (!(season.teams || []).length) { if (tile) tile.hidden = true; return; }
     ensureWeekSelected(user);
 
-    // Resting state: a strip of your team logos + the selected week.
+    // Resting state: only the logos of your teams that actually play this week.
     const g = document.getElementById('uh-glance-games');
+    const label = window.localStorage.getItem('week') || 'This week';
+    if (g) g.innerHTML = `<span class="uh-glance-sub uh-games-wk">${escapeHtml(label)}</span>`;
     if (g) {
-        const label = window.localStorage.getItem('week') || 'This week';
-        const logos = (season.teams || []).map(t => `<img src="${t.logos.at(-1)}" alt="">`).join('');
-        g.innerHTML = `<span class="uh-games-logos">${logos}</span><span class="uh-glance-sub uh-games-wk">${escapeHtml(label)}</span>`;
+        try {
+            let week = (window.localStorage.getItem('weekCode') || 'week-1').substring(5);
+            let seasonType = 'regular';
+            if (week === '17') { seasonType = 'postseason'; week = 1; }
+            const per = await Promise.all((season.teams || []).map(t =>
+                getGame(seasonType, week, t).then(gs => ({ t, plays: !!(gs && gs.length) })).catch(() => ({ t, plays: false }))));
+            const playing = per.filter(x => x.plays).map(x => x.t);
+            if (playing.length) {
+                const logos = playing.map(t => `<img src="${t.logos.at(-1)}" alt="">`).join('');
+                g.innerHTML = `<span class="uh-games-logos">${logos}</span><span class="uh-glance-sub uh-games-wk">${playing.length} of your teams · ${escapeHtml(label)}</span>`;
+            } else {
+                g.innerHTML = `<span class="uh-glance-sub">No games for your teams · ${escapeHtml(label)}</span>`;
+            }
+        } catch (e) { /* keep the week label */ }
     }
 
     uhDrawer.games = (body) => {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -131,9 +131,9 @@ async function renderBento(data) {
         + tile('captain', 'Captain', 'Double a team each week', 1)
         + tile('recap', 'Your week', 'Latest recap', 1)
         + tile('schedule', 'Schedule', 'Up next', 1, 'Full schedule ›')
+        + tile('games', 'Games', 'This week’s games', 1, 'This week ›')
         + tile('trajectory', 'Trajectory', 'Season points', 1)
-        + tile('draft', 'Draft grade', 'Preseason projection', 2)
-        + tile('games', 'Games', 'This week’s games', 2);
+        + tile('draft', 'Draft grade', 'Preseason projection', 1);
 
     renderAvatar(document.getElementById('uh-hero-av'), data);
     const statsEl = document.getElementById('uh-hero-stats');
@@ -234,15 +234,20 @@ function hydrateGames(user) {
     if (!(season.teams || []).length) { if (tile) tile.hidden = true; return; }
     ensureWeekSelected(user);
 
+    // Resting state: a strip of your team logos + the selected week.
     const g = document.getElementById('uh-glance-games');
-    if (g) g.textContent = `${window.localStorage.getItem('week') || 'This week'} · your teams`;
+    if (g) {
+        const label = window.localStorage.getItem('week') || 'This week';
+        const logos = (season.teams || []).map(t => `<img src="${t.logos.at(-1)}" alt="">`).join('');
+        g.innerHTML = `<span class="uh-games-logos">${logos}</span><span class="uh-glance-sub uh-games-wk">${escapeHtml(label)}</span>`;
+    }
 
     uhDrawer.games = (body) => {
         const weeks = [];
         for (let w = 1; w <= 16; w++) weeks.push(['week-' + w, 'Week ' + w]);
         weeks.push(['week-17', 'Postseason']);
         const cur = window.localStorage.getItem('weekCode') || 'week-1';
-        body.innerHTML = `<label class="uh-games-pick"><span>Week</span><select uh-games-week>${weeks.map(([v, l]) => `<option value="${v}"${v === cur ? ' selected' : ''}>${l}</option>`).join('')}</select></label>
+        body.innerHTML = `<label class="uh-games-pick"><select uh-games-week aria-label="Week">${weeks.map(([v, l]) => `<option value="${v}"${v === cur ? ' selected' : ''}>${l}</option>`).join('')}</select></label>
             <div class="football-loader" style="display:none"><div class="football-icon">🏈</div><p class="loading-text">Scouting for games...</p></div>
             <div class="schedule-grid" schedule-body><div id="no-games-container"></div></div>`;
         const sel = body.querySelector('[uh-games-week]');
@@ -255,7 +260,7 @@ function hydrateGames(user) {
             const label = sel.options[sel.selectedIndex].text;
             window.localStorage.setItem('weekCode', sel.value);
             window.localStorage.setItem('week', label);
-            if (g) g.textContent = `${label} · your teams`;
+            const wk = g && g.querySelector('.uh-games-wk'); if (wk) wk.textContent = label;
             run();
         });
         run();

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -154,6 +154,60 @@ async function renderBento(data) {
     hydrateCaptain(data);
     hydrateRecap(data);
     hydrateDraft(data);
+    hydrateRoster(data);
+    hydrateTrajectory(data);
+}
+
+// Roster → Roster tile. Glance shows your top performer; drawer lists all teams
+// as cards (points + share bar) then the full week-by-week grid (reused
+// displayTeams). Sums per-team points from this season's weekly scoreByTeam.
+function hydrateRoster(user) {
+    const tile = document.getElementById('uh-tile-roster');
+    const season = (user.seasons || []).at(-1) || {};
+    const teams = season.teams || [];
+    if (!teams.length) { if (tile) tile.hidden = true; return; }
+
+    const totalById = {};
+    (season.weeklyScore || []).forEach(e => (e.scoreByTeam || []).forEach(st => {
+        totalById[st.teamId] = (totalById[st.teamId] || 0) + (st.score || 0);
+    }));
+    const cards = teams.map(t => ({ t, pts: Math.round((totalById[t.id] || 0) * 10) / 10 })).sort((a, b) => b.pts - a.pts);
+    const top = cards[0];
+
+    const g = document.getElementById('uh-glance-roster');
+    if (g) g.innerHTML = top && top.pts > 0
+        ? `<span class="uh-mu-opp">${escapeHtml(top.t.school)}</span> <b class="num">${top.pts}</b> <span class="uh-glance-sub">leads your roster</span>`
+        : 'Your 10 teams';
+
+    uhDrawer.roster = (body) => {
+        const max = (cards[0] && cards[0].pts) || 1;
+        const list = cards.map(c => `<a class="uh-rc" href="/team?team=${c.t.id}">
+            <img src="${c.t.logos.at(-1)}" alt="">
+            <span class="uh-rc-meta"><span class="uh-rc-nm">${escapeHtml(c.t.school)}</span><span class="uh-rc-bar"><i style="width:${Math.round((c.pts / max) * 100)}%"></i></span></span>
+            <span class="uh-rc-pts num">${c.pts}</span></a>`).join('');
+        body.innerHTML = `<div class="uh-roster-cards">${list}</div>
+            <div class="uh-drawer-cap">Week by week</div>
+            <div class="table-wrapper"><table class="fl-table"><thead user-table-head></thead><tbody user-table-body></tbody></table></div>`;
+        displayTeams(user);
+    };
+}
+
+// Trajectory → Trajectory tile. Glance shows total points; drawer hosts the
+// cumulative-points line chart (reused renderProfileChart).
+function hydrateTrajectory(user) {
+    const tile = document.getElementById('uh-tile-trajectory');
+    const season = (user.seasons || []).at(-1) || {};
+    if (!(season.weeklyScore || []).length) { if (tile) tile.hidden = true; return; }
+
+    const g = document.getElementById('uh-glance-trajectory');
+    if (g) g.innerHTML = `<b class="num">${season.cumulativeScore || 0}</b> <span class="uh-glance-sub">total points</span>`;
+
+    uhDrawer.trajectory = (body) => {
+        body.innerHTML = `<div class="profile-chart-section" profile-chart-section hidden><div class="profile-chart-wrap"><canvas id="profile-chart"></canvas></div></div><p class="uh-stub" id="uh-traj-empty" hidden>Not enough scored weeks yet to chart a trend.</p>`;
+        renderProfileChart(user);
+        const section = body.querySelector('[profile-chart-section]');
+        if (section && section.hidden) { const e = body.querySelector('#uh-traj-empty'); if (e) e.hidden = false; }
+    };
 }
 
 var UH_DRAWERS = {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -448,7 +448,7 @@ async function hydrateH2H(user, activeYear) {
 
     let enabled = false;
     try {
-        const r = await fetch('/scoring-config/' + encodeURIComponent(user.league), { headers: { Accept: 'application/json' } });
+        const r = await fetch('/scoring-config/' + encodeURIComponent(user.league) + '?season=' + encodeURIComponent(season), { headers: { Accept: 'application/json' } });
         if (r.ok) { const c = await r.json(); enabled = !!(c.engagement && c.engagement.h2hEnabled); }
     } catch (e) { /* preview gate below */ }
     if (!enabled && new URLSearchParams(location.search).get('h2h') !== '1') return hide();
@@ -552,7 +552,7 @@ async function hydrateCaptain(user, activeYear) {
     const preview = new URLSearchParams(location.search).get('captain') === '1';
     let enabled = false;
     try {
-        const r = await fetch('/scoring-config/' + encodeURIComponent(user.league), { headers: { Accept: 'application/json' } });
+        const r = await fetch('/scoring-config/' + encodeURIComponent(user.league) + '?season=' + encodeURIComponent(activeYear), { headers: { Accept: 'application/json' } });
         if (r.ok) { const c = await r.json(); enabled = !!(c.engagement && c.engagement.captainEnabled); }
     } catch (e) { /* fall through to preview gate */ }
     if (!enabled && !preview) return hide();

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -569,13 +569,11 @@ async function hydrateDraft(user) {
             + `<span class="uh-ds"><b class="num">${mine.cfpCount}</b>CFP teams</span>`
             + `</span></span>`;
 
-        let me;
-        try { me = userState.user_metadata.metadata.userId; } catch (e) { /* fall through */ }
-        me = me || window.localStorage.getItem('userId') || user._id;
         uhDrawer.draft = (body) => {
             if (typeof renderDraftGradeCard === 'function') {
+                // No currentUserId → no "you" tag / red highlight (it's always
+                // your own grade on My Team).
                 renderDraftGradeCard(body, mine, {
-                    currentUserId: me,
                     note: season + ' preseason grade — projected fantasy points in your league’s scoring (schedule + SP+ win odds + market CFP odds). Each draft graded on its own merit.'
                 });
             }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -158,7 +158,7 @@ async function renderBento(data) {
                     ${lastLine}
                 </div>`;
         renderAvatar(document.getElementById('uh-hero-av'), data);
-        if (own) setupEditModal(data, season);
+        if (own) setupEditModal(data, season, false);   // no season yet → name locked
         return;
     }
 
@@ -195,7 +195,7 @@ async function renderBento(data) {
     if (bt && bt.total > 0) sh += statTile(`<img src="${bt.team.logos.at(-1)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
     statsEl.innerHTML = sh;
 
-    if (own) setupEditModal(data, season);
+    if (own) setupEditModal(data, season, true);
 
     bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
     setupDrawer();
@@ -787,10 +787,15 @@ function refreshHeroIdentity(data, season) {
 
 // ---------- Edit modal (franchise name + avatar upload) ----------
 
-function setupEditModal(data, season) {
+function setupEditModal(data, season, franchiseEditable) {
+    // Franchise name is per-season — until the active season exists on the doc
+    // (i.e. the league has drafted), there's nothing to name, so the field is
+    // locked and only the avatar can be changed.
+    franchiseEditable = franchiseEditable !== false;
     const btn = document.querySelector('[edit-profile-btn]');
     const modal = document.querySelector('[profile-modal]');
     const nameInput = document.querySelector('[profile-name-input]');
+    const nameNote = document.querySelector('[profile-name-note]');
     const modalAvatar = document.querySelector('[profile-modal-avatar]');
     const fileInput = document.querySelector('[profile-file-input]');
     const uploadBtn = document.querySelector('[profile-upload-btn]');
@@ -810,7 +815,16 @@ function setupEditModal(data, season) {
 
     function open() {
         pendingAvatar = undefined;
-        nameInput.value = season.franchiseName || '';
+        if (franchiseEditable) {
+            nameInput.value = season.franchiseName || '';
+            nameInput.disabled = false;
+            nameInput.placeholder = 'Name your team';
+        } else {
+            nameInput.value = '';
+            nameInput.disabled = true;
+            nameInput.placeholder = 'Available after the draft';
+        }
+        if (nameNote) { nameNote.textContent = franchiseEditable ? '' : 'You can name your team once your league drafts this season.'; nameNote.hidden = franchiseEditable; }
         renderAvatar(modalAvatar, data);
         showError('');
         // Set the upload control's state every open so a missing Cloudinary
@@ -858,7 +872,8 @@ function setupEditModal(data, season) {
     saveBtn.addEventListener('click', async () => {
         showError('');
         saveBtn.disabled = true;
-        const body = { franchiseName: nameInput.value };
+        const body = {};
+        if (franchiseEditable) body.franchiseName = nameInput.value;
         if (pendingAvatar !== undefined) body.avatarUrl = pendingAvatar;
         try {
             const res = await fetch('/users/me/profile', {
@@ -869,7 +884,7 @@ function setupEditModal(data, season) {
             const out = await res.json();
             if (!res.ok) throw new Error(out.message || 'Save failed');
             data.avatarUrl = out.avatarUrl;
-            season.franchiseName = out.franchiseName;
+            if (franchiseEditable) season.franchiseName = out.franchiseName;
             refreshHeroIdentity(data, season);
             close();
         } catch (e) {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -114,7 +114,7 @@ async function renderBento(data) {
     document.title = `${franchise || manager} · Campus Clash`;
     const own = currentUserId() && String(currentUserId()) === String(data._id);
     const pencil = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
-    const tile = (k, label, glance, span) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">›</span></span><span class="uh-glance">${glance}</span></button>`;
+    const tile = (k, label, glance, span) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" id="uh-tile-${k}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">›</span></span><span class="uh-glance" id="uh-glance-${k}">${glance}</span></button>`;
 
     bento.innerHTML =
         `<div class="uh-tile span2 uh-hero">
@@ -148,6 +148,9 @@ async function renderBento(data) {
 
     bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
     setupDrawer();
+
+    // Hydrate each tile's glance + drawer from real data.
+    hydrateH2H(data);
 }
 
 var UH_DRAWERS = {
@@ -155,11 +158,15 @@ var UH_DRAWERS = {
     recap: 'Your week', schedule: 'Schedule', trajectory: 'Trajectory',
     draft: 'Draft grade', games: 'Games'
 };
+// key -> function(bodyEl) that fills the drawer body. Populated by the hydrators.
+var uhDrawer = {};
 function openDrawer(key) {
     const title = UH_DRAWERS[key];
     if (title == null) return;
     document.getElementById('uh-drawer-title').textContent = title;
-    document.getElementById('uh-drawer-body').innerHTML = '<p class="uh-stub">This opens the “' + title + '” detail — wired to real data in the next step.</p>';
+    const body = document.getElementById('uh-drawer-body');
+    if (uhDrawer[key]) { body.innerHTML = ''; uhDrawer[key](body); }
+    else body.innerHTML = '<p class="uh-stub">This opens the “' + title + '” detail — wired to real data in the next step.</p>';
     const d = document.getElementById('uh-drawer');
     d.hidden = false;
     document.getElementById('uh-scrim').classList.add('open');
@@ -182,17 +189,20 @@ function setupDrawer() {
     document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDrawer(); });
 }
 
-// Head-to-Head matchups (#230): a spotlight banner in the profile hero for the
-// current/latest matchup, plus an always-visible "Head-to-Head" section with the
-// full week-by-week history. Shown when the league has H2H on (or ?h2h=1 to
-// preview). Public info, like standings.
-async function renderMatchups(user) {
-    const banner = document.getElementById('uh-h2h-banner');
-    const panel = document.getElementById('uh-h2h');
-    if (!banner || !panel || !user || !user.league || !(user.seasons || []).length) return;
+// Head-to-Head (#230) → Matchup + Schedule tiles. Fetches the league's H2H
+// payload once, fills both tiles' glances, and registers their drawers:
+//  - Matchup: this week's (or latest) matchup, full lineups + win-prob + captain.
+//  - Schedule: up-next (in-season) + the full week-by-week schedule; tap a week
+//    to expand its detail.
+// Both tiles hide when the league doesn't have H2H on (and ?h2h=1 isn't set).
+async function hydrateH2H(user) {
+    const mTile = document.getElementById('uh-tile-matchup');
+    const sTile = document.getElementById('uh-tile-schedule');
+    const hide = () => { if (mTile) mTile.hidden = true; if (sTile) sTile.hidden = true; };
+    if (!user || !user.league || !(user.seasons || []).length || !window.ccH2H) return hide();
 
     const played = (user.seasons || []).filter(s => (s.weeklyScore || []).length > 0).sort((a, b) => Number(b.season) - Number(a.season));
-    if (!played.length) return;
+    if (!played.length) return hide();
     const season = played[0].season;
 
     let enabled = false;
@@ -200,45 +210,63 @@ async function renderMatchups(user) {
         const r = await fetch('/scoring-config/' + encodeURIComponent(user.league), { headers: { Accept: 'application/json' } });
         if (r.ok) { const c = await r.json(); enabled = !!(c.engagement && c.engagement.h2hEnabled); }
     } catch (e) { /* preview gate below */ }
-    if (!enabled && new URLSearchParams(location.search).get('h2h') !== '1') return;
+    if (!enabled && new URLSearchParams(location.search).get('h2h') !== '1') return hide();
 
     let data;
     try {
         data = await fetch(`/standings/h2h/${encodeURIComponent(user.league)}/${encodeURIComponent(season)}`, { headers: { Accept: 'application/json' } }).then(r => r.json());
-    } catch (e) { return; }
-    if (!data || !(data.schedule || []).length || !window.ccH2H) return;
+    } catch (e) { return hide(); }
+    if (!data || !(data.schedule || []).length) return hide();
 
     const byId = {};
     (data.managers || []).forEach(m => { byId[m.userId] = m; });
     const uid = String(user._id);
     const mine = [];
     (data.schedule || []).forEach(s => { const g = s.games.find(x => x.aId === uid || x.bId === uid); if (g) mine.push({ week: s.week, final: s.final !== false, g }); });
-    if (!mine.length) return;
+    if (!mine.length) return hide();
 
     const me = byId[uid];
-    const swords = window.ccIcon ? window.ccIcon('swords', { size: 15 }) : '';
-    // Featured matchup = the current/live week in-season, else the most recent.
-    // It headlines the hero banner (collapsed, tap to expand); the rest make up
-    // the history section below (newest first). One shared card, you on the left.
-    const featuredWk = (data.currentWeek != null && mine.some(x => x.week === data.currentWeek))
-        ? data.currentWeek
-        : mine[mine.length - 1].week;
+    const liveWk = (data.currentWeek != null && mine.some(x => x.week === data.currentWeek)) ? data.currentWeek : null;
+    const featuredWk = liveWk != null ? liveWk : mine[mine.length - 1].week;
     const featured = mine.find(x => x.week === featuredWk);
-    const rest = mine.filter(x => x.week !== featuredWk).sort((a, b) => b.week - a.week);
+    const rest = mine.slice().sort((a, b) => b.week - a.week);
     const cardOf = (x, open) => window.ccH2H.matchupCard(x.g, { byId, youId: uid, week: x.week, open });
-    const fLabel = featured && featured.final === false ? 'This week' : 'Latest matchup';
+    // My-perspective summary of a matchup (for glances).
+    const summary = (x) => {
+        const g = x.g, iAmA = g.aId === uid;
+        const meScore = iAmA ? g.aScore : g.bScore, opScore = iAmA ? g.bScore : g.aScore;
+        const opp = byId[iAmA ? g.bId : g.aId];
+        const nm = (opp && (opp.franchise || opp.name)) || 'Opponent';
+        const res = x.final ? (meScore > opScore ? 'W' : opScore > meScore ? 'L' : 'T') : 'LIVE';
+        return { meScore, opScore, nm, res };
+    };
 
-    // Hero spotlight banner: the featured matchup + your record.
-    banner.innerHTML = `<div class="uh-h2h-blabel">${swords}<span>${fLabel}</span>${me ? `<span class="uh-h2h-brec">${escapeHtml(me.record)}</span>` : ''}</div>${featured ? cardOf(featured, false) : ''}`;
-    banner.hidden = false;
-    window.ccH2H.wire(banner);
+    // Matchup tile — this week / latest.
+    if (mTile) mTile.hidden = false;
+    const mg = document.getElementById('uh-glance-matchup');
+    if (mg && featured) {
+        const s = summary(featured);
+        mg.innerHTML = `<span class="uh-mu-glance"><b class="num">${s.meScore}</b><span class="uh-mu-dash">–</span><span class="num">${s.opScore}</span> <span class="uh-mu-opp">${escapeHtml(s.nm)}</span> <span class="uh-res r-${s.res}">${s.res}</span></span>`;
+    }
+    uhDrawer.matchup = (body) => {
+        const lead = `${featured.final === false ? 'This week' : 'Latest'} · Week ${featured.week}${me ? ` · ${escapeHtml(me.record)}` : ''}`;
+        body.innerHTML = `<div class="uh-drawer-lead">${lead}</div>` + cardOf(featured, true);
+        window.ccH2H.wire(body);
+    };
 
-    // Always-visible history section (no chip).
-    panel.innerHTML = `
-        <div class="recap-head"><div class="header-title">Head-to-Head · ${season}</div></div>
-        ${rest.length ? `<div class="uh-h2h-log">${rest.map(x => cardOf(x, false)).join('')}</div>` : '<p class="uh-h2h-empty">No other matchups yet this season.</p>'}`;
-    panel.classList.add('is-open');
-    window.ccH2H.wire(panel);
+    // Schedule tile — up next (in-season) + full schedule.
+    if (sTile) sTile.hidden = false;
+    const sg = document.getElementById('uh-glance-schedule');
+    if (sg) {
+        if (liveWk != null) { const s = summary(featured); sg.textContent = `Up next · vs ${s.nm}`; }
+        else sg.textContent = `Full schedule${me ? ' · ' + me.record : ''}`;
+    }
+    uhDrawer.schedule = (body) => {
+        const listWeeks = liveWk != null ? rest.filter(x => x.week !== featuredWk) : rest;
+        const lead = liveWk != null ? `<div class="uh-drawer-lead">This week</div>` + cardOf(featured, true) : '';
+        body.innerHTML = lead + `<div class="uh-drawer-cap">Full schedule · tap a week</div><div class="uh-h2h-log">${listWeeks.map(x => cardOf(x, false)).join('')}</div>`;
+        window.ccH2H.wire(body);
+    };
 }
 
 // Captain picker (#230): the profile owner sets which rostered team to double

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -188,10 +188,19 @@ function hydrateRoster(user) {
             <img src="${c.t.logos.at(-1)}" alt="">
             <span class="uh-rc-meta"><span class="uh-rc-nm">${escapeHtml(c.t.school)}</span><span class="uh-rc-bar"><i style="width:${Math.round((c.pts / max) * 100)}%"></i></span></span>
             <span class="uh-rc-pts num">${c.pts}</span></a>`).join('');
-        body.innerHTML = `<div class="uh-roster-cards">${list}</div>
-            <div class="uh-drawer-cap">Week by week</div>
-            <div class="table-wrapper"><table class="fl-table"><thead user-table-head></thead><tbody user-table-body></tbody></table></div>`;
-        displayTeams(user);
+        body.innerHTML = `<div class="uh-seg">
+                <button type="button" class="uh-seg-btn active" data-view="cards">Sorted</button>
+                <button type="button" class="uh-seg-btn" data-view="grid">Week by week</button>
+            </div>
+            <div class="uh-roster-cards" data-view-panel="cards">${list}</div>
+            <div data-view-panel="grid" hidden><div class="table-wrapper"><table class="fl-table"><thead user-table-head></thead><tbody user-table-body></tbody></table></div></div>`;
+        displayTeams(user);   // fills the grid (hidden until toggled)
+        const segs = body.querySelectorAll('.uh-seg-btn');
+        segs.forEach(b => b.addEventListener('click', () => {
+            segs.forEach(x => x.classList.toggle('active', x === b));
+            const v = b.getAttribute('data-view');
+            body.querySelectorAll('[data-view-panel]').forEach(p => { p.hidden = p.getAttribute('data-view-panel') !== v; });
+        }));
     };
 }
 
@@ -203,7 +212,11 @@ function hydrateTrajectory(user) {
     if (!(season.weeklyScore || []).length) { if (tile) tile.hidden = true; return; }
 
     const g = document.getElementById('uh-glance-trajectory');
-    if (g) g.innerHTML = `<b class="num">${season.cumulativeScore || 0}</b> <span class="uh-glance-sub">total points</span>`;
+    if (g) {
+        let cum = 0; const series = [];
+        (typeof weeklyColumns === 'function' ? weeklyColumns(season) : []).forEach(c => { if (!c.entry) return; cum += c.entry.score || 0; series.push(cum); });
+        g.innerHTML = `<span class="uh-traj-g"><b class="uh-traj-num num">${season.cumulativeScore || 0}</b><span class="uh-glance-sub">total points</span></span>${series.length >= 2 ? `<span class="uh-traj-spark">${uhSpark(series, 260, 34, '#5BD08D')}</span>` : ''}`;
+    }
 
     uhDrawer.trajectory = (body) => {
         body.innerHTML = `<div class="profile-chart-section" profile-chart-section hidden><div class="profile-chart-wrap"><canvas id="profile-chart"></canvas></div></div><p class="uh-stub" id="uh-traj-empty" hidden>Not enough scored weeks yet to chart a trend.</p>`;
@@ -263,6 +276,15 @@ function uhMiniBar(youPct) {
     const opp = 100 - youPct;
     const tone = (a, b) => a > b ? 'fav' : a < b ? 'dog' : 'even';
     return `<span class="uh-mug-bar"><span class="uh-mug-pct ${tone(youPct, opp)}">${youPct}%</span><span class="uh-mug-track"><i class="${tone(youPct, opp)}" style="width:${youPct}%"></i><i class="r ${tone(opp, youPct)}" style="width:${opp}%"></i></span><span class="uh-mug-pct ${tone(opp, youPct)}">${opp}%</span></span>`;
+}
+
+// Tiny inline sparkline (cumulative-points trend) for the Trajectory glance.
+function uhSpark(pts, w, h, color) {
+    if (!pts || pts.length < 2) return '';
+    const max = Math.max.apply(null, pts), min = Math.min.apply(null, pts), rng = (max - min) || 1, step = w / (pts.length - 1);
+    const d = pts.map((p, i) => (i ? 'L' : 'M') + (i * step).toFixed(1) + ' ' + (h - ((p - min) / rng) * h).toFixed(1)).join(' ');
+    const ex = w.toFixed(1), ey = (h - ((pts[pts.length - 1] - min) / rng) * h).toFixed(1);
+    return `<svg width="100%" height="${h}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" style="display:block"><path d="${d}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="${ex}" cy="${ey}" r="2.6" fill="${color}"/></svg>`;
 }
 function openDrawer(key) {
     const title = UH_DRAWERS[key];
@@ -330,6 +352,18 @@ async function hydrateH2H(user) {
     if (!mine.length) return hide();
 
     const me = byId[uid];
+
+    // H2H record into the hero, right after Total points.
+    const statsEl = document.getElementById('uh-hero-stats');
+    if (statsEl && me && me.record && !statsEl.querySelector('.uh-hero-rec')) {
+        const rec = document.createElement('div');
+        rec.className = 'stat uh-hero-rec';
+        rec.innerHTML = `<span class="stat-value num">${escapeHtml(me.record)}</span><span class="stat-label">H2H record</span>`;
+        const pts = [...statsEl.querySelectorAll('.stat')].find(s => /total points/i.test(s.textContent));
+        if (pts && pts.nextSibling) statsEl.insertBefore(rec, pts.nextSibling);
+        else statsEl.appendChild(rec);
+    }
+
     const liveWk = (data.currentWeek != null && mine.some(x => x.week === data.currentWeek)) ? data.currentWeek : null;
     const featuredWk = liveWk != null ? liveWk : mine[mine.length - 1].week;
     const featured = mine.find(x => x.week === featuredWk);
@@ -373,8 +407,11 @@ async function hydrateH2H(user) {
     if (sTile) sTile.hidden = false;
     const sg = document.getElementById('uh-glance-schedule');
     if (sg) {
-        if (liveWk != null) { const s = summary(featured); sg.textContent = `Up next · vs ${s.nm}`; }
-        else sg.textContent = `Full schedule${me ? ' · ' + me.record : ''}`;
+        if (liveWk != null) {
+            const s = summary(featured), fg = featured.g, iAmA = fg.aId === uid;
+            const pct = fg.winP ? (iAmA ? fg.winP.a : fg.winP.b) : null;
+            sg.innerHTML = `<span class="uh-sched-lbl">Up next</span><span class="uh-sched-row"><span class="uh-sched-opp">vs ${escapeHtml(s.nm)}</span>${pct != null ? `<span class="uh-sched-pct">${pct}%</span>` : ''}</span>`;
+        } else sg.innerHTML = `<span class="uh-mu-opp">Full schedule</span>${me ? ` <span class="uh-glance-sub">${escapeHtml(me.record)}</span>` : ''}`;
     }
     uhDrawer.schedule = (body) => {
         const listWeeks = liveWk != null ? rest.filter(x => x.week !== featuredWk) : rest;
@@ -508,7 +545,11 @@ async function hydrateDraft(user) {
 
         const tier = (mine.grade || '').charAt(0).toLowerCase();
         const g = document.getElementById('uh-glance-draft');
-        if (g) g.innerHTML = `<span class="uh-grade gg-tier-${tier}">${escapeHtml(mine.grade)}</span><span class="uh-glance-sub">preseason projection</span>`;
+        if (g) g.innerHTML = `<span class="uh-draft-g"><span class="uh-grade gg-tier-${tier}">${escapeHtml(mine.grade)}</span><span class="uh-draft-stats">`
+            + `<span class="uh-ds"><b class="num">${mine.projPoints}</b>proj pts</span>`
+            + `<span class="uh-ds"><b class="num">${mine.projWins}</b>proj wins</span>`
+            + `<span class="uh-ds"><b class="num">${mine.cfpCount}</b>CFP teams</span>`
+            + `</span></span>`;
 
         let me;
         try { me = userState.user_metadata.metadata.userId; } catch (e) { /* fall through */ }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -97,16 +97,89 @@ async function getUser() {
 
     response.json().then(async data => {
         userData = data[0];
-        renderHero(data[0]);
-        displayTeams(data[0]);
-        renderProfileChart(data[0]);
-        ensureWeekSelected(data[0]);
-        displaySchedule(data[0]);
-        loadHomeGrades(data[0]);
-        renderRecap(data[0]);
-        renderCaptain(data[0]);
-        renderMatchups(data[0]);
+        renderBento(data[0]);
     });
+}
+
+// ---------- My Team bento (#230 redesign, feat/my-team-redesign) ----------
+// Renders the tile grid; each tile opens the slide-over drawer. STAGE 2 (shell):
+// the hero tile shows real identity + edit; the other tiles open placeholder
+// drawers that the next stage wires to the real renderers.
+async function renderBento(data) {
+    const bento = document.getElementById('uh-bento');
+    if (!bento || !data) return;
+    const season = data.seasons.at(-1) || {};
+    const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
+    const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
+    document.title = `${franchise || manager} · Campus Clash`;
+    const own = currentUserId() && String(currentUserId()) === String(data._id);
+    const pencil = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
+    const tile = (k, label, glance, span) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">›</span></span><span class="uh-glance">${glance}</span></button>`;
+
+    bento.innerHTML =
+        `<div class="uh-tile span2 uh-hero">
+            <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
+            <div class="uh-hero-meta">
+                <div class="uh-hero-name">${escapeHtml(franchise)}</div>
+                <div class="uh-hero-sub">${escapeHtml(franchise ? ('Managed by ' + manager) : manager)}</div>
+                <div class="uh-hero-stats" id="uh-hero-stats"></div>
+            </div>
+            ${own ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
+        </div>`
+        + tile('matchup', 'This week · matchup', 'Your current H2H matchup', 2)
+        + tile('roster', 'Roster', 'Your 10 teams', 2)
+        + tile('captain', 'Captain', 'Double a team each week', 1)
+        + tile('recap', 'Your week', 'Latest recap', 1)
+        + tile('schedule', 'Schedule', 'Up next', 1)
+        + tile('trajectory', 'Trajectory', 'Season points', 1)
+        + tile('draft', 'Draft grade', 'Preseason projection', 2)
+        + tile('games', 'Games', 'This week’s games', 2);
+
+    renderAvatar(document.getElementById('uh-hero-av'), data);
+    const statsEl = document.getElementById('uh-hero-stats');
+    let sh = '';
+    try { const rank = await computeRank(data); if (rank) sh += statTile(escapeHtml(ordinal(rank.rank)), `of ${rank.total} teams`); } catch (e) { /* rank optional */ }
+    sh += statTile(String(season.cumulativeScore || 0), 'Total points');
+    const bt = bestTeam(season);
+    if (bt && bt.total > 0) sh += statTile(`<img src="${bt.team.logos.at(-1)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
+    statsEl.innerHTML = sh;
+
+    if (own) setupEditModal(data, season);
+
+    bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
+    setupDrawer();
+}
+
+var UH_DRAWERS = {
+    matchup: 'This week · matchup', roster: 'Roster', captain: 'Captain',
+    recap: 'Your week', schedule: 'Schedule', trajectory: 'Trajectory',
+    draft: 'Draft grade', games: 'Games'
+};
+function openDrawer(key) {
+    const title = UH_DRAWERS[key];
+    if (title == null) return;
+    document.getElementById('uh-drawer-title').textContent = title;
+    document.getElementById('uh-drawer-body').innerHTML = '<p class="uh-stub">This opens the “' + title + '” detail — wired to real data in the next step.</p>';
+    const d = document.getElementById('uh-drawer');
+    d.hidden = false;
+    document.getElementById('uh-scrim').classList.add('open');
+    requestAnimationFrame(() => d.classList.add('open'));
+    document.getElementById('uh-drawer-close').focus();
+}
+function closeDrawer() {
+    const d = document.getElementById('uh-drawer');
+    if (!d) return;
+    d.classList.remove('open');
+    document.getElementById('uh-scrim').classList.remove('open');
+    setTimeout(() => { d.hidden = true; }, 300);
+}
+function setupDrawer() {
+    const scrim = document.getElementById('uh-scrim'), close = document.getElementById('uh-drawer-close');
+    if (!scrim || scrim.dataset.wired) return;
+    scrim.dataset.wired = '1';
+    scrim.addEventListener('click', closeDrawer);
+    close.addEventListener('click', closeDrawer);
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDrawer(); });
 }
 
 // Head-to-Head matchups (#230): a spotlight banner in the profile hero for the

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -609,32 +609,18 @@ function currentUserId() {
     catch (e) { return window.localStorage.getItem('userId'); }
 }
 
-async function renderHero(data) {
-    const season = data.seasons.at(-1) || {};
+// Refresh the bento hero tile's identity after a profile edit (name/avatar),
+// without re-fetching/re-rendering the whole grid.
+function refreshHeroIdentity(data, season) {
     const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
-    const franchise = season.franchiseName;
-
-    document.querySelector('[profile-franchise]').textContent = franchise || `${data.firstName || 'Unnamed'}'s Team`;
-    document.querySelector('[profile-manager]').textContent = franchise ? `Managed by ${manager}` : manager;
+    const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
+    const av = document.getElementById('uh-hero-av');
+    if (av) renderAvatar(av, data);
+    const nameEl = document.querySelector('.uh-hero-name');
+    if (nameEl) nameEl.textContent = franchise;
+    const subEl = document.querySelector('.uh-hero-sub');
+    if (subEl) subEl.textContent = franchise && season.franchiseName ? `Managed by ${manager}` : manager;
     document.title = `${franchise || manager} · Campus Clash`;
-    renderAvatar(document.querySelector('[profile-avatar]'), data);
-
-    const statsEl = document.querySelector('[profile-stats]');
-    let html = '';
-    const rank = await computeRank(data);
-    if (rank) html += statTile(escapeHtml(ordinal(rank.rank)), `of ${rank.total} teams`);
-    html += statTile(String(season.cumulativeScore || 0), 'Total points');
-    const bt = bestTeam(season);
-    if (bt && bt.total > 0) {
-        html += statTile(`<img src="${bt.team.logos.at(-1)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
-    }
-    statsEl.innerHTML = html;
-
-    // Edit is only offered on the viewer's own profile (the endpoint enforces
-    // this too, from the session).
-    if (currentUserId() && String(currentUserId()) === String(data._id)) {
-        setupEditModal(data, season);
-    }
 }
 
 // ---------- Edit modal (franchise name + avatar upload) ----------
@@ -722,7 +708,7 @@ function setupEditModal(data, season) {
             if (!res.ok) throw new Error(out.message || 'Save failed');
             data.avatarUrl = out.avatarUrl;
             season.franchiseName = out.franchiseName;
-            renderHero(data);
+            refreshHeroIdentity(data, season);
             close();
         } catch (e) {
             showError(e.message || 'Save failed.');

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -114,7 +114,7 @@ async function renderBento(data) {
     document.title = `${franchise || manager} · Campus Clash`;
     const own = currentUserId() && String(currentUserId()) === String(data._id);
     const pencil = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
-    const tile = (k, label, glance, span) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" id="uh-tile-${k}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">›</span></span><span class="uh-glance" id="uh-glance-${k}">${glance}</span></button>`;
+    const tile = (k, label, glance, span, affordance) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" id="uh-tile-${k}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">${affordance || '›'}</span></span><span class="uh-glance" id="uh-glance-${k}">${glance}</span></button>`;
 
     bento.innerHTML =
         `<div class="uh-tile span2 uh-hero">
@@ -126,11 +126,11 @@ async function renderBento(data) {
             </div>
             ${own ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
         </div>`
-        + tile('matchup', 'This week · matchup', 'Your current H2H matchup', 2)
-        + tile('roster', 'Roster', 'Your 10 teams', 2)
+        + tile('matchup', 'This week · matchup', 'Your current H2H matchup', 2, 'Lineups ›')
+        + tile('roster', 'Roster · top performers', 'Your 10 teams', 2, 'All 10 teams ›')
         + tile('captain', 'Captain', 'Double a team each week', 1)
         + tile('recap', 'Your week', 'Latest recap', 1)
-        + tile('schedule', 'Schedule', 'Up next', 1)
+        + tile('schedule', 'Schedule', 'Up next', 1, 'Full schedule ›')
         + tile('trajectory', 'Trajectory', 'Season points', 1)
         + tile('draft', 'Draft grade', 'Preseason projection', 2)
         + tile('games', 'Games', 'This week’s games', 2);
@@ -176,9 +176,11 @@ function hydrateRoster(user) {
     const top = cards[0];
 
     const g = document.getElementById('uh-glance-roster');
-    if (g) g.innerHTML = top && top.pts > 0
-        ? `<span class="uh-mu-opp">${escapeHtml(top.t.school)}</span> <b class="num">${top.pts}</b> <span class="uh-glance-sub">leads your roster</span>`
-        : 'Your 10 teams';
+    if (g) {
+        g.innerHTML = top && top.pts > 0
+            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => `<span class="uh-rg-row"><img src="${c.t.logos.at(-1)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></span>`).join('')}</span>`
+            : 'Your 10 teams';
+    }
 
     uhDrawer.roster = (body) => {
         const max = (cards[0] && cards[0].pts) || 1;
@@ -254,6 +256,14 @@ var UH_DRAWERS = {
 };
 // key -> function(bodyEl) that fills the drawer body. Populated by the hydrators.
 var uhDrawer = {};
+
+// Compact win-probability bar for a tile glance (you% on the left).
+function uhMiniBar(youPct) {
+    youPct = Math.round(youPct);
+    const opp = 100 - youPct;
+    const tone = (a, b) => a > b ? 'fav' : a < b ? 'dog' : 'even';
+    return `<span class="uh-mug-bar"><span class="uh-mug-pct ${tone(youPct, opp)}">${youPct}%</span><span class="uh-mug-track"><i class="${tone(youPct, opp)}" style="width:${youPct}%"></i><i class="r ${tone(opp, youPct)}" style="width:${opp}%"></i></span><span class="uh-mug-pct ${tone(opp, youPct)}">${opp}%</span></span>`;
+}
 function openDrawer(key) {
     const title = UH_DRAWERS[key];
     if (title == null) return;
@@ -335,12 +345,23 @@ async function hydrateH2H(user) {
         return { meScore, opScore, nm, res };
     };
 
-    // Matchup tile — this week / latest.
+    // Matchup tile — this week / latest. Rich glance: avatars, scores, win bar.
     if (mTile) mTile.hidden = false;
     const mg = document.getElementById('uh-glance-matchup');
     if (mg && featured) {
+        const g = featured.g, iAmA = g.aId === uid;
         const s = summary(featured);
-        mg.innerHTML = `<span class="uh-mu-glance"><b class="num">${s.meScore}</b><span class="uh-mu-dash">–</span><span class="num">${s.opScore}</span> <span class="uh-mu-opp">${escapeHtml(s.nm)}</span> <span class="uh-res r-${s.res}">${s.res}</span></span>`;
+        const oppM = byId[iAmA ? g.bId : g.aId];
+        const av = (m) => (window.ccH2H.avatar ? window.ccH2H.avatar(m) : '');
+        let youPct = null;
+        if (featured.final) youPct = s.res === 'W' ? 100 : s.res === 'L' ? 0 : 50;
+        else if (g.winP) youPct = iAmA ? g.winP.a : g.winP.b;
+        const wc = s.res === 'W' ? ' win' : '', oc = s.res === 'L' ? ' win' : '';
+        mg.innerHTML = `<span class="uh-mug">
+                <span class="uh-mug-side">${av(me)}<span class="uh-mug-nm">You</span><span class="uh-mug-sc num${wc}">${s.meScore}</span></span>
+                <span class="uh-mug-vs">${featured.final ? (s.res === 'T' ? 'T' : 'vs') : 'LIVE'}</span>
+                <span class="uh-mug-side r"><span class="uh-mug-sc num${oc}">${s.opScore}</span><span class="uh-mug-nm">${escapeHtml(s.nm)}</span>${av(oppM)}</span>
+            </span>${youPct == null ? '' : uhMiniBar(youPct)}`;
     }
     uhDrawer.matchup = (body) => {
         const lead = `${featured.final === false ? 'This week' : 'Latest'} · Week ${featured.week}${me ? ` · ${escapeHtml(me.record)}` : ''}`;
@@ -409,9 +430,10 @@ async function hydrateCaptain(user) {
     const setGlance = () => {
         if (!g) return;
         const t = pick != null ? teamById[pick] : null;
-        g.innerHTML = t
+        const lead = t
             ? `<span class="uh-cap-glance"><img src="${t.logos.at(-1)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></span>`
             : `<span class="captain-unset">Set for Wk ${week}</span>`;
+        g.innerHTML = lead + `<span class="uh-cap-sub">Doubles this week’s points</span>`;
     };
     const paint = (container) => {
         container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${week}. Tap the current pick to clear. Locks at kickoff.</p>

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const ScoringConfig = require('../models/scoringConfig');
-const { resolveConfig, fieldsForModel } = require('../modules/scoring-defaults');
+const { resolveConfig, fieldsForModel, engagementForSeason } = require('../modules/scoring-defaults');
 const { canManageLeague } = require('../modules/league-access');
 
 // Attaches the ordered field metadata (for the admin form + rules page) to a
@@ -17,10 +17,19 @@ function withFields(cfg) {
 router.get('/:league', async (req, res) => {
     try {
         const doc = await ScoringConfig.findOne({ league: req.params.league });
+        const bySeason = (doc && doc.engagementBySeason) || {};
         const overrides = doc
-            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, engagement: doc.engagement }
+            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, engagement: doc.engagement, engagementBySeason: bySeason }
             : null;
-        res.json(withFields(resolveConfig(req.params.league, overrides)));
+        // `engagement` is resolved for the requested season (default: the active
+        // YEAR) so callers get the right game-mode state without knowing the
+        // per-season storage. `engagementBySeason` is the full map for the admin.
+        const season = req.query.season || process.env.YEAR;
+        const cfg = withFields(resolveConfig(req.params.league, overrides));
+        cfg.engagement = engagementForSeason(bySeason, season);
+        cfg.engagementBySeason = bySeason;
+        cfg.season = String(season);
+        res.json(cfg);
     } catch (err) {
         res.status(500).json({ message: err.message });
     }
@@ -59,8 +68,10 @@ router.post('/', async (req, res) => {
     }
 });
 
-// Toggle the weekly-engagement layer (#230) for a league without touching the
-// scoring values. Commissioner-gated + scoped to the caller's own league.
+// Toggle the weekly-engagement layer (#230) for a league, PER SEASON, without
+// touching the scoring values. Commissioner-gated + scoped to the caller's own
+// league. The `season` (body, default active YEAR) selects which season's game
+// modes are being set — other seasons are untouched.
 router.patch('/:league/engagement', async (req, res) => {
     try {
         const league = req.params.league;
@@ -68,6 +79,10 @@ router.patch('/:league/engagement', async (req, res) => {
             return res.status(403).json({ message: 'Forbidden: not your league' });
         }
         const b = req.body || {};
+        const season = String(b.season || process.env.YEAR);
+        if (!/^\d{4}$/.test(season)) {
+            return res.status(400).json({ message: 'A four-digit season is required.' });
+        }
         const clamp = (v, lo, hi, dflt) => {
             const n = Number(v);
             return Number.isFinite(n) ? Math.min(hi, Math.max(lo, n)) : dflt;
@@ -78,14 +93,15 @@ router.patch('/:league/engagement', async (req, res) => {
             captainEnabled: !!b.captainEnabled,
             captainMultiplier: clamp(b.captainMultiplier, 1.5, 5, 2)
         };
+        // Set only this season's slot in the map (dot-path) so the other seasons'
+        // settings are preserved.
         const doc = await ScoringConfig.findOneAndUpdate(
             { league },
-            { $set: { league, engagement, updatedAt: new Date() } },
+            { $set: { league, ['engagementBySeason.' + season]: engagement, updatedAt: new Date() } },
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
-        res.json(resolveConfig(league, {
-            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, engagement: doc.engagement
-        }).engagement);
+        const saved = engagementForSeason(doc.engagementBySeason, season);
+        res.json(Object.assign({ season }, saved));
     } catch (err) {
         res.status(400).json({ message: err.message });
     }

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -8,7 +8,7 @@ const Betting = require('../models/bettingLine');
 const Draft = require('../models/draft');
 const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
-const { resolveConfig } = require('../modules/scoring-defaults');
+const { resolveConfig, engagementForSeason } = require('../modules/scoring-defaults');
 const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../modules/draft-projection');
 const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
@@ -243,7 +243,9 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const seasonNum = Number(season);
 
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
-        const eng = resolveConfig(league, cfgDoc || null).engagement;
+        // Engagement is per-season: resolve H2H on/off + win bonus for THIS season
+        // (a season with no entry is off), so one season's setting never leaks.
+        const eng = engagementForSeason(cfgDoc && cfgDoc.engagementBySeason, season);
         const winBonus = eng.h2hWinBonus;
 
         // H2H matchups run the fantasy regular season only. Weeks 15+ (conf

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -392,7 +392,21 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // weeks show scored contributing teams; the current week shows each
         // rostered team's live game status (final / live / kickoff time).
         const teamsFinal = (id, w) => Object.values((teamDetail[id] && teamDetail[id][w]) || {})
-            .map(t => ({ school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: !!(caps[id] && caps[id][w] === t.teamId) }))
+            .map(t => {
+                // Opponent + final CFB score for the retrospective sub-line (same
+                // source the live week uses), so past matchup rows aren't bare.
+                const g = gameTW[t.teamId] && gameTW[t.teamId][w];
+                let opp = '', ha = 'vs', gameScore = null;
+                if (g) {
+                    const isHome = g.homeId === t.teamId;
+                    opp = oppAbbrById[isHome ? g.awayId : g.homeId] || (isHome ? g.awayTeam : g.homeTeam) || '';
+                    ha = isHome ? 'vs' : '@';
+                    if (g.completed && g.homePoints != null && g.awayPoints != null) {
+                        gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
+                    }
+                }
+                return { school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: !!(caps[id] && caps[id][w] === t.teamId), opp, ha, gameScore };
+            })
             .sort((a, b) => b.score - a.score);
         const fmtKick = (g) => {
             if (!g || !g.startDate || g.startTimeTbd) return 'TBD';

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -255,7 +255,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const users = await User.find({ league, 'seasons.season': season });
         const isRegular = w => w.season !== 'postseason' && w.week <= 16;
         const round = v => Math.round(v * 10) / 10;
-        const ids = [], meta = {}, totals = {}, teamDetail = {};
+        const ids = [], meta = {}, totals = {}, teamDetail = {}, caps = {};
         const draftedSet = new Set();
         users.forEach(u => {
             const s = (u.seasons || []).find(x => String(x.season) === String(season));
@@ -287,6 +287,8 @@ router.get('/h2h/:league/:season', async (req, res) => {
             });
             totals[id] = tw;
             teamDetail[id] = twTeams;
+            caps[id] = {};
+            (s.captains || []).forEach(c => { if (c && c.week != null) caps[id][c.week] = c.teamId; });
         });
         if (!ids.length) return res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, weeks: [], managers: [], schedule: [] });
 
@@ -390,7 +392,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // weeks show scored contributing teams; the current week shows each
         // rostered team's live game status (final / live / kickoff time).
         const teamsFinal = (id, w) => Object.values((teamDetail[id] && teamDetail[id][w]) || {})
-            .map(t => ({ school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final' }))
+            .map(t => ({ school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: !!(caps[id] && caps[id][w] === t.teamId) }))
             .sort((a, b) => b.score - a.score);
         const fmtKick = (g) => {
             if (!g || !g.startDate || g.startTimeTbd) return 'TBD';
@@ -410,7 +412,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             if (g.completed && g.homePoints != null && g.awayPoints != null) {
                 gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
             }
-            return { school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? fmtKick(g) : null, opp, ha: isHome ? 'vs' : '@', gameScore };
+            return { school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? fmtKick(g) : null, opp, ha: isHome ? 'vs' : '@', gameScore, captain: !!(caps[id] && caps[id][w] === t.id) };
         }).filter(Boolean).sort((a, b) => (statusOrder[a.status] - statusOrder[b.status]) || ((b.score || 0) - (a.score || 0)));
 
         // Projected pre-game odds for a matchup: each manager's teams that play
@@ -472,7 +474,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             w.final = false;
             const doctor = (arr) => (arr || []).map((t, j) => {
                 const status = mode === 'pregame' ? 'scheduled' : (j === 0 ? 'final' : (j === 1 ? 'live' : 'scheduled'));
-                return { school: t.school, abbr: t.abbr, logo: t.logo, status, score: status === 'final' ? t.score : null, kickoff: status === 'scheduled' ? 'Sat 3:30' : null, opp: j % 2 ? 'UGA' : 'ARK', ha: j % 2 ? '@' : 'vs', gameScore: status === 'final' ? '31–20' : null };
+                return { school: t.school, abbr: t.abbr, logo: t.logo, status, score: status === 'final' ? t.score : null, kickoff: status === 'scheduled' ? 'Sat 3:30' : null, opp: j % 2 ? 'UGA' : 'ARK', ha: j % 2 ? '@' : 'vs', gameScore: status === 'final' ? '31–20' : null, captain: j === 0 };
             });
             // Live odds from the doctored slate: final games lock their actual
             // points, everything else is a neutral coin-flip projection — so the

--- a/routes/users.js
+++ b/routes/users.js
@@ -34,9 +34,11 @@ router.patch('/me/profile', async (req, res) => {
         if (clean.prompted !== undefined) user.profilePrompted = clean.prompted;
 
         if (clean.franchiseName !== undefined) {
+            // Only name the active season — never fall back to a prior season.
+            // Before the league drafts the active year there's no entry to name,
+            // so the update is ignored (the client locks the field to match).
             const year = Number(process.env.YEAR);
-            const season = (user.seasons || []).find(s => Number(s.season) === year)
-                || (user.seasons && user.seasons[user.seasons.length - 1]);
+            const season = (user.seasons || []).find(s => Number(s.season) === year);
             if (season) season.franchiseName = clean.franchiseName;
         }
 

--- a/server.js
+++ b/server.js
@@ -262,7 +262,7 @@ app.get('/userHome', async function(req, res) {
         const user = buildUserContext(req.effUser);
         const userState = safeJson(req.effUser);
 
-        res.render('userHome', {user, userState, cloudinary: cloudinaryConfig()});
+        res.render('userHome', {user, userState, year: process.env.YEAR, cloudinary: cloudinaryConfig()});
     } else {
         res.redirect("/login");
     }

--- a/tests/EngagementSeason.spec.js
+++ b/tests/EngagementSeason.spec.js
@@ -1,0 +1,59 @@
+const { engagementForSeason, normalizeEngagement, ENGAGEMENT_DEFAULTS, resolveConfig } = require('../modules/scoring-defaults');
+
+describe('normalizeEngagement', () => {
+    test('fills defaults and coerces types', () => {
+        expect(normalizeEngagement()).toEqual(ENGAGEMENT_DEFAULTS);
+        expect(normalizeEngagement({})).toEqual(ENGAGEMENT_DEFAULTS);
+        expect(normalizeEngagement({ h2hEnabled: 1, captainEnabled: 'yes' }))
+            .toEqual({ h2hEnabled: true, h2hWinBonus: 3, captainEnabled: true, captainMultiplier: 2 });
+    });
+
+    test('keeps provided numeric bonus / multiplier', () => {
+        expect(normalizeEngagement({ h2hEnabled: true, h2hWinBonus: 5, captainEnabled: true, captainMultiplier: 3 }))
+            .toEqual({ h2hEnabled: true, h2hWinBonus: 5, captainEnabled: true, captainMultiplier: 3 });
+    });
+});
+
+describe('engagementForSeason', () => {
+    const bySeason = {
+        '2026': { h2hEnabled: true, h2hWinBonus: 3, captainEnabled: true, captainMultiplier: 2 },
+        '2027': { h2hEnabled: true, h2hWinBonus: 4, captainEnabled: false, captainMultiplier: 2 }
+    };
+
+    test('returns the exact season entry', () => {
+        expect(engagementForSeason(bySeason, '2026'))
+            .toEqual({ h2hEnabled: true, h2hWinBonus: 3, captainEnabled: true, captainMultiplier: 2 });
+    });
+
+    test('seasons are independent — 2027 has Captain off while 2026 has it on', () => {
+        expect(engagementForSeason(bySeason, '2026').captainEnabled).toBe(true);
+        expect(engagementForSeason(bySeason, '2027').captainEnabled).toBe(false);
+        expect(engagementForSeason(bySeason, '2027').h2hWinBonus).toBe(4);
+    });
+
+    test('a season with no entry is fully OFF (so a rescore adds no bonus)', () => {
+        expect(engagementForSeason(bySeason, '2025')).toEqual(ENGAGEMENT_DEFAULTS);
+        expect(engagementForSeason(bySeason, 2025)).toEqual(ENGAGEMENT_DEFAULTS);
+    });
+
+    test('handles number/string season keys and an empty/absent map', () => {
+        expect(engagementForSeason(bySeason, 2026).h2hEnabled).toBe(true);   // number lookup
+        expect(engagementForSeason({}, '2026')).toEqual(ENGAGEMENT_DEFAULTS);
+        expect(engagementForSeason(undefined, '2026')).toEqual(ENGAGEMENT_DEFAULTS);
+        expect(engagementForSeason(null, 2026)).toEqual(ENGAGEMENT_DEFAULTS);
+    });
+});
+
+describe('resolveConfig passes engagementBySeason through', () => {
+    test('carries the raw map so engagementForSeason can read it', () => {
+        const bySeason = { '2026': { h2hEnabled: true } };
+        const cfg = resolveConfig('graham-league', { engagementBySeason: bySeason });
+        expect(cfg.engagementBySeason).toBe(bySeason);
+        expect(engagementForSeason(cfg.engagementBySeason, '2026').h2hEnabled).toBe(true);
+        expect(engagementForSeason(cfg.engagementBySeason, '2025').h2hEnabled).toBe(false);
+    });
+
+    test('defaults engagementBySeason to an empty object when absent', () => {
+        expect(resolveConfig('graham-league', null).engagementBySeason).toEqual({});
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -312,8 +312,9 @@
                     </button>
                 </div>
                 <div class="sub-container" engagement-container style="display: none">
-                    <p class="function-description">Turn on optional game modes for this league — Head-to-Head matchups and a weekly Captain. Off by default; other leagues stay classic. The two are independent, so run either, both, or neither.</p>
+                    <p class="function-description">Turn on optional game modes for this league — Head-to-Head matchups and a weekly Captain. Off by default; other leagues stay classic. The two are independent, so run either, both, or neither. Settings are <strong>per season</strong>: choose a season below — turning a mode on for one season never affects another (or alters a past season on a rescore).</p>
                     <form id="engagement-form" class="draft-config-form">
+                        <div class="draft-field"><label>Season</label><select eng-season></select></div>
                         <div class="draft-field"><label><input type="checkbox" eng-h2h-enabled> Head-to-Head <span class="mode-hint">— weekly matchup vs one rival</span></label></div>
                         <div class="draft-field"><label>Win bonus (pts)</label><input type="number" eng-h2h-bonus min="0" max="20" step="1" value="3"></div>
                         <div class="draft-field"><label><input type="checkbox" eng-captain-enabled> Captain <span class="mode-hint">— double one team each week</span></label></div>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -29,6 +29,10 @@
     <% } %>
     <script>
         var CLOUDINARY = <%- JSON.stringify(cloudinary || { cloudName: '', uploadPreset: '' }) %>;
+        // Authoritative active season from the server (process.env.YEAR) so every
+        // My Team tile keys off the season the league is actually playing — not
+        // the wall-clock year or "latest season with data".
+        window.APP_YEAR = "<%= year %>";
     </script>
 
     <!-- My Team bento (#230 redesign, feat/my-team-redesign). Tiles rendered by

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -45,6 +45,7 @@
             <label class="field">
                 <span>Team name</span>
                 <input type="text" profile-name-input maxlength="40" placeholder="Name your team">
+                <span class="field-note" profile-name-note hidden></span>
             </label>
             <div class="avatar-edit">
                 <div class="avatar avatar-md" profile-modal-avatar></div>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -31,46 +31,9 @@
         var CLOUDINARY = <%- JSON.stringify(cloudinary || { cloudName: '', uploadPreset: '' }) %>;
     </script>
 
-    <div class="profile-hero" profile-hero>
-        <div class="avatar avatar-lg" profile-avatar></div>
-        <div class="profile-meta">
-            <h1 class="franchise-name" profile-franchise></h1>
-            <p class="manager-name" profile-manager></p>
-            <div class="profile-stats" profile-stats></div>
-            <div class="profile-chips">
-                <button type="button" class="grade-chip" profile-grade-chip hidden
-                        aria-expanded="false" aria-controls="uh-grades">
-                    <span class="grade-chip-label">Draft grade</span>
-                    <span class="grade-chip-letter" profile-grade-letter></span>
-                    <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
-                </button>
-                <button type="button" class="grade-chip recap-chip" recap-chip hidden
-                        aria-expanded="false" aria-controls="uh-recap">
-                    <span class="grade-chip-label"><i class="fa-regular fa-calendar-check" aria-hidden="true"></i> Weekly recap</span>
-                    <span class="recap-chip-teaser" recap-chip-teaser></span>
-                    <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
-                </button>
-                <button type="button" class="grade-chip captain-chip" captain-chip hidden
-                        aria-expanded="false" aria-controls="uh-captain">
-                    <span class="grade-chip-label"><i class="fa-solid fa-star" aria-hidden="true"></i> Captain</span>
-                    <span class="captain-chip-teaser" captain-chip-teaser></span>
-                    <i class="fa-solid fa-chevron-down grade-chip-caret" aria-hidden="true"></i>
-                </button>
-            </div>
-            <div class="uh-h2h-banner" id="uh-h2h-banner" hidden></div>
-        </div>
-        <button type="button" class="edit-profile-btn" edit-profile-btn hidden>
-            <i class="fa-solid fa-pen"></i> Edit profile
-        </button>
-    </div>
-
-    <section class="uh-grades" id="uh-grades" hidden></section>
-
-    <section class="uh-recap" id="uh-recap"></section>
-
-    <section class="uh-captain" id="uh-captain"></section>
-
-    <section class="uh-h2h" id="uh-h2h"></section>
+    <!-- My Team bento (#230 redesign, feat/my-team-redesign). Tiles rendered by
+         renderBento(); each opens the slide-over drawer below. -->
+    <div class="uh-bento" id="uh-bento"></div>
 
     <div class="modal-backdrop" profile-modal hidden>
         <div class="profile-modal-card" role="dialog" aria-modal="true" aria-labelledby="profile-modal-title">
@@ -94,64 +57,13 @@
             </div>
         </div>
     </div>
-    <div class="content">
-        <div class="get-users-container" get-users-container>
-            <div class="table-wrapper">
-                <table class="fl-table">
-                    <thead user-table-head></thead>
-                    <tbody user-table-body>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-    <div class="profile-chart-section" profile-chart-section hidden>
-        <div class="header"><div class="header-title">Season Progress</div></div>
-        <div class="profile-chart-wrap"><canvas id="profile-chart"></canvas></div>
-    </div>
-    <hr class="hr-subtle">
-    <div class="header">
-        <div class="header-title" poll-name>
-            Games
-        </div>
-    </div>
-    <div class="dropdown dropdownWeek">
-        <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButtonWeek" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Week X
-        </button>
-        <div class="dropdown-menu dropdown-menu-week" aria-labelledby="dropdownMenuButton">
-            <a class="dropdown-item dropdown-week selected" value="week-1">Week 1</a>
-            <a class="dropdown-item dropdown-week" value="week-2">Week 2</a>
-            <a class="dropdown-item dropdown-week" value="week-3">Week 3</a>
-            <a class="dropdown-item dropdown-week" value="week-4">Week 4</a>
-            <a class="dropdown-item dropdown-week" value="week-5">Week 5</a>
-            <a class="dropdown-item dropdown-week" value="week-6">Week 6</a>
-            <a class="dropdown-item dropdown-week" value="week-7">Week 7</a>
-            <a class="dropdown-item dropdown-week" value="week-8">Week 8</a>
-            <a class="dropdown-item dropdown-week" value="week-9">Week 9</a>
-            <a class="dropdown-item dropdown-week" value="week-10">Week 10</a>
-            <a class="dropdown-item dropdown-week" value="week-11">Week 11</a>
-            <a class="dropdown-item dropdown-week" value="week-12">Week 12</a>
-            <a class="dropdown-item dropdown-week" value="week-13">Week 13</a>
-            <a class="dropdown-item dropdown-week" value="week-14">Week 14</a>
-            <a class="dropdown-item dropdown-week" value="week-15">Week 15</a>
-            <a class="dropdown-item dropdown-week" value="week-16">Week 16</a>
-            <a class="dropdown-item dropdown-week" value="week-17">Postseason</a>
-        </div>
-        </div>
-    <div class="game-content">
-        <div class="football-loader">
-            <div class="football-icon">🏈</div>
-            <p class="loading-text">Scouting for games...</p>
-        </div>
-        <div class="get-users-container">
-            <div class="schedule-wrapper" schedule-container>
-                <div class="schedule-grid" schedule-body>
-                    <div id="no-games-container"></div>
-                </div>
-            </div>
-        </div>
-    </div>
+
+    <div class="uh-scrim" id="uh-scrim"></div>
+    <aside class="uh-drawer" id="uh-drawer" role="dialog" aria-modal="true" aria-label="Detail" hidden>
+        <div class="uh-drawer-grab"></div>
+        <div class="uh-drawer-head"><span class="uh-drawer-title" id="uh-drawer-title"></span><button class="uh-drawer-close" id="uh-drawer-close" type="button" aria-label="Close">✕</button></div>
+        <div class="uh-drawer-body" id="uh-drawer-body"></div>
+    </aside>
 
     <footer>
         <a href="https://collegefootballdata.com/" class="cfb-data">Powered by College Football Data</a>


### PR DESCRIPTION
Brings the My Team redesign + per-season game modes to `main`.

**Why this PR exists:** #232 was merged into its stacked base (`feat/weekly-engagement`) instead of `main`, so only #231 (the game-mode engine, league-wide config) reached `main`. This PR delivers the rest of the stack that got stranded.

## What lands
- **My Team bento redesign** (Option B): tile grid + slide-over drawers, reusing the existing renderers.
- **Single active-season source of truth** — every tile + reused renderer keys off `process.env.YEAR` (`window.APP_YEAR`) via `uhSeasonFor`.
- **Preseason empty state** for the undrafted window; **franchise-name edits locked** until the active season exists (client + server).
- **Per-season game modes** — engagement is stored/resolved per season (`engagementBySeason`), so enabling H2H/Captain for one season never affects another, and a rescore of a season with no entry adds no bonus. Admin "Game Modes" form gains a season selector.
- Trajectory summary row, drawer scroll-lock/focus, finished-matchup scores, +8 unit tests (193 total green).

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
