### PR TITLE
Fixed scoring: optional ranked/tiered win categories (opt-in, off by default)

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -13,6 +13,10 @@ const scoringConfigSchema = new mongoose.Schema({
     // conditions are switched off (by condition key).
     combineMode: { type: String, enum: ['first', 'sum'] },
     disabled: { type: [String], default: [] },
+    // Opt-in list for default-off rules (the finer Fixed-shape win categories).
+    // A condition here is ON; absence keeps a default-off rule OFF — so adding a
+    // new default-off rule never changes an existing league's scoring.
+    enabled: { type: [String], default: [] },
     // Optional weekly-engagement layer (GitHub #230), per-league opt-in.
     // DEPRECATED / legacy: a single league-wide engagement blob. Superseded by
     // engagementBySeason (below) so a league can run the game modes in one

--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -17,6 +17,13 @@ const CLAUNTS_DEFAULTS = {
     nonConfWinUnranked: 1,
     nonConfWinRanked: 3,
     confWin: 2,
+    // Optional finer categories (off by default; starting values a commissioner
+    // can tune before enabling).
+    confWinRanked: 3,
+    confWinTop25: 3,
+    confWinTop10: 4,
+    nonConfWinTop25: 3,
+    nonConfWinTop10: 4,
     confChampionship: 6,
     bowlAppearance: 4,
     bowlWin: 5,
@@ -62,9 +69,18 @@ const GRAHAM_DEFAULTS = {
 const STRUCTURES = {
     claunts: {
         combineMode: 'first',
+        // Ordered most-specific -> most-general (first match wins). The tiered /
+        // ranked conference + non-conference categories are optional (defaultOff)
+        // so Claunts scores exactly as before until a commissioner opts in; when
+        // enabled they sit above the flat categories and take precedence.
         regularWin: [
+            { condition: 'confWinTop10', pointsKey: 'confWinTop10', label: 'Conference win vs. opponent ranked #1–10', toggleable: true, defaultOff: true },
+            { condition: 'confWinTop25', pointsKey: 'confWinTop25', label: 'Conference win vs. opponent ranked #11–25', toggleable: true, defaultOff: true },
+            { condition: 'confRankedWin', pointsKey: 'confWinRanked', label: 'Conference win vs. a ranked opponent', toggleable: true, defaultOff: true },
             { condition: 'conferenceWin', pointsKey: 'confWin', label: 'Conference win' },
-            { condition: 'nonConfRankedWin', pointsKey: 'nonConfWinRanked', label: 'Non-conference win vs. ranked opponent' },
+            { condition: 'nonConfWinTop10', pointsKey: 'nonConfWinTop10', label: 'Non-conference win vs. opponent ranked #1–10', toggleable: true, defaultOff: true },
+            { condition: 'nonConfWinTop25', pointsKey: 'nonConfWinTop25', label: 'Non-conference win vs. opponent ranked #11–25', toggleable: true, defaultOff: true },
+            { condition: 'nonConfRankedWin', pointsKey: 'nonConfWinRanked', label: 'Non-conference win vs. ranked opponent', toggleable: true },
             { condition: 'baseWin', pointsKey: 'nonConfWinUnranked', label: 'Non-conference win vs. unranked opponent' }
         ],
         postseason: [
@@ -116,22 +132,31 @@ const LEAGUES = [
     { code: 'graham-league', name: 'Graham League' }
 ];
 
-// Flat, ordered field metadata for the admin form + rules page. Regular-win
-// fields carry group 'regular'; postseason fields group 'postseason' and are
-// toggleable (enable/disable). `enabled` reflects the resolved `disabled` set.
-function fieldsForModel(model, disabled) {
+// Whether a rule is on for a config. A `defaultOff` rule is off unless its
+// condition is explicitly in the `enabled` opt-in list; every other rule is on
+// unless explicitly in the `disabled` list. Non-toggleable rules never appear in
+// either list, so they resolve to on. Shared by the admin display and the engine
+// so the two never disagree.
+function ruleEnabled(rule, disabled, enabled) {
+    if (rule.defaultOff) return (enabled || []).indexOf(rule.condition) !== -1;
+    return (disabled || []).indexOf(rule.condition) === -1;
+}
+
+// Flat, ordered field metadata for the admin form + rules page. Each field
+// carries `toggleable`, `defaultOff`, and its resolved `enabled` state (from the
+// `disabled` + `enabled` lists). Regular-win fields keep engine/priority order;
+// postseason fields are sorted into chronological `displayOrder` for the UI.
+function fieldsForModel(model, disabled, enabled) {
     const structure = (MODELS[model] || MODELS.claunts).structure;
-    const off = new Set(disabled || []);
-    const regular = structure.regularWin.map(r => ({
+    const field = (r, group, extra) => Object.assign({
         key: r.pointsKey, condition: r.condition, label: r.label,
-        additive: !!r.additive, group: 'regular', toggleable: false, enabled: true
-    }));
-    // Postseason fields are sorted into chronological `displayOrder` for the UI
-    // (conference championship -> bowls -> playoff rounds). This is display-only:
-    // the engine iterates structure.postseason in its own evaluation order.
-    const post = structure.postseason.map(r => ({
-        key: r.pointsKey, condition: r.condition, label: r.label,
-        additive: !!r.additive, group: 'postseason', toggleable: true, enabled: !off.has(r.condition),
+        additive: !!r.additive, group,
+        toggleable: !!r.toggleable, defaultOff: !!r.defaultOff,
+        enabled: ruleEnabled(r, disabled, enabled)
+    }, extra || {});
+    const regular = structure.regularWin.map(r => field(r, 'regular'));
+    const post = structure.postseason.map(r => field(r, 'postseason', {
+        toggleable: true,                       // postseason events are always toggleable
         stacksNote: r.stacksNote || null,
         displayOrder: typeof r.displayOrder === 'number' ? r.displayOrder : 0
     })).sort((a, b) => a.displayOrder - b.displayOrder);
@@ -148,11 +173,14 @@ function resolveConfig(league, overrides) {
         ? overrides.combineMode
         : modelDef.structure.combineMode;
     const disabled = (overrides && Array.isArray(overrides.disabled)) ? overrides.disabled.slice() : [];
+    const enabled = (overrides && Array.isArray(overrides.enabled)) ? overrides.enabled.slice() : [];
     return {
         model,
         combineMode,
         values: Object.assign({}, modelDef.defaults, (overrides && overrides.values) || {}),
         disabled,
+        // Opt-in list for defaultOff rules (finer Fixed-shape win categories).
+        enabled,
         // Legacy flat engagement (deprecated — see engagementBySeason). Kept in
         // the resolved shape for back-compat with any old reader.
         engagement: normalizeEngagement((overrides && overrides.engagement) || {}),
@@ -187,6 +215,6 @@ function engagementForSeason(bySeason, season) {
 
 module.exports = {
     CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, STRUCTURES, MODELS, LEAGUES,
-    modelForLeague, fieldsForModel, resolveConfig,
+    modelForLeague, fieldsForModel, resolveConfig, ruleEnabled,
     ENGAGEMENT_DEFAULTS, normalizeEngagement, engagementForSeason
 };

--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -74,13 +74,13 @@ const STRUCTURES = {
         // so Claunts scores exactly as before until a commissioner opts in; when
         // enabled they sit above the flat categories and take precedence.
         regularWin: [
-            { condition: 'confWinTop10', pointsKey: 'confWinTop10', label: 'Conference win vs. opponent ranked #1–10', toggleable: true, defaultOff: true },
-            { condition: 'confWinTop25', pointsKey: 'confWinTop25', label: 'Conference win vs. opponent ranked #11–25', toggleable: true, defaultOff: true },
-            { condition: 'confRankedWin', pointsKey: 'confWinRanked', label: 'Conference win vs. a ranked opponent', toggleable: true, defaultOff: true },
+            { condition: 'confWinTop10', pointsKey: 'confWinTop10', label: 'Conference win vs. opponent ranked #1–10', toggleable: true, defaultOff: true, rankGroup: 'conference' },
+            { condition: 'confWinTop25', pointsKey: 'confWinTop25', label: 'Conference win vs. opponent ranked #11–25', toggleable: true, defaultOff: true, rankGroup: 'conference' },
+            { condition: 'confRankedWin', pointsKey: 'confWinRanked', label: 'Conference win vs. a ranked opponent', toggleable: true, defaultOff: true, rankGroup: 'conference', rankFlat: true },
             { condition: 'conferenceWin', pointsKey: 'confWin', label: 'Conference win' },
-            { condition: 'nonConfWinTop10', pointsKey: 'nonConfWinTop10', label: 'Non-conference win vs. opponent ranked #1–10', toggleable: true, defaultOff: true },
-            { condition: 'nonConfWinTop25', pointsKey: 'nonConfWinTop25', label: 'Non-conference win vs. opponent ranked #11–25', toggleable: true, defaultOff: true },
-            { condition: 'nonConfRankedWin', pointsKey: 'nonConfWinRanked', label: 'Non-conference win vs. ranked opponent', toggleable: true },
+            { condition: 'nonConfWinTop10', pointsKey: 'nonConfWinTop10', label: 'Non-conference win vs. opponent ranked #1–10', toggleable: true, defaultOff: true, rankGroup: 'nonconference' },
+            { condition: 'nonConfWinTop25', pointsKey: 'nonConfWinTop25', label: 'Non-conference win vs. opponent ranked #11–25', toggleable: true, defaultOff: true, rankGroup: 'nonconference' },
+            { condition: 'nonConfRankedWin', pointsKey: 'nonConfWinRanked', label: 'Non-conference win vs. ranked opponent', toggleable: true, rankGroup: 'nonconference', rankFlat: true },
             { condition: 'baseWin', pointsKey: 'nonConfWinUnranked', label: 'Non-conference win vs. unranked opponent' }
         ],
         postseason: [
@@ -152,6 +152,9 @@ function fieldsForModel(model, disabled, enabled) {
         key: r.pointsKey, condition: r.condition, label: r.label,
         additive: !!r.additive, group,
         toggleable: !!r.toggleable, defaultOff: !!r.defaultOff,
+        // Mutual-exclusivity hints for the admin: within a rankGroup the flat
+        // "vs ranked" rule and the tiered "#1-10 / #11-25" rules can't both be on.
+        rankGroup: r.rankGroup || null, rankFlat: !!r.rankFlat,
         enabled: ruleEnabled(r, disabled, enabled)
     }, extra || {});
     const regular = structure.regularWin.map(r => field(r, 'regular'));

--- a/modules/scoring-detectors.js
+++ b/modules/scoring-detectors.js
@@ -115,6 +115,14 @@ const CONDITIONS = {
     rankedTop10Bonus: (ctx) => ctx.won && ctx.isRegular && ctx.rankVal === 2 && !isConferenceChampion(ctx.game),
     nonP5UpsetBonus: (ctx) => ctx.won && ctx.isRegular && ctx.isPowerFiveUpset && !isConferenceChampion(ctx.game),
 
+    // Optional finer Fixed-shape categories: conference/non-conference wins
+    // split by opponent rank. rankVal is 2 for #1-10, 1 for #11-25, 0 unranked.
+    confRankedWin: (ctx) => ctx.won && ctx.isRegular && ctx.isConference && ctx.rankVal > 0 && !isConferenceChampion(ctx.game),
+    confWinTop10: (ctx) => ctx.won && ctx.isRegular && ctx.isConference && ctx.rankVal === 2 && !isConferenceChampion(ctx.game),
+    confWinTop25: (ctx) => ctx.won && ctx.isRegular && ctx.isConference && ctx.rankVal === 1 && !isConferenceChampion(ctx.game),
+    nonConfWinTop10: (ctx) => ctx.won && ctx.isRegular && !ctx.isConference && ctx.rankVal === 2 && !isConferenceChampion(ctx.game),
+    nonConfWinTop25: (ctx) => ctx.won && ctx.isRegular && !ctx.isConference && ctx.rankVal === 1 && !isConferenceChampion(ctx.game),
+
     // Conference championship (regular-season titled game), win only.
     confChampionship: (ctx) => ctx.won && isConferenceChampion(ctx.game),
 

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -1,5 +1,5 @@
 const { internalFetch } = require('./internal-api');
-const { resolveConfig, MODELS, engagementForSeason } = require('./scoring-defaults');
+const { resolveConfig, MODELS, engagementForSeason, ruleEnabled } = require('./scoring-defaults');
 const { CONDITIONS, buildContext } = require('./scoring-detectors');
 const { resolveCaptain, captainWeeklyBonus } = require('./captain');
 // Configure API key authorization: ApiKeyAuth
@@ -359,16 +359,18 @@ async function getScoringConfig(league) {
             method: 'GET', headers: { 'Accept': 'application/json' }
         });
         var data = await res.json();
-        // Forward the FULL config — model, values, combineMode AND disabled — so
-        // the scoring jobs honor a commissioner's structural changes (combine
-        // mode, disabled postseason events), not just point values. Dropping
-        // combineMode/disabled here made computed scores silently ignore
-        // structural config while the rules page still showed it.
+        // Forward the FULL config — model, values, combineMode, disabled AND
+        // enabled — so the scoring jobs honor every structural change a
+        // commissioner makes (combine mode, disabled postseason events, opted-in
+        // finer win categories), not just point values. Dropping any of these
+        // here would make computed scores silently ignore structural config while
+        // the rules page still showed it.
         if (data && data.values) return resolveConfig(league, {
             model: data.model,
             values: data.values,
             combineMode: data.combineMode,
             disabled: data.disabled,
+            enabled: data.enabled,
             engagement: data.engagement,
             engagementBySeason: data.engagementBySeason
         });
@@ -410,9 +412,9 @@ async function getRankingsForGame(game, week, season, cache) {
 // all postseason events enabled.
 function normalizeCfg(model, cfg) {
     if (cfg && typeof cfg === 'object' && cfg.values && typeof cfg.values === 'object') {
-        return { combineMode: cfg.combineMode, values: cfg.values, disabled: cfg.disabled || [] };
+        return { combineMode: cfg.combineMode, values: cfg.values, disabled: cfg.disabled || [], enabled: cfg.enabled || [] };
     }
-    return { combineMode: undefined, values: cfg || {}, disabled: [] };
+    return { combineMode: undefined, values: cfg || {}, disabled: [], enabled: [] };
 }
 
 function pointsOf(values, key) {
@@ -428,20 +430,21 @@ function pointsOf(values, key) {
 function evaluate(model, team, game, rankings, cfg) {
     var structure = (MODELS[model] || MODELS.claunts).structure;
     var values = cfg.values || {};
-    var disabled = new Set(cfg.disabled || []);
+    var disabled = cfg.disabled || [];
+    var enabled = cfg.enabled || [];
     var combineMode = (cfg.combineMode === 'sum' || cfg.combineMode === 'first')
         ? cfg.combineMode : structure.combineMode;
     var ctx = buildContext(team, game, rankings);
 
-    // 1. Postseason events, in order. Each enabled matching rule adds its
-    //    points; a non-additive match stops evaluation. This first-match-stop
-    //    reproduces the old elif precedence (bracket rounds short-circuit the
-    //    bowl/regular paths, so a CFP game at a bowl venue never double-counts).
+    // 1. Postseason events, in order. Each ON matching rule adds its points; a
+    //    non-additive match stops evaluation. This first-match-stop reproduces
+    //    the old elif precedence (bracket rounds short-circuit the bowl/regular
+    //    paths, so a CFP game at a bowl venue never double-counts).
     var score = 0;
     var matchedPost = false;
     for (var i = 0; i < structure.postseason.length; i++) {
         var pr = structure.postseason[i];
-        if (disabled.has(pr.condition)) continue;
+        if (!ruleEnabled(pr, disabled, enabled)) continue;
         var pd = CONDITIONS[pr.condition];
         if (pd && pd(ctx)) {
             score += pointsOf(values, pr.pointsKey);
@@ -451,11 +454,13 @@ function evaluate(model, team, game, rankings, cfg) {
     }
     if (matchedPost) return score;
 
-    // 2. Regular-win group (only if no postseason event matched). Combine mode
-    //    'sum' adds every matching rule (Graham); 'first' takes the first match
-    //    in priority order (Claunts).
+    // 2. Regular-win group (only if no postseason event matched). Off rules
+    //    (a disabled default-on, or a not-opted-in default-off category) are
+    //    skipped. Combine mode 'sum' adds every matching rule (Graham); 'first'
+    //    takes the first match in priority order (Claunts).
     for (var j = 0; j < structure.regularWin.length; j++) {
         var rr = structure.regularWin[j];
+        if (!ruleEnabled(rr, disabled, enabled)) continue;
         var rd = CONDITIONS[rr.condition];
         if (rd && rd(ctx)) {
             score += pointsOf(values, rr.pointsKey);
@@ -488,11 +493,13 @@ var EXAMPLE_SCENARIOS = {
 
 // Runs the model's signature win through the REAL condition detectors and
 // reports which regular-win rules it matches, in the model's priority order.
-// Each match carries its point `key` so the admin can recompute the example
-// live from the (possibly-unsaved) input values; `points` is the saved-value
-// fallback. The client derives the per-mode totals ('first' = only the first
-// match; 'sum' = every match added).
-function explainRegularWin(model, values) {
+// Off rules (a disabled default-on, or a not-opted-in default-off category) are
+// skipped so the example matches how the win actually scores. Each match carries
+// its point `key` so the admin can recompute the example live from the
+// (possibly-unsaved) input values; `points` is the saved-value fallback. The
+// client derives the per-mode totals ('first' = only the first match; 'sum' =
+// every match added).
+function explainRegularWin(model, values, disabled, enabled) {
     var structure = (MODELS[model] || MODELS.claunts).structure;
     var scn = EXAMPLE_SCENARIOS[model] || EXAMPLE_SCENARIOS.claunts;
     var ctx = Object.assign({
@@ -502,6 +509,7 @@ function explainRegularWin(model, values) {
     var matched = [];
     for (var i = 0; i < structure.regularWin.length; i++) {
         var rr = structure.regularWin[i];
+        if (!ruleEnabled(rr, disabled || [], enabled || [])) continue;
         var det = CONDITIONS[rr.condition];
         if (det && det(ctx)) {
             matched.push({ key: rr.pointsKey, label: rr.label, points: pointsOf(values, rr.pointsKey) });

--- a/public/admin.css
+++ b/public/admin.css
@@ -587,13 +587,14 @@
 .scoring-toggle:checked::after {
     content: '';
     position: absolute;
-    left: 5px;
-    top: 2px;
+    left: 50%;
+    top: 50%;
     width: 4px;
     height: 8px;
     border: solid #0C0F1C;
     border-width: 0 2px 2px 0;
-    transform: rotate(45deg);
+    /* -60% Y nudges up so the checkmark's descending tail reads as centered. */
+    transform: translate(-50%, -60%) rotate(45deg);
 }
 .scoring-toggle:focus-visible {
     outline: 2px solid #64B5F6;

--- a/public/admin.js
+++ b/public/admin.js
@@ -1678,7 +1678,7 @@ function renderScoringFields() {
 
     function fieldRow(f) {
         var toggle = f.toggleable
-            ? `<input type="checkbox" class="scoring-toggle" data-condition="${f.condition}" ${f.enabled ? 'checked' : ''} title="Enable this event">`
+            ? `<input type="checkbox" class="scoring-toggle" data-condition="${f.condition}" data-default-off="${!!f.defaultOff}" ${f.enabled ? 'checked' : ''} title="Enable this rule">`
             : '';
         // "+" marks a regular-season bonus that stacks (only meaningful in the
         // Stacking shape). Postseason events combine on their own rules
@@ -1738,9 +1738,16 @@ async function saveScoringConfig() {
     document.querySelectorAll('[scoring-config-fields] input[data-key]').forEach(function (inp) {
         values[inp.getAttribute('data-key')] = parseFloat(inp.value);
     });
-    var disabled = [];
+    // Default-on rules that are unchecked go in `disabled`; default-off rules
+    // (the finer opt-in categories) that are checked go in `enabled`.
+    var disabled = [], enabled = [];
     document.querySelectorAll('[scoring-config-fields] .scoring-toggle').forEach(function (cb) {
-        if (!cb.checked) disabled.push(cb.getAttribute('data-condition'));
+        var cond = cb.getAttribute('data-condition');
+        if (cb.getAttribute('data-default-off') === 'true') {
+            if (cb.checked) enabled.push(cond);
+        } else if (!cb.checked) {
+            disabled.push(cond);
+        }
     });
 
     var res = await fetch('/scoring-config', {
@@ -1748,7 +1755,7 @@ async function saveScoringConfig() {
         headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
         body: JSON.stringify({
             league: leagueCode, model: getShape(),
-            values: values, disabled: disabled
+            values: values, disabled: disabled, enabled: enabled
         })
     });
     var data = await res.json();

--- a/public/admin.js
+++ b/public/admin.js
@@ -1677,8 +1677,9 @@ function renderScoringFields() {
     var fields = scoringConfigData.fields || [];
 
     function fieldRow(f) {
+        var rankAttrs = f.rankGroup ? ` data-rank-group="${f.rankGroup}" data-rank-flat="${!!f.rankFlat}"` : '';
         var toggle = f.toggleable
-            ? `<input type="checkbox" class="scoring-toggle" data-condition="${f.condition}" data-default-off="${!!f.defaultOff}" ${f.enabled ? 'checked' : ''} title="Enable this rule">`
+            ? `<input type="checkbox" class="scoring-toggle" data-condition="${f.condition}" data-default-off="${!!f.defaultOff}"${rankAttrs} ${f.enabled ? 'checked' : ''} title="Enable this rule">`
             : '';
         // "+" marks a regular-season bonus that stacks (only meaningful in the
         // Stacking shape). Postseason events combine on their own rules
@@ -1704,11 +1705,29 @@ function renderScoringFields() {
         '<div class="draft-status-row">Regular season</div>' + regular.map(fieldRow).join('') +
         '<div class="draft-status-row">Postseason</div>' + post.map(fieldRow).join('');
 
-    // Grey out a postseason row when its event is disabled.
+    // Grey out a row when its rule is off.
+    function syncToggleRow(cb) {
+        var row = wrap.querySelector('.scoring-field[data-condition="' + cb.getAttribute('data-condition') + '"]');
+        if (row) row.classList.toggle('scoring-disabled', !cb.checked);
+    }
     wrap.querySelectorAll('.scoring-toggle').forEach(function (cb) {
         cb.addEventListener('change', function () {
-            var row = wrap.querySelector('.scoring-field[data-condition="' + cb.getAttribute('data-condition') + '"]');
-            if (row) row.classList.toggle('scoring-disabled', !cb.checked);
+            // Within a rank group, the flat "vs ranked" rule and the tiered
+            // "#1-10 / #11-25" rules are mutually exclusive: turning one kind on
+            // turns the other kind off. (Two tiers can still coexist.)
+            var group = cb.getAttribute('data-rank-group');
+            if (cb.checked && group) {
+                var isFlat = cb.getAttribute('data-rank-flat') === 'true';
+                wrap.querySelectorAll('.scoring-toggle[data-rank-group="' + group + '"]').forEach(function (other) {
+                    if (other === cb) return;
+                    var otherFlat = other.getAttribute('data-rank-flat') === 'true';
+                    if (isFlat !== otherFlat && other.checked) {
+                        other.checked = false;
+                        syncToggleRow(other);
+                    }
+                });
+            }
+            syncToggleRow(cb);
         });
     });
 

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -43,7 +43,7 @@ router.get('/grades/:league/:season', async (req, res) => {
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
         const config = resolveConfig(league, cfgDoc ? {
             model: cfgDoc.model, values: cfgDoc.values,
-            combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled
+            combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled, enabled: cfgDoc.enabled
         } : null);
 
         const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -11,8 +11,8 @@ const { canManageLeague } = require('../modules/league-access');
 // computed from the live point values so it tracks edits.
 function withFields(cfg) {
     return Object.assign({}, cfg, {
-        fields: fieldsForModel(cfg.model, cfg.disabled),
-        example: explainRegularWin(cfg.model, cfg.values)
+        fields: fieldsForModel(cfg.model, cfg.disabled, cfg.enabled),
+        example: explainRegularWin(cfg.model, cfg.values, cfg.disabled, cfg.enabled)
     });
 }
 
@@ -24,7 +24,7 @@ router.get('/:league', async (req, res) => {
         const doc = await ScoringConfig.findOne({ league: req.params.league });
         const bySeason = (doc && doc.engagementBySeason) || {};
         let overrides = doc
-            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, engagement: doc.engagement, engagementBySeason: bySeason }
+            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, engagement: doc.engagement, engagementBySeason: bySeason }
             : null;
         // `?model=` lets the admin preview a different rule shape (Fixed =
         // claunts, Stacking = graham): force that model and drop the saved
@@ -50,19 +50,20 @@ router.get('/:league', async (req, res) => {
 
 // Upsert a league's scoring config (commissioner-gated via the mutation gate).
 // Accepts a rule-shape `model` (Fixed = claunts, Stacking = graham), point
-// `values`, and a `disabled` list of postseason condition keys. The combine
-// behavior is derived from the model's default — it is NOT a separate setting,
-// so a nonsensical shape/mode combo can't be saved.
+// `values`, a `disabled` list (default-on rules turned off), and an `enabled`
+// list (default-off finer win categories turned on). The combine behavior is
+// derived from the model's default — it is NOT a separate setting, so a
+// nonsensical shape/mode combo can't be saved.
 router.post('/', async (req, res) => {
     try {
-        const { league, model, values, disabled } = req.body;
+        const { league, model, values, disabled, enabled } = req.body;
         if (!league) {
             return res.status(400).json({ message: 'league is required' });
         }
         if (!canManageLeague(req, league)) {
             return res.status(403).json({ message: 'Forbidden: not your league' });
         }
-        const resolved = resolveConfig(league, { model, values, disabled });
+        const resolved = resolveConfig(league, { model, values, disabled, enabled });
         const doc = await ScoringConfig.findOneAndUpdate(
             { league },
             { $set: {
@@ -71,12 +72,13 @@ router.post('/', async (req, res) => {
                 values: resolved.values,
                 combineMode: resolved.combineMode,
                 disabled: resolved.disabled,
+                enabled: resolved.enabled,
                 updatedAt: new Date()
             } },
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
         res.json(withFields(resolveConfig(league, {
-            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled
+            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled
         })));
     } catch (err) {
         res.status(400).json({ message: err.message });

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -124,7 +124,7 @@ router.get('/projections/:league/:season', async (req, res) => {
 
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
         const cfg = resolveConfig(league, cfgDoc ? {
-            model: cfgDoc.model, values: cfgDoc.values, combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled
+            model: cfgDoc.model, values: cfgDoc.values, combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled, enabled: cfgDoc.enabled
         } : null);
         const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
         const apPoll = apDoc && Array.isArray(apDoc.polls) ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;

--- a/server.js
+++ b/server.js
@@ -209,12 +209,12 @@ app.get('/rules', async (req, res) => {
         try {
             const doc = await ScoringConfig.findOne({ league: leagueCode });
             cfg = resolveConfig(leagueCode, doc
-                ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled }
+                ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled }
                 : null);
         } catch (err) {
             cfg = resolveConfig(leagueCode, null);
         }
-        const fields = fieldsForModel(cfg.model, cfg.disabled);
+        const fields = fieldsForModel(cfg.model, cfg.disabled, cfg.enabled);
 
         res.render('scoringRules', { user, userState, cfg, fields, leagueCode });
     } else {

--- a/tests/ScoringStructure.spec.js
+++ b/tests/ScoringStructure.spec.js
@@ -46,6 +46,48 @@ describe('combine mode override', () => {
     });
 });
 
+describe('Fixed-shape optional win categories (Claunts)', () => {
+    it('are off by default, so scoring is unchanged', async () => {
+        mockRankings([{ school: 'Opp', rank: 5 }]); // #5 => top-10
+        const cfg = resolveConfig('claunts-league', null);
+        // A conference win vs a top-10 opponent still scores the flat Conference win (2).
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: true, awayConf: 'SEC' }), 5, 2025, cfg)).toBe(2);
+        // A non-conference win vs a top-10 opponent still scores the flat ranked win (3).
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: false }), 5, 2025, cfg)).toBe(3);
+    });
+
+    it('opting into "Conference win vs #1-10" scores it above the flat conference win', async () => {
+        mockRankings([{ school: 'Opp', rank: 5 }]);
+        const cfg = resolveConfig('claunts-league', { enabled: ['confWinTop10'] });
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: true, awayConf: 'SEC' }), 5, 2025, cfg)).toBe(4);
+    });
+
+    it('a conference win outside the opted-in tier falls back to the flat conference win', async () => {
+        mockRankings([{ school: 'Opp', rank: 15 }]); // #15 => #11-25, not top-10
+        const cfg = resolveConfig('claunts-league', { enabled: ['confWinTop10'] });
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: true, awayConf: 'SEC' }), 5, 2025, cfg)).toBe(2);
+    });
+
+    it('non-conference tiers (flat ranked rule turned off) score by rank', async () => {
+        const cfg = resolveConfig('claunts-league', {
+            enabled: ['nonConfWinTop10', 'nonConfWinTop25'], disabled: ['nonConfRankedWin']
+        });
+        mockRankings([{ school: 'Opp', rank: 5 }]);    // top-10
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: false }), 5, 2025, cfg)).toBe(4);
+        mockRankings([{ school: 'Opp', rank: 15 }]);   // #11-25
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: false }), 5, 2025, cfg)).toBe(3);
+        mockRankings([]);                               // unranked -> base win
+        expect(await scoring.calculateScoreV1(1, homeWin({ conf: false }), 5, 2025, cfg)).toBe(1);
+    });
+
+    it('fieldsForModel marks the new categories toggleable + off by default, on when opted in', () => {
+        const off = fieldsForModel('claunts', [], []).find(f => f.condition === 'confWinTop10');
+        expect(off).toMatchObject({ toggleable: true, defaultOff: true, enabled: false, group: 'regular' });
+        const on = fieldsForModel('claunts', [], ['confWinTop10']).find(f => f.condition === 'confWinTop10');
+        expect(on.enabled).toBe(true);
+    });
+});
+
 describe('disabled postseason events', () => {
     it('disabling bowlWin (Claunts) leaves only the bowl appearance points', async () => {
         mockRankings([]);


### PR DESCRIPTION
Adds finer regular-season win categories to the **Fixed (Claunts)** rule shape, so a commissioner can optionally score conference and non-conference wins by opponent rank. Everything starts **disabled** — Claunts scores exactly as it does today until someone opts in.

## New categories (all off by default)
- **Conference win vs. a ranked opponent** (flat)
- **Conference win vs. #1–10** / **vs. #11–25**
- **Non-conference win vs. #1–10** / **vs. #11–25**

The existing flat **"Non-conference win vs. ranked opponent"** becomes toggleable too, so a league can switch flat → tiered. With first-match-wins, the finer categories sit above the flat ones and take precedence only when enabled.

## Mechanics
- New condition detectors (conference/non-conference × rank tier) in `scoring-detectors.js`.
- Regular-season rules are now individually **toggleable** (like postseason already are). A per-rule `defaultOff` flag + a new `enabled` opt-in list let a brand-new rule default to **off** for a league that already has a saved config — **no migration**.
- `ruleEnabled()` centralizes on/off so the admin display and the engine can't disagree; `evaluate()` skips off rules in both the postseason and regular-win loops.
- `enabled` is plumbed through **every** scoring-config builder (`getScoringConfig`, the scoring-config route, `standings`, `draft`, and `/rules`) so an opted-in category can never be silently ignored on one path.

## Safety
- **No rescore, no migration.** Default-off means existing Claunts scoring is byte-for-byte unchanged; `ScoringParity` and all prior tests still pass.
- The member-facing rules page hides disabled categories (verified live).
- **198 tests pass** (5 new covering: off-by-default = no change, opting into a tier, tier fallback, non-conf tiers with the flat rule off, and the field metadata).

## Verified live (dev server, as Admin, read-only)
- Admin panel shows the 5 new categories unchecked with sensible default values, the flat non-conf ranked rule now toggleable + checked, and the base rules with no checkbox.
- The Claunts rules page still shows only the three original categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)