### PR TITLE
For the Claunts manager: scoring breakdown + lock scoring mid-season for League Managers

### DIFF
--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -518,3 +518,44 @@ function explainRegularWin(model, values, disabled, enabled) {
     return { scenario: scn.label, matched: matched };
 }
 module.exports.explainRegularWin = explainRegularWin;
+
+// Like evaluate(), but for a REAL game: returns the rule(s) that fired (label +
+// points) plus the total, instead of a bare number. Mirrors evaluate()'s order
+// and skip logic exactly, so `total` equals evaluate()'s score for the same
+// inputs (locked by a parity test). Powers the member-facing "why did this game
+// score this?" breakdown.
+function explainGame(model, team, game, rankings, cfg) {
+    var structure = (MODELS[model] || MODELS.claunts).structure;
+    var values = cfg.values || {};
+    var disabled = cfg.disabled || [];
+    var enabled = cfg.enabled || [];
+    var combineMode = (cfg.combineMode === 'sum' || cfg.combineMode === 'first')
+        ? cfg.combineMode : structure.combineMode;
+    var ctx = buildContext(team, game, rankings);
+    var matched = [];
+    var add = function (r, group) {
+        matched.push({ key: r.pointsKey, label: r.label, points: pointsOf(values, r.pointsKey), group: group });
+    };
+
+    var matchedPost = false;
+    for (var i = 0; i < structure.postseason.length; i++) {
+        var pr = structure.postseason[i];
+        if (!ruleEnabled(pr, disabled, enabled)) continue;
+        var pd = CONDITIONS[pr.condition];
+        if (pd && pd(ctx)) { add(pr, 'postseason'); matchedPost = true; if (!pr.additive) break; }
+    }
+    if (!matchedPost) {
+        for (var j = 0; j < structure.regularWin.length; j++) {
+            var rr = structure.regularWin[j];
+            if (!ruleEnabled(rr, disabled, enabled)) continue;
+            var rd = CONDITIONS[rr.condition];
+            if (rd && rd(ctx)) { add(rr, 'regular'); if (combineMode !== 'sum') break; }
+        }
+    }
+    return { matched: matched, total: matched.reduce(function (s, m) { return s + m.points; }, 0) };
+}
+module.exports.explainGame = explainGame;
+// Exposed so the per-game breakdown route can reuse the EXACT scoring inputs
+// (resolved config + the game's week rankings) the scoring jobs use.
+module.exports.getScoringConfig = getScoringConfig;
+module.exports.getRankingsForGame = getRankingsForGame;

--- a/public/admin.css
+++ b/public/admin.css
@@ -457,6 +457,20 @@
 
 /* Combine mode: two plain-language radio cards + a live worked example, in
    place of the old jargon dropdown ("First match wins (priority)"). */
+/* Shown to a League Manager when scoring is locked (season underway). */
+.scoring-locked {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85em;
+    color: #E0B341;
+    background: rgba(224, 179, 65, 0.10);
+    border: 1px solid rgba(224, 179, 65, 0.35);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 6px;
+}
+
 .combine-mode-q { font-size: 0.9em; margin-bottom: 4px; }
 .combine-mode { display: flex; flex-direction: column; gap: 8px; }
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -1606,6 +1606,21 @@ function applyScoringConfig() {
     setShape(scoringConfigData.model);
     renderScoringFields();
     renderShapeExample();
+    applyScoringLock();
+}
+
+// League Managers can't change scoring once the season is underway (server
+// enforces this too). When locked, disable every control, hide Save, and show
+// the "contact an admin" banner so it's clear before they try.
+function applyScoringLock() {
+    var locked = !!(scoringConfigData && scoringConfigData.locked);
+    var form = document.getElementById('scoring-config-form');
+    if (!form) return;
+    form.querySelectorAll('input, button').forEach(function (el) { el.disabled = locked; });
+    var banner = form.querySelector('[scoring-config-locked]');
+    if (banner) banner.style.display = locked ? 'flex' : 'none';
+    var actions = form.querySelector('.draft-config-actions');
+    if (actions) actions.style.display = locked ? 'none' : '';
 }
 
 // Rule shape is a two-card radio bound to the league's model (claunts/graham).
@@ -1781,7 +1796,13 @@ async function saveScoringConfig() {
     if (res.status === 200) {
         scoringConfigData = data;
         applyScoringConfig();
-        document.querySelector('[scoring-config-note]').style.display = 'block';
+        // Admins can re-score; League Managers can't (and only reach save
+        // pre-season anyway), so don't tell them to run a rescore.
+        var note = document.querySelector('[scoring-config-note]');
+        note.textContent = data.isAdmin
+            ? 'Saved. Run a full-season rescore to apply this to existing scores.'
+            : 'Saved. Your changes take effect when scores are next calculated.';
+        note.style.display = 'block';
         successToast.options.text = 'Scoring config saved';
         successToast.showToast();
     } else {

--- a/public/standings.css
+++ b/public/standings.css
@@ -402,6 +402,33 @@
         max-width: 75%;
     }
 }
+/* Tappable "+N" scoring badge + the per-game breakdown it reveals. */
+.game-table .score-explain {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    cursor: pointer;
+    border-bottom: 1px dotted rgba(34, 195, 122, 0.6);
+}
+.game-table .score-explain:hover,
+.game-table .score-explain.is-open { border-bottom-style: solid; }
+.game-table .score-explain:focus-visible { outline: 2px solid #64B5F6; outline-offset: 2px; }
+.game-table .gc-breakdown {
+    margin-top: 0.5em;
+    padding-top: 0.5em;
+    border-top: 1px solid #2A2E42;
+    font-size: 0.8rem;
+    color: #A4A9C2;
+    text-align: left;
+}
+.game-table .gc-breakdown .bd-row { display: flex; gap: 0.5em; align-items: baseline; }
+.game-table .gc-breakdown .bd-pts { color: #22C37A; font-weight: 700; font-variant-numeric: tabular-nums; }
+.game-table .gc-breakdown .bd-label { color: #F4F6FB; }
+.game-table .gc-breakdown .bd-note { margin-top: 0.4em; color: #E0B341; font-style: italic; }
+
 /* ---------- Standings UX enhancements ---------- */
 /* Ranked table: movement, medals, crown, gap-to-leader */
 .rank-num { font-weight: 700; margin-right: 5px; }

--- a/public/standings.js
+++ b/public/standings.js
@@ -574,6 +574,54 @@ function teamGameScoreById(weeklyScore, teamId, gameId) {
     return 0;
 }
 
+// A rostered team's per-game points as a tappable "+N" badge — tap to reveal
+// which scoring rule earned them (see the delegated handler below). '' at 0.
+function scoreBadge(teamId, gameId, pts) {
+    return pts > 0
+        ? '<button type="button" class="score-explain" data-team="' + teamId + '" data-game="' + gameId + '" data-pts="' + pts + '" title="Why these points?"><strong style="color: #22C37A;">+' + pts + '</strong></button>'
+        : '';
+}
+
+// Tap a "+N" badge to reveal which scoring rule earned the points. Standings
+// game cards are <table class="game-table"> (no .game-card wrapper), so the
+// breakdown is appended as a row on that table. Toggles off on a second tap.
+document.addEventListener('click', async function (e) {
+    var btn = e.target && e.target.closest && e.target.closest('.score-explain');
+    if (!btn) return;
+    var table = btn.closest('table.game-table');
+    if (!table) return;
+    var open = table.querySelector('.gc-breakdown-row');
+    if (open) { open.remove(); btn.classList.remove('is-open'); return; }
+    var league = window.localStorage.getItem('leagueCode');
+    if (!league || league === 'undefined') {
+        league = (userState && userState.user_metadata.metadata.league == 'gg') ? 'graham-league' : 'claunts-league';
+    }
+    var teamId = btn.getAttribute('data-team');
+    var gameId = btn.getAttribute('data-game');
+    var banked = Number(btn.getAttribute('data-pts'));
+    var row = document.createElement('tr');
+    row.className = 'gc-breakdown-row';
+    row.innerHTML = '<td colspan="3"><div class="gc-breakdown">Loading…</div></td>';
+    (table.querySelector('tbody') || table).appendChild(row);
+    btn.classList.add('is-open');
+    var box = row.querySelector('.gc-breakdown');
+    try {
+        var res = await fetch('/scoring-config/' + encodeURIComponent(league) + '/explain?teamId='
+            + encodeURIComponent(teamId) + '&gameId=' + encodeURIComponent(gameId), { headers: { Accept: 'application/json' } });
+        var data = await res.json();
+        if (!res.ok || !data || !Array.isArray(data.matched) || !data.matched.length) { box.textContent = 'Breakdown unavailable.'; return; }
+        var rows = data.matched.map(function (m) {
+            return '<div class="bd-row"><span class="bd-pts">+' + m.points + '</span><span class="bd-label">' + m.label + '</span></div>';
+        }).join('');
+        var note = (typeof data.total === 'number' && data.total !== banked)
+            ? '<div class="bd-note">Scoring rules or rankings changed since this game was scored, so this differs from the banked +' + banked + '.</div>'
+            : '';
+        box.innerHTML = rows + note;
+    } catch (err) {
+        box.textContent = 'Breakdown unavailable.';
+    }
+});
+
 async function displaySchedule(data) {
     const scheduleStart = new Date();
     var usersAndTeams = [];
@@ -740,8 +788,8 @@ async function displaySchedule(data) {
                             // so gate on >0 to avoid a spurious "+0" badge on the opponent's row.
                             var awayPts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id);
                             var homePts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id);
-                            var awayScoreAdded = awayPts > 0 ? '<strong style="color: #22C37A;">+' + awayPts + '</strong>' : '';
-                            var homeScoreAdded = homePts > 0 ? '<strong style="color: #22C37A;">+' + homePts + '</strong>' : '';
+                            var awayScoreAdded = scoreBadge(game.awayId, game.id, awayPts);
+                            var homeScoreAdded = scoreBadge(game.homeId, game.id, homePts);
 
                             if (game.awayPoints > game.homePoints) {
                                 topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + awayScoreAdded + '</td>';
@@ -753,21 +801,21 @@ async function displaySchedule(data) {
 
                         } else if ( game.awayPoints > game.homePoints ) {
                             if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                                scoreAdded = scoreBadge(game.awayId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id));
                             }
                             topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             bottomData = (game.homePoints != null ? game.homePoints : '-');
                         } else if (game.homePoints > game.awayPoints) {
 
                             if(!isAway) {
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
+                                scoreAdded = scoreBadge(game.homeId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id));
                             }
 
                             topData = (game.awayPoints != null ? game.awayPoints : '-');
                             bottomData = (game.homePoints != null ? game.homePoints : '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                         } else {
                             if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                                scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                                scoreAdded = scoreBadge(game.awayId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id));
                             }
                             topData = (game.awayPoints != null ? game.awayPoints : '-');
                             bottomData = (game.homePoints != null ? game.homePoints : '-');
@@ -865,7 +913,7 @@ async function displaySchedule(data) {
                             if( game.awayPoints > game.homePoints ) {
                                 if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
                                     shouldReplace = true;
-                                    scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id) + '<strong>';
+                                    scoreAdded = scoreBadge(game.awayId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id));
                                 }
                                 topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                                 bottomData = (game.homePoints != null ? game.homePoints : '-');
@@ -873,7 +921,7 @@ async function displaySchedule(data) {
 
                                 if(game.homeId == userData.seasons.at(-1).teams[iterNum].id) {
                                     shouldReplace = true;
-                                    scoreAdded = '<strong style="color: #22C37A;">+' + teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id) + '<strong>';
+                                    scoreAdded = scoreBadge(game.homeId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id));
                                 }
 
                                 topData = (game.awayPoints != null ? game.awayPoints : '-');

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -465,6 +465,37 @@
 .game-card .gc-score { text-align: left; white-space: nowrap; padding-left: 0.9em; width: 1%; }
 .game-card .score-added { white-space: nowrap; padding-left: 0.5em; }
 
+/* The "+N" badge is a button: tap to reveal the scoring breakdown. Looks like
+   the old badge, but signals it's tappable (pointer + dotted underline). */
+.game-card .score-explain {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: #22C37A;
+    cursor: pointer;
+    border-bottom: 1px dotted rgba(34, 195, 122, 0.6);
+}
+.game-card .score-explain:hover,
+.game-card .score-explain.is-open { border-bottom-style: solid; }
+.game-card .score-explain:focus-visible { outline: 2px solid #64B5F6; outline-offset: 2px; }
+
+/* Per-game scoring breakdown revealed under the card. */
+.game-card .gc-breakdown {
+    margin-top: 0.6em;
+    padding-top: 0.6em;
+    border-top: 1px solid #2A2E42;
+    font-size: 0.82em;
+    color: #A4A9C2;
+    text-align: left;
+}
+.game-card .gc-breakdown .bd-row { display: flex; gap: 0.5em; align-items: baseline; }
+.game-card .gc-breakdown .bd-pts { color: #22C37A; font-weight: 700; font-variant-numeric: tabular-nums; }
+.game-card .gc-breakdown .bd-label { color: #F4F6FB; }
+.game-card .gc-breakdown .bd-note { margin-top: 0.4em; color: #E0B341; font-style: italic; }
+
 /* Draft grades review section on the profile (cards styled by draftGrades.css). */
 /* Draft-grade chip in the profile hero → expands the detail panel below. */
 .grade-chip {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -1187,6 +1187,44 @@ function teamGameScoreById(weeklyScore, teamId, gameId) {
     return 0;
 }
 
+// Tap a game card's "+N" badge to reveal WHICH scoring rule earned the points.
+// Lazily fetches the breakdown (server reuses the real engine on the game's
+// week rankings + the league's config) and shows it under the card; tapping
+// again hides it. Delegated so it covers every game card on the page.
+document.addEventListener('click', async function (e) {
+    var btn = e.target && e.target.closest && e.target.closest('.score-explain');
+    if (!btn) return;
+    var card = btn.closest('.game-card');
+    if (!card) return;
+    var open = card.querySelector('.gc-breakdown');
+    if (open) { open.remove(); btn.classList.remove('is-open'); return; }
+    var league = (typeof userData !== 'undefined' && userData && userData.league) || '';
+    var teamId = btn.getAttribute('data-team');
+    var gameId = btn.getAttribute('data-game');
+    var banked = Number(btn.getAttribute('data-pts'));
+    var box = document.createElement('div');
+    box.className = 'gc-breakdown';
+    box.textContent = 'Loading…';
+    card.appendChild(box);
+    btn.classList.add('is-open');
+    try {
+        var res = await fetch('/scoring-config/' + encodeURIComponent(league) + '/explain?teamId='
+            + encodeURIComponent(teamId) + '&gameId=' + encodeURIComponent(gameId), { headers: { Accept: 'application/json' } });
+        var data = await res.json();
+        if (!res.ok || !data || !Array.isArray(data.matched)) { box.textContent = 'Breakdown unavailable.'; return; }
+        if (!data.matched.length) { box.textContent = 'No scoring rule applied to this game.'; return; }
+        var rows = data.matched.map(function (m) {
+            return '<div class="bd-row"><span class="bd-pts">+' + m.points + '</span><span class="bd-label">' + m.label + '</span></div>';
+        }).join('');
+        var note = (typeof data.total === 'number' && data.total !== banked)
+            ? '<div class="bd-note">Scoring rules or rankings changed since this game was scored, so this differs from the banked +' + banked + '.</div>'
+            : '';
+        box.innerHTML = rows + note;
+    } catch (err) {
+        box.textContent = 'Breakdown unavailable.';
+    }
+});
+
 // Fetch every team logo the week's games need in ONE request, returning a
 // { teamId: <img html> } map. Replaces the old per-game POST to
 // /teams/teamLogos (one round-trip per game); missing teams fall back to the
@@ -1259,7 +1297,9 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
     const badgeCell = (id, rostered) => {
         if (!rostered) return '';
         const pts = teamGameScoreById(uhSeasonFor(userData, uhActiveYear).weeklyScore, id, game.id);
-        return pts > 0 ? `<td class="score-added"><strong style="color: #22C37A;">+${pts}</strong></td>` : '';
+        // The badge is a button: tap to reveal WHY this team earned these points
+        // (which scoring rule fired). See the delegated handler below.
+        return pts > 0 ? `<td class="score-added"><button type="button" class="score-explain" data-team="${id}" data-game="${game.id}" data-pts="${pts}" title="Why these points?"><strong>+${pts}</strong></button></td>` : '';
     };
     const caret = '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i>';
 

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -1,9 +1,22 @@
 const express = require('express');
 const router = express.Router();
 const ScoringConfig = require('../models/scoringConfig');
+const User = require('../models/user');
+const Game = require('../models/game');
 const { resolveConfig, fieldsForModel, engagementForSeason } = require('../modules/scoring-defaults');
-const { explainRegularWin } = require('../modules/scoring');
+const { explainRegularWin, explainGame, getScoringConfig, getRankingsForGame } = require('../modules/scoring');
 const { canManageLeague } = require('../modules/league-access');
+const { effectiveRoles } = require('../modules/dev-role');
+
+// True once at least one drafted-team game has been scored in `season` for this
+// league — used to lock scoring edits for League Managers mid-season.
+async function hasScoredGames(league, season) {
+    const hit = await User.exists({
+        league,
+        seasons: { $elemMatch: { season: Number(season), 'weeklyScore.scoreByTeam.0': { $exists: true } } }
+    });
+    return !!hit;
+}
 
 // Attaches the ordered field metadata (for the admin form + rules page) and a
 // plain-language combine-mode `example` to a resolved config. `fields` reflect
@@ -42,7 +55,45 @@ router.get('/:league', async (req, res) => {
         cfg.engagement = engagementForSeason(bySeason, season);
         cfg.engagementBySeason = bySeason;
         cfg.season = String(season);
+        // Whether this caller may still edit scoring. Admins always can (they can
+        // trigger a rescore). League Managers are locked out once the season has a
+        // scored game — they must ask an admin. Only computed for a signed-in
+        // manager (skipped for regular members and internal token calls).
+        cfg.editable = false;
+        cfg.locked = false;
+        cfg.isAdmin = false;
+        if (req.oidc && req.oidc.isAuthenticated && req.oidc.isAuthenticated() && canManageLeague(req, req.params.league)) {
+            cfg.isAdmin = effectiveRoles(req).includes('Admin');
+            if (cfg.isAdmin) {
+                cfg.editable = true;
+            } else {
+                const scored = await hasScoredGames(req.params.league, season);
+                cfg.editable = !scored;
+                cfg.locked = scored;
+            }
+        }
         res.json(cfg);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Per-game scoring breakdown: which rule(s) earned a rostered team its points
+// for one game. Reuses the EXACT engine inputs (resolved config + the game's
+// week rankings) the scoring jobs use, so the breakdown reconciles with the
+// banked per-game score (barring rankings/rules changing after it was scored).
+router.get('/:league/explain', async (req, res) => {
+    try {
+        const teamId = Number(req.query.teamId);
+        const gameId = Number(req.query.gameId);
+        if (!Number.isFinite(teamId) || !Number.isFinite(gameId)) {
+            return res.status(400).json({ message: 'teamId and gameId are required' });
+        }
+        const game = await Game.findOne({ id: gameId }).lean();
+        if (!game) return res.status(404).json({ message: 'Game not found' });
+        const cfg = await getScoringConfig(req.params.league);
+        const rankings = await getRankingsForGame(game, game.week, game.season);
+        res.json(explainGame(cfg.model, teamId, game, rankings, cfg));
     } catch (err) {
         res.status(500).json({ message: err.message });
     }
@@ -62,6 +113,12 @@ router.post('/', async (req, res) => {
         }
         if (!canManageLeague(req, league)) {
             return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
+        // League Managers can't change scoring once the season is underway — a
+        // change would need a full-season rescore, which only an admin can run.
+        // Admins are exempt (they can rescore).
+        if (!effectiveRoles(req).includes('Admin') && await hasScoredGames(league, process.env.YEAR)) {
+            return res.status(423).json({ message: 'Scoring is locked once the season is underway. Ask an admin to change it — the change needs a re-score.' });
         }
         const resolved = resolveConfig(league, { model, values, disabled, enabled });
         const doc = await ScoringConfig.findOneAndUpdate(

--- a/tests/ScoringExplain.spec.js
+++ b/tests/ScoringExplain.spec.js
@@ -1,0 +1,54 @@
+// explainGame() powers the member-facing "why did this game score this?"
+// breakdown. It must never drift from the real scorer, so every case asserts
+// its summed points equal evaluate()'s total for the same inputs.
+
+const scoring = require('../modules/scoring');
+const { resolveConfig } = require('../modules/scoring-defaults');
+
+const ranks = (r) => ({ polls: [{ poll: 'AP Top 25', ranks: r }] });
+const win = (o = {}) => ({
+    seasonType: 'regular', notes: '', conferenceGame: !!o.conf,
+    homeId: 1, awayId: 2, homeTeam: 'Us', awayTeam: 'Opp',
+    homePoints: 30, awayPoints: 20,
+    homeConference: o.homeConf || 'SEC', awayConference: o.awayConf || 'ACC'
+});
+const bowl = { seasonType: 'postseason', notes: 'Famous Toastery Bowl', homeId: 1, awayId: 2, homeTeam: 'Us', awayTeam: 'Opp', homePoints: 30, awayPoints: 20 };
+const quarterfinal = { seasonType: 'postseason', notes: 'CFP Quarterfinal at the Rose Bowl Game', homeId: 1, awayId: 2, homeTeam: 'Us', awayTeam: 'Opp', homePoints: 30, awayPoints: 20 };
+
+function parity(model, league, game, rankings, overrides) {
+    const cfg = resolveConfig(league, overrides || null);
+    const total = scoring.evaluate(model, 1, game, rankings, cfg);
+    const ex = scoring.explainGame(model, 1, game, rankings, cfg);
+    expect(ex.total).toBe(total);
+    return ex;
+}
+
+describe('explainGame parity with evaluate', () => {
+    it('matches for Claunts regular wins (conference / non-conf ranked / unranked)', () => {
+        parity('claunts', 'claunts-league', win({ conf: true }), ranks([{ school: 'Opp', rank: 5 }]));
+        parity('claunts', 'claunts-league', win({ conf: false }), ranks([{ school: 'Opp', rank: 5 }]));
+        parity('claunts', 'claunts-league', win({ conf: false }), ranks([]));
+    });
+
+    it('matches for a Graham stacking win', () => {
+        const ex = parity('graham', 'graham-league', win({ conf: true }), ranks([{ school: 'Opp', rank: 5 }]));
+        expect(ex.matched.length).toBeGreaterThan(1); // base + conference + top-10 stack
+    });
+
+    it('matches for postseason (bowl appearance+win, and a top-4 quarterfinal)', () => {
+        parity('claunts', 'claunts-league', bowl, ranks([]));
+        parity('graham', 'graham-league', quarterfinal, ranks([]));
+    });
+
+    it('reports the single matched rule for a Claunts non-conference ranked win', () => {
+        const ex = parity('claunts', 'claunts-league', win({ conf: false }), ranks([{ school: 'Opp', rank: 5 }]));
+        expect(ex.matched.length).toBe(1);
+        expect(ex.matched[0].label).toBe('Non-conference win vs. ranked opponent');
+        expect(ex.matched[0].points).toBe(3);
+    });
+
+    it('reflects an opted-in Claunts tier and stays in parity', () => {
+        const ex = parity('claunts', 'claunts-league', win({ conf: true }), ranks([{ school: 'Opp', rank: 5 }]), { enabled: ['confWinTop10'] });
+        expect(ex.matched[0].label).toContain('Conference win vs. opponent ranked');
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -385,6 +385,10 @@
                     <p class="function-description">Choose how this league scores wins, then tune the point values and postseason events.</p>
                     <form id="scoring-config-form" class="draft-config-form">
                         <div class="draft-status-row"><span scoring-config-model></span></div>
+                        <div scoring-config-locked class="scoring-locked" style="display:none">
+                            <span data-icon="lock" data-icon-size="16"></span>
+                            Scoring is locked once the season is underway. Contact an admin to change it &mdash; the change needs a full-season re-score.
+                        </div>
                         <div class="draft-field combine-mode-field">
                             <label class="combine-mode-q">How does this league score wins?</label>
                             <div class="combine-mode" scoring-config-shape>


### PR DESCRIPTION
Two changes aimed at a non-technical league manager: a "show your work" scoring breakdown, and a guardrail so a League Manager can't accidentally change scoring mid-season.

## 1. Scoring "show your work" (per-game breakdown)
Tap a game card's green **"+N"** badge on **My Team** to see *why* a rostered team earned those points — the exact rule(s) that fired.
- Claunts (one rule per win): a single line, e.g. *"+3 · Non-conference win vs. ranked opponent."*
- Stacking leagues: each bonus listed.

**How it stays correct:** `explainGame()` mirrors `evaluate()` but keeps the matched rules instead of a bare total, and a **parity test** locks `explainGame().total === evaluate()`. The `/explain` route reuses the **exact** engine inputs (resolved config + the game's week rankings), so the breakdown reconciles with the banked score; if rankings/rules changed since it was scored, a small note says so.

## 2. Lock scoring for League Managers once the season is underway
A League Manager can no longer change scoring after the first game of the season is scored — that would require a full-season rescore, which only an admin can run. **Admins keep full edit + rescore.**
- `POST /scoring-config` → **423** for a non-admin when the league has a scored game, with an "ask an admin" message.
- `GET /scoring-config` reports `editable` / `locked` / `isAdmin` so the admin UI locks proactively: disables every control, hides Save, shows a **"contact an admin"** banner.
- The saved-note is role-aware — League Managers are never told to "run a rescore" (they only ever save pre-season); admins still get the reminder.

## Verified live (dev server, read-only + role-spoof)
- Breakdown: opened the Games drawer, tapped a real "+6" → **"+6 Non-playoff bowl win"** (matches the banked points).
- Explain endpoint on a real scored Claunts game → `Non-conference win vs. unranked opponent = 1`, total == banked.
- Lock: spoofed a Claunts **League Manager** → `locked:true`, a save returned **423**, and the **Admin** was unaffected; spoof cleanly restored.

## Safety
- **No scoring-engine change** — `evaluate()` untouched; `explainGame()` is a read-only sibling.
- **No rescore, no migration.** `hasScoredGames()` is a read; the lock only gates future edits.
- **203 tests pass** (5 new `explainGame`↔`evaluate` parity cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)