### PR TITLE
Admin/league management cleanup: simpler Add a Player + non-destructive Season Roster

### DIFF
--- a/modules/season-status.js
+++ b/modules/season-status.js
@@ -1,0 +1,15 @@
+const User = require('../models/user');
+
+// True once at least one drafted-team game has been scored in `season` for this
+// league — the "season is underway" signal. Used to lock destructive edits
+// (scoring config, season roster) for League Managers mid-season; only an admin
+// (who can run a rescore) may change them once scoring has started.
+async function hasScoredGames(league, season) {
+    const hit = await User.exists({
+        league,
+        seasons: { $elemMatch: { season: Number(season), 'weeklyScore.scoreByTeam.0': { $exists: true } } }
+    });
+    return !!hit;
+}
+
+module.exports = { hasScoredGames };

--- a/public/admin.css
+++ b/public/admin.css
@@ -457,6 +457,20 @@
 
 /* Combine mode: two plain-language radio cards + a live worked example, in
    place of the old jargon dropdown ("First match wins (priority)"). */
+/* Season roster: include/exclude checklist (reuses .scoring-toggle checkbox). */
+.season-roster-list { display: flex; flex-direction: column; gap: 4px; }
+.roster-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 6px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+.roster-row:hover { background: #101322; }
+.roster-dot { width: 12px; height: 12px; border-radius: 50%; flex: none; }
+.roster-name { font-size: 0.95em; }
+
 /* Shown to a League Manager when scoring is locked (season underway). */
 .scoring-locked {
     display: flex;

--- a/public/admin.css
+++ b/public/admin.css
@@ -457,6 +457,20 @@
 
 /* Combine mode: two plain-language radio cards + a live worked example, in
    place of the old jargon dropdown ("First match wins (priority)"). */
+/* Locked state (season underway): make disabled controls clearly non-editable.
+   The custom-styled inputs don't change on the `disabled` attribute alone, so
+   dim them + show a not-allowed cursor, and dim the section as a whole. */
+.draft-config-form input:disabled,
+.num-stepper button:disabled,
+.scoring-toggle:disabled { opacity: 0.5; cursor: not-allowed; }
+.num-stepper input[type="number"]:disabled { opacity: 0.5; }
+[scoring-config-fields].is-locked,
+[scoring-config-shape].is-locked { opacity: 0.75; }
+[scoring-config-shape].is-locked .mode-card { cursor: not-allowed; }
+[scoring-config-shape].is-locked .mode-card:hover { border-color: #2A2E42; background: #101322; }
+.season-roster-list.is-locked .roster-row { opacity: 0.6; cursor: not-allowed; }
+.season-roster-list.is-locked .roster-row:hover { background: none; }
+
 /* Season roster: include/exclude checklist (reuses .scoring-toggle checkbox). */
 .season-roster-list { display: flex; flex-direction: column; gap: 4px; }
 .roster-row {

--- a/public/admin.js
+++ b/public/admin.js
@@ -371,33 +371,15 @@ if (createForm) {
     
         const firstName = document.querySelector('[first-name]').value;
         const lastName = document.querySelector('[last-name]').value;
-        const displayColor = document.querySelector('[display-color]').value;
-        const teams = [];
-        const teamDocuments = [];
-        document.querySelectorAll('[team-options]').forEach(
-            team => {
-                teams.push(team.value);
-                var temp = teamList.find((element) => element.id == team.value);
-                teamDocuments.push(temp);
-            }
-        );
 
+        // Color and the active-season roster entry are assigned server-side —
+        // the manager just provides a name; the draft fills the roster.
         var userBody = {
             firstName: firstName,
             lastName: lastName,
-            color: displayColor,
-            seasons: [
-                {
-                    season: new Date().getFullYear()
-                }
-            ],
             league: leagueCode
         };
 
-        if (teamDocuments[0] != null) {
-            userBody.seasons[0].teams = JSON.stringify(teamDocuments);
-        }
-    
         const response = await fetch("/users", {
             method: 'POST',
             headers: {

--- a/public/admin.js
+++ b/public/admin.js
@@ -407,38 +407,77 @@ if (createForm) {
     });
 }
 
-const removeForm = document.getElementById('remove-form');
-
-if (removeForm) {
-    removeForm.addEventListener('submit', async function(event) {
-        event.preventDefault();
-
-        const userId = document.querySelector('[user-options]').value;
-    
-        const response = await fetch("/users/" + userId, {
-            method: 'DELETE',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            }
-        });
-    
-        response.json().then(data => {
-            if (data.message == 'Deleted User') {
-                removeForm.reset();
-                getUsers();
-                displayRemoveUserContainer();
-
-                successToast.options.text = "User successfully deleted"
-                successToast.showToast();
-            } else {
-                failToast.options.text = response.status + " User could not be deleted";
-                failToast.showToast();
-            }
-
-        });
+// Season roster: an include/exclude checklist for the active season. Replaces
+// the old destructive "Remove a Player" (which hard-deleted the whole record).
+// Toggling only adds/drops the player's current-season entry — history is kept.
+function escHtml(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
     });
 }
+
+async function loadSeasonRoster() {
+    var leagueCode = getDraftLeagueCode();
+    var list = document.querySelector('[season-roster-list]');
+    if (list) list.textContent = 'Loading…';
+    try {
+        var res = await fetch('/users/league/' + encodeURIComponent(leagueCode) + '/roster', { headers: { 'Accept': 'application/json' } });
+        var data = await res.json();
+        var yearEl = document.querySelector('[season-roster-year]');
+        if (yearEl) yearEl.textContent = data.season || 'current';
+        if (!res.ok || !Array.isArray(data.players)) { if (list) list.textContent = 'Could not load the roster.'; return; }
+        list.innerHTML = data.players.map(function (p) {
+            var color = /^#[0-9a-fA-F]{3,8}$/.test(p.color || '') ? p.color : '#5B6690';
+            var name = escHtml(p.firstName + ' ' + p.lastName);
+            return '<label class="roster-row">' +
+                '<input type="checkbox" class="scoring-toggle roster-toggle" data-id="' + escHtml(p._id) + '" data-name="' + name + '" data-scored="' + !!p.scored + '"' + (p.inSeason ? ' checked' : '') + '>' +
+                '<span class="roster-dot" style="background:' + color + '"></span>' +
+                '<span class="roster-name">' + name + '</span>' +
+            '</label>';
+        }).join('');
+    } catch (err) {
+        if (list) list.textContent = 'Could not load the roster.';
+    }
+}
+
+// Toggle a player's active-season membership. Confirms before removing someone
+// who already has points this season (that year's scores would be dropped).
+document.addEventListener('change', async function (e) {
+    var cb = e.target;
+    if (!cb || !cb.classList || !cb.classList.contains('roster-toggle')) return;
+    var included = cb.checked;
+    var name = cb.getAttribute('data-name');
+    if (!included && cb.getAttribute('data-scored') === 'true') {
+        if (!window.confirm('Remove ' + name + ' from this season? Their scores for this year will be dropped — past seasons and records are kept.')) {
+            cb.checked = true;
+            return;
+        }
+    }
+    cb.disabled = true;
+    try {
+        var res = await fetch('/users/' + encodeURIComponent(cb.getAttribute('data-id')) + '/season-membership', {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ included: included })
+        });
+        var data = await res.json();
+        if (!res.ok) {
+            cb.checked = !included;
+            failToast.options.text = data.message || 'Could not update the roster';
+            failToast.showToast();
+        } else {
+            cb.checked = !!data.inSeason;
+            successToast.options.text = name + (data.inSeason ? ' added to the season' : ' removed from this season');
+            successToast.showToast();
+        }
+    } catch (err) {
+        cb.checked = !included;
+        failToast.options.text = 'Could not update the roster';
+        failToast.showToast();
+    } finally {
+        cb.disabled = false;
+    }
+});
 
 const calculateForm = document.getElementById('score-form')
 
@@ -1092,7 +1131,7 @@ function toggleSub(attr) {
 
 function displayCreateUserContainer() { toggleSub('create-user-container'); }
 
-function displayRemoveUserContainer() { toggleSub('remove-user-container'); }
+function displaySeasonRosterContainer() { if (toggleSub('season-roster-container')) loadSeasonRoster(); }
 
 function displayTeamContainer() { toggleSub('calculate-team-score-container'); }
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -441,6 +441,7 @@ async function loadSeasonRoster() {
                 '<span class="roster-name">' + name + '</span>' +
             '</label>';
         }).join('');
+        list.classList.toggle('is-locked', !!data.locked);
     } catch (err) {
         if (list) list.textContent = 'Could not load the roster.';
     }
@@ -1644,6 +1645,12 @@ function applyScoringLock() {
     var form = document.getElementById('scoring-config-form');
     if (!form) return;
     form.querySelectorAll('input, button').forEach(function (el) { el.disabled = locked; });
+    // Dim the editable areas so the disabled state is obvious (the disabled
+    // attribute alone doesn't visibly change the custom-styled controls).
+    var fields = form.querySelector('[scoring-config-fields]');
+    if (fields) fields.classList.toggle('is-locked', locked);
+    var shape = form.querySelector('[scoring-config-shape]');
+    if (shape) shape.classList.toggle('is-locked', locked);
     var banner = form.querySelector('[scoring-config-locked]');
     if (banner) banner.style.display = locked ? 'flex' : 'none';
     var actions = form.querySelector('.draft-config-actions');

--- a/public/admin.js
+++ b/public/admin.js
@@ -426,11 +426,17 @@ async function loadSeasonRoster() {
         var yearEl = document.querySelector('[season-roster-year]');
         if (yearEl) yearEl.textContent = data.season || 'current';
         if (!res.ok || !Array.isArray(data.players)) { if (list) list.textContent = 'Could not load the roster.'; return; }
-        list.innerHTML = data.players.map(function (p) {
+        // Once the season is underway the roster is locked for League Managers
+        // (removing a scored player would drop that year's data). Show a banner
+        // and disable the toggles; the server enforces it regardless.
+        var banner = data.locked
+            ? '<div class="scoring-locked"><span data-icon="lock" data-icon-size="16"></span>The roster is locked once the season is underway. Contact an admin to change it.</div>'
+            : '';
+        list.innerHTML = banner + data.players.map(function (p) {
             var color = /^#[0-9a-fA-F]{3,8}$/.test(p.color || '') ? p.color : '#5B6690';
             var name = escHtml(p.firstName + ' ' + p.lastName);
             return '<label class="roster-row">' +
-                '<input type="checkbox" class="scoring-toggle roster-toggle" data-id="' + escHtml(p._id) + '" data-name="' + name + '" data-scored="' + !!p.scored + '"' + (p.inSeason ? ' checked' : '') + '>' +
+                '<input type="checkbox" class="scoring-toggle roster-toggle" data-id="' + escHtml(p._id) + '" data-name="' + name + '" data-scored="' + !!p.scored + '"' + (p.inSeason ? ' checked' : '') + (data.locked ? ' disabled' : '') + '>' +
                 '<span class="roster-dot" style="background:' + color + '"></span>' +
                 '<span class="roster-name">' + name + '</span>' +
             '</label>';

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -1,22 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const ScoringConfig = require('../models/scoringConfig');
-const User = require('../models/user');
 const Game = require('../models/game');
 const { resolveConfig, fieldsForModel, engagementForSeason } = require('../modules/scoring-defaults');
 const { explainRegularWin, explainGame, getScoringConfig, getRankingsForGame } = require('../modules/scoring');
 const { canManageLeague } = require('../modules/league-access');
 const { effectiveRoles } = require('../modules/dev-role');
-
-// True once at least one drafted-team game has been scored in `season` for this
-// league — used to lock scoring edits for League Managers mid-season.
-async function hasScoredGames(league, season) {
-    const hit = await User.exists({
-        league,
-        seasons: { $elemMatch: { season: Number(season), 'weeklyScore.scoreByTeam.0': { $exists: true } } }
-    });
-    return !!hit;
-}
+const { hasScoredGames } = require('../modules/season-status');
 
 // Attaches the ordered field metadata (for the admin form + rules page) and a
 // plain-language combine-mode `example` to a resolved config. `fields` reflect

--- a/routes/users.js
+++ b/routes/users.js
@@ -136,6 +136,30 @@ router.get('/league/:leagueCodeReq/all', async (req, res) => {
     }
 });
 
+// Full league roster with active-season membership, for the admin "Season
+// Roster" toggle. `inSeason` = has an entry for the active season; `scored` =
+// that season already has banked points (so removing them would drop this
+// year's scores — the UI confirms before doing that).
+router.get('/league/:leagueCodeReq/roster', async (req, res) => {
+    const leagueCode = req.params.leagueCodeReq;
+    if (!canManageLeague(req, leagueCode)) {
+        return res.status(403).json({ message: 'Forbidden: not your league' });
+    }
+    try {
+        const year = Number(process.env.YEAR);
+        const users = await User.find({ league: leagueCode },
+            { firstName: 1, lastName: 1, color: 1, 'seasons.season': 1, 'seasons.weeklyScore.scoreByTeam': 1 }).lean();
+        const players = users.map(u => {
+            const s = (u.seasons || []).find(x => Number(x.season) === year);
+            const scored = !!(s && (s.weeklyScore || []).some(w => (w.scoreByTeam || []).length > 0));
+            return { _id: u._id, firstName: u.firstName, lastName: u.lastName, color: u.color, inSeason: !!s, scored };
+        }).sort((a, b) => (a.firstName + ' ' + a.lastName).localeCompare(b.firstName + ' ' + b.lastName));
+        res.json({ season: String(year), players });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
 //Getting All By League & Current Year
 router.get('/league/:leagueCodeReq', async (req, res) => {
     var leagueCode = req.params.leagueCodeReq;
@@ -282,17 +306,30 @@ router.patch('/draft/:id', getUserNewSeason, async (req, res) => {
     }
 });
 
-//Deleting One
-router.delete('/:id', getUser, async (req, res) => {
-    // A League Manager may only remove players from their own league.
-    if (!canManageLeague(req, res.user.league)) {
-        return res.status(403).json({ message: 'Forbidden: not your league' });
-    }
+// Include or exclude a player for the ACTIVE season, without touching any other
+// season. This is the non-destructive replacement for hard-deleting a manager:
+// unchecking only drops their current-season entry, so all prior seasons,
+// scores, and draft history are preserved.
+router.post('/:id/season-membership', async (req, res) => {
     try {
-        await res.user.deleteOne();
-        res.json({message: 'Deleted User'});
+        const included = !!(req.body && req.body.included);
+        const user = await User.findById(req.params.id);
+        if (!user) return res.status(404).json({ message: 'Cannot find user' });
+        if (!canManageLeague(req, user.league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
+        const year = Number(process.env.YEAR);
+        const has = (user.seasons || []).some(s => Number(s.season) === year);
+        if (included && !has) {
+            user.seasons.push({ season: year });
+        } else if (!included && has) {
+            user.seasons = user.seasons.filter(s => Number(s.season) !== year);
+        }
+        user.lastUpdated = new Date().toLocaleString("en-US", { timeZone: "America/Chicago" });
+        await user.save();
+        res.json({ inSeason: (user.seasons || []).some(s => Number(s.season) === year) });
     } catch (err) {
-        res.status(500).json({message: err.message});
+        res.status(400).json({ message: err.message });
     }
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,6 +4,8 @@ const User = require('../models/user');
 const scoring = require('../modules/scoring');
 const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
 const { canManageLeague } = require('../modules/league-access');
+const { effectiveRoles } = require('../modules/dev-role');
+const { hasScoredGames } = require('../modules/season-status');
 
 // Distinct, vibrant avatar/display colors for managers — same family as the
 // app's accent palette. A new player gets one not already used in the league.
@@ -154,7 +156,11 @@ router.get('/league/:leagueCodeReq/roster', async (req, res) => {
             const scored = !!(s && (s.weeklyScore || []).some(w => (w.scoreByTeam || []).length > 0));
             return { _id: u._id, firstName: u.firstName, lastName: u.lastName, color: u.color, inSeason: !!s, scored };
         }).sort((a, b) => (a.firstName + ' ' + a.lastName).localeCompare(b.firstName + ' ' + b.lastName));
-        res.json({ season: String(year), players });
+        // Once the season is underway, only an admin can change the roster —
+        // removing a scored player would drop that year's data (needs a rescore).
+        const isAdmin = effectiveRoles(req).includes('Admin');
+        const seasonUnderway = await hasScoredGames(leagueCode, year);
+        res.json({ season: String(year), isAdmin, editable: isAdmin || !seasonUnderway, locked: !isAdmin && seasonUnderway, players });
     } catch (err) {
         res.status(500).json({ message: err.message });
     }
@@ -319,6 +325,11 @@ router.post('/:id/season-membership', async (req, res) => {
             return res.status(403).json({ message: 'Forbidden: not your league' });
         }
         const year = Number(process.env.YEAR);
+        // Locked once the season is underway (would drop scored data); admins
+        // only, since applying it needs a rescore.
+        if (!effectiveRoles(req).includes('Admin') && await hasScoredGames(user.league, year)) {
+            return res.status(423).json({ message: 'The roster is locked once the season is underway. Ask an admin to change it.' });
+        }
         const has = (user.seasons || []).some(s => Number(s.season) === year);
         if (included && !has) {
             user.seasons.push({ season: year });

--- a/routes/users.js
+++ b/routes/users.js
@@ -5,6 +5,18 @@ const scoring = require('../modules/scoring');
 const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
 const { canManageLeague } = require('../modules/league-access');
 
+// Distinct, vibrant avatar/display colors for managers — same family as the
+// app's accent palette. A new player gets one not already used in the league.
+const USER_COLORS = ['#ED5858', '#E0B341', '#71D28D', '#64B5F6', '#8E8CF0', '#F27E3F', '#4FC3C7', '#EC6FA6', '#9CCC65', '#C97BE0'];
+
+async function pickUnusedColor(league) {
+    const users = await User.find({ league }, { color: 1 }).lean();
+    const used = new Set(users.map(u => String(u.color || '').toUpperCase()));
+    const free = USER_COLORS.filter(c => !used.has(c.toUpperCase()));
+    const pool = free.length ? free : USER_COLORS;
+    return pool[Math.floor(Math.random() * pool.length)];
+}
+
 // Self-service profile edit: a signed-in user updates THEIR OWN franchise name
 // / avatar / onboarding flag. The identity comes from the Auth0 session (never
 // from the client), so a user can only edit their own record. This route is
@@ -187,11 +199,20 @@ router.post('/', async (req, res) => {
     var date = new Date();
     var centralTime = date.toLocaleString("en-US", {timeZone: "America/Chicago"});
 
+    // A new player joins the ACTIVE season (process.env.YEAR) with an empty
+    // roster — the draft fills it. Server-owned so it can't drift to the wall-
+    // clock calendar year. `color` is auto-assigned from the palette when the
+    // caller doesn't supply one (the admin form no longer does).
+    const seasons = (Array.isArray(req.body.seasons) && req.body.seasons.length)
+        ? req.body.seasons
+        : [{ season: Number(process.env.YEAR) }];
+    const color = req.body.color || await pickUnusedColor(req.body.league);
+
     const user = new User({
         firstName: req.body.firstName,
         lastName: req.body.lastName,
-        seasons: req.body.seasons,
-        color: req.body.color,
+        seasons: seasons,
+        color: color,
         league: req.body.league,
         lastUpdated: centralTime
     });

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -428,18 +428,10 @@
                     </button>
                 </div>
                 <div class="sub-container" create-user-container style="display: none">
-                    <p class="function-description">Add a manager to this league with a display color and starting roster.</p>
+                    <p class="function-description">Add a manager to this league. They're added to the current season with an auto-assigned color; the draft fills their roster.</p>
                     <form id="create-form">
                         <input type="text" class="first-name" first-name placeholder="First Name">
                         <input type="text" class="last-name" last-name placeholder="Last Name">
-                        <div style="padding-top: 5px;">
-                            <label style="padding-right: 5px;">Display Color</label>
-                            <input style="border-radius: 5px;" type="color" class="display-color" display-color>
-                        </div>
-                        <div class="team-container" team-container>
-                            <select class="team-picker" id="team-picker" team-options>
-                            </select>
-                        </div>
                         <button type="submit">Create Player</button>
                     </form>
                     <hr>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -439,20 +439,14 @@
             </div>
             <div class="function-container">
                 <div class="button-container">
-                    <button onclick="displayRemoveUserContainer()">
-                        <i class="fa-solid fa-user-minus" style="padding-right: 5px;"></i>
-                        Remove a Player
+                    <button onclick="displaySeasonRosterContainer()">
+                        <i class="fa-solid fa-users" style="padding-right: 5px;"></i>
+                        Season Roster
                     </button>
                 </div>
-                <div class="sub-container" remove-user-container style="display: none">
-                    <p class="function-description">Remove a manager from this league.</p>
-                    <form id="remove-form">
-                        <div class="user-container" user-container>
-                            <select class="user-picker" id="user-picker" user-options>
-                            </select>
-                        </div>
-                        <button type="submit">Remove Player</button>
-                    </form>
+                <div class="sub-container" season-roster-container style="display: none">
+                    <p class="function-description">Choose which managers are in the <span season-roster-year>current</span> season. Unchecking removes a manager from this season only &mdash; their past seasons, scores, and draft history are kept.</p>
+                    <div season-roster-list class="season-roster-list"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Cleans up the Add/Remove player admin flows for league managers.

## 1 & 2 — Add a Player: name-only
Now that the live draft fills rosters, adding a player just needs a name.
- **Removed the team-selection picker** (the draft assigns teams).
- **Removed the Display Color input** — the server auto-assigns a distinct color from the app's accent palette that isn't already used in the league.

## 3 — Adds to the *active* season (bug fix)
The old form used the browser's **wall-clock calendar year** (`new Date().getFullYear()`), which isn't necessarily the app's active season — so it could create a player in the wrong year. Now the **server** adds a new player to the active season (`process.env.YEAR`) with an empty roster. Answer to "what should it do": the current/active season, server-owned.

## 4 — "Remove a Player" → non-destructive Season Roster
**"Remove a Player" hard-deleted the entire user document** — every season, all scores, draft history, Hall-of-Fame records — and a **League Manager** could do it with one click. Replaced with an include/exclude model:
- **Season Roster**: a checklist of every league player; the checkbox = "in the active season." Unchecking drops only that season's entry — **prior seasons, scores, and draft history are kept**.
- Removing a player who already has points this season **asks for confirmation** first.
- **The hard-delete route is removed entirely**, so history can no longer be destroyed.

New endpoints (gated to the league's managers): `GET /users/league/:league/roster`, `POST /users/:id/season-membership`.

## Verified live (dev server, read-only / non-destructive)
- Add-a-Player form is now name-only; description updated.
- Roster read returns the 6 Claunts managers with membership + scored flags; the checklist renders.
- Membership endpoint round-trips correctly (idempotent re-include; no data change).

## Safety
- **No scoring-engine change.** No migration. The only destructive path (hard delete) is *removed*; season removal is scoped to one season and confirms when scores exist.
- **203 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)