### PR TITLE
Pre-2026 fixes: franchise-name wipe, draft season, HOF in-progress champion

### DIFF
--- a/docs/announcements/offseason-2026.html
+++ b/docs/announcements/offseason-2026.html
@@ -302,7 +302,7 @@
           <h3>Draft Grades</h3>
           <p>The moment the draft ends, get a grade on your class — built from a per-league
              projection of expected fantasy points. Bragging rights start early.</p>
-          <div class="find"><span class="arw">&#9656;</span><span><span class="lab">Find it</span><br>The <b>Draft Grades</b> page, plus a grade chip on your profile.</span></div>
+          <div class="find"><span class="arw">&#9656;</span><span><span class="lab">Find it</span><br>In the <b>Draft Room</b> when the draft ends, plus a grade chip on your profile.</span></div>
         </article>
 
       </div>

--- a/docs/season-flip-runbook.md
+++ b/docs/season-flip-runbook.md
@@ -1,0 +1,95 @@
+# Season Flip Runbook (e.g. 2025 → 2026)
+
+Steps to open a new season. **Order matters:** the data loads, engagement, and
+draft config all take an explicit season and can be staged anytime; but the
+**Season Roster** action writes to the *active* season (`process.env.YEAR`), so
+it must come **after** you flip `YEAR`. Substitute the new year for `2026` below.
+
+## TL;DR checklist
+
+Stage anytime (explicit season — safe to do before the flip):
+- [ ] **Enrich teams** for 2026 (SP+ / FPI / talent / conference)
+- [ ] **Expected Wins** for 2026 (needs the season subdoc from Enrich first)
+- [ ] **CFP Odds** for 2026 (manual paste — make + champ boards)
+- [ ] **Ingest the full 2026 schedule** ← easy to forget; grades are silently wrong without it
+- [ ] **Configure Engagement** for 2026 per league (H2H + Captain) — off by default otherwise
+- [ ] **Configure the 2026 Draft** per league
+
+The pivot:
+- [ ] **Set `YEAR=2026`** in the prod (Heroku) config vars and restart
+
+After the flip (writes to the active season):
+- [ ] **Populate the 2026 Season Roster** — add each returning manager
+- [ ] Run the draft
+- [ ] Spot-check draft grades render after the draft
+
+---
+
+## Step detail
+
+### 1. Enrich teams — `POST /teams/2026/enrich`
+Admin → **Enrichment** (or `node update-enrichment-job.js 2026`). Creates each
+team's 2026 season subdoc with SP+/FPI/talent/coach/conference.
+*If skipped:* the draft pool and grades silently fall back to **2025** ratings.
+SP+ itself falls back to the prior year until CFBD publishes the new season.
+
+### 2. Expected Wins — `POST /teams/2026/expectedWins`
+Admin → **Expected Wins**. Reads `json/expectedWins2026.json` (already present).
+Requires the season subdoc from step 1 to exist first.
+
+### 3. CFP Odds — `POST /teams/2026/cfp-odds`
+Admin → **CFP Odds**. Paste the market **make** and **champ** boards (dry-run,
+then commit). *If skipped:* the projection falls back to an SP+-rank make-prob —
+degraded, not obviously so.
+
+### 4. Ingest the full 2026 schedule — `POST /games/2026/schedule`  ⚠️
+Admin → **Ingest Full Schedule / Schedule**. **The most-forgotten step.**
+*If skipped:* every team's regular-season projection zeroes out and Draft Grades
+compute from postseason points only — a full, **convincing-but-wrong** payload
+with no error and no empty state. Load it and spot-check before draft day.
+
+### 5. Configure Engagement (per league) — `POST /scoring-config/:league/engagement`
+Admin → **Engagement**, pick season **2026** in the dropdown. Set H2H + Captain
+per league. *If skipped:* `engagementForSeason` returns OFF defaults, so both
+silently disable for 2026 until configured.
+
+### 6. Configure the 2026 Draft (per league)
+Admin → **Configure Draft** (defaults to the active season). Sets pick order
+(reverse-2025-standings default, reorderable) and creates the `Draft` doc the
+draft room needs. Nothing carries over from 2025; a fresh draft starts clean.
+
+### 7. Flip `YEAR=2026` (the pivot)
+Set the `YEAR` config var to `2026` in prod and restart. This switches the
+scoring jobs, standings, records, team-enrichment reads, roster queries, and the
+season lock to 2026. There is no admin UI for this — it's an env var.
+
+### 8. Populate the 2026 Season Roster (after the flip)
+Admin → **Season Roster**, toggle each returning manager in. This writes to
+`process.env.YEAR`, so it only targets 2026 **after** step 7. *If skipped:*
+Standings and My Team are empty (no 2026 members).
+
+### 9. Draft, then grades
+Run the live draft (commissioner clicks **Start Draft**; there is no auto-open
+or per-pick clock, so cover absent managers by picking for the on-the-clock
+slot). After it completes, confirm grades render in the draft-room panel and the
+profile chip.
+
+---
+
+## Post-flip verification
+- Standings loads for each league (managers present; empty state is fine pre-scoring).
+- My Team shows the 2026 preseason state.
+- Draft Room shows the configured 2026 draft (not "no draft scheduled").
+- Draft Grades render and look sane (schedule + enrich + odds all loaded).
+- Hall of Fame shows 2023–2025 and does **not** crown 2026 yet.
+- H2H + Captain are on where you configured them.
+
+## Notes / gotchas
+- **Draft Grades degrade silently, never empty** — always spot-check after loading data.
+- **Hall of Fame** crowns a season once it's a past season *or* its postseason is
+  scored; the in-progress season is never crowned (fixed in PR #240).
+- **Draft completion** merges teams into the season and preserves `franchiseName`
+  (fixed in PR #240) — but re-running a *completed* draft after a reset leaves the
+  old teams on rosters until the next completion overwrites them.
+- **Confirm `YEAR`** is actually `2026` in prod before drafting — the draft writes
+  rosters to the active season, and a mismatch lands them in the wrong year.

--- a/public/admin.js
+++ b/public/admin.js
@@ -1378,7 +1378,7 @@ function getSelectedDraftSeason() {
 function populateDraftSeasonOptions() {
     var sel = document.querySelector('[draft-season]');
     if (!sel) return;
-    var currentYear = new Date().getFullYear();
+    var currentYear = Number(window.APP_YEAR) || new Date().getFullYear();   // active season, not wall clock
     var str = '';
     for (var y = currentYear + 1; y >= currentYear - 3; y--) {
         str += `<option value="${y}">${y}</option>`;

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -233,6 +233,9 @@
     font-weight: 700;
     margin: 0;
 }
+/* Size the leading icon to the label text (scales with the responsive font)
+   instead of the fixed 18px baked into ccIcon. */
+.draft-live-label .cc-icon { width: 1em; height: 1em; }
 
 .draft-start-btn {
     background-color: #71d28d;

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -11,7 +11,7 @@ var myUserId;
 var isCommish = false;
 var leagueCode;
 var leagueVersion = 'V2';
-var season = new Date().getFullYear();
+var season = Number(window.APP_YEAR) || new Date().getFullYear();   // active season, not wall clock
 var isMobile = false;
 var countdownTimer;
 var justPickedKey = null;    // "userId-round" of the pick to animate in once
@@ -115,7 +115,7 @@ async function getMembers() {
 }
 
 async function getRecruitingRankings() {
-    const res = await fetch(`/recruiting/${new Date().getFullYear()}`, { headers: { 'Accept': 'application/json' } });
+    const res = await fetch(`/recruiting/${season}`, { headers: { 'Accept': 'application/json' } });
     return res.json().catch(() => []);
 }
 
@@ -132,7 +132,7 @@ async function getTeams() {
 }
 
 function buildPool(teams, recruiting) {
-    var yr = new Date().getFullYear();
+    var yr = season;   // active season (window.APP_YEAR), not wall clock
     pool = teams.map(t => {
         var conf = '-', score = null, xwins = 0, sp = null, spRank = null;
         if (t.seasons && t.seasons.length) {

--- a/routes/history.js
+++ b/routes/history.js
@@ -8,13 +8,27 @@ const User = require('../models/user');
 // manager's year-by-year record. Read-only; no new data — cumulativeScore,
 // draftPosition and franchiseName already live on user.seasons.
 //
-// A season counts as "completed" once at least one manager has a
-// cumulativeScore (excludes the in-progress current season, which has none).
+// A season is "finished" (and thus crownable) once it is a PAST season relative
+// to the active season, or its postseason has been scored (bowls / CFP played).
+// This keeps the in-progress current season out of the Hall of Fame — otherwise
+// it would crown the live points leader the moment scoring begins.
 router.get('/:league', async (req, res) => {
     try {
         const league = req.params.league;
         const users = await User.find({ league },
             { firstName: 1, lastName: 1, avatarUrl: 1, color: 1, seasons: 1 }).lean();
+
+        // A season-year with a scored postseason entry has wrapped. Combined with
+        // "any past season", this crowns a season as soon as it truly finishes
+        // (even before the YEAR flip) and never before.
+        const activeYear = Number(process.env.YEAR);
+        const postseasonScored = {};
+        users.forEach(u => (u.seasons || []).forEach(s => {
+            if ((s.weeklyScore || []).some(w => w && w.season === 'postseason' && w.score != null)) {
+                postseasonScored[s.season] = true;
+            }
+        }));
+        const seasonFinished = (yr) => Number(yr) < activeYear || !!postseasonScored[yr];
 
         const fullName = (u) => `${u.firstName || ''} ${u.lastName || ''}`.trim();
         const initials = (u) => (((u.firstName || '')[0] || '') + ((u.lastName || '')[0] || '')).toUpperCase();
@@ -29,7 +43,8 @@ router.get('/:league', async (req, res) => {
         const bySeason = {};
         users.forEach(u => {
             (u.seasons || []).forEach(s => {
-                if (s.cumulativeScore == null) return;      // in-progress / never scored
+                if (s.cumulativeScore == null) return;      // never scored
+                if (!seasonFinished(s.season)) return;      // season still in progress → no champion yet
                 (bySeason[s.season] = bySeason[s.season] || []).push({
                     userId: String(u._id), name: fullName(u),
                     franchise: s.franchiseName || null,

--- a/routes/users.js
+++ b/routes/users.js
@@ -283,24 +283,21 @@ router.patch('/:id', getUser, async (req, res) => {
 //Updating new Season & Teams for One
 router.patch('/draft/:id', getUserNewSeason, async (req, res) => {
 
-    var newSeason = {
-        "season": req.body.season,
-        "teams": req.body.teams
-    };
-
     var date = new Date();
     var centralTime = date.toLocaleString("en-US", {timeZone: "America/Chicago"});
     res.user.lastUpdated = centralTime;
 
-    console.log("res.user", res.user)
-
     if (req.body.season != null && req.body.teams != null) {
-        var seasonExist = res.user.seasons.findIndex(x => x.season == newSeason.season);
+        var seasonExist = res.user.seasons.findIndex(x => x.season == req.body.season);
 
         if (seasonExist > -1) {
-            res.user.seasons[seasonExist] = newSeason;
+            // Merge: replace only the drafted teams and keep the rest of the
+            // season (franchiseName, captains, cumulativeScore, weeklyScore,
+            // draftPosition). Overwriting the whole subdoc wiped those.
+            res.user.seasons[seasonExist].teams = req.body.teams;
+            res.user.markModified('seasons');
         } else {
-            res.user.seasons.push(newSeason);
+            res.user.seasons.push({ season: req.body.season, teams: req.body.teams });
         }
     }
 

--- a/server.js
+++ b/server.js
@@ -228,7 +228,7 @@ app.get('/draft-room', (req, res) => {
         user.isDraft = false;
         const userState = safeJson(req.effUser);
 
-        res.render('draftRoom', {user, userState});
+        res.render('draftRoom', {user, userState, year: process.env.YEAR});
     } else {
         res.redirect("/login");
     }

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -21,6 +21,7 @@
 </head>
 <body>
     <%- include('partials/navbar') %>
+    <script>window.APP_YEAR = "<%= year %>";</script>
     <% if (userState) { %>
         <script>
             var userState = <%- userState %>;


### PR DESCRIPTION
Four pre-kickoff fixes surfaced by the 2026 readiness audit.

## 1. Draft completion wiped franchise names (data loss)
`persistTeamsToUsers` → `PATCH /users/draft/:id` replaced the entire season sub-document with `{season, teams}`, erasing `franchiseName`, `captains`, `cumulativeScore`, `weeklyScore`, `draftPosition` the moment a draft finished. Now merges the drafted teams into the existing season. (Also removed a stray `console.log`.)

## 2. Draft subsystem used the wall-clock year, not the active season
`draftRoom.js` / admin draft-config keyed off `new Date().getFullYear()`, which desyncs from `process.env.YEAR` (the app's active season) whenever they differ — silently writing drafted rosters to the wrong season. Now injects `window.APP_YEAR` into `draftRoom.ejs` (mirroring `userHome.ejs`/`admin.ejs`) and reads it for the draft season, recruiting fetch, pool year, and the admin season default.

## 3. Hall of Fame crowned the in-progress season
Champion was the cumulative-points leader of any scored season, so the current season got a "champion" as soon as scoring began. Now a season is crownable only once finished — a past season (`< active year`) **or** one whose postseason has been scored — so it's crowned exactly when it wraps, never mid-flight. Verified against the DB: all finished seasons still crown; an in-progress season evaluates to not-crowned.

## 4. Announcement referenced a non-existent "Draft Grades page"
Grades render in the Draft Room panel + profile chip; updated the "Find it" hint.

## Testing
- All 203 tests pass.
- Fixes #1 and #3 verified against the database via a read/write round-trip (franchise name preserved through the persist; HOF crowning logic correct). #2 mirrors the existing `APP_YEAR` pattern; #4 is copy.

Note: this does not change the operational prep (loading the 2026 schedule/enrichment, populating the 2026 roster, configuring engagement, setting `YEAR=2026` in prod) — those remain admin steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)