### PR TITLE
Draft Grades: link managers and teams on the grade cards

### DIFF
--- a/modules/draft-grades.js
+++ b/modules/draft-grades.js
@@ -34,7 +34,7 @@ function displayName(u) {
 
 function pickView(p) {
     return p ? {
-        school: p.school, round: p.round, overall: p.overall,
+        teamId: p.teamId, school: p.school, round: p.round, overall: p.overall,
         points: Math.round(p.points), value: p.value, logo: p.logo || null
     } : null;
 }
@@ -77,7 +77,7 @@ function computeGrades(draft, usersById, teamsById, opts = {}) {
     const picks = (draft.picks || []).map(p => {
         const proj = projByTeam[String(p.team.id)] || { total: 0, projWins: 0, makeProb: 0 };
         return {
-            userId: String(p.userId), overall: p.overall, round: p.round,
+            userId: String(p.userId), teamId: String(p.team.id), overall: p.overall, round: p.round,
             school: p.team.school, logo: (p.team.logos || [])[0],
             points: proj.total, wins: proj.projWins, makeProb: proj.makeProb || 0,
             reg: proj.regular || 0,                                   // regular-season floor

--- a/public/draftGrades.css
+++ b/public/draftGrades.css
@@ -56,6 +56,11 @@
 
 .gg-card-head { display: flex; align-items: center; gap: 0.7rem; }
 
+/* Manager block links through to their profile; keep the flex layout the
+   plain avatar + who used to have, and only underline the name on hover. */
+.gg-who-link { display: flex; align-items: center; gap: 0.7rem; flex: 1; min-width: 0; text-decoration: none; color: inherit; }
+.gg-who-link:hover .gg-name, .gg-who-link:focus-visible .gg-name { text-decoration: underline; }
+
 .gg-avatar {
     width: 40px;
     height: 40px;
@@ -115,6 +120,8 @@
 .gg-steal .gg-pick-label { color: #22C37A; }
 .gg-bust .gg-pick-label { color: #ED5858; }
 .gg-pick-team { display: flex; align-items: center; gap: 0.4rem; font-weight: 600; color: #F4F6FB; }
+.gg-tlink { text-decoration: none; }
+.gg-tlink:hover, .gg-tlink:focus-visible { text-decoration: underline; }
 .gg-logo { height: 18px; width: 18px; object-fit: contain; }
 .gg-pick-meta { color: #A4A9C2; font-size: 0.78rem; font-variant-numeric: tabular-nums; }
 

--- a/public/draftGrades.js
+++ b/public/draftGrades.js
@@ -24,9 +24,13 @@
         if (!p) return '';
         var cls = kind === 'best' ? 'gg-steal' : 'gg-bust';
         var label = kind === 'best' ? 'Best value' : 'Biggest reach';
+        var teamInner = logo(p.logo) + esc(p.school);
+        var team = p.teamId != null
+            ? '<a class="gg-pick-team gg-tlink" href="/team?team=' + esc(p.teamId) + '" target="_blank" rel="noopener">' + teamInner + '</a>'
+            : '<span class="gg-pick-team">' + teamInner + '</span>';
         return '<div class="gg-pick ' + cls + '">'
             + '<span class="gg-pick-label">' + label + '</span>'
-            + '<span class="gg-pick-team">' + logo(p.logo) + esc(p.school) + '</span>'
+            + team
             + '<span class="gg-pick-meta">R' + p.round + ' · ' + p.points + ' proj pts · ' + signed(p.value) + ' slots</span>'
             + '</div>';
     }
@@ -52,13 +56,17 @@
     function card(m, currentUserId) {
         var tier = (m.grade || '').charAt(0).toLowerCase();
         var you = (currentUserId && String(m.userId) === String(currentUserId)) ? ' gg-you' : '';
+        var whoInner = avatar(m)
+            + '<div class="gg-who">'
+            +   '<span class="gg-name">' + esc(m.franchise || m.name) + (you ? ' <span class="gg-youtag">you</span>' : '') + '</span>'
+            +   (m.franchise ? '<span class="gg-sub">' + esc(m.name) + '</span>' : '')
+            + '</div>';
+        var who = m.userId != null
+            ? '<a class="gg-who-link" href="/userHome?user=' + esc(m.userId) + '" target="_blank" rel="noopener">' + whoInner + '</a>'
+            : whoInner;
         return '<div class="gg-card gg-tier-' + esc(tier) + you + '">'
             + '<div class="gg-card-head">'
-            +   avatar(m)
-            +   '<div class="gg-who">'
-            +     '<span class="gg-name">' + esc(m.franchise || m.name) + (you ? ' <span class="gg-youtag">you</span>' : '') + '</span>'
-            +     (m.franchise ? '<span class="gg-sub">' + esc(m.name) + '</span>' : '')
-            +   '</div>'
+            +   who
             +   '<span class="gg-grade">' + esc(m.grade) + '</span>'
             + '</div>'
             + '<div class="gg-stats">'


### PR DESCRIPTION
## What

The draft grade cards (shown in the Draft Room after a draft completes, and on the user profile) were static. This makes the two entities on each card clickable:

- **Manager** (avatar + franchise/name) → their profile, `/userHome?user=<id>`
- **Best-value / biggest-reach teams** → the team page, `/team?team=<id>`

Both open in a new tab, matching the rest of the Draft Room's team links. The grade badge stays outside the manager link.

## How

- `modules/draft-grades.js` — thread `teamId` through the pick object and `pickView` so the payload carries an id to link to.
- `public/draftGrades.js` — wrap the manager block and each pick team in anchors; fall back to plain `<span>` when an id is missing (keeps older payloads safe).
- `public/draftGrades.css` — `.gg-who-link` reproduces the old avatar+name flex layout with a hover underline on the name; `.gg-tlink` adds a hover underline on the team. No visual change until hover.

The renderer is shared, so both the Draft Room and the user profile card get the links.

## Verification

The live Draft Room requires auth + a completed-draft state, so I verified the rendered markup by running the real `draftGrades.js` against a mock payload. Confirmed output:
- `<a class="gg-who-link" href="/userHome?user=u123" target="_blank">` around the manager
- `<a class="gg-pick-team gg-tlink" href="/team?team=333">` for the teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)