### PR TITLE
Enrichment: split weekly ratings from season-fixed fields

### DIFF
--- a/docs/season-flip-runbook.md
+++ b/docs/season-flip-runbook.md
@@ -8,7 +8,7 @@ it must come **after** you flip `YEAR`. Substitute the new year for `2026` below
 ## TL;DR checklist
 
 Stage anytime (explicit season — safe to do before the flip):
-- [ ] **Enrich teams** for 2026 (SP+ / FPI / talent / conference)
+- [ ] **Enrich teams** for 2026 — full/preseason mode (SP+ / FPI / talent / returning / coaches / conference)
 - [ ] **Expected Wins** for 2026 (needs the season subdoc from Enrich first)
 - [ ] **CFP Odds** for 2026 (manual paste — make + champ boards)
 - [ ] **Ingest the full 2026 schedule** ← easy to forget; grades are silently wrong without it
@@ -27,11 +27,18 @@ After the flip (writes to the active season):
 
 ## Step detail
 
-### 1. Enrich teams — `POST /teams/2026/enrich`
-Admin → **Enrichment** (or `node update-enrichment-job.js 2026`). Creates each
-team's 2026 season subdoc with SP+/FPI/talent/coach/conference.
+### 1. Enrich teams — `POST /teams/2026/enrich` (full/preseason)
+Admin → **Enrichment** (or `node update-enrichment-job.js 2026 preseason`).
+Creates each team's 2026 season subdoc with SP+/FPI/talent/coach/conference.
+The `preseason` mode (scope=all) is required here — it pulls the season-fixed
+fields (talent, returning production, coaches) that the *weekly* Tuesday job no
+longer fetches. Run it once before the draft.
 *If skipped:* the draft pool and grades silently fall back to **2025** ratings.
 SP+ itself falls back to the prior year until CFBD publishes the new season.
+
+> Note: the scheduled Tuesday enrichment runs `scope=weekly` (SP+/FPI + media
+> only, ~3 CFBD calls) all season. Talent/returning/coaches don't change
+> in-season, so they're pulled once here rather than every week.
 
 ### 2. Expected Wins — `POST /teams/2026/expectedWins`
 Admin → **Expected Wins**. Reads `json/expectedWins2026.json` (already present).

--- a/modules/scheduler.js
+++ b/modules/scheduler.js
@@ -8,8 +8,10 @@ const JOB_SCHEDULES = [
     { job: 'daily-scores', modulePath: '../update-daily-scores-job', rule: { hour: 23, minute: 0 } },
     { job: 'saturday-scores', modulePath: '../update-saturday-scores-job', rule: { dayOfWeek: 6, hour: [15, 18, 22], minute: 0 } },
     { job: 'sunday-scores', modulePath: '../update-sunday-scores-job', rule: { dayOfWeek: 0, hour: [3, 6], minute: 0 } },
-    // Weekly enrichment (SP+/FPI/talent/returning/coaches + broadcast outlets).
-    // Tuesday morning, after the weekend's ratings have refreshed. ~6 CFBD calls.
+    // Weekly enrichment (SP+/FPI ratings + broadcast outlets). Tuesday morning,
+    // after the weekend's ratings have refreshed. ~3 CFBD calls. Season-fixed
+    // fields (talent/returning/coaches) are pulled preseason instead — run
+    // `node update-enrichment-job.js <year> preseason` before the season/draft.
     { job: 'enrichment', modulePath: '../update-enrichment-job', rule: { dayOfWeek: 2, hour: 5, minute: 30 } }
 ];
 

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -264,13 +264,28 @@ router.post('/:season/enrich', async (req, res) => {
 
     const norm = (s) => String(s == null ? '' : s).toLowerCase().trim();
 
+    // Enrichment splits into two cadences (see modules/scheduler.js):
+    //   weekly    — SP+/FPI ratings, which move every week all season
+    //   preseason — talent, returning production, coaches: FIXED for the whole
+    //               season, so re-pulling them weekly just burns CFBD budget
+    // Default 'all' keeps the admin button and preseason prep pulling everything
+    // in one shot. Only the requested endpoints are fetched, so scope=weekly
+    // costs 2 CFBD calls instead of 5.
+    const scope = (req.body && req.body.scope) || 'all';
+    if (!['all', 'weekly', 'preseason'].includes(scope)) {
+        return res.status(400).json({ message: `Invalid scope '${scope}' (expected all|weekly|preseason)` });
+    }
+    const wantWeekly = scope === 'all' || scope === 'weekly';
+    const wantPreseason = scope === 'all' || scope === 'preseason';
+    const NONE = Promise.resolve([]);
+
     try {
         const [sp, fpi, talent, returning, coaches] = await Promise.all([
-            cfbd(`/ratings/sp?year=${season}`),
-            cfbd(`/ratings/fpi?year=${season}`),
-            cfbd(`/talent?year=${season}`),
-            cfbd(`/player/returning?year=${season}`),
-            cfbd(`/coaches?year=${season}`)
+            wantWeekly ? cfbd(`/ratings/sp?year=${season}`) : NONE,
+            wantWeekly ? cfbd(`/ratings/fpi?year=${season}`) : NONE,
+            wantPreseason ? cfbd(`/talent?year=${season}`) : NONE,
+            wantPreseason ? cfbd(`/player/returning?year=${season}`) : NONE,
+            wantPreseason ? cfbd(`/coaches?year=${season}`) : NONE
         ]);
 
         // Build lookup maps keyed by normalized team name.
@@ -338,7 +353,7 @@ router.post('/:season/enrich', async (req, res) => {
         }
 
         res.status(200).json({
-            season, updated,
+            season, scope, updated,
             counts: {
                 sp: (sp || []).length, fpi: (fpi || []).length, talent: (talent || []).length,
                 returning: (returning || []).length, coaches: (coaches || []).length

--- a/update-enrichment-job.js
+++ b/update-enrichment-job.js
@@ -4,32 +4,41 @@ if (process.env.NODE_ENV !== 'production') {
 
 const { internalFetch } = require('./modules/internal-api');
 
-// Pulls opponent-agnostic CFBD data (SP+/FPI ratings, talent, returning
-// production, coaches) onto each team's season, and broadcast outlets onto
-// games. Cheap on the CFBD budget: ~6 calls total per run (each endpoint
-// returns the whole season), so it's safe to run weekly. Timing is owned by
-// modules/scheduler.js; running this file directly is a manual fallback:
-//   node update-enrichment-job.js 2025
+// Pulls opponent-agnostic CFBD data onto each team's season, plus broadcast
+// outlets onto games. Two cadences (the enrich route splits by `scope`):
+//   weekly (default)  — SP+/FPI ratings + media = ~3 CFBD calls. Safe to run
+//                       every week; this is what modules/scheduler.js fires.
+//   preseason         — adds talent, returning production, coaches (all fixed
+//                       for the season) = ~6 CFBD calls. Run ONCE before the
+//                       season, ideally before the draft.
+// Timing for the weekly run is owned by modules/scheduler.js; running this file
+// directly is a manual fallback:
+//   node update-enrichment-job.js 2026            (weekly: ratings + media)
+//   node update-enrichment-job.js 2026 preseason  (full: adds talent/returning/coaches)
 const JOB_NAME = 'enrichment';
 
-async function run() {
+async function run(opts = {}) {
     const season = parseInt(process.argv[2], 10) || parseInt(process.env.YEAR, 10);
+    // Weekly by default; 'preseason' (via opts or CLI arg) pulls everything.
+    const preseason = opts.preseason || process.argv[3] === 'preseason';
+    const scope = preseason ? 'all' : 'weekly';
     const results = {};
 
-    async function post(path) {
+    async function post(path, body) {
         const res = await internalFetch(`${process.env.URL}${path}`, {
             method: 'POST',
-            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: body ? JSON.stringify(body) : undefined
         });
-        const body = await res.json().catch(() => ({}));
-        if (res.status !== 200) console.log(`${path} -> ${res.status}:`, body.message || body);
-        return { status: res.status, body };
+        const resBody = await res.json().catch(() => ({}));
+        if (res.status !== 200) console.log(`${path} -> ${res.status}:`, resBody.message || resBody);
+        return { status: res.status, body: resBody };
     }
 
-    results.teams = await post(`/teams/${season}/enrich`);
+    results.teams = await post(`/teams/${season}/enrich`, { scope });
     results.media = await post(`/games/${season}/media`);
 
-    console.log(`[${JOB_NAME}] season ${season}:`,
+    console.log(`[${JOB_NAME}] season ${season} (scope=${scope}):`,
         `teams enriched=${results.teams.body.updated}`,
         `media updated=${results.media.body.updated}`);
     return results;


### PR DESCRIPTION
## What

**Fix #1 of the CFBD-budget plan.** The Tuesday enrichment job pulled SP+, FPI, talent, returning production, and coaches every week (~6 CFBD calls). But talent, returning production, and coaches are **fixed for the whole season** — re-fetching them weekly just burns the monthly CFBD budget for no benefit.

## How

Parameterize `POST /teams/:season/enrich` with a `scope`:

| scope | pulls | CFBD calls |
|---|---|---|
| `weekly` | SP+, FPI | 2 |
| `preseason` | talent, returning, coaches | 3 |
| `all` (default) | everything | 5 |

Only the requested endpoints are fetched, so the weekly path is genuinely cheaper (not just filtered after the fact).

- **Scheduled Tuesday job** → now `scope=weekly` (~3 calls incl. media), down from ~6.
- **Season-fixed fields** → pulled once preseason via `node update-enrichment-job.js <year> preseason` (or the Admin → Enrichment button, which posts `scope=all`).
- Unknown scope → `400` (typos can't silently trigger a full pull).

## Backward compatibility

- Admin **Enrichment** button posts no body → defaults to `scope=all` → unchanged full enrichment. ✅
- Scheduler calls `run()` with no args → `scope=weekly`. ✅
- Runbook updated: step 1 now specifies `preseason` mode and notes the weekly job is slimmed.

## Budget impact

Weekly enrichment drops from ~26 → ~13 calls/month, clearing headroom for the game-day live-polling work (calendar cache + windowed poller) coming next.

## Testing

- Full suite green (203/203), including `Scheduler.spec.js` (schedule timings unchanged).
- `node --check` clean on all edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)