### PR TITLE
CFBD calendar: cache getCalendar per-season with a TTL

### DIFF
--- a/modules/cfbd-calendar.js
+++ b/modules/cfbd-calendar.js
@@ -1,0 +1,80 @@
+// Cached wrapper around CFBD's getCalendar.
+//
+// The season "calendar" (per-week firstGameStart / lastGameStart windows) is
+// essentially static once the schedule is published — the boundaries don't move
+// intra-day. But runFullUpdate (and the game-day live poller) calls getCalendar
+// on EVERY poll just to work out the current week, so uncached it costs one CFBD
+// call per poll. During frequent game-day polling that's the single biggest
+// avoidable drain on the monthly budget.
+//
+// The in-process scheduler (server.js runs jobs inside the one long-lived web
+// dyno) means a plain in-memory cache persists across every poll, so we cache
+// the calendar per-season with a TTL and collapse dozens of daily fetches into
+// a handful. The current-week math is time-based against the cached boundaries,
+// so even a slightly stale calendar still returns the correct week.
+
+const { withRetry } = require('./retry');
+const cfb = require('cfb.js');
+
+// Ensure the shared CFBD client is authenticated even if this module is the
+// first one required in a given process (idempotent — it's a singleton).
+cfb.ApiClient.instance.authentications['ApiKeyAuth'].apiKey = process.env.CFBD_API_KEY;
+
+// At most one CFBD calendar fetch per season per TTL window. 6h keeps staleness
+// to a fraction of a day while collapsing a full game-day of polls into a couple
+// of fetches. Overridable via env for ops.
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
+
+function realFetch(year) {
+    const gamesApi = new cfb.GamesApi();
+    return withRetry(() => gamesApi.getCalendar(year), { label: 'getCalendar' });
+}
+
+// Factory so tests can inject a fake fetcher + clock. Production uses the default
+// instance exported below.
+function createCalendarCache({ fetchCalendar = realFetch, now = Date.now, ttlMs = DEFAULT_TTL_MS } = {}) {
+    const cache = new Map(); // year -> { at, data }
+
+    async function getCalendar(year, { force = false } = {}) {
+        const key = String(year);
+        const hit = cache.get(key);
+        if (!force && hit && (now() - hit.at) < ttlMs) {
+            return hit.data;
+        }
+
+        let data;
+        try {
+            data = await fetchCalendar(year);
+        } catch (err) {
+            // On a hard failure, a stale-but-usable calendar beats none.
+            if (hit) {
+                console.log(`⚠️  getCalendar failed; serving cached calendar for ${key}: ${err.message || err}`);
+                return hit.data;
+            }
+            throw err;
+        }
+
+        if (Array.isArray(data) && data.length) {
+            cache.set(key, { at: now(), data });
+            return data;
+        }
+        // Empty/garbage response: keep any prior good value rather than caching junk.
+        return hit ? hit.data : data;
+    }
+
+    function clear() { cache.clear(); }
+
+    return { getCalendar, clear };
+}
+
+// Process-wide default instance — what the scoring jobs and live poller use.
+const defaultCache = createCalendarCache({
+    ttlMs: Number(process.env.CFBD_CALENDAR_TTL_MS) || DEFAULT_TTL_MS
+});
+
+module.exports = {
+    getCalendar: (year, opts) => defaultCache.getCalendar(year, opts),
+    clearCalendarCache: () => defaultCache.clear(),
+    createCalendarCache,
+    DEFAULT_TTL_MS
+};

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -1,5 +1,4 @@
 const { internalFetch } = require('./internal-api');
-const { withRetry } = require('./retry');
 
 // Configure CFB Data
 const CFBD_API_KEY = process.env.CFBD_API_KEY;
@@ -8,6 +7,7 @@ var defaultClient = cfb.ApiClient.instance;
 var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
 ApiKeyAuth.apiKey = CFBD_API_KEY;
 
+const { getCalendar } = require('./cfbd-calendar');
 const retrieveGamesModule = require('./retrieve-games.js');
 const scoringModule = require('./scoring.js');
 const teamScoringModule = require('./team-scoring.js');
@@ -22,8 +22,10 @@ const bettingModule = require('./betting.js');
 // Returns { week, seasonType } for logging.
 async function runFullUpdate({ withBetting = false } = {}) {
 
-    var gamesApi = new cfb.GamesApi();
-    var calendar = await withRetry(() => gamesApi.getCalendar(process.env.YEAR), { label: 'getCalendar' });
+    // Cached per-season (modules/cfbd-calendar.js): the week windows are static
+    // intra-day, so frequent polls reuse one fetch instead of spending a CFBD
+    // call each time just to compute the current week.
+    var calendar = await getCalendar(process.env.YEAR);
     var weekNumber = 1;
     var isPostseason = false;
 

--- a/tests/CfbdCalendar.spec.js
+++ b/tests/CfbdCalendar.spec.js
@@ -1,0 +1,105 @@
+const { createCalendarCache } = require('../modules/cfbd-calendar');
+
+// A controllable fetcher + clock so we can assert exactly when a CFBD call
+// would be spent. sample() returns a fresh non-empty calendar each time so we
+// can tell cached results (same array) from refetched ones (new array).
+function makeFetcher() {
+    let calls = 0;
+    const fetcher = async (year) => {
+        calls += 1;
+        return [{ week: 1, seasonType: 'regular', firstGameStart: `${year}-08-24`, _call: calls }];
+    };
+    fetcher.callCount = () => calls;
+    return fetcher;
+}
+
+describe('cfbd-calendar cache', () => {
+    it('fetches once, then serves cached within the TTL', async () => {
+        const fetchCalendar = makeFetcher();
+        let t = 1000;
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => t, ttlMs: 6 * 60 * 60 * 1000 });
+
+        const a = await getCalendar(2026);
+        t += 60 * 1000;          // 1 minute later, well inside the TTL
+        const b = await getCalendar(2026);
+
+        expect(fetchCalendar.callCount()).toBe(1);
+        expect(b).toBe(a);        // same array reference => no refetch
+    });
+
+    it('refetches once the TTL has elapsed', async () => {
+        const fetchCalendar = makeFetcher();
+        let t = 0;
+        const ttlMs = 6 * 60 * 60 * 1000;
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => t, ttlMs });
+
+        await getCalendar(2026);
+        t += ttlMs + 1;           // just past the TTL
+        await getCalendar(2026);
+
+        expect(fetchCalendar.callCount()).toBe(2);
+    });
+
+    it('force:true bypasses a still-fresh cache', async () => {
+        const fetchCalendar = makeFetcher();
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => 0, ttlMs: 1e9 });
+
+        await getCalendar(2026);
+        await getCalendar(2026, { force: true });
+
+        expect(fetchCalendar.callCount()).toBe(2);
+    });
+
+    it('caches each season independently', async () => {
+        const fetchCalendar = makeFetcher();
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => 0, ttlMs: 1e9 });
+
+        await getCalendar(2025);
+        await getCalendar(2026);
+        await getCalendar(2025);  // still cached
+
+        expect(fetchCalendar.callCount()).toBe(2);
+    });
+
+    it('serves the stale calendar when a refetch fails', async () => {
+        let calls = 0;
+        const fetchCalendar = async () => {
+            calls += 1;
+            if (calls === 1) return [{ week: 3, seasonType: 'regular' }];
+            throw new Error('CFBD 500');
+        };
+        let t = 0;
+        const ttlMs = 1000;
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => t, ttlMs });
+
+        const good = await getCalendar(2026);
+        t += ttlMs + 1;                   // force the next call to refetch (and fail)
+        const stale = await getCalendar(2026);
+
+        expect(stale).toEqual(good);      // fell back to the last good value
+    });
+
+    it('does not overwrite a good calendar with an empty response', async () => {
+        let calls = 0;
+        const fetchCalendar = async () => {
+            calls += 1;
+            return calls === 1 ? [{ week: 5, seasonType: 'regular' }] : [];
+        };
+        let t = 0;
+        const ttlMs = 1000;
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => t, ttlMs });
+
+        const good = await getCalendar(2026);
+        t += ttlMs + 1;
+        const afterEmpty = await getCalendar(2026);
+
+        expect(afterEmpty).toEqual(good); // kept the prior non-empty calendar
+    });
+
+    it('propagates the error when the very first fetch fails (no cache to fall back on)', async () => {
+        const fetchCalendar = async () => { throw new Error('CFBD down'); };
+        const { getCalendar } = createCalendarCache({ fetchCalendar, now: () => 0, ttlMs: 1000 });
+
+        await expect(getCalendar(2026)).rejects.toThrow('CFBD down');
+    });
+});


### PR DESCRIPTION
## What

**Step 2 of the CFBD-budget plan.** `runFullUpdate` called `getCalendar` on *every* poll just to work out the current week — one CFBD call per poll. The season's week windows are static intra-day, so this is the biggest avoidable drain once the game-day live poller starts hitting the scoring pipeline every 10–20 minutes.

## How

New `modules/cfbd-calendar.js` — an in-memory, per-season TTL cache:

- **6h default TTL** (`CFBD_CALENDAR_TTL_MS` override). The in-process scheduler ([server.js:409](../blob/main/server.js#L409)) means one long-lived web dyno, so the cache persists across all polls and collapses a full game-day of calendar fetches into a couple.
- **Correctness:** the current-week math is time-based against the cached `firstGameStart`/`lastGameStart` boundaries, so even a slightly stale calendar returns the right week.
- **Resilience:** on a fetch failure it serves the last good calendar; an empty/garbage response never overwrites a cached one; a first-ever failure still propagates.
- Factory-based (injectable fetcher + clock) so it's unit-testable without mocking `cfb.js`.

`modules/score-update.js` now reads through the cache (and drops its now-dead `withRetry` import).

## Budget impact

Halves the per-poll cost of the live poller (2 calls → 1). This is what makes the 10-min Saturday cadence affordable — it's the difference between the full live-polling plan costing ~950/mo (~10 slack) and ~552/mo (~348 slack).

## Testing

- New `tests/CfbdCalendar.spec.js` (7 tests): fetch-once-within-TTL, refetch-after-TTL, `force`, per-season isolation, stale-on-failure fallback, empty-response guard, first-fetch-error propagation.
- Full suite green: **210/210**.
- `node --check` clean.

Next: step 3 — the game-window live poller (Thu/Fri/Sat, "games live" DB gate + hard monthly ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)