### PR TITLE
Live scores: game-day poller for near-live standings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,18 @@ ISSUER_BASE_URL=
 # --- College Football Data API ---
 CFBD_API_KEY=
 
+# --- Game-day live scoring poller (modules/live-poll.js) ---
+# Opt-in. When 'true', the in-process scheduler also runs a poller every 10 min
+# on Thu/Fri/Sat that refreshes scores while games are in progress. It only
+# spends a CFBD call when a game is genuinely live and there are calls to spare,
+# so standings feel near-live without blowing the monthly budget.
+LIVE_POLL_ENABLED=false              # set 'true' to turn the live poller on
+# Optional tuning (defaults shown):
+# LIVE_POLL_CALL_BUFFER=100          # stop polling once this many CFBD calls remain
+# LIVE_POLL_MAX_GAME_HOURS=6         # a kickoff counts as "in progress" for this long
+# LIVE_POLL_INFO_TTL_MS=1800000      # how often to re-check CFBD's remaining-calls count
+# CFBD_CALENDAR_TTL_MS=21600000      # calendar cache TTL (modules/cfbd-calendar.js), default 6h
+
 # --- Internal API token ---
 # Shared secret that lets the scheduled jobs / scoring modules authenticate to
 # the app's own API. MUST be set to the SAME value on the web host AND wherever

--- a/modules/live-poll.js
+++ b/modules/live-poll.js
@@ -1,0 +1,168 @@
+// Game-day live scoring poller.
+//
+// Refreshes scores frequently during games so standings feel "live" WITHOUT
+// blowing the CFBD monthly budget. The scheduler fires this every 10 min on
+// Thu/Fri/Sat, but it only spends a CFBD call when a game is genuinely in
+// progress. Three independent guards, cheapest first:
+//
+//   1. cadence / day — Saturday every 10 min; Thu/Fri every 20; nothing else.
+//      Pure arithmetic, no I/O.
+//   2. games-live gate — poll only if some active-season REGULAR game kicked off
+//      within the last MAX_GAME_HOURS and isn't marked completed. Read from the
+//      local Game collection (the full schedule is ingested preseason), so it
+//      costs 0 CFBD calls. This alone means August, empty nights, and finished
+//      slates spend nothing, and the 6h tail stops a game whose `completed` flag
+//      never flips from polling forever.
+//   3. hard ceiling — skip if CFBD's own remainingCalls has fallen to the
+//      reserved buffer (default 100), so headroom for manual admin work is never
+//      touched. remainingCalls is authoritative (counts ALL usage) and cached so
+//      the check is ~free.
+//
+// Each actual poll runs the shared scoring pipeline with betting off (calendar
+// is cached → ~1 CFBD call) and records a JobRun (no email) so the standings
+// "last updated" badge advances during live play.
+//
+// Regular season only: the postseason path in runFullUpdate retrieves games
+// per-team (many calls per poll), which is too expensive to poll frequently, so
+// bowls/CFP stay on the daily 11pm job. A mass postseason pull would let the
+// poller cover the playoff too — a good follow-up.
+
+const Game = require('../models/game');
+const { runFullUpdate } = require('./score-update');
+const { startRun, finishRun } = require('./job-logger');
+const { internalFetch } = require('./internal-api');
+
+const JOB_NAME = 'live-scores';
+
+// Tunables (env-overridable).
+const MAX_GAME_HOURS = Number(process.env.LIVE_POLL_MAX_GAME_HOURS) || 6;
+const CALL_BUFFER = Number(process.env.LIVE_POLL_CALL_BUFFER) || 100;
+const INFO_TTL_MS = Number(process.env.LIVE_POLL_INFO_TTL_MS) || 30 * 60 * 1000;
+
+// ---- pure decision helpers (unit-tested) ------------------------------------
+
+// Central day-of-week: Thu(4) Fri(5) Sat(6) are the live-poll days.
+function isLivePollDay(dow) { return dow === 4 || dow === 5 || dow === 6; }
+
+// Saturday polls every 10-min mark; Thu/Fri every 20 (:00/:20/:40).
+function isOnCadence(dow, minute) {
+    if (dow === 6) return minute % 10 === 0;
+    if (dow === 4 || dow === 5) return minute % 20 === 0;
+    return false;
+}
+
+// Any game in progress right now? Kicked off within maxHours and not yet final.
+// `games` are already-narrowed active-season regular candidates from the DB.
+function anyGameInProgress(games, nowMs, maxHours) {
+    const windowMs = maxHours * 3600 * 1000;
+    return (games || []).some(g => {
+        if (g.completed === true) return false;
+        const start = Date.parse(g.startDate);
+        if (Number.isNaN(start)) return false;
+        return start <= nowMs && (nowMs - start) <= windowMs;
+    });
+}
+
+// Final poll/skip verdict from already-gathered inputs. remainingCalls === null
+// means "unknown" (info check failed) — we don't block scoring on that; the
+// games-live gate still bounds the spend.
+function decide({ dow, minute, gameLive, remainingCalls, buffer }) {
+    if (!isLivePollDay(dow)) return { poll: false, reason: 'not a live-poll day' };
+    if (!isOnCadence(dow, minute)) return { poll: false, reason: 'off-cadence' };
+    if (!gameLive) return { poll: false, reason: 'no game in progress' };
+    if (remainingCalls != null && remainingCalls <= buffer) {
+        return { poll: false, reason: `ceiling reached: ${remainingCalls} CFBD calls left (buffer ${buffer})` };
+    }
+    return { poll: true, reason: 'game in progress' };
+}
+
+// America/Chicago day-of-week + minute, without a tz library.
+function centralNow(now) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/Chicago', weekday: 'short', minute: '2-digit', hour12: false
+    }).formatToParts(now);
+    const map = {};
+    parts.forEach(p => { map[p.type] = p.value; });
+    const dow = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }[map.weekday];
+    return { dow, minute: Number(map.minute) };
+}
+
+// ---- CFBD remaining-calls, cached so the ceiling check is ~free -------------
+// remainingCalls only decreases as calls are spent, so between refreshes we
+// subtract the polls we've made to stay on the conservative side.
+let infoState = { at: 0, remaining: null, pollsSince: 0 };
+
+async function remainingCalls(nowMs) {
+    if (infoState.remaining == null || (nowMs - infoState.at) >= INFO_TTL_MS) {
+        try {
+            const res = await internalFetch(`${process.env.URL}/games/info`, { headers: { Accept: 'application/json' } });
+            const data = await res.json();
+            if (res.ok && data && typeof data.remainingCalls === 'number') {
+                infoState = { at: nowMs, remaining: data.remainingCalls, pollsSince: 0 };
+            }
+        } catch (e) {
+            console.log('live-poll: remainingCalls check failed:', e.message);
+        }
+    }
+    if (infoState.remaining == null) return null;
+    return infoState.remaining - infoState.pollsSince;
+}
+
+// ---- orchestration ----------------------------------------------------------
+
+async function run() {
+    if (process.env.LIVE_POLL_ENABLED === 'false') return { skipped: 'disabled' };
+
+    const now = new Date();
+    const nowMs = now.getTime();
+    const { dow, minute } = centralNow(now);
+
+    // Cheap gates first — avoid the DB / CFBD when it isn't even our cadence.
+    if (!isLivePollDay(dow)) return { skipped: 'not a live-poll day' };
+    if (!isOnCadence(dow, minute)) return { skipped: 'off-cadence' };
+
+    // Games-live gate (DB only). Not-completed regular games that have already
+    // kicked off — normally just the current slate's live/unfinalized games. The
+    // 6h tail is applied in JS so a stuck `completed` flag can't poll forever.
+    const season = Number(process.env.YEAR);
+    const candidates = await Game.find(
+        { season, seasonType: 'regular', completed: { $ne: true }, startDate: { $lte: now.toISOString() } },
+        { startDate: 1, completed: 1 }
+    ).lean();
+    const gameLive = anyGameInProgress(candidates, nowMs, MAX_GAME_HOURS);
+    if (!gameLive) return { skipped: 'no game in progress' };
+
+    // Hard ceiling (authoritative CFBD remainingCalls, cached).
+    const remaining = await remainingCalls(nowMs);
+    const decision = decide({ dow, minute, gameLive, remainingCalls: remaining, buffer: CALL_BUFFER });
+    if (!decision.poll) {
+        console.log(`live-poll skip — ${decision.reason}`);
+        return { skipped: decision.reason };
+    }
+
+    // Poll: shared pipeline, betting off (calendar cached → ~1 CFBD call).
+    console.log(`live-poll: game in progress, refreshing scores (${remaining == null ? 'calls left unknown' : remaining + ' calls left'})`);
+    const id = await startRun(JOB_NAME, { season: process.env.YEAR });
+    try {
+        const r = await runFullUpdate({ withBetting: false });
+        infoState.pollsSince += 1;
+        await finishRun(id, 'success',
+            `Live update ${r.seasonType} wk ${r.week} · ${r.gamesNew} new / ${r.gamesUpdated} updated`,
+            { week: r.week, seasonType: r.seasonType });
+        return { polled: true, week: r.week };
+    } catch (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        await finishRun(id, 'error', msg);
+        console.error('❌ live-poll failed:', err);
+        return { error: msg };
+    }
+}
+
+module.exports = {
+    run, JOB_NAME,
+    // exported for tests
+    isLivePollDay, isOnCadence, anyGameInProgress, decide, centralNow,
+    _resetInfoState: () => { infoState = { at: 0, remaining: null, pollsSince: 0 }; }
+};
+
+if (require.main === module) { run().then(r => { console.log('live-poll result:', r); process.exit(0); }); }

--- a/modules/scheduler.js
+++ b/modules/scheduler.js
@@ -15,19 +15,37 @@ const JOB_SCHEDULES = [
     { job: 'enrichment', modulePath: '../update-enrichment-job', rule: { dayOfWeek: 2, hour: 5, minute: 30 } }
 ];
 
+// Opt-in game-day live poller (modules/live-poll.js). Fires every 10 min on
+// Thu/Fri/Sat; the module's own gates decide whether to actually spend a CFBD
+// call (game in progress + cadence + under the call ceiling). Kept OUT of the
+// always-on JOB_SCHEDULES and gated behind LIVE_POLL_ENABLED=true so it can be
+// switched on/off independently of the core scoring jobs.
+const LIVE_POLL_SCHEDULE = {
+    job: 'live-scores', modulePath: '../modules/live-poll',
+    rule: { dayOfWeek: [4, 5, 6], minute: [0, 10, 20, 30, 40, 50] }
+};
+
+function livePollEnabled() { return process.env.LIVE_POLL_ENABLED === 'true'; }
+
 function toRule(spec) {
     const r = new schedule.RecurrenceRule();
     if (spec.dayOfWeek != null) r.dayOfWeek = spec.dayOfWeek;
-    r.hour = spec.hour;
-    r.minute = spec.minute;
+    // Leave hour unset for jobs that run every hour (e.g. the live poller); an
+    // unset field means "any" in node-schedule.
+    if (spec.hour != null) r.hour = spec.hour;
+    if (spec.minute != null) r.minute = spec.minute;
     r.tz = TZ;
     return r;
 }
 
 // Registers the recurring jobs. Each job's own run() already logs and emails;
-// we just guard against an unhandled rejection here.
+// we just guard against an unhandled rejection here. The live poller is included
+// only when LIVE_POLL_ENABLED=true.
 function start() {
-    JOB_SCHEDULES.forEach(function (s) {
+    const schedules = JOB_SCHEDULES.slice();
+    if (livePollEnabled()) schedules.push(LIVE_POLL_SCHEDULE);
+
+    schedules.forEach(function (s) {
         const mod = require(s.modulePath);
         schedule.scheduleJob(toRule(s.rule), function () {
             Promise.resolve().then(function () { return mod.run(); })
@@ -37,4 +55,4 @@ function start() {
     });
 }
 
-module.exports = { start, JOB_SCHEDULES, TZ, toRule };
+module.exports = { start, JOB_SCHEDULES, LIVE_POLL_SCHEDULE, livePollEnabled, TZ, toRule };

--- a/public/admin.js
+++ b/public/admin.js
@@ -263,7 +263,8 @@ function timeAgo(iso) {
 }
 
 var JOB_LABELS = {
-    'daily-scores': 'Daily', 'saturday-scores': 'Saturday', 'sunday-scores': 'Sunday'
+    'daily-scores': 'Daily', 'saturday-scores': 'Saturday', 'sunday-scores': 'Sunday',
+    'live-scores': 'Live'
 };
 
 function renderAdminStatus(el, s, api, year, jobs) {
@@ -288,8 +289,16 @@ function renderAdminStatus(el, s, api, year, jobs) {
     // Automated-job last-run summary (green success, red error, amber running).
     var jobsBlock = '';
     if (jobs && jobs.length) {
-        var order = ['daily-scores', 'saturday-scores', 'sunday-scores'];
-        var sorted = jobs.slice().sort(function (a, b) { return order.indexOf(a.jobName) - order.indexOf(b.jobName); });
+        var order = ['daily-scores', 'saturday-scores', 'sunday-scores', 'live-scores'];
+        // Collapse to the latest run per job — the live poller writes a run every
+        // few minutes on game days, so showing raw history would bury the others.
+        var latest = {};
+        jobs.forEach(function (j) {
+            var prev = latest[j.jobName];
+            if (!prev || new Date(j.startedAt) > new Date(prev.startedAt)) latest[j.jobName] = j;
+        });
+        var sorted = Object.keys(latest).map(function (k) { return latest[k]; })
+            .sort(function (a, b) { return order.indexOf(a.jobName) - order.indexOf(b.jobName); });
         var jobItems = sorted.map(function (j) {
             var dot = j.status === 'success' ? 'g' : (j.status === 'error' ? 'r' : 'a');
             var label = JOB_LABELS[j.jobName] || j.jobName;

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -16,8 +16,10 @@ const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
 const { scheduleForWeeks, resolveWeek, gameStatus, isWeekFinal, matchupWinProb } = require('../modules/h2h');
 
-// The scoring jobs that actually refresh standings data (see modules/score-job.js).
-const SCORING_JOBS = ['daily-scores', 'saturday-scores', 'sunday-scores'];
+// The scoring jobs that actually refresh standings data (see modules/score-job.js
+// and modules/live-poll.js). 'live-scores' is the game-day live poller, so the
+// "data as of" time advances during live play too.
+const SCORING_JOBS = ['daily-scores', 'saturday-scores', 'sunday-scores', 'live-scores'];
 
 // The honest "data as of" time for the standings: the most recent SUCCESSFUL
 // scoring run. Unlike user.lastUpdated — which is bumped by unrelated writes

--- a/tests/LivePoll.spec.js
+++ b/tests/LivePoll.spec.js
@@ -1,0 +1,97 @@
+const { isLivePollDay, isOnCadence, anyGameInProgress, decide } = require('../modules/live-poll');
+
+// Day-of-week: Sun=0 ... Sat=6.
+describe('isLivePollDay', () => {
+    it('is true only for Thu/Fri/Sat', () => {
+        expect([0, 1, 2, 3, 4, 5, 6].map(isLivePollDay))
+            .toEqual([false, false, false, false, true, true, true]);
+    });
+});
+
+describe('isOnCadence', () => {
+    it('Saturday polls on every 10-min mark', () => {
+        expect(isOnCadence(6, 0)).toBe(true);
+        expect(isOnCadence(6, 10)).toBe(true);
+        expect(isOnCadence(6, 30)).toBe(true);
+        expect(isOnCadence(6, 50)).toBe(true);
+    });
+
+    it('Thu/Fri only poll every 20 min (skip :10/:30/:50)', () => {
+        [4, 5].forEach(dow => {
+            expect(isOnCadence(dow, 0)).toBe(true);
+            expect(isOnCadence(dow, 20)).toBe(true);
+            expect(isOnCadence(dow, 40)).toBe(true);
+            expect(isOnCadence(dow, 10)).toBe(false);
+            expect(isOnCadence(dow, 30)).toBe(false);
+            expect(isOnCadence(dow, 50)).toBe(false);
+        });
+    });
+
+    it('never polls on a non-live-poll day', () => {
+        expect(isOnCadence(0, 0)).toBe(false);
+        expect(isOnCadence(2, 20)).toBe(false);
+    });
+});
+
+describe('anyGameInProgress', () => {
+    const now = Date.parse('2026-09-05T20:00:00.000Z');
+    const iso = ms => new Date(ms).toISOString();
+
+    it('true for a game that kicked off recently and is not completed', () => {
+        const games = [{ startDate: iso(now - 60 * 60 * 1000), completed: false }]; // 1h ago
+        expect(anyGameInProgress(games, now, 6)).toBe(true);
+    });
+
+    it('false when the only game is already completed', () => {
+        const games = [{ startDate: iso(now - 60 * 60 * 1000), completed: true }];
+        expect(anyGameInProgress(games, now, 6)).toBe(false);
+    });
+
+    it('false for a game that has not kicked off yet', () => {
+        const games = [{ startDate: iso(now + 30 * 60 * 1000), completed: false }]; // 30m from now
+        expect(anyGameInProgress(games, now, 6)).toBe(false);
+    });
+
+    it('false past the max-hours tail (stuck completed flag stops polling)', () => {
+        const games = [{ startDate: iso(now - 7 * 60 * 60 * 1000), completed: false }]; // 7h ago
+        expect(anyGameInProgress(games, now, 6)).toBe(false);
+    });
+
+    it('true right at the edge of the tail', () => {
+        const games = [{ startDate: iso(now - 6 * 60 * 60 * 1000), completed: false }]; // exactly 6h
+        expect(anyGameInProgress(games, now, 6)).toBe(true);
+    });
+
+    it('ignores unparseable/empty inputs', () => {
+        expect(anyGameInProgress([{ startDate: 'nope', completed: false }], now, 6)).toBe(false);
+        expect(anyGameInProgress([], now, 6)).toBe(false);
+        expect(anyGameInProgress(undefined, now, 6)).toBe(false);
+    });
+});
+
+describe('decide', () => {
+    const base = { dow: 6, minute: 0, gameLive: true, remainingCalls: 500, buffer: 100 };
+
+    it('polls when it is the cadence, a game is live, and under the ceiling', () => {
+        expect(decide(base)).toMatchObject({ poll: true });
+    });
+
+    it('skips off-day and off-cadence', () => {
+        expect(decide({ ...base, dow: 1 }).poll).toBe(false);
+        expect(decide({ ...base, dow: 4, minute: 10 }).poll).toBe(false);
+    });
+
+    it('skips when no game is in progress', () => {
+        expect(decide({ ...base, gameLive: false })).toMatchObject({ poll: false, reason: 'no game in progress' });
+    });
+
+    it('skips at or below the call buffer (protects manual-admin headroom)', () => {
+        expect(decide({ ...base, remainingCalls: 100 }).poll).toBe(false);
+        expect(decide({ ...base, remainingCalls: 99 }).poll).toBe(false);
+        expect(decide({ ...base, remainingCalls: 101 }).poll).toBe(true);
+    });
+
+    it('does not block scoring when remaining calls are unknown', () => {
+        expect(decide({ ...base, remainingCalls: null }).poll).toBe(true);
+    });
+});

--- a/tests/Scheduler.spec.js
+++ b/tests/Scheduler.spec.js
@@ -1,10 +1,28 @@
-const { JOB_SCHEDULES, TZ, toRule } = require('../modules/scheduler');
+const { JOB_SCHEDULES, LIVE_POLL_SCHEDULE, livePollEnabled, TZ, toRule } = require('../modules/scheduler');
 
 describe('scheduler config', () => {
     it('schedules the three score jobs plus enrichment (expected wins is manual)', () => {
         const jobs = JOB_SCHEDULES.map(s => s.job).sort();
         expect(jobs).toEqual(['daily-scores', 'enrichment', 'saturday-scores', 'sunday-scores']);
         expect(JOB_SCHEDULES.find(s => s.job === 'expected-wins')).toBeUndefined();
+    });
+
+    it('keeps the live poller out of the always-on jobs (it is opt-in)', () => {
+        expect(JOB_SCHEDULES.find(s => s.job === 'live-scores')).toBeUndefined();
+    });
+
+    it('live poller fires every 10 min on Thu/Fri/Sat, gated by env', () => {
+        expect(LIVE_POLL_SCHEDULE.job).toBe('live-scores');
+        expect(LIVE_POLL_SCHEDULE.rule).toEqual({ dayOfWeek: [4, 5, 6], minute: [0, 10, 20, 30, 40, 50] });
+
+        const prev = process.env.LIVE_POLL_ENABLED;
+        process.env.LIVE_POLL_ENABLED = 'true';
+        expect(livePollEnabled()).toBe(true);
+        process.env.LIVE_POLL_ENABLED = 'false';
+        expect(livePollEnabled()).toBe(false);
+        delete process.env.LIVE_POLL_ENABLED;
+        expect(livePollEnabled()).toBe(false); // default off
+        if (prev !== undefined) process.env.LIVE_POLL_ENABLED = prev;
     });
 
     it('matches the intended Central-time schedule', () => {
@@ -23,5 +41,13 @@ describe('scheduler config', () => {
         expect(rule.hour).toEqual([15, 18, 22]);
         expect(rule.minute).toBe(0);
         expect(rule.dayOfWeek).toBe(6);
+    });
+
+    it('leaves hour unset for an every-hour rule (live poller)', () => {
+        const rule = toRule(LIVE_POLL_SCHEDULE.rule);
+        expect(rule.dayOfWeek).toEqual([4, 5, 6]);
+        expect(rule.minute).toEqual([0, 10, 20, 30, 40, 50]);
+        // hour was never assigned, so node-schedule treats it as "any hour".
+        expect(rule.hour == null).toBe(true);
     });
 });


### PR DESCRIPTION
## What

**Step 3 (final) of the CFBD-budget plan.** An opt-in poller that refreshes scores every 10 min on Thu/Fri/Sat so standings feel near-live — without risking the monthly CFBD budget.

## Three independent guards (cheapest first)

`modules/live-poll.js` fires every 10 min but only spends a CFBD call when all pass:

1. **Cadence / day** — Saturday every 10 min; Thu/Fri every 20 (:00/:20/:40); nothing else. Pure arithmetic, no I/O.
2. **Games-live gate** — poll only if an active-season **regular** game kicked off within `MAX_GAME_HOURS` (6h) and isn't `completed`, read from the local `Game` collection (the full schedule is ingested preseason, so **0 CFBD calls**). This is what makes August, empty nights, and finished slates cost **nothing** — and the 6h tail stops a game whose `completed` flag never flips from polling forever.
3. **Hard ceiling** — skip once CFBD's own `remainingCalls` (`/games/info`) hits the reserved buffer (default 100), so headroom for manual admin work is never touched. Authoritative (counts *all* usage) and cached with a TTL so the check is ~free.

Each actual poll runs the shared scoring pipeline with betting off (calendar cached → ~1 CFBD call) and logs a JobRun (no email) so the standings "last updated" badge advances during play.

## Wiring

- **Scheduler** — `LIVE_POLL_SCHEDULE` registered only when `LIVE_POLL_ENABLED=true`; kept out of the always-on `JOB_SCHEDULES`. `toRule` now leaves `hour` unset for every-hour rules.
- **Standings last-updated** — `live-scores` added to `SCORING_JOBS` so the "data as of" time reflects live polling.
- **Admin status strip** — collapses to the latest run *per job* (fixes a latent all-history render) so frequent live polls don't bury the daily/Saturday/Sunday chips; adds a `Live` label.

## Safety / rollout

- **Opt-in**: nothing changes until `LIVE_POLL_ENABLED=true` is set on the dyno.
- **Regular season only** for now: the postseason path in `runFullUpdate` pulls per-team (many calls/poll), so bowls/CFP stay on the daily 11pm job. A mass postseason pull would extend the poller to the playoff — noted as a follow-up.
- Tunables documented in `.env.example` (`LIVE_POLL_CALL_BUFFER`, `LIVE_POLL_MAX_GAME_HOURS`, `LIVE_POLL_INFO_TTL_MS`).

## Budget

With the calendar cache (step 2), the full plan — Sat @10 min, Thu/Fri @20 min — is ~552/mo worst-case, and the games-live gate makes real spend track actual game hours (well under that). ~350+ calls of slack above the 100 buffer.

## Testing

- New `tests/LivePoll.spec.js` — pure gates: day, cadence, in-progress (incl. the 6h tail edge + stuck-flag case), and the ceiling/buffer decision.
- `tests/Scheduler.spec.js` — live poller stays out of always-on jobs, fires every 10 min Thu/Fri/Sat, env gating, and the every-hour `toRule`.
- `centralNow` spot-checked against known CDT dates incl. the Friday→Saturday midnight rollover.
- Full suite green: **228/228**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)