### PR TITLE
Scoring jobs: email on failure only (opt-in for success)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ INTERNAL_API_TOKEN=                  # long random string
 # --- Email (nodemailer / Gmail) ---
 GMAIL_USER=                          # sender Gmail address
 GMAIL_APP_PASSWORD=                  # Gmail app password (NOT your account password)
+# Scoring jobs email on FAILURE only by default. Set to 'true' to also get a
+# report on every successful run (~50/month in season).
+# JOB_EMAIL_ON_SUCCESS=false
 
 # --- Cloudinary (profile picture uploads) ---
 # Both are PUBLIC (they ship to the browser for unsigned uploads), not secrets.

--- a/modules/score-job.js
+++ b/modules/score-job.js
@@ -2,9 +2,17 @@ const { runFullUpdate } = require('./score-update');
 const { startRun, finishRun } = require('./job-logger');
 const { sendJobEmail } = require('./job-mailer');
 
+// Emails on a successful run only when explicitly opted in. Default is
+// failure-only: a healthy run is the norm (~50/month in season) and just adds
+// inbox noise — the admin status strip and standings "last updated" badge cover
+// the healthy state. Failures always email. Set JOB_EMAIL_ON_SUCCESS=true to
+// restore a report on every run.
+function emailOnSuccess() { return process.env.JOB_EMAIL_ON_SUCCESS === 'true'; }
+
 // Builds a job's run(): logs the run (start -> success/error), executes the
-// shared pipeline, and emails a run report. The three score jobs differ only in
-// name/label and whether they refresh betting lines, so they share this.
+// shared pipeline, and emails a run report on failure (and on success only when
+// opted in). The three score jobs differ only in name/label and whether they
+// refresh betting lines, so they share this.
 function makeJob({ jobName, label, withBetting }) {
     return async function run() {
         const startMs = Date.now();
@@ -16,18 +24,20 @@ function makeJob({ jobName, label, withBetting }) {
             const secs = Math.round((Date.now() - startMs) / 1000);
             const summary = `Updated ${r.seasonType} week ${r.week} · ${r.gamesNew} new / ${r.gamesUpdated} updated games · ${r.teams} teams (${secs}s)`;
             await finishRun(id, 'success', summary, { week: r.week, seasonType: r.seasonType });
-            await sendJobEmail({
-                label: label,
-                when: when,
-                ok: true,
-                rows: [
-                    ['Season', `${r.seasonType} ${process.env.YEAR}`],
-                    ['Week', String(r.week)],
-                    ['Games', `${r.gamesNew} new · ${r.gamesUpdated} updated`],
-                    ['Teams', String(r.teams)],
-                    ['Duration', `${secs}s`]
-                ]
-            });
+            if (emailOnSuccess()) {
+                await sendJobEmail({
+                    label: label,
+                    when: when,
+                    ok: true,
+                    rows: [
+                        ['Season', `${r.seasonType} ${process.env.YEAR}`],
+                        ['Week', String(r.week)],
+                        ['Games', `${r.gamesNew} new · ${r.gamesUpdated} updated`],
+                        ['Teams', String(r.teams)],
+                        ['Duration', `${secs}s`]
+                    ]
+                });
+            }
             return r;
         } catch (err) {
             const secs = Math.round((Date.now() - startMs) / 1000);
@@ -46,4 +56,4 @@ function makeJob({ jobName, label, withBetting }) {
     };
 }
 
-module.exports = { makeJob };
+module.exports = { makeJob, emailOnSuccess };

--- a/tests/JobEmail.spec.js
+++ b/tests/JobEmail.spec.js
@@ -1,4 +1,25 @@
 const { buildJobEmailHtml } = require('../modules/job-mailer');
+const { emailOnSuccess } = require('../modules/score-job');
+
+describe('emailOnSuccess (scoring jobs are failure-only by default)', () => {
+    const prev = process.env.JOB_EMAIL_ON_SUCCESS;
+    afterEach(() => {
+        if (prev === undefined) delete process.env.JOB_EMAIL_ON_SUCCESS;
+        else process.env.JOB_EMAIL_ON_SUCCESS = prev;
+    });
+
+    it('defaults to off (no email on a healthy run)', () => {
+        delete process.env.JOB_EMAIL_ON_SUCCESS;
+        expect(emailOnSuccess()).toBe(false);
+    });
+
+    it('opts in only for the exact string "true"', () => {
+        process.env.JOB_EMAIL_ON_SUCCESS = 'true';
+        expect(emailOnSuccess()).toBe(true);
+        process.env.JOB_EMAIL_ON_SUCCESS = 'yes';
+        expect(emailOnSuccess()).toBe(false);
+    });
+});
 
 describe('buildJobEmailHtml', () => {
     it('renders a success run report with the stat rows', () => {


### PR DESCRIPTION
## What

The daily / Saturday / Sunday scoring jobs emailed a run report on **every** run — ~50 "✅ Update complete" emails a month in season, plus failures. That's almost all noise: a healthy run is the norm.

Now they're **failure-only** by default. Failures still always email; a successful run is silent unless you opt back in with `JOB_EMAIL_ON_SUCCESS=true`.

## How

- `makeJob` ([modules/score-job.js](modules/score-job.js)) guards the success-path `sendJobEmail` behind `emailOnSuccess()` (`JOB_EMAIL_ON_SUCCESS === 'true'`, default off). The failure path is unchanged.
- The healthy state is already visible without email: the admin status strip and the standings "last updated" badge.
- Documented in `.env.example`.

## Scope

- Only the three `makeJob`-based scoring jobs emailed; the enrichment job never did, and the live poller (separate PR) never did either. So this covers everything that was mailing you.

## Testing

- New `emailOnSuccess` tests: default off, opts in only for the exact string `"true"`.
- `buildJobEmailHtml` tests unchanged (the email content is untouched — this only changes *whether* the success email sends).
- Full suite green: **212/212**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)