### PR TITLE
Postseason: single-call mass pull + score every CFP round

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,6 @@ LIVE_POLL_ENABLED=false              # set 'true' to turn the live poller on
 # Optional tuning (defaults shown):
 # LIVE_POLL_CALL_BUFFER=100          # stop polling once this many CFBD calls remain
 # LIVE_POLL_MAX_GAME_HOURS=6         # a kickoff counts as "in progress" for this long
-# LIVE_POLL_INFO_TTL_MS=1800000      # how often to re-check CFBD's remaining-calls count
 # CFBD_CALENDAR_TTL_MS=21600000      # calendar cache TTL (modules/cfbd-calendar.js), default 6h
 
 # --- Internal API token ---

--- a/modules/live-poll.js
+++ b/modules/live-poll.js
@@ -37,7 +37,6 @@ const JOB_NAME = 'live-scores';
 // Tunables (env-overridable).
 const MAX_GAME_HOURS = Number(process.env.LIVE_POLL_MAX_GAME_HOURS) || 6;
 const CALL_BUFFER = Number(process.env.LIVE_POLL_CALL_BUFFER) || 100;
-const INFO_TTL_MS = Number(process.env.LIVE_POLL_INFO_TTL_MS) || 30 * 60 * 1000;
 
 // ---- pure decision helpers (unit-tested) ------------------------------------
 
@@ -87,25 +86,24 @@ function centralNow(now) {
     return { dow, minute: Number(map.minute) };
 }
 
-// ---- CFBD remaining-calls, cached so the ceiling check is ~free -------------
-// remainingCalls only decreases as calls are spent, so between refreshes we
-// subtract the polls we've made to stay on the conservative side.
-let infoState = { at: 0, remaining: null, pollsSince: 0 };
+// ---- CFBD remaining-calls, learned for free from the poll response ----------
+// CFBD returns the remaining monthly call count in the `x-calllimit-remaining`
+// header on every response; runFullUpdate surfaces it from the games pull. So
+// after the first poll this stays fresh with zero extra calls. On a cold start
+// (process just booted, nothing polled yet) we seed it once from /games/info so
+// we never poll blind near the ceiling.
+let lastKnownRemaining = null;
 
-async function remainingCalls(nowMs) {
-    if (infoState.remaining == null || (nowMs - infoState.at) >= INFO_TTL_MS) {
-        try {
-            const res = await internalFetch(`${process.env.URL}/games/info`, { headers: { Accept: 'application/json' } });
-            const data = await res.json();
-            if (res.ok && data && typeof data.remainingCalls === 'number') {
-                infoState = { at: nowMs, remaining: data.remainingCalls, pollsSince: 0 };
-            }
-        } catch (e) {
-            console.log('live-poll: remainingCalls check failed:', e.message);
-        }
+async function currentRemaining() {
+    if (lastKnownRemaining != null) return lastKnownRemaining;
+    try {
+        const res = await internalFetch(`${process.env.URL}/games/info`, { headers: { Accept: 'application/json' } });
+        const data = await res.json();
+        if (res.ok && data && typeof data.remainingCalls === 'number') lastKnownRemaining = data.remainingCalls;
+    } catch (e) {
+        console.log('live-poll: seed remainingCalls failed:', e.message);
     }
-    if (infoState.remaining == null) return null;
-    return infoState.remaining - infoState.pollsSince;
+    return lastKnownRemaining;
 }
 
 // ---- orchestration ----------------------------------------------------------
@@ -132,8 +130,8 @@ async function run() {
     const gameLive = anyGameInProgress(candidates, nowMs, MAX_GAME_HOURS);
     if (!gameLive) return { skipped: 'no game in progress' };
 
-    // Hard ceiling (authoritative CFBD remainingCalls, cached).
-    const remaining = await remainingCalls(nowMs);
+    // Hard ceiling (authoritative CFBD remainingCalls).
+    const remaining = await currentRemaining();
     const decision = decide({ dow, minute, gameLive, remainingCalls: remaining, buffer: CALL_BUFFER });
     if (!decision.poll) {
         console.log(`live-poll skip — ${decision.reason}`);
@@ -145,7 +143,8 @@ async function run() {
     const id = await startRun(JOB_NAME, { season: process.env.YEAR });
     try {
         const r = await runFullUpdate({ withBetting: false });
-        infoState.pollsSince += 1;
+        // Keep the ceiling fresh for free from this poll's own CFBD response.
+        if (typeof r.remainingCalls === 'number') lastKnownRemaining = r.remainingCalls;
         await finishRun(id, 'success',
             `Live update ${r.seasonType} wk ${r.week} · ${r.gamesNew} new / ${r.gamesUpdated} updated`,
             { week: r.week, seasonType: r.seasonType });
@@ -162,7 +161,7 @@ module.exports = {
     run, JOB_NAME,
     // exported for tests
     isLivePollDay, isOnCadence, anyGameInProgress, decide, centralNow,
-    _resetInfoState: () => { infoState = { at: 0, remaining: null, pollsSince: 0 }; }
+    _resetRemaining: () => { lastKnownRemaining = null; }
 };
 
 if (require.main === module) { run().then(r => { console.log('live-poll result:', r); process.exit(0); }); }

--- a/modules/retrieve-games.js
+++ b/modules/retrieve-games.js
@@ -1,13 +1,4 @@
 const { internalFetch } = require('./internal-api');
-const { withRetry } = require('./retry');
-// Configure API key authorization: ApiKeyAuth
-const CFBD_API_KEY = process.env.CFBD_API_KEY;
-var cfb = require('cfb.js');
-var defaultClient = cfb.ApiClient.instance;
-var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
-ApiKeyAuth.apiKey = CFBD_API_KEY;
-
-var gamesApi = new cfb.GamesApi();
 
 // Dedupes games by id. Two teams in the same league can play each other, so the
 // same game gets collected twice; [...new Set(objects)] does NOT dedupe those
@@ -31,8 +22,14 @@ function dedupeGamesById(games) {
 // rejected BEFORE calling CFBD: an empty week makes CFBD return a 400 JSON
 // object instead of an array, and iterating that object throws "not iterable"
 // — an unhandled rejection that crashes the Node process.
+//
+// seasonType is always required. A week is required for regular-season pulls (we
+// fetch one week at a time), but NOT for postseason: CFBD returns the whole
+// postseason slate in one call when week is omitted, and it can span several
+// weeks (12-team CFP), so we pull every round at once.
 function massCreateInputError(week, seasonType) {
-    if (!week || !seasonType) return 'week and seasonType are required';
+    if (!seasonType) return 'seasonType is required';
+    if (seasonType !== 'postseason' && !week) return 'week is required for regular-season requests';
     return null;
 }
 
@@ -70,32 +67,14 @@ module.exports = {
         return uniqueTeams;
     },
 
-    retrieveGames: async (teams, week) => {
-        var allGameData = [];
-        var year = process.env.YEAR;
-        var opts = {
-            'week': week,
-            'seasonType': "regular",
-            'division': "fbs"
-        };
-
-        for (const team of teams) {
-            opts.team = team;
-
-            try {
-                var gameData = await withRetry(() => gamesApi.getGames(year, opts), { label: `getGames(${team})` });
-                for (let x = 0; x < gameData.length; x++) {
-                    allGameData.push(gameData[x]);
-                }
-            } catch (err) {
-                console.log(`❌ Skipping team ${team} after repeated getGames failures: ${err.message || err}`);
-            }
-        }
-
-        return dedupeGamesById(allGameData);
-    },
-
+    // Ingest a whole slate in ONE CFBD call via the /games/week/mass-create
+    // route. Regular season fetches a single week; postseason omits the week to
+    // pull every CFP round at once. Returns { newGames, existingGames,
+    // remainingCalls } — remainingCalls comes from CFBD's x-calllimit-remaining
+    // header so callers can track the budget for free.
     massRetrieveGames: async (week, seasonType) => {
+        const payload = { seasonType };
+        if (week != null && week !== '') payload.week = String(week);
 
         const response = await internalFetch(`${process.env.URL}/games/week/mass-create`, {
             method: 'POST',
@@ -103,10 +82,7 @@ module.exports = {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
             },
-            body: `{
-            "week": "${week}",
-            "seasonType": "${seasonType}"
-            }`
+            body: JSON.stringify(payload)
         });
 
         var dataToReturn;
@@ -121,31 +97,6 @@ module.exports = {
         });
 
         return dataToReturn;
-    },
-
-    retrievePostseasonGames: async (teams, week) => {
-        var allGameData = [];
-        var year = process.env.YEAR;
-        var opts = {
-            'week': week,
-            'seasonType': "postseason",
-            'division': "fbs"
-        };
-
-        for (const team of teams) {
-            opts.team = team;
-
-            try {
-                var gameData = await withRetry(() => gamesApi.getGames(year, opts), { label: `getGames(${team})` });
-                for (let x = 0; x < gameData.length; x++) {
-                    allGameData.push(gameData[x]);
-                }
-            } catch (err) {
-                console.log(`❌ Skipping team ${team} after repeated getGames failures: ${err.message || err}`);
-            }
-        }
-
-        return dedupeGamesById(allGameData);
     },
 
     retrieveGameBySeasonWeekTeam: async (season, week, team) => {
@@ -171,29 +122,6 @@ module.exports = {
         }
     
         return games;
-    },
-
-    saveGames: async (games) => {
-
-        for (const game of games) {
-            var savedGamePromise = await internalFetch(process.env.URL + "/games", {
-                method: 'POST',
-                headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(game),
-            });
-
-            var savedGame = await savedGamePromise;
-            var response = await savedGame.json();
-
-            if (savedGame.status == 201) {
-                console.log("successfully created game with ID: ", response.id);
-            } else {
-                console.log(response.message);
-            }
-        }
     },
 
     // Exported for testing.

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -14,6 +14,16 @@ const teamScoringModule = require('./team-scoring.js');
 const recordsModule = require('./records.js');
 const bettingModule = require('./betting.js');
 
+// Distinct postseason weeks present in a mass-pull result, ascending. The
+// 12-team CFP spreads across several postseason weeks and scoring keys entries
+// by (season, week), so we score each one. Falls back to [1] when no weeks are
+// present (e.g. schedule not loaded yet) to preserve the historical behavior.
+function postseasonWeeksToScore(massResult) {
+    const games = [].concat((massResult && massResult.newGames) || [], (massResult && massResult.existingGames) || []);
+    const weeks = [...new Set(games.map(g => g.week).filter(w => w != null))].sort((a, b) => a - b);
+    return weeks.length ? weeks : [1];
+}
+
 // The shared "update everything for the current week" pipeline that the daily /
 // Saturday / Sunday jobs all run. Determines the current week from the CFBD
 // calendar, ensures rankings exist, pulls games, then updates scores, cumulative
@@ -103,18 +113,25 @@ async function runFullUpdate({ withBetting = false } = {}) {
     var teamCount = 0;
     var gamesNew = 0;
     var gamesUpdated = 0;
+    var remainingCalls;
 
     if (isPostseason) {
-        var teams = await retrieveGamesModule.retrieveTeams();
-        teamCount = teams.length;
-        console.log("number of returned teams", teamCount);
+        // One CFBD call pulls the whole postseason slate (all CFP rounds).
+        var games = await retrieveGamesModule.massRetrieveGames(null, "postseason");
+        gamesNew = games.newGames.length;
+        gamesUpdated = games.existingGames.length;
+        remainingCalls = games.remainingCalls;
+        console.log("number of returned new games", gamesNew);
+        console.log("number of returned existing games", gamesUpdated);
 
-        var games = await retrieveGamesModule.retrievePostseasonGames(teams, 1);
-        gamesNew = games.length;
-        console.log("number of returned games", gamesNew);
+        // The 12-team CFP spans several postseason weeks, and scoring keys each
+        // entry by (season, week) — so score every week present, not just week 1.
+        var postWeeks = postseasonWeeksToScore(games);
+        for (const pw of postWeeks) {
+            await scoringModule.updateScores("postseason", pw);
+        }
+        week = postWeeks[postWeeks.length - 1];   // report the latest for logging
 
-        await retrieveGamesModule.saveGames(games);
-        await scoringModule.updateScores("postseason", 1);
         await scoringModule.updateCumulativeScores();
         await teamScoringModule.updateAllTeamScores();
         await recordsModule.updateAllTeamRecords();
@@ -127,6 +144,7 @@ async function runFullUpdate({ withBetting = false } = {}) {
         var games = await retrieveGamesModule.massRetrieveGames(weekNumber, "regular");
         gamesNew = games.newGames.length;
         gamesUpdated = games.existingGames.length;
+        remainingCalls = games.remainingCalls;
         console.log("number of returned new games", gamesNew);
         console.log("number of returned existing games", gamesUpdated);
 
@@ -137,7 +155,7 @@ async function runFullUpdate({ withBetting = false } = {}) {
         if (withBetting) await bettingModule.updateAllBettingLines();
     }
 
-    return { week, seasonType, teams: teamCount, gamesNew, gamesUpdated };
+    return { week, seasonType, teams: teamCount, gamesNew, gamesUpdated, remainingCalls };
 }
 
-module.exports = { runFullUpdate };
+module.exports = { runFullUpdate, postseasonWeeksToScore };

--- a/routes/games.js
+++ b/routes/games.js
@@ -117,22 +117,22 @@ router.post('/week/mass-create', async (req, res) => {
     var allNewGames = [];
     var allExistingGames = [];
     var year = process.env.YEAR;
-    var opts = {
-        'week': req.body.week,
-        'seasonType': req.body.seasonType,
-        'division': 'fbs'
-    };
 
     // Reject a missing week/seasonType before hitting CFBD: an empty week makes
     // CFBD return a 400 JSON object instead of an array, and iterating that
     // object below throws "not iterable" — an unhandled rejection in this async
-    // handler, which crashes the Node process.
+    // handler, which crashes the Node process. (Week is optional for postseason —
+    // see massCreateInputError.)
     var inputError = massCreateInputError(req.body.week, req.body.seasonType);
     if (inputError) {
         return res.status(400).json({ message: inputError });
     }
 
-    const response = await fetch(`https://api.collegefootballdata.com/games?year=${year}&week=${req.body.week}&seasonType=${req.body.seasonType}&division=fbs`, {
+    // Regular season fetches a single week; postseason omits the week to pull
+    // the whole slate (every CFP round) in one call. `classification` is the
+    // current CFBD param (the old `division` alias still works but is legacy).
+    const weekParam = req.body.seasonType === 'postseason' ? '' : `&week=${req.body.week}`;
+    const response = await fetch(`https://api.collegefootballdata.com/games?year=${year}${weekParam}&seasonType=${req.body.seasonType}&classification=fbs`, {
         method: 'GET',
         headers: {
         'Accept': 'application/json',
@@ -146,6 +146,11 @@ router.post('/week/mass-create', async (req, res) => {
     if (responseError) {
         return res.status(400).json({ message: responseError });
     }
+
+    // CFBD reports remaining monthly calls on every response — surface it so the
+    // live poller's ceiling can read it for free instead of a separate /info hit.
+    const remHeader = response.headers.get('x-calllimit-remaining');
+    const remainingCalls = remHeader != null ? Number(remHeader) : undefined;
 
     for (const game of gameData) {
         var alreadyExists = await Game.find({ id: game.id });
@@ -205,7 +210,8 @@ router.post('/week/mass-create', async (req, res) => {
 
             var returnedGames = {
                 newGames: newGames,
-                existingGames: allExistingGames
+                existingGames: allExistingGames,
+                remainingCalls: remainingCalls
             };
 
             return res.status(201).json(returnedGames);
@@ -228,7 +234,7 @@ router.post('/:season/schedule', async (req, res) => {
     }
     const season = req.params.season;
 
-    const response = await fetch(`https://api.collegefootballdata.com/games?year=${season}&seasonType=regular&division=fbs`, {
+    const response = await fetch(`https://api.collegefootballdata.com/games?year=${season}&seasonType=regular&classification=fbs`, {
         method: 'GET',
         headers: { 'Accept': 'application/json', 'Authorization': process.env.CFBD_API_KEY }
     });

--- a/tests/RetrieveGames.spec.js
+++ b/tests/RetrieveGames.spec.js
@@ -33,13 +33,19 @@ describe('dedupeGamesById', () => {
 });
 
 describe('massCreateInputError', () => {
-    it('rejects a missing week (the dropdown-unselected case that crashed the server)', () => {
-        expect(massCreateInputError('', 'regular')).toBe('week and seasonType are required');
-        expect(massCreateInputError(undefined, 'regular')).toBe('week and seasonType are required');
+    it('rejects a missing week for regular season (the dropdown-unselected case that crashed the server)', () => {
+        expect(massCreateInputError('', 'regular')).toBe('week is required for regular-season requests');
+        expect(massCreateInputError(undefined, 'regular')).toBe('week is required for regular-season requests');
     });
 
     it('rejects a missing seasonType', () => {
-        expect(massCreateInputError('5', '')).toBe('week and seasonType are required');
+        expect(massCreateInputError('5', '')).toBe('seasonType is required');
+        expect(massCreateInputError('', '')).toBe('seasonType is required');
+    });
+
+    it('allows a missing week for postseason (whole slate pulled in one call)', () => {
+        expect(massCreateInputError('', 'postseason')).toBeNull();
+        expect(massCreateInputError(undefined, 'postseason')).toBeNull();
     });
 
     it('passes valid inputs', () => {

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -1,0 +1,27 @@
+const { postseasonWeeksToScore } = require('../modules/score-update');
+
+describe('postseasonWeeksToScore', () => {
+    const g = (week) => ({ week });
+
+    it('returns the distinct weeks present, ascending', () => {
+        const result = { newGames: [g(1), g(2)], existingGames: [g(2), g(3)] };
+        expect(postseasonWeeksToScore(result)).toEqual([1, 2, 3]);
+    });
+
+    it('covers a multi-week 12-team CFP (first round → championship)', () => {
+        // e.g. first round wk1, quarters wk2, semis wk3, final wk4
+        const result = { newGames: [g(4), g(1)], existingGames: [g(3), g(2), g(1)] };
+        expect(postseasonWeeksToScore(result)).toEqual([1, 2, 3, 4]);
+    });
+
+    it('falls back to [1] when no games/weeks are present', () => {
+        expect(postseasonWeeksToScore({ newGames: [], existingGames: [] })).toEqual([1]);
+        expect(postseasonWeeksToScore({})).toEqual([1]);
+        expect(postseasonWeeksToScore(null)).toEqual([1]);
+    });
+
+    it('ignores games with a missing week', () => {
+        const result = { newGames: [g(1), { }], existingGames: [g(null)] };
+        expect(postseasonWeeksToScore(result)).toEqual([1]);
+    });
+});


### PR DESCRIPTION
## What

Part 1 of the postseason plan — plus a real bug it surfaced. Two problems in the postseason branch of `runFullUpdate`:

1. **Budget:** it fetched games **one CFBD call per rostered team** (dozens per night during bowl season) instead of one call for the whole slate.
2. **Correctness:** it only ever scored postseason **"week 1"**, so with the 12-team CFP — whose quarters/semis/final land in *later* postseason weeks — those rounds **never scored**.

## Changes (the four you asked for + the scoring fix)

1. **Mass postseason pull** — reuse `/games/week/mass-create` with the week omitted, so CFBD returns the entire postseason slate in **one call** (per-team → 1). `massCreateInputError` makes `week` optional for postseason; the route drops the `&week=` param in that case.
2. **Score every postseason round** — not just week 1. Scoring already keys entries by `(season, week)`, so we score each week present. New pure helper `postseasonWeeksToScore`. *(This is a scope expansion beyond "1 call" — without it, a 1-call pull would still leave the CFP semis/final unscored, so it's required for postseason to actually work.)*
3. **`classification=fbs`** — switch the games pull and the schedule pull off the legacy `division` alias to CFBD's current param (you verified it returns FBS). Removing the two SDK-based functions (below) means no SDK-param risk.
4. **`x-calllimit-remaining` header** — surface CFBD's remaining-calls count from the games response through `runFullUpdate`. The live poller's ceiling now reads it **for free** off its own poll, with a one-time `/games/info` seed only on a cold start. Drops the periodic `/info` polling and `LIVE_POLL_INFO_TTL_MS`.

**Cleanup:** removed the superseded per-team/manual-save trio (`retrieveGames`, `retrievePostseasonGames`, `saveGames`), the now-dead `cfb.js` SDK setup in `retrieve-games.js`, and the vestigial `opts` block in the mass-create route.

## Impact

- Nightly bowl-season cost drops from ~N calls (one per rostered team) to **1** — fixes a latent Dec/Jan budget blowout.
- The full CFP now scores correctly across all rounds.
- The live poller's ceiling is now free and always-fresh (no `/info` overhead in steady state).
- Still **regular-season only** for live polling (Part 2 would extend the poller's schedule/gate to postseason days) — but the daily job now handles bowls efficiently and correctly.

## Testing

- New `tests/ScoreUpdate.spec.js` — `postseasonWeeksToScore` (multi-week CFP, fallback to [1], missing weeks).
- Updated `massCreateInputError` tests — postseason allows a missing week; regular still requires it.
- Full suite green: **235/235**. `node --check` clean.

Note: the admin "mass create games" form is unaffected — for regular season it still passes a week; for postseason it now pulls the whole slate regardless of the week picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)