### PR TITLE
Live poller: cover the postseason (bowls/CFP), phase-aware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,11 @@ ISSUER_BASE_URL=
 CFBD_API_KEY=
 
 # --- Game-day live scoring poller (modules/live-poll.js) ---
-# Opt-in. When 'true', the in-process scheduler also runs a poller every 10 min
-# on Thu/Fri/Sat that refreshes scores while games are in progress. It only
-# spends a CFBD call when a game is genuinely live and there are calls to spare,
-# so standings feel near-live without blowing the monthly budget.
+# Opt-in. When 'true', the in-process scheduler runs a poller every 10 min that
+# refreshes scores while games are in progress: regular-season games on
+# Thu/Fri/Sat, and postseason (bowls/CFP) games any day. It only spends a CFBD
+# call when a game is genuinely live and there are calls to spare, so standings
+# feel near-live without blowing the monthly budget.
 LIVE_POLL_ENABLED=false              # set 'true' to turn the live poller on
 # Optional tuning (defaults shown):
 # LIVE_POLL_CALL_BUFFER=100          # stop polling once this many CFBD calls remain

--- a/docs/season-flip-runbook.md
+++ b/docs/season-flip-runbook.md
@@ -55,6 +55,12 @@ Admin → **Ingest Full Schedule / Schedule**. **The most-forgotten step.**
 compute from postseason points only — a full, **convincing-but-wrong** payload
 with no error and no empty state. Load it and spot-check before draft day.
 
+> Postseason (mid-December, once the bowl/CFP bracket is published): re-hit the
+> same route with `{ "seasonType": "postseason" }` to preload the bowl schedule.
+> Not required for scoring (the nightly job pulls postseason games itself), but
+> it lets the **live poller** detect day-1 postseason kickoffs the first
+> afternoon rather than waiting for that night's job.
+
 ### 5. Configure Engagement (per league) — `POST /scoring-config/:league/engagement`
 Admin → **Engagement**, pick season **2026** in the dropdown. Set H2H + Captain
 per league. *If skipped:* `engagementForSeason` returns OFF defaults, so both

--- a/modules/live-poll.js
+++ b/modules/live-poll.js
@@ -1,31 +1,29 @@
 // Game-day live scoring poller.
 //
 // Refreshes scores frequently during games so standings feel "live" WITHOUT
-// blowing the CFBD monthly budget. The scheduler fires this every 10 min on
-// Thu/Fri/Sat, but it only spends a CFBD call when a game is genuinely in
-// progress. Three independent guards, cheapest first:
+// blowing the CFBD monthly budget. The scheduler fires this every 10 min, every
+// day, but it only spends a CFBD call when a game is genuinely in progress.
+// Three independent guards, cheapest first:
 //
-//   1. cadence / day — Saturday every 10 min; Thu/Fri every 20; nothing else.
-//      Pure arithmetic, no I/O.
-//   2. games-live gate — poll only if some active-season REGULAR game kicked off
-//      within the last MAX_GAME_HOURS and isn't marked completed. Read from the
-//      local Game collection (the full schedule is ingested preseason), so it
-//      costs 0 CFBD calls. This alone means August, empty nights, and finished
-//      slates spend nothing, and the 6h tail stops a game whose `completed` flag
-//      never flips from polling forever.
+//   1. games-live gate + PHASE — read the local Game collection (0 CFBD calls,
+//      the schedule is ingested ahead of time) for any active-season game that
+//      kicked off within the last MAX_GAME_HOURS and isn't completed. Regular
+//      and postseason don't overlap in time, so at most one phase is live. This
+//      is what makes August, empty days, and finished slates spend nothing, and
+//      the 6h tail stops a stuck `completed` flag from polling forever.
+//   2. cadence — depends on the live phase:
+//        • regular    → Thu/Fri/Sat only (Sat every 10 min, Thu/Fri every 20).
+//        • postseason → every 10 min, ANY day. Bowls/CFP run Mon–Sat (the
+//          national championship is a Monday) and are sparse + high-value, so
+//          they get the tighter cadence on whatever day they fall.
 //   3. hard ceiling — skip if CFBD's own remainingCalls has fallen to the
 //      reserved buffer (default 100), so headroom for manual admin work is never
-//      touched. remainingCalls is authoritative (counts ALL usage) and cached so
-//      the check is ~free.
+//      touched. remainingCalls is authoritative (counts ALL usage).
 //
 // Each actual poll runs the shared scoring pipeline with betting off (calendar
-// is cached → ~1 CFBD call) and records a JobRun (no email) so the standings
-// "last updated" badge advances during live play.
-//
-// Regular season only: the postseason path in runFullUpdate retrieves games
-// per-team (many calls per poll), which is too expensive to poll frequently, so
-// bowls/CFP stay on the daily 11pm job. A mass postseason pull would let the
-// poller cover the playoff too — a good follow-up.
+// cached, postseason mass-pulled → ~1 CFBD call) and records a JobRun (no email)
+// so the standings "last updated" badge advances during live play. runFullUpdate
+// picks the regular vs postseason pull from the calendar, matching the phase.
 
 const Game = require('../models/game');
 const { runFullUpdate } = require('./score-update');
@@ -50,8 +48,17 @@ function isOnCadence(dow, minute) {
     return false;
 }
 
+// Whether this fire is on-cadence for the live phase.
+//   postseason → every 10 min, any day (the scheduler fires on 10-min marks).
+//   regular    → Thu/Fri/Sat only, at the regular cadence above.
+function cadenceOk(phase, dow, minute) {
+    if (phase === 'postseason') return minute % 10 === 0;
+    if (phase === 'regular') return isLivePollDay(dow) && isOnCadence(dow, minute);
+    return false;
+}
+
 // Any game in progress right now? Kicked off within maxHours and not yet final.
-// `games` are already-narrowed active-season regular candidates from the DB.
+// `games` are already-narrowed active-season candidates (one phase) from the DB.
 function anyGameInProgress(games, nowMs, maxHours) {
     const windowMs = maxHours * 3600 * 1000;
     return (games || []).some(g => {
@@ -62,17 +69,19 @@ function anyGameInProgress(games, nowMs, maxHours) {
     });
 }
 
-// Final poll/skip verdict from already-gathered inputs. remainingCalls === null
-// means "unknown" (info check failed) — we don't block scoring on that; the
-// games-live gate still bounds the spend.
-function decide({ dow, minute, gameLive, remainingCalls, buffer }) {
-    if (!isLivePollDay(dow)) return { poll: false, reason: 'not a live-poll day' };
-    if (!isOnCadence(dow, minute)) return { poll: false, reason: 'off-cadence' };
-    if (!gameLive) return { poll: false, reason: 'no game in progress' };
+// Final poll/skip verdict from already-gathered inputs. `phase` is the live
+// phase ('regular' | 'postseason' | null). remainingCalls === null means
+// "unknown" (info check failed) — we don't block scoring on that; the games-live
+// gate still bounds the spend.
+function decide({ dow, minute, phase, remainingCalls, buffer }) {
+    if (!phase) return { poll: false, reason: 'no game in progress' };
+    if (!cadenceOk(phase, dow, minute)) {
+        return { poll: false, reason: phase === 'regular' ? 'regular game, off-cadence / not Thu-Fri-Sat' : 'off-cadence' };
+    }
     if (remainingCalls != null && remainingCalls <= buffer) {
         return { poll: false, reason: `ceiling reached: ${remainingCalls} CFBD calls left (buffer ${buffer})` };
     }
-    return { poll: true, reason: 'game in progress' };
+    return { poll: true, reason: `${phase} game in progress` };
 }
 
 // America/Chicago day-of-week + minute, without a tz library.
@@ -115,31 +124,35 @@ async function run() {
     const nowMs = now.getTime();
     const { dow, minute } = centralNow(now);
 
-    // Cheap gates first — avoid the DB / CFBD when it isn't even our cadence.
-    if (!isLivePollDay(dow)) return { skipped: 'not a live-poll day' };
-    if (!isOnCadence(dow, minute)) return { skipped: 'off-cadence' };
-
-    // Games-live gate (DB only). Not-completed regular games that have already
-    // kicked off — normally just the current slate's live/unfinalized games. The
-    // 6h tail is applied in JS so a stuck `completed` flag can't poll forever.
+    // Games-live gate (DB only, 0 CFBD calls). Not-completed games that have
+    // already kicked off — normally just the current slate's live/unfinalized
+    // games. The 6h tail (applied in JS) stops a stuck `completed` flag from
+    // polling forever. Regular and postseason never overlap in time, so at most
+    // one phase is live; postseason wins if somehow both look live.
     const season = Number(process.env.YEAR);
     const candidates = await Game.find(
-        { season, seasonType: 'regular', completed: { $ne: true }, startDate: { $lte: now.toISOString() } },
-        { startDate: 1, completed: 1 }
+        { season, completed: { $ne: true }, startDate: { $lte: now.toISOString() } },
+        { startDate: 1, completed: 1, seasonType: 1 }
     ).lean();
-    const gameLive = anyGameInProgress(candidates, nowMs, MAX_GAME_HOURS);
-    if (!gameLive) return { skipped: 'no game in progress' };
+    const postLive = anyGameInProgress(candidates.filter(g => g.seasonType === 'postseason'), nowMs, MAX_GAME_HOURS);
+    const regLive = anyGameInProgress(candidates.filter(g => g.seasonType === 'regular'), nowMs, MAX_GAME_HOURS);
+    const phase = postLive ? 'postseason' : (regLive ? 'regular' : null);
+    if (!phase) return { skipped: 'no game in progress' };
+
+    // Cadence for the live phase (pure). Off-cadence fires cost nothing more.
+    if (!cadenceOk(phase, dow, minute)) return { skipped: 'off-cadence' };
 
     // Hard ceiling (authoritative CFBD remainingCalls).
     const remaining = await currentRemaining();
-    const decision = decide({ dow, minute, gameLive, remainingCalls: remaining, buffer: CALL_BUFFER });
+    const decision = decide({ dow, minute, phase, remainingCalls: remaining, buffer: CALL_BUFFER });
     if (!decision.poll) {
         console.log(`live-poll skip — ${decision.reason}`);
         return { skipped: decision.reason };
     }
 
-    // Poll: shared pipeline, betting off (calendar cached → ~1 CFBD call).
-    console.log(`live-poll: game in progress, refreshing scores (${remaining == null ? 'calls left unknown' : remaining + ' calls left'})`);
+    // Poll: shared pipeline, betting off (calendar cached / postseason mass-pull
+    // → ~1 CFBD call).
+    console.log(`live-poll: ${phase} game in progress, refreshing scores (${remaining == null ? 'calls left unknown' : remaining + ' calls left'})`);
     const id = await startRun(JOB_NAME, { season: process.env.YEAR });
     try {
         const r = await runFullUpdate({ withBetting: false });
@@ -160,7 +173,7 @@ async function run() {
 module.exports = {
     run, JOB_NAME,
     // exported for tests
-    isLivePollDay, isOnCadence, anyGameInProgress, decide, centralNow,
+    isLivePollDay, isOnCadence, cadenceOk, anyGameInProgress, decide, centralNow,
     _resetRemaining: () => { lastKnownRemaining = null; }
 };
 

--- a/modules/scheduler.js
+++ b/modules/scheduler.js
@@ -15,14 +15,16 @@ const JOB_SCHEDULES = [
     { job: 'enrichment', modulePath: '../update-enrichment-job', rule: { dayOfWeek: 2, hour: 5, minute: 30 } }
 ];
 
-// Opt-in game-day live poller (modules/live-poll.js). Fires every 10 min on
-// Thu/Fri/Sat; the module's own gates decide whether to actually spend a CFBD
-// call (game in progress + cadence + under the call ceiling). Kept OUT of the
-// always-on JOB_SCHEDULES and gated behind LIVE_POLL_ENABLED=true so it can be
-// switched on/off independently of the core scoring jobs.
+// Opt-in game-day live poller (modules/live-poll.js). Fires every 10 min, every
+// day; the module's own phase-aware gates decide whether to actually spend a
+// CFBD call (a regular game live on Thu/Fri/Sat, or a postseason game live any
+// day — bowls/CFP run Mon–Sat — plus under the call ceiling). Firing daily is
+// cheap: the games-live gate is a local DB check, so non-game times cost nothing.
+// Kept OUT of the always-on JOB_SCHEDULES and gated behind LIVE_POLL_ENABLED=true
+// so it can be switched on/off independently of the core scoring jobs.
 const LIVE_POLL_SCHEDULE = {
     job: 'live-scores', modulePath: '../modules/live-poll',
-    rule: { dayOfWeek: [4, 5, 6], minute: [0, 10, 20, 30, 40, 50] }
+    rule: { minute: [0, 10, 20, 30, 40, 50] }
 };
 
 function livePollEnabled() { return process.env.LIVE_POLL_ENABLED === 'true'; }

--- a/routes/games.js
+++ b/routes/games.js
@@ -224,17 +224,22 @@ router.post('/week/mass-create', async (req, res) => {
     }
 });
 
-// Bulk-ingest a full regular-season FBS schedule in one CFBD call. Preseason
-// prerequisite for draft grades (the projection reads each team's schedule).
+// Bulk-ingest a full FBS schedule in one CFBD call. Preseason prerequisite for
+// draft grades (the projection reads each team's schedule) and for the live
+// poller's games-live gate (it needs kickoff times in the DB ahead of time).
 // Upserts by game id, so it's safe to re-run and future games (no scores yet)
-// store fine. One shot instead of looping /week/mass-create over 15 weeks.
+// store fine. One shot instead of looping /week/mass-create over the weeks.
+// Defaults to the regular season; pass { seasonType: 'postseason' } to preload
+// the bowl/CFP schedule once the bracket is published (so day-1 postseason games
+// are live-pollable). `postseason` omits the week param to pull every round.
 router.post('/:season/schedule', async (req, res) => {
     if (!/^\d{4}$/.test(req.params.season)) {
         return res.status(400).json({ message: 'Invalid season' });
     }
     const season = req.params.season;
+    const seasonType = req.body && req.body.seasonType === 'postseason' ? 'postseason' : 'regular';
 
-    const response = await fetch(`https://api.collegefootballdata.com/games?year=${season}&seasonType=regular&classification=fbs`, {
+    const response = await fetch(`https://api.collegefootballdata.com/games?year=${season}&seasonType=${seasonType}&classification=fbs`, {
         method: 'GET',
         headers: { 'Accept': 'application/json', 'Authorization': process.env.CFBD_API_KEY }
     });
@@ -258,7 +263,7 @@ router.post('/:season/schedule', async (req, res) => {
             catch (err) { console.log('Error updating game', filter.id, err.message); }
         }
     }
-    return res.status(201).json({ season: Number(season), created, updated, total: gameData.length });
+    return res.status(201).json({ season: Number(season), seasonType, created, updated, total: gameData.length });
 });
 
 // Populate broadcast info (TV/web outlet) onto existing game docs from CFBD

--- a/tests/LivePoll.spec.js
+++ b/tests/LivePoll.spec.js
@@ -1,4 +1,4 @@
-const { isLivePollDay, isOnCadence, anyGameInProgress, decide } = require('../modules/live-poll');
+const { isLivePollDay, isOnCadence, cadenceOk, anyGameInProgress, decide } = require('../modules/live-poll');
 
 // Day-of-week: Sun=0 ... Sat=6.
 describe('isLivePollDay', () => {
@@ -30,6 +30,27 @@ describe('isOnCadence', () => {
     it('never polls on a non-live-poll day', () => {
         expect(isOnCadence(0, 0)).toBe(false);
         expect(isOnCadence(2, 20)).toBe(false);
+    });
+});
+
+describe('cadenceOk (phase-aware)', () => {
+    it('regular: Thu/Fri/Sat only, at the regular cadence', () => {
+        expect(cadenceOk('regular', 6, 10)).toBe(true);   // Sat @10
+        expect(cadenceOk('regular', 4, 20)).toBe(true);   // Thu @20
+        expect(cadenceOk('regular', 4, 10)).toBe(false);  // Thu off-cadence
+        expect(cadenceOk('regular', 1, 0)).toBe(false);   // Monday — no regular polling
+        expect(cadenceOk('regular', 0, 0)).toBe(false);   // Sunday
+    });
+
+    it('postseason: every 10 min, ANY day (incl. the Monday championship)', () => {
+        expect(cadenceOk('postseason', 1, 0)).toBe(true);   // Monday @00
+        expect(cadenceOk('postseason', 1, 30)).toBe(true);  // Monday @30
+        expect(cadenceOk('postseason', 3, 40)).toBe(true);  // Wednesday bowl
+        expect(cadenceOk('postseason', 6, 10)).toBe(true);  // Saturday
+    });
+
+    it('no phase never polls', () => {
+        expect(cadenceOk(null, 6, 0)).toBe(false);
     });
 });
 
@@ -70,19 +91,23 @@ describe('anyGameInProgress', () => {
 });
 
 describe('decide', () => {
-    const base = { dow: 6, minute: 0, gameLive: true, remainingCalls: 500, buffer: 100 };
+    const base = { dow: 6, minute: 0, phase: 'regular', remainingCalls: 500, buffer: 100 };
 
-    it('polls when it is the cadence, a game is live, and under the ceiling', () => {
+    it('polls a live regular game on the cadence, under the ceiling', () => {
         expect(decide(base)).toMatchObject({ poll: true });
     });
 
-    it('skips off-day and off-cadence', () => {
-        expect(decide({ ...base, dow: 1 }).poll).toBe(false);
-        expect(decide({ ...base, dow: 4, minute: 10 }).poll).toBe(false);
+    it('polls a live postseason game any day (Monday championship)', () => {
+        expect(decide({ ...base, phase: 'postseason', dow: 1, minute: 30 })).toMatchObject({ poll: true });
+    });
+
+    it('skips a regular game off its day/cadence', () => {
+        expect(decide({ ...base, dow: 1 }).poll).toBe(false);          // Monday
+        expect(decide({ ...base, dow: 4, minute: 10 }).poll).toBe(false); // Thu off-cadence
     });
 
     it('skips when no game is in progress', () => {
-        expect(decide({ ...base, gameLive: false })).toMatchObject({ poll: false, reason: 'no game in progress' });
+        expect(decide({ ...base, phase: null })).toMatchObject({ poll: false, reason: 'no game in progress' });
     });
 
     it('skips at or below the call buffer (protects manual-admin headroom)', () => {

--- a/tests/Scheduler.spec.js
+++ b/tests/Scheduler.spec.js
@@ -11,9 +11,11 @@ describe('scheduler config', () => {
         expect(JOB_SCHEDULES.find(s => s.job === 'live-scores')).toBeUndefined();
     });
 
-    it('live poller fires every 10 min on Thu/Fri/Sat, gated by env', () => {
+    it('live poller fires every 10 min, every day (phase gates decide), gated by env', () => {
         expect(LIVE_POLL_SCHEDULE.job).toBe('live-scores');
-        expect(LIVE_POLL_SCHEDULE.rule).toEqual({ dayOfWeek: [4, 5, 6], minute: [0, 10, 20, 30, 40, 50] });
+        // No dayOfWeek — postseason games run any day; the module's phase-aware
+        // gates restrict regular-season polling to Thu/Fri/Sat.
+        expect(LIVE_POLL_SCHEDULE.rule).toEqual({ minute: [0, 10, 20, 30, 40, 50] });
 
         const prev = process.env.LIVE_POLL_ENABLED;
         process.env.LIVE_POLL_ENABLED = 'true';
@@ -43,11 +45,12 @@ describe('scheduler config', () => {
         expect(rule.dayOfWeek).toBe(6);
     });
 
-    it('leaves hour unset for an every-hour rule (live poller)', () => {
+    it('leaves hour and dayOfWeek unset for the every-day live poller', () => {
         const rule = toRule(LIVE_POLL_SCHEDULE.rule);
-        expect(rule.dayOfWeek).toEqual([4, 5, 6]);
         expect(rule.minute).toEqual([0, 10, 20, 30, 40, 50]);
-        // hour was never assigned, so node-schedule treats it as "any hour".
+        // Neither hour nor dayOfWeek assigned → node-schedule treats them as
+        // "any", so the poller fires every 10 min, every day.
         expect(rule.hour == null).toBe(true);
+        expect(rule.dayOfWeek == null).toBe(true);
     });
 });


### PR DESCRIPTION
## What

**Part 2 of the postseason work.** The live poller was regular-season only and fired only Thu/Fri/Sat — so it missed the entire postseason. Bowls and the CFP run **Mon–Sat** (the national championship is a **Monday**), exactly when "live" matters most.

## How — make the poller phase-aware

- **Scheduler fires every 10 min, every day** (dropped the Thu/Fri/Sat `dayOfWeek`). Firing daily is cheap: the games-live gate is a local DB check, so non-game times cost **0 CFBD calls**.
- **The games-live gate reads both regular and postseason** candidates and derives the live `phase` (they never overlap in time; postseason wins if somehow both look live). Cadence is then phase-aware:
  - **regular** → unchanged: Thu/Fri/Sat only (Sat every 10 min, Thu/Fri every 20).
  - **postseason** → every 10 min, **any day**. Sparse + high-value, so the budget easily absorbs it.
- `runFullUpdate` already picks regular vs postseason from the calendar (postseason is now the 1-call mass pull from PR #246), so a postseason poll is ~1 CFBD call — same as regular.

## Day-1 coverage

Generalized `POST /:season/schedule` to accept `{ "seasonType": "postseason" }`, so the bowl/CFP schedule can be **preloaded** once the bracket is published. Not required for scoring (the nightly job pulls postseason games itself), but it lets the gate detect day-1 postseason kickoffs the first afternoon instead of waiting for that night's job. Documented in the season-flip runbook.

## Safety

- Still **opt-in** (`LIVE_POLL_ENABLED`), still guarded by the games-live gate and the hard ceiling — those are unchanged.
- Regular-season behavior is identical to before (Thu/Fri/Sat, same cadences).
- The every-day schedule only adds cheap local DB checks on non-game days.

## Testing

- New `cadenceOk` tests — regular (Thu/Fri/Sat, right cadence) vs postseason (every 10 min, any day incl. the Monday championship).
- `decide()` updated to the `phase` signature (live regular vs live postseason vs none).
- Scheduler tests updated: live-poll rule is now every-day (no `dayOfWeek`), still opt-in and out of the always-on jobs.
- Full suite green: **239/239**. `node --check` clean.

With this, the whole CFBD-budget + live-scoring plan is complete: enrichment split, calendar cache, live poller, failure-only emails, postseason mass pull, and now postseason live polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)