### PR TITLE
Captain: lock at the manager's own first kickoff

### DIFF
--- a/modules/captain.js
+++ b/modules/captain.js
@@ -53,4 +53,54 @@ function captainWeeklyBonus(scoreByTeam, captainTeamId, multiplier) {
     return Math.round(base * (mult - 1) * 10) / 10;
 }
 
-module.exports = { captainForWeek, autoCaptainTeamId, resolveCaptain, captainWeeklyBonus };
+// --- Per-manager kickoff lock (spec: captain locks when the manager's own
+// first team of the week kicks off, not at the league-wide first game). ---
+
+// First & last kickoff (ms since epoch) among a manager's rostered teams in a
+// set of week games, or null if they don't play that week. `weekGames` =
+// regular-season games for one week as { homeId, awayId, startDate, startTimeTbd }.
+// TBD-kickoff games carry a placeholder startDate that only firms up ~12 days
+// out, so they're excluded while any firm-time game exists — a placeholder must
+// never lock the pick early.
+function captainWeekWindow(weekGames, teamIds) {
+    const ids = new Set((teamIds || []).map(Number));
+    const mine = (weekGames || []).filter(g => ids.has(Number(g.homeId)) || ids.has(Number(g.awayId)));
+    if (!mine.length) return null;
+    const firm = mine.filter(g => !g.startTimeTbd);
+    const pool = firm.length ? firm : mine;
+    const times = pool.map(g => Date.parse(g.startDate)).filter(t => !Number.isNaN(t));
+    if (!times.length) return null;
+    return { first: Math.min.apply(null, times), last: Math.max.apply(null, times) };
+}
+
+// The lock instant for a week: the manager's earliest kickoff. null = no game
+// (or no usable kickoff) that week → nothing to lock.
+function captainLockMs(weekGames, teamIds) {
+    const w = captainWeekWindow(weekGames, teamIds);
+    return w ? w.first : null;
+}
+
+// The week the Captain tile should focus on: the earliest regular-season week
+// (1..16) the manager plays that isn't over yet (now < last kickoff + grace).
+// So a week stays in focus through its games — editable before the manager's
+// first kickoff, then shown locked — and only advances to the next week once
+// this week's games are done. Returns { week, first, last } or null at season end.
+// `games` = the manager's regular-season games across the season.
+function captainFocusWeek(games, teamIds, nowMs, graceMs) {
+    const byWeek = {};
+    (games || []).forEach(g => {
+        if (g.seasonType !== 'regular') return;
+        const w = Number(g.week);
+        if (w >= 1 && w <= 16) (byWeek[w] = byWeek[w] || []).push(g);
+    });
+    for (let w = 1; w <= 16; w++) {
+        const win = captainWeekWindow(byWeek[w], teamIds);
+        if (win && nowMs < win.last + graceMs) return { week: w, first: win.first, last: win.last };
+    }
+    return null;
+}
+
+module.exports = {
+    captainForWeek, autoCaptainTeamId, resolveCaptain, captainWeeklyBonus,
+    captainWeekWindow, captainLockMs, captainFocusWeek
+};

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -567,6 +567,11 @@
 .captain-team span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .captain-team:hover { border-color: #3A3F58; background: #151a2e; }
 .captain-team.is-captain { border-color: #8E8CF0; background: rgba(142, 140, 240, 0.14); font-weight: 700; }
+/* Locked week: cells are read-only (no pointer, no hover lift). */
+.captain-team.is-locked { cursor: default; opacity: 0.6; }
+.captain-team.is-locked.is-captain { opacity: 1; }
+.captain-team.is-locked:hover { border-color: #2A2E42; background: #101322; }
+.captain-team.is-locked.is-captain:hover { border-color: #8E8CF0; background: rgba(142, 140, 240, 0.14); }
 @media (prefers-reduced-motion: reduce) { .uh-captain { transition: none; } }
 
 /* ---------- H2H matchups (#230, My Team) ----------

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -543,6 +543,22 @@ async function hydrateH2H(user, activeYear) {
 // Captain (#230) → Captain tile. Own profile only, and only when the league has
 // Captain on (or ?captain=1). Glance shows the current pick; drawer is the team
 // picker (set/clear a 2× team for the current open week).
+// Kickoff-lock display helpers (Central time, matching the app's schedule).
+function uhFmtLock(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    const day = d.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'America/Chicago' });
+    const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' });
+    return `${day} ${time}`;
+}
+function uhTimeLeft(iso) {
+    if (!iso) return '';
+    const ms = new Date(iso).getTime() - Date.now();
+    if (ms <= 0) return '';
+    const d = Math.floor(ms / 86400000), h = Math.floor((ms % 86400000) / 3600000), m = Math.floor((ms % 3600000) / 60000);
+    return d ? `${d}d ${h}h` : (h ? `${h}h ${m}m` : `${m}m`);
+}
+
 async function hydrateCaptain(user, activeYear) {
     const tile = document.getElementById('uh-tile-captain');
     const hide = () => { if (tile) tile.hidden = true; };
@@ -557,50 +573,73 @@ async function hydrateCaptain(user, activeYear) {
     } catch (e) { /* fall through to preview gate */ }
     if (!enabled && !preview) return hide();
 
-    // Captain is set for the active season's next unplayed regular week. The
-    // active season is the server's authoritative YEAR (window.APP_YEAR), the
-    // same season every other tile keys off. No roster or no open week
-    // (finished season) → nothing to set → hide.
-    const firstOpenWeek = (s) => {
-        const scored = new Set((s.weeklyScore || []).filter(e => e.season !== 'postseason' && e.week <= 16).map(e => Number(e.week)));
-        for (let w = 1; w <= 16; w++) if (!scored.has(w)) return w;
-        return null;
-    };
-    const season = uhSeasonFor(user, activeYear);
-    const week = (season.teams || []).length ? firstOpenWeek(season) : null;
-    if (!(season.teams || []).length || week == null) return hide();
+    // The server owns the lock rule: which regular week is in focus, when it
+    // locks (the manager's own first kickoff), the current pick, and whether it's
+    // already locked. No focus week (season over / no schedule) → nothing to show.
+    let state;
+    try {
+        const r = await fetch('/users/me/captain?season=' + encodeURIComponent(activeYear), { headers: { Accept: 'application/json' } });
+        if (!r.ok) return hide();
+        state = await r.json();
+    } catch (e) { return hide(); }
+    if (!state || state.week == null) return hide();
 
-    let pick = ((season.captains || []).find(c => Number(c.week) === week) || {}).teamId;
+    const season = uhSeasonFor(user, activeYear);
     const teamById = {};
     (season.teams || []).forEach(t => { teamById[t.id] = t; });
+    if (!(season.teams || []).length) return hide();
     if (tile) tile.hidden = false;
 
     const g = document.getElementById('uh-glance-captain');
     const setGlance = () => {
         if (!g) return;
-        const t = pick != null ? teamById[pick] : null;
+        const t = state.teamId != null ? teamById[state.teamId] : null;
         const lead = t
             ? `<span class="uh-cap-glance"><img src="${t.logos.at(-1)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></span>`
-            : `<span class="captain-unset">Set for Wk ${week}</span>`;
-        g.innerHTML = lead + `<span class="uh-cap-sub">Doubles this week’s points</span>`;
+            : `<span class="captain-unset">${state.locked ? 'No pick · Wk ' + state.week : 'Set for Wk ' + state.week}</span>`;
+        let sub;
+        if (state.locked) sub = 'Locked for this week';
+        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt)}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
+        else sub = 'Doubles this week’s points';
+        g.innerHTML = lead + `<span class="uh-cap-sub">${sub}</span>`;
     };
     const paint = (container) => {
-        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${week}. Tap the current pick to clear. Locks at kickoff.</p>
+        if (state.locked) {
+            const t = state.teamId != null ? teamById[state.teamId] : null;
+            container.innerHTML = `<p class="captain-note">Locked — your first team of Week ${state.week} has kicked off. `
+                + (t ? `<b>${escapeHtml(t.school)}</b> is your 2× this week.` : `No captain was set (your best team auto-doubles).`) + `</p>`
+                + `<div class="captain-grid">${(season.teams || []).map(tm => `
+                    <div class="captain-team is-locked${Number(state.teamId) === Number(tm.id) ? ' is-captain' : ''}">
+                        <img src="${tm.logos.at(-1)}" alt=""><span>${escapeHtml(tm.school)}</span>
+                    </div>`).join('')}</div>`;
+            return;
+        }
+        const lockLine = state.lockAt
+            ? ` Locks ${uhFmtLock(state.lockAt)} — when your first team kicks off${uhTimeLeft(state.lockAt) ? ` (${uhTimeLeft(state.lockAt)} left)` : ''}.`
+            : ' Locks when your first team kicks off.';
+        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}</p>
             <div class="captain-grid">${(season.teams || []).map(t => `
-                <button type="button" class="captain-team${Number(pick) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(pick) === Number(t.id)}">
+                <button type="button" class="captain-team${Number(state.teamId) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(state.teamId) === Number(t.id)}">
                     <img src="${t.logos.at(-1)}" alt=""><span>${escapeHtml(t.school)}</span>
                 </button>`).join('')}</div>`;
         container.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {
             const teamId = Number(btn.getAttribute('data-team'));
-            const next = Number(pick) === teamId ? null : teamId;   // click current to clear
+            const next = Number(state.teamId) === teamId ? null : teamId;   // click current to clear
             try {
                 const res = await fetch('/users/me/captain', {
                     method: 'PATCH', headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-                    body: JSON.stringify({ season: season.season, week, teamId: next })
+                    body: JSON.stringify({ season: state.season, week: state.week, teamId: next })
                 });
                 const data = await res.json();
+                if (res.status === 409) {
+                    // Kicked off between load and click — re-sync to the locked state.
+                    state.locked = true;
+                    setGlance(); paint(container);
+                    if (window.ccToast) ccToast.error(data.message || 'Captain is locked for this week.');
+                    return;
+                }
                 if (!res.ok) throw new Error(data.message || 'Could not set captain');
-                pick = next;
+                state.teamId = next;
                 setGlance(); paint(container);
                 if (window.ccToast) ccToast.success(next ? `Captain set: ${teamById[next].school}` : 'Captain cleared');
             } catch (e) { if (window.ccToast) ccToast.error(e.message); }

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,11 +1,27 @@
 const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
+const Game = require('../models/game');
 const scoring = require('../modules/scoring');
 const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
 const { canManageLeague } = require('../modules/league-access');
 const { effectiveRoles } = require('../modules/dev-role');
 const { hasScoredGames } = require('../modules/season-status');
+const { captainLockMs, captainFocusWeek } = require('../modules/captain');
+
+// A week's Captain edits close when the manager's earliest game finishes; the
+// tile keeps that week in focus for this long after its last kickoff before
+// advancing to the next week.
+const CAPTAIN_WEEK_GRACE_MS = 6 * 60 * 60 * 1000;
+
+// The manager's regular-season games for a season, projected to the fields the
+// kickoff-lock helpers need. Shared by the GET and PATCH captain handlers.
+function captainGamesQuery(season, teamIds) {
+    return Game.find(
+        { season, seasonType: 'regular', $or: [{ homeId: { $in: teamIds } }, { awayId: { $in: teamIds } }] },
+        { week: 1, homeId: 1, awayId: 1, startDate: 1, startTimeTbd: 1, seasonType: 1, completed: 1 }
+    ).lean();
+}
 
 // Distinct, vibrant avatar/display colors for managers — same family as the
 // app's accent palette. A new player gets one not already used in the league.
@@ -69,8 +85,45 @@ router.patch('/me/profile', async (req, res) => {
     }
 });
 
+// The Captain state the tile renders from: which regular-season week the manager
+// can currently act on, when it locks (their first kickoff, ISO), their current
+// pick, and whether that week has already locked. `week` is null once the season
+// is out of reach. Single source of truth for the lock rule.
+router.get('/me/captain', async (req, res) => {
+    const oidcUser = req.oidc && req.oidc.user;
+    const meta = oidcUser && oidcUser.user_metadata && oidcUser.user_metadata.metadata;
+    const userId = meta && meta.userId;
+    if (!userId) return res.status(401).json({ message: 'No profile in session.' });
+
+    const seasonYear = Number(req.query.season) || Number(process.env.YEAR);
+    const none = { season: seasonYear, week: null, lockAt: null, teamId: null, locked: true };
+    try {
+        const user = await User.findById(userId);
+        if (!user) return res.status(404).json({ message: 'User not found.' });
+        const season = (user.seasons || []).find(s => Number(s.season) === seasonYear);
+        if (!season || !(season.teams || []).length) return res.json(none);
+
+        const teamIds = (season.teams || []).map(t => Number(t.id));
+        const games = await captainGamesQuery(seasonYear, teamIds);
+        const focus = captainFocusWeek(games, teamIds, Date.now(), CAPTAIN_WEEK_GRACE_MS);
+        if (!focus) return res.json(none);
+
+        const pick = ((season.captains || []).find(c => Number(c.week) === focus.week) || {}).teamId;
+        res.json({
+            season: seasonYear,
+            week: focus.week,
+            lockAt: new Date(focus.first).toISOString(),
+            teamId: pick != null ? Number(pick) : null,
+            locked: Date.now() >= focus.first
+        });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
 // Self-service Captain pick (#230): the logged-in manager sets/clears their
-// captained team for a regular-season week. Locks once the week is scored.
+// captained team for a regular-season week. Locks at the kickoff of their own
+// earliest team that week (not the league-wide first game).
 router.patch('/me/captain', async (req, res) => {
     const oidcUser = req.oidc && req.oidc.user;
     const meta = oidcUser && oidcUser.user_metadata && oidcUser.user_metadata.metadata;
@@ -88,13 +141,23 @@ router.patch('/me/captain', async (req, res) => {
         if (!user) return res.status(404).json({ message: 'User not found.' });
         const season = (user.seasons || []).find(s => Number(s.season) === seasonYear);
         if (!season) return res.status(404).json({ message: 'No roster for that season.' });
-        if (teamId != null && !(season.teams || []).some(t => Number(t.id) === teamId)) {
+        const teamIds = (season.teams || []).map(t => Number(t.id));
+        if (teamId != null && !teamIds.includes(teamId)) {
             return res.status(400).json({ message: 'That team is not on your roster.' });
         }
-        // Lock: once a week has been scored, its captain can't change.
-        if ((season.weeklyScore || []).some(e => e.season !== 'postseason' && Number(e.week) === week)) {
-            return res.status(409).json({ message: 'That week is already scored — captain is locked.' });
+
+        // Lock: the manager's earliest team of the week has kicked off.
+        const weekGames = (await captainGamesQuery(seasonYear, teamIds)).filter(g => Number(g.week) === week);
+        const lockMs = captainLockMs(weekGames, teamIds);
+        if (lockMs != null && Date.now() >= lockMs) {
+            return res.status(409).json({ message: "That week's captain is locked — your first team has kicked off." });
         }
+        // Safety backstop: if a kickoff can't be determined (schedule missing) but
+        // the week already has a completed game, never allow retro-editing it.
+        if (lockMs == null && weekGames.some(g => g.completed === true)) {
+            return res.status(409).json({ message: 'That week is locked.' });
+        }
+
         if (!Array.isArray(season.captains)) season.captains = [];
         season.captains = season.captains.filter(c => Number(c.week) !== week);   // drop any existing pick for the week
         if (teamId != null) season.captains.push({ week, teamId });

--- a/tests/Captain.spec.js
+++ b/tests/Captain.spec.js
@@ -1,4 +1,7 @@
-const { captainForWeek, autoCaptainTeamId, resolveCaptain, captainWeeklyBonus } = require('../modules/captain');
+const {
+    captainForWeek, autoCaptainTeamId, resolveCaptain, captainWeeklyBonus,
+    captainWeekWindow, captainLockMs, captainFocusWeek
+} = require('../modules/captain');
 
 const roster = [{ id: 1, school: 'Oregon' }, { id: 2, school: 'Duke' }, { id: 3, school: 'Iowa' }];
 
@@ -51,5 +54,98 @@ describe('captainWeeklyBonus', () => {
     test('no captain / not found → 0', () => {
         expect(captainWeeklyBonus([{ teamId: 1, score: 10 }], null, 2)).toBe(0);
         expect(captainWeeklyBonus([{ teamId: 1, score: 10 }], 99, 2)).toBe(0);
+    });
+});
+
+const iso = (s) => new Date(s).toISOString();
+const ms = (s) => Date.parse(s);
+
+describe('captainWeekWindow', () => {
+    // Manager rosters teams 1 & 3. Week games below involve various teams.
+    const games = [
+        { homeId: 1, awayId: 50, startDate: iso('2026-09-05T16:00:00Z'), startTimeTbd: false }, // team 1, Sat 11am CT
+        { homeId: 3, awayId: 51, startDate: iso('2026-09-04T23:30:00Z'), startTimeTbd: false }, // team 3, Fri 6:30pm CT (earliest)
+        { homeId: 9, awayId: 8, startDate: iso('2026-09-03T20:00:00Z'), startTimeTbd: false }   // neither team — ignored
+    ];
+
+    test('first = earliest of the manager’s own games; last = latest', () => {
+        const w = captainWeekWindow(games, [1, 3]);
+        expect(w.first).toBe(ms('2026-09-04T23:30:00Z'));   // team 3 Friday
+        expect(w.last).toBe(ms('2026-09-05T16:00:00Z'));    // team 1 Saturday
+    });
+
+    test('ignores games not involving the manager’s teams', () => {
+        expect(captainWeekWindow(games, [9]).first).toBe(ms('2026-09-03T20:00:00Z'));
+    });
+
+    test('null when the manager has no game that week', () => {
+        expect(captainWeekWindow(games, [77])).toBeNull();
+        expect(captainWeekWindow([], [1])).toBeNull();
+    });
+
+    test('excludes TBD-kickoff games while a firm-time game exists (no early lock)', () => {
+        const g = [
+            { homeId: 1, awayId: 5, startDate: iso('2026-09-05T00:00:00Z'), startTimeTbd: true },  // placeholder, would lock too early
+            { homeId: 3, awayId: 6, startDate: iso('2026-09-05T19:00:00Z'), startTimeTbd: false }
+        ];
+        expect(captainWeekWindow(g, [1, 3]).first).toBe(ms('2026-09-05T19:00:00Z'));
+    });
+
+    test('falls back to TBD games when no firm-time game exists', () => {
+        const g = [{ homeId: 1, awayId: 5, startDate: iso('2026-09-05T17:00:00Z'), startTimeTbd: true }];
+        expect(captainWeekWindow(g, [1]).first).toBe(ms('2026-09-05T17:00:00Z'));
+    });
+});
+
+describe('captainLockMs', () => {
+    test('is the manager’s earliest kickoff', () => {
+        const g = [
+            { homeId: 1, awayId: 5, startDate: iso('2026-09-05T16:00:00Z'), startTimeTbd: false },
+            { homeId: 3, awayId: 6, startDate: iso('2026-09-04T23:30:00Z'), startTimeTbd: false }
+        ];
+        expect(captainLockMs(g, [1, 3])).toBe(ms('2026-09-04T23:30:00Z'));
+    });
+    test('null on a bye', () => {
+        expect(captainLockMs([], [1])).toBeNull();
+    });
+});
+
+describe('captainFocusWeek', () => {
+    const GRACE = 6 * 3600 * 1000;
+    // Manager (team 1) plays wk1 Sat 9/5, wk2 Sat 9/12.
+    const games = [
+        { seasonType: 'regular', week: 1, homeId: 1, awayId: 5, startDate: iso('2026-09-05T17:00:00Z'), startTimeTbd: false },
+        { seasonType: 'regular', week: 2, homeId: 1, awayId: 6, startDate: iso('2026-09-12T17:00:00Z'), startTimeTbd: false }
+    ];
+
+    test('before wk1 kickoff → focus wk1 (editable)', () => {
+        const f = captainFocusWeek(games, [1], ms('2026-09-02T12:00:00Z'), GRACE);
+        expect(f.week).toBe(1);
+        expect(ms('2026-09-02T12:00:00Z') < f.first).toBe(true);
+    });
+
+    test('during wk1 games → still wk1 (shown locked, not advanced yet)', () => {
+        const f = captainFocusWeek(games, [1], ms('2026-09-05T18:00:00Z'), GRACE);
+        expect(f.week).toBe(1);
+    });
+
+    test('after wk1 finishes (+grace) → advances to wk2', () => {
+        const f = captainFocusWeek(games, [1], ms('2026-09-06T02:00:00Z'), GRACE);
+        expect(f.week).toBe(2);
+    });
+
+    test('skips weeks the manager does not play', () => {
+        const byeGames = [{ seasonType: 'regular', week: 4, homeId: 1, awayId: 5, startDate: iso('2026-09-26T17:00:00Z'), startTimeTbd: false }];
+        const f = captainFocusWeek(byeGames, [1], ms('2026-09-01T12:00:00Z'), GRACE);
+        expect(f.week).toBe(4);
+    });
+
+    test('null once every played week is done', () => {
+        expect(captainFocusWeek(games, [1], ms('2026-12-01T12:00:00Z'), GRACE)).toBeNull();
+    });
+
+    test('ignores postseason games', () => {
+        const g = [{ seasonType: 'postseason', week: 1, homeId: 1, awayId: 5, startDate: iso('2026-12-20T17:00:00Z'), startTimeTbd: false }];
+        expect(captainFocusWeek(g, [1], ms('2026-09-01T12:00:00Z'), GRACE)).toBeNull();
     });
 });


### PR DESCRIPTION
## What

Implements the per-manager first-kickoff lock we spec'd. **A manager's captain for a week now locks at the kickoff of their own earliest rostered team that week** — not at the league-wide first game.

The old rule locked "once the week is scored," which fired at the week's first kickoff *league-wide*. So a Thursday nighter (or Tuesday/Wednesday MACtion game) involving teams you don't even roster would lock your captain days before any of your teams played — the core intuition violation. The new rule is:

- **Intuitive** — "locks when my first team plays."
- **Fair** — you can never have seen one of your own teams' results before committing.
- **Never triggered by games you have no stake in.**

## How

**`modules/captain.js`** — three pure helpers:
- `captainWeekWindow` — first/last kickoff among the manager's week games. TBD-kickoff games are excluded while any firm-time game exists, so a placeholder time can't lock early.
- `captainLockMs` — the lock instant = earliest kickoff.
- `captainFocusWeek` — the week the tile focuses on: the earliest week you play that isn't over yet (`now < last kickoff + 6h grace`). A week stays in focus through its games — editable before your first kickoff, then shown locked — and only advances to the next week once its games are done, so your pick doesn't "vanish" to next week the instant your game starts.

**`routes/users.js`**:
- `PATCH /me/captain` — rejects (409) at/after the manager's first kickoff, with a completed-game backstop if the schedule can't be read.
- New `GET /me/captain` — returns `{ week, lockAt, teamId, locked }`, the single source of truth the tile renders from.

**`public/userHome.js`** — the Captain tile renders from the GET: a concrete lock time in Central plus a countdown (`Locks Sat 11:00 AM · 2d 4h left`), and a read-only **Locked** state (dimmed grid, your pick still highlighted) once the week is underway. A 409 race (kickoff between load and click) re-syncs to locked.

## Behavior worth noting

Because scoring re-resolves the captain on every run, an edit made *after* the week is preliminarily scored (a leaguemate's Thursday game) but *before your own kickoff* still applies — which is exactly the point.

## Testing

- 21 Captain tests incl. the 3 new helpers: multi-team earliest, TBD exclusion + fallback, byes, in-progress vs advanced weeks, postseason exclusion.
- Full suite green: **252/252**. `node --check` clean.
- Note: the tile itself needs auth + a loaded roster/schedule to render, so it can't be exercised in the current offseason data state; the lock logic is fully covered by the pure-helper tests.

## Compatibility

No schema change (the lock is computed, not stored). Still behind the `captainEnabled` engagement flag — classic leagues unaffected, no new env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)