### PR TITLE
Logos: centralize selection for CFBD's new many-logo array

### DIFF
--- a/modules/draft-grades.js
+++ b/modules/draft-grades.js
@@ -9,6 +9,7 @@
 // drafted.
 
 const { resolveConfig } = require('./scoring-defaults');
+const { pickLogo } = require('../public/logo.js');
 const {
     buildRankingProxy, buildPoolContext, projectTeamPoints, computeLeagueBands,
     spFor, winsFor
@@ -78,7 +79,7 @@ function computeGrades(draft, usersById, teamsById, opts = {}) {
         const proj = projByTeam[String(p.team.id)] || { total: 0, projWins: 0, makeProb: 0 };
         return {
             userId: String(p.userId), teamId: String(p.team.id), overall: p.overall, round: p.round,
-            school: p.team.school, logo: (p.team.logos || [])[0],
+            school: p.team.school, logo: pickLogo(p.team.logos),
             points: proj.total, wins: proj.projWins, makeProb: proj.makeProb || 0,
             reg: proj.regular || 0,                                   // regular-season floor
             post: (proj.cfp || 0) + (proj.confChamp || 0) + (proj.bowl || 0)  // postseason upside

--- a/modules/standings-highlights.js
+++ b/modules/standings-highlights.js
@@ -4,6 +4,8 @@
 // DB-free so it's unit-testable. Each builder returns a highlight card in the
 // same shape the client renderer (buildHighlightsHtml) expects, or null.
 
+const { pickLogo } = require('../public/logo.js');
+
 function escapeHtml(v) {
     return String(v == null ? '' : v).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
@@ -13,7 +15,8 @@ function ordinal(n) {
     return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 function logoImg(meta) {
-    return (meta && meta.logos && meta.logos.length) ? `<img src="${meta.logos[meta.logos.length - 1]}" class="hl-logo">` : '';
+    const src = meta && pickLogo(meta.logos);
+    return src ? `<img src="${src}" class="hl-logo">` : '';
 }
 function teamLabel(meta, fallback) {
     return escapeHtml((meta && meta.mascot) || fallback || '');

--- a/modules/weekly-recap.js
+++ b/modules/weekly-recap.js
@@ -6,6 +6,8 @@
 // optional upset index) and hands it here. Kept DB-free so it's unit-testable
 // AND so a future weekly-recap EMAIL job can reuse it verbatim — no rework.
 
+const { pickLogo } = require('../public/logo.js');
+
 function ordinal(n) {
     const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
     return n + (s[(v - 20) % 10] || s[v] || s[0]);
@@ -132,7 +134,7 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
     (mySeason.teams || []).forEach(t => { metaBySchool[t.school] = t; });
     const logoFor = (school) => {
         const m = metaBySchool[school];
-        return m && m.logos && m.logos.length ? m.logos[m.logos.length - 1] : null;
+        return (m && pickLogo(m.logos)) || null;
     };
 
     // Distinct effective weeks across the whole league, ascending — so "the

--- a/public/admin.js
+++ b/public/admin.js
@@ -182,7 +182,7 @@ function displayUsers(data) {
             var refLink = `/team?team=${team.id}`;
 
             str += '<div>';
-            str += '<a href="' + refLink + '"><img src="' + team.logos.at(-1) + '" alt="' + team.mascot + '">'
+            str += '<a href="' + refLink + '"><img src="' + ccLogo(team.logos) + '" alt="' + team.mascot + '">'
             str += '</div></a>';
         }
         str += '</td></tr>';

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -437,7 +437,7 @@ function renderTicker() {
     // Chronological order (defensive sort in case picks aren't stored ordered).
     var ordered = draft.picks.slice().sort(function (a, b) { return (a.overall || 0) - (b.overall || 0); });
     var chips = ordered.map(function (p) {
-        var logo = (p.team.logos && p.team.logos.length) ? p.team.logos.at(-1) : '';
+        var logo = (p.team.logos && p.team.logos.length) ? ccLogo(p.team.logos) : '';
         return `<a class="pick-chip" href="/team?team=${p.team.id}" target="_blank" rel="noopener"><span class="pk">#${p.overall}</span>`
             + `<img src="${logo}" alt="">${escapeHtml(p.team.school)}</a>`;
     }).join('');
@@ -515,7 +515,7 @@ function renderBoard() {
             var cls = isClock ? 'draft-board-cell on-clock-cell' : 'draft-board-cell';
             if (pick) {
                 var freshCls = (justPickedKey === String(userId) + '-' + round) ? ' just-picked' : '';
-                bodyStr += `<td class="${cls}${freshCls}"><a href="/team?team=${pick.team.id}" target="_blank" rel="noopener" title="${escapeHtml(pick.team.school)}"><img src="${pick.team.logos ? pick.team.logos.at(-1) : ''}" alt="${escapeHtml(pick.team.school)}"></a></td>`;
+                bodyStr += `<td class="${cls}${freshCls}"><a href="/team?team=${pick.team.id}" target="_blank" rel="noopener" title="${escapeHtml(pick.team.school)}"><img src="${pick.team.logos ? ccLogo(pick.team.logos) : ''}" alt="${escapeHtml(pick.team.school)}"></a></td>`;
             } else {
                 bodyStr += `<td class="${cls}"></td>`;
             }

--- a/public/logo.js
+++ b/public/logo.js
@@ -1,0 +1,45 @@
+// Shared team-logo selector (client + server; UMD so both can load this one file).
+//
+// CFBD's /teams endpoint now returns many logo URLs — 8 sizes × light/dark
+// variants, ordered largest-first, e.g.
+//   logos/500/333.png, logos-dark/500/333.png, logos/256/333.png, ... logos-dark/16/333.png
+// (Older ESPN payloads were just [light-500, dark-500].)
+//
+// The app is dark-themed, so it wants the DARK variant at the LARGEST size.
+// Picking by array POSITION is fragile against this: the codebase used
+// `logos.at(-1)`, which was the dark-500 logo on the old 2-element array but
+// becomes the dark-*16px* logo on the new one — blurry everywhere. pickLogo
+// chooses by variant + resolution instead, so it's correct on both shapes.
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) module.exports = factory();
+    else root.ccLogo = factory().pickLogo;
+}(typeof self !== 'undefined' ? self : this, function () {
+    // The pixel size from a logo URL — the path segment before the filename
+    // (".../500/333.png" -> 500; ESPN's ".../500-dark/333.png" -> 500). 0 if none.
+    function logoSize(url) {
+        var seg = String(url == null ? '' : url).split('/').slice(-2)[0] || '';
+        var n = parseInt(seg, 10);
+        return isFinite(n) ? n : 0;
+    }
+
+    // Best logo for a surface: the wanted variant (dark by default, for the dark
+    // UI; opts.dark === false picks light, e.g. for emails / light pages) at the
+    // highest resolution. Falls back to the full list when a team has only one
+    // variant, and to '' for an empty/missing array.
+    function pickLogo(logos, opts) {
+        var wantDark = !(opts && opts.dark === false);
+        var list = Array.isArray(logos) ? logos.filter(Boolean) : [];
+        if (!list.length) return '';
+        var pref = list.filter(function (u) { return /dark/i.test(u) === wantDark; });
+        var pool = pref.length ? pref : list;
+        // Largest size wins; on a tie (or no size info at all) prefer the LAST
+        // entry, so with variant-less / unsized arrays we fall back to exactly the
+        // old `.at(-1)` behavior. pickLogo only ever changes the choice when it can
+        // identify a genuinely better (dark, higher-res) logo.
+        var best = pool.map(function (u, i) { return { u: u, i: i, s: logoSize(u) }; })
+            .sort(function (a, b) { return (b.s - a.s) || (b.i - a.i); })[0];
+        return best.u;
+    }
+
+    return { pickLogo: pickLogo, logoSize: logoSize };
+}));

--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -89,7 +89,7 @@ function movementHtml(delta) {
 // shapes: classic rows carry teams as { id, logos:[…], mascot }; the H2H payload
 // carries { id, logo, school }.
 function teamLogoLink(t) {
-    const src = t.logo != null ? t.logo : ((t.logos && t.logos.at) ? t.logos.at(-1) : '');
+    const src = t.logo != null ? t.logo : ((t.logos && t.logos.at) ? ccLogo(t.logos) : '');
     const label = t.school || t.mascot || '';
     return `<a class="std-team" href="/team?team=${t.id}" title="${escapeHtml(label)}"><img src="${escapeHtml(src)}" alt="${escapeHtml(label)}"></a>`;
 }
@@ -130,7 +130,7 @@ function gapHtml(r) {
 // { logo, school }.
 function inlineTeamLogos(teams) {
     return (teams || []).map(t => {
-        const src = t.logo != null ? t.logo : (t.logos && t.logos.at ? t.logos.at(-1) : '');
+        const src = t.logo != null ? t.logo : (t.logos && t.logos.at ? ccLogo(t.logos) : '');
         return `<a href="/team?team=${t.id}"><img src="${src}" alt="${escapeHtml(t.school || t.mascot || '')}"></a>`;
     }).join('');
 }
@@ -187,7 +187,7 @@ function teamTotals(users) {
                     if (st.team === team.school) total += (st.score || 0);
                 });
             });
-            totals.push({ team: team.mascot, school: team.school, owner: initialName(u), logo: team.logos.at(-1), score: total });
+            totals.push({ team: team.mascot, school: team.school, owner: initialName(u), logo: ccLogo(team.logos), score: total });
         });
     });
     return totals.sort((a, b) => b.score - a.score);

--- a/public/standings.js
+++ b/public/standings.js
@@ -662,13 +662,13 @@ async function parseTeamLogos (game, allTeamLogos) {
         if (awayTeamLogo == null) {
             awayTeamLogo = '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
         } else {
-            awayTeamLogo = '<img src="' + awayTeamLogo.logos.at(-1) + '" style="padding-right: 5px;">';
+            awayTeamLogo = '<img src="' + ccLogo(awayTeamLogo.logos) + '" style="padding-right: 5px;">';
         }
 
         if (homeTeamLogo == null) {
             homeTeamLogo = '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
         } else {
-            homeTeamLogo = '<img src="' + homeTeamLogo.logos.at(-1) + '" style="padding-right: 5px;">';
+            homeTeamLogo = '<img src="' + ccLogo(homeTeamLogo.logos) + '" style="padding-right: 5px;">';
         }
 
         const logoResponse = {awayTeamLogo, homeTeamLogo};

--- a/public/team.js
+++ b/public/team.js
@@ -537,7 +537,7 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
     const html = `
 
         <div class="team-header">
-            <img class="team-logo" src="${team.logos.at(-1)}" alt="${team.school}" />
+            <img class="team-logo" src="${ccLogo(team.logos)}" alt="${team.school}" />
             <div class="team-meta">
             <div class="team-name-row">
                 <h2 class="team-name">${team.school} ${team.mascot}</h2>
@@ -662,10 +662,10 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
                 }
             }
 
-            var homeLogo = logos.find((team) => team.id == game.homeId)?.logos.at(-1);
+            var homeLogo = ccLogo((logos.find((team) => team.id == game.homeId))?.logos);
             homeLogo = homeLogo ? `<img src="${homeLogo}" alt="${game.homeTeam}">` : '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
 
-            var awayLogo = logos.find((team) => team.id == game.awayId)?.logos.at(-1);
+            var awayLogo = ccLogo((logos.find((team) => team.id == game.awayId))?.logos);
             awayLogo = awayLogo ? `<img src="${awayLogo}" alt="${game.awayTeam}">` : '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
 
             var pollName = 'Playoff Committee Rankings';
@@ -798,7 +798,7 @@ function renderNextGame(schedule, logos, teamId) {
     var isHome = game.homeId == teamId;
     var oppName = isHome ? game.awayTeam : game.homeTeam;
     var oppId = isHome ? game.awayId : game.homeId;
-    var oppLogoUrl = logos.find(t => t.id == oppId)?.logos.at(-1);
+    var oppLogoUrl = ccLogo((logos.find(t => t.id == oppId))?.logos);
     var oppLogo = oppLogoUrl ? `<img src="${oppLogoUrl}" alt="${oppName}">` : '<i class="fa-solid fa-helmet-un"></i>';
     var prefix = game.neutralSite ? 'vs' : (isHome ? 'vs' : '@');
 
@@ -884,7 +884,7 @@ async function renderConferenceStandings(data, teamData, logos, conference) {
         `;
 
         standings.forEach((team, index) => {
-            var teamLogo = logos.find((logo) => logo.id == team.teamId)?.logos.at(-1);
+            var teamLogo = ccLogo((logos.find((logo) => logo.id == team.teamId))?.logos);
             teamLogo = teamLogo ? `<img src="${teamLogo}" alt="${team.mascot}">` : '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
 
             var isViewedTeam = team.team == teamData.school;

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -198,7 +198,7 @@ async function renderBento(data) {
     }
     sh += statTile(String(season.cumulativeScore || 0), 'Total points');
     const bt = bestTeam(season);
-    if (bt && bt.total > 0) sh += statTile(`<img src="${bt.team.logos.at(-1)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
+    if (bt && bt.total > 0) sh += statTile(`<img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
     statsEl.innerHTML = sh;
 
     if (own) setupEditModal(data, season, true);
@@ -235,14 +235,14 @@ function hydrateRoster(user, activeYear) {
     const g = document.getElementById('uh-glance-roster');
     if (g) {
         g.innerHTML = top && top.pts > 0
-            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => `<span class="uh-rg-row"><img src="${c.t.logos.at(-1)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></span>`).join('')}</span>`
+            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => `<span class="uh-rg-row"><img src="${ccLogo(c.t.logos)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></span>`).join('')}</span>`
             : 'Your 10 teams';
     }
 
     uhDrawer.roster = (body) => {
         const max = (cards[0] && cards[0].pts) || 1;
         const list = cards.map(c => `<a class="uh-rc" href="/team?team=${c.t.id}">
-            <img src="${c.t.logos.at(-1)}" alt="">
+            <img src="${ccLogo(c.t.logos)}" alt="">
             <span class="uh-rc-meta"><span class="uh-rc-nm">${escapeHtml(c.t.school)}</span><span class="uh-rc-bar"><i style="width:${Math.round((c.pts / max) * 100)}%"></i></span></span>
             <span class="uh-rc-pts num">${c.pts}</span></a>`).join('');
         body.innerHTML = `<div class="uh-seg">
@@ -338,7 +338,7 @@ async function hydrateGames(user, activeYear) {
                 getGame(seasonType, week, t).then(gs => ({ t, plays: !!(gs && gs.length) })).catch(() => ({ t, plays: false }))));
             const playing = per.filter(x => x.plays).map(x => x.t);
             if (playing.length) {
-                const logos = playing.map(t => `<img src="${t.logos.at(-1)}" alt="">`).join('');
+                const logos = playing.map(t => `<img src="${ccLogo(t.logos)}" alt="">`).join('');
                 g.innerHTML = `<span class="uh-games-logos">${logos}</span><span class="uh-glance-sub uh-games-wk">${playing.length} of your teams · ${escapeHtml(label)}</span>`;
             } else {
                 g.innerHTML = `<span class="uh-glance-sub">No games for your teams · ${escapeHtml(label)}</span>`;
@@ -595,7 +595,7 @@ async function hydrateCaptain(user, activeYear) {
         if (!g) return;
         const t = state.teamId != null ? teamById[state.teamId] : null;
         const lead = t
-            ? `<span class="uh-cap-glance"><img src="${t.logos.at(-1)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></span>`
+            ? `<span class="uh-cap-glance"><img src="${ccLogo(t.logos)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></span>`
             : `<span class="captain-unset">${state.locked ? 'No pick · Wk ' + state.week : 'Set for Wk ' + state.week}</span>`;
         let sub;
         if (state.locked) sub = 'Locked for this week';
@@ -610,7 +610,7 @@ async function hydrateCaptain(user, activeYear) {
                 + (t ? `<b>${escapeHtml(t.school)}</b> is your 2× this week.` : `No captain was set (your best team auto-doubles).`) + `</p>`
                 + `<div class="captain-grid">${(season.teams || []).map(tm => `
                     <div class="captain-team is-locked${Number(state.teamId) === Number(tm.id) ? ' is-captain' : ''}">
-                        <img src="${tm.logos.at(-1)}" alt=""><span>${escapeHtml(tm.school)}</span>
+                        <img src="${ccLogo(tm.logos)}" alt=""><span>${escapeHtml(tm.school)}</span>
                     </div>`).join('')}</div>`;
             return;
         }
@@ -620,7 +620,7 @@ async function hydrateCaptain(user, activeYear) {
         container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}</p>
             <div class="captain-grid">${(season.teams || []).map(t => `
                 <button type="button" class="captain-team${Number(state.teamId) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(state.teamId) === Number(t.id)}">
-                    <img src="${t.logos.at(-1)}" alt=""><span>${escapeHtml(t.school)}</span>
+                    <img src="${ccLogo(t.logos)}" alt=""><span>${escapeHtml(t.school)}</span>
                 </button>`).join('')}</div>`;
         container.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {
             const teamId = Number(btn.getAttribute('data-team'));
@@ -1017,7 +1017,7 @@ function displayTeams(data) {
         });
         const refLink = `/team?team=${team.id}`;
         str += '<tr><th class="team-header sticky-header" scope="row">'
-            + '<a href="' + refLink + '"><img src="' + team.logos.at(-1) + '" alt="' + escapeHtml(team.mascot) + '">'
+            + '<a href="' + refLink + '"><img src="' + ccLogo(team.logos) + '" alt="' + escapeHtml(team.mascot) + '">'
             + escapeHtml(team.school) + '</a></th>'
             + cells
             + '<th class="sticky-header-score">' + totalScore + '</th></tr>';
@@ -1170,13 +1170,13 @@ async function getTeamLogos (game) {
         if (awayTeamLogo == null) {
             awayTeamLogo = '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
         } else {
-            awayTeamLogo = '<img src="' + awayTeamLogo.logos.at(-1) + '" style="padding-right: 5px;">';
+            awayTeamLogo = '<img src="' + ccLogo(awayTeamLogo.logos) + '" style="padding-right: 5px;">';
         }
 
         if (homeTeamLogo == null) {
             homeTeamLogo = '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
         } else {
-            homeTeamLogo = '<img src="' + homeTeamLogo.logos.at(-1) + '" style="padding-right: 5px;">';
+            homeTeamLogo = '<img src="' + ccLogo(homeTeamLogo.logos) + '" style="padding-right: 5px;">';
         }
 
         const logoResponse = {awayTeamLogo, homeTeamLogo};
@@ -1280,7 +1280,7 @@ async function batchTeamLogos(games) {
         });
         if (res.status === 200) {
             (await res.json()).forEach(t => {
-                if (t && t.logos && t.logos.length) map[t.id] = '<img src="' + t.logos.at(-1) + '" style="padding-right: 5px;">';
+                if (t && t.logos && t.logos.length) map[t.id] = '<img src="' + ccLogo(t.logos) + '" style="padding-right: 5px;">';
             });
         }
     } catch (e) { /* fall back to helmet icons */ }

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -15,6 +15,7 @@ const { buildProjections, simulateTitleOdds } = require('../modules/standings-pr
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
 const { scheduleForWeeks, resolveWeek, gameStatus, isWeekFinal, matchupWinProb } = require('../modules/h2h');
+const { pickLogo } = require('../public/logo.js');
 
 // The scoring jobs that actually refresh standings data (see modules/score-job.js
 // and modules/live-poll.js). 'live-scores' is the game-day live poller, so the
@@ -312,7 +313,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             const id = String(u._id);
             ids.push(id);
             const logoBy = {}, abbrBy = {};
-            const roster = (s.teams || []).map(t => { const logo = (t.logos || []).slice(-1)[0] || null; logoBy[t.id] = logo; abbrBy[t.id] = t.abbreviation || null; draftedSet.add(t.id); return { id: t.id, school: t.school, abbr: t.abbreviation || null, logo }; });
+            const roster = (s.teams || []).map(t => { const logo = pickLogo(t.logos) || null; logoBy[t.id] = logo; abbrBy[t.id] = t.abbreviation || null; draftedSet.add(t.id); return { id: t.id, school: t.school, abbr: t.abbreviation || null, logo }; });
             meta[id] = {
                 userId: id,
                 name: `${u.firstName || ''} ${u.lastName ? u.lastName[0] + '.' : ''}`.trim(),

--- a/tests/Logo.spec.js
+++ b/tests/Logo.spec.js
@@ -1,0 +1,59 @@
+const { pickLogo, logoSize } = require('../public/logo.js');
+
+// The new CFBD /teams shape: 8 sizes × light/dark, largest first.
+const CFBD = [
+    'https://cdn.collegefootballdata.com/logos/500/333.png',
+    'https://cdn.collegefootballdata.com/logos-dark/500/333.png',
+    'https://cdn.collegefootballdata.com/logos/256/333.png',
+    'https://cdn.collegefootballdata.com/logos-dark/256/333.png',
+    'https://cdn.collegefootballdata.com/logos/128/333.png',
+    'https://cdn.collegefootballdata.com/logos-dark/128/333.png',
+    'https://cdn.collegefootballdata.com/logos/16/333.png',
+    'https://cdn.collegefootballdata.com/logos-dark/16/333.png'
+];
+// The old ESPN shape: [light-500, dark-500].
+const ESPN = [
+    'http://a.espncdn.com/i/teamlogos/ncaa/500/333.png',
+    'http://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png'
+];
+
+describe('logoSize', () => {
+    test('reads the size segment before the filename', () => {
+        expect(logoSize('https://cdn.collegefootballdata.com/logos-dark/500/333.png')).toBe(500);
+        expect(logoSize('https://cdn.collegefootballdata.com/logos/16/333.png')).toBe(16);
+        expect(logoSize('http://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png')).toBe(500);
+    });
+    test('0 when there is no numeric size', () => {
+        expect(logoSize('https://x/logo.png')).toBe(0);
+        expect(logoSize(null)).toBe(0);
+    });
+});
+
+describe('pickLogo', () => {
+    test('CFBD: dark variant at the largest size (default)', () => {
+        expect(pickLogo(CFBD)).toBe('https://cdn.collegefootballdata.com/logos-dark/500/333.png');
+    });
+    test('CFBD: light variant at the largest size when asked', () => {
+        expect(pickLogo(CFBD, { dark: false })).toBe('https://cdn.collegefootballdata.com/logos/500/333.png');
+    });
+    test('regression: does NOT return the tiny dark-16 that .at(-1) would', () => {
+        expect(pickLogo(CFBD)).not.toContain('/16/');
+    });
+    test('ESPN back-compat: still the dark-500 (matches the old .at(-1))', () => {
+        expect(pickLogo(ESPN)).toBe('http://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png');
+        expect(pickLogo(ESPN, { dark: false })).toBe('http://a.espncdn.com/i/teamlogos/ncaa/500/333.png');
+    });
+    test('single-logo team: returns the only logo regardless of variant', () => {
+        expect(pickLogo(['https://cdn.collegefootballdata.com/logos/500/1.png']))
+            .toBe('https://cdn.collegefootballdata.com/logos/500/1.png');
+    });
+    test('empty / missing → empty string', () => {
+        expect(pickLogo([])).toBe('');
+        expect(pickLogo(null)).toBe('');
+        expect(pickLogo(undefined)).toBe('');
+    });
+    test('drops falsy entries', () => {
+        expect(pickLogo([null, '', 'https://cdn.collegefootballdata.com/logos-dark/500/1.png']))
+            .toBe('https://cdn.collegefootballdata.com/logos-dark/500/1.png');
+    });
+});

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -18,6 +18,9 @@
 <script src="/toast.js"></script>
 <!-- Custom icon suite (ccIcon + [data-icon] hydration), emitted once app-wide. -->
 <script src="/icons.js"></script>
+<!-- Shared team-logo selector (ccLogo): picks the dark, highest-res variant from
+     CFBD's many-logo array. Loaded before page scripts that render team logos. -->
+<script src="/logo.js"></script>
 <!-- Weekly Recap: shared card rendering + the once-a-week popup, app-wide so the
      popup can greet the logged-in viewer on whatever page they land on. -->
 <link rel="stylesheet" type="text/css" href="/weekly-recap.css">


### PR DESCRIPTION
## Why

CFBD's `/teams` endpoint changed: it now returns **8 sizes × light/dark** per team (largest first) on its own CDN —

```
logos/500/333.png, logos-dark/500/333.png, logos/256/333.png, ... logos-dark/16/333.png
```

— instead of ESPN's old `[light-500, dark-500]`. The app selected logos by **array position** at **28 sites** (mostly `logos.at(-1)`). On the old 2-element array that was the crisp **dark-500** logo; on the new array `.at(-1)` becomes **`logos-dark/16/333.png`** — the dark variant at **16px**, blurry everywhere the app renders logos (22–40px+). A blind `/teams/refresh` would have degraded every logo in the app.

## What

A shared, isomorphic **`pickLogo`** (`public/logo.js`, UMD → `window.ccLogo` on the client, `require()` on the server) that selects by **variant + resolution** instead of position:

- Dark variant (the app is dark-themed) at the **largest** size by default.
- `pickLogo(logos, { dark: false })` → light variant, for light surfaces (emails, the landing page).
- **Strict superset of the old behavior:** on variant-less / unsized arrays it falls back to exactly the old last-element pick, and it stays correct on the old ESPN shape. So nothing changes until you refresh, and it's safe both **before and after** a `/teams/refresh`.

Replaced all 28 positional selects:
- **24 client sites** (`userHome`, `team`, `standings`, `standings-insights`, `draftRoom`, `admin`) → `ccLogo(...)`. `/logo.js` is loaded app-wide via the navbar partial, before the page scripts.
- **4 server sites** — `draft-grades` used `[0]` (light-500); `standings`, `weekly-recap`, `standings-highlights` used the last element. All now `pickLogo(...)`, so the draft-grade cards also get the dark variant, consistent with everything else.

Verified `pickLogo` against the real Alabama array: dark → `logos-dark/500`, light → `logos/500`, old ESPN → `500-dark` (unchanged).

## Follow-up (your side, optional)

After merge, run the admin **`/teams/refresh`** to pull the new CFBD-CDN URLs + higher-res logos. Not required — the old ESPN URLs keep working via back-compat — but it moves logo hosting off ESPN hotlinks (likely why CFBD made the change) and gives crisper art.

## Testing

- New `tests/Logo.spec.js`: real CFBD + ESPN shapes, the dark-16 regression, light variant, single-logo, empty/missing, falsy filtering.
- Full suite green: **261/261**. `node --check` clean across all 13 files.
- The logos render behind auth + team data, so an in-app screenshot isn't possible in the current state; the selector is a pure function verified by tests + the real array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)