### PR TITLE
Refresh: propagate all safe team fields into rosters/drafts; score-match by teamId

### DIFF
--- a/modules/team-refresh.js
+++ b/modules/team-refresh.js
@@ -1,0 +1,37 @@
+// Helpers for propagating refreshed team data into the DENORMALIZED copies the
+// app renders from. A team's logos live in three places: the `teams` collection
+// (source of truth, updated by /teams/refresh) and two snapshots taken at draft
+// time — `users.seasons[].teams[]` and `drafts.picks[].team`. Refreshing only
+// the source leaves Standings / My Team / Draft Room rendering the old logos, so
+// after a refresh we push the new logos into those embedded copies.
+//
+// Pure + DB-free so the sync logic is unit-testable; the route does the Mongo I/O.
+
+// Map of team id -> logos array, from the freshly-fetched CFBD teams.
+function logosById(teams) {
+    const map = {};
+    (teams || []).forEach(t => { if (t && t.id != null && Array.isArray(t.logos)) map[t.id] = t.logos; });
+    return map;
+}
+
+function sameLogos(a, b) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+}
+
+// Overwrite each embedded team's `logos` from the id->logos map, in place.
+// Returns the number of teams actually changed (0 => nothing to save). Skips
+// teams not in the map and teams whose logos already match, so re-running is a
+// cheap no-op.
+function applyLogos(embeddedTeams, map) {
+    let changed = 0;
+    (embeddedTeams || []).forEach(t => {
+        if (!t || t.id == null) return;
+        const next = map[t.id];
+        if (next && !sameLogos(t.logos, next)) { t.logos = next.slice(); changed += 1; }
+    });
+    return changed;
+}
+
+module.exports = { logosById, applyLogos, sameLogos };

--- a/modules/team-refresh.js
+++ b/modules/team-refresh.js
@@ -1,37 +1,53 @@
 // Helpers for propagating refreshed team data into the DENORMALIZED copies the
-// app renders from. A team's logos live in three places: the `teams` collection
+// app renders from. Team data lives in three places: the `teams` collection
 // (source of truth, updated by /teams/refresh) and two snapshots taken at draft
 // time — `users.seasons[].teams[]` and `drafts.picks[].team`. Refreshing only
-// the source leaves Standings / My Team / Draft Room rendering the old logos, so
-// after a refresh we push the new logos into those embedded copies.
+// the source leaves Standings / My Team / Draft Room rendering stale team info,
+// so after a refresh we push the fresh fields into those embedded copies.
 //
 // Pure + DB-free so the sync logic is unit-testable; the route does the Mongo I/O.
 
-// Map of team id -> logos array, from the freshly-fetched CFBD teams.
-function logosById(teams) {
+// Fields safe to overwrite in the embedded copies. All are display data that
+// nothing keys off — including `school`: the score aggregations now match by the
+// stable teamId (with a school fallback), so a rename ("Louisiana St." ->
+// "Louisiana State") flows through without dropping points. Deliberately NOT
+// synced: `id` (the join key), and `conference`/`division` (year-sensitive — a
+// global overwrite would mislabel past seasons for teams that changed leagues).
+const SCALAR_FIELDS = ['school', 'mascot', 'abbreviation', 'color', 'alt_color', 'twitter'];
+const ARRAY_FIELDS = ['logos', 'alternateNames'];
+
+// Map of team id -> source team object, from the freshly-fetched CFBD teams.
+function teamsById(teams) {
     const map = {};
-    (teams || []).forEach(t => { if (t && t.id != null && Array.isArray(t.logos)) map[t.id] = t.logos; });
+    (teams || []).forEach(t => { if (t && t.id != null) map[t.id] = t; });
     return map;
 }
 
-function sameLogos(a, b) {
+function sameArray(a, b) {
     if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
     return true;
 }
 
-// Overwrite each embedded team's `logos` from the id->logos map, in place.
+// Overwrite each embedded team's synced fields from the id->team map, in place.
 // Returns the number of teams actually changed (0 => nothing to save). Skips
-// teams not in the map and teams whose logos already match, so re-running is a
-// cheap no-op.
-function applyLogos(embeddedTeams, map) {
+// teams not in the map and fields already equal, so re-running is a cheap no-op.
+function applyTeamFields(embeddedTeams, byId) {
     let changed = 0;
     (embeddedTeams || []).forEach(t => {
         if (!t || t.id == null) return;
-        const next = map[t.id];
-        if (next && !sameLogos(t.logos, next)) { t.logos = next.slice(); changed += 1; }
+        const src = byId[t.id];
+        if (!src) return;
+        let dirty = false;
+        SCALAR_FIELDS.forEach(f => {
+            if (src[f] !== undefined && t[f] !== src[f]) { t[f] = src[f]; dirty = true; }
+        });
+        ARRAY_FIELDS.forEach(f => {
+            if (Array.isArray(src[f]) && !sameArray(t[f], src[f])) { t[f] = src[f].slice(); dirty = true; }
+        });
+        if (dirty) changed += 1;
     });
     return changed;
 }
 
-module.exports = { logosById, applyLogos, sameLogos };
+module.exports = { teamsById, applyTeamFields, sameArray, SCALAR_FIELDS, ARRAY_FIELDS };

--- a/modules/weekly-recap.js
+++ b/modules/weekly-recap.js
@@ -129,13 +129,12 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
         .map(u => { const s = seasonOf(u, season); return s ? { userId: String(u._id), weekly: s.weeklyScore || [] } : null; })
         .filter(Boolean);
 
-    // Roster meta by school name (scoreByTeam[].team is the school string).
-    const metaBySchool = {};
-    (mySeason.teams || []).forEach(t => { metaBySchool[t.school] = t; });
-    const logoFor = (school) => {
-        const m = metaBySchool[school];
-        return (m && pickLogo(m.logos)) || null;
-    };
+    // Roster meta by stable teamId (rename-safe), with a school-name fallback for
+    // any legacy scoreByTeam entry stored without a teamId.
+    const metaById = {}, metaBySchool = {};
+    (mySeason.teams || []).forEach(t => { metaById[t.id] = t; metaBySchool[t.school] = t; });
+    const metaOf = (teamId, school) => (teamId != null && metaById[teamId]) || metaBySchool[school] || null;
+    const logoOf = (teamId, school) => { const m = metaOf(teamId, school); return (m && pickLogo(m.logos)) || null; };
 
     // Distinct effective weeks across the whole league, ascending — so "the
     // previous week" for rank movement is the real prior week, not W-1 (which
@@ -203,7 +202,8 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
         // so the MVP is a team's total for the week, not a single game.
         const teamAgg = {};
         (entry.scoreByTeam || []).forEach(st => {
-            const t = teamAgg[st.team] || (teamAgg[st.team] = { school: st.team, score: 0, logo: logoFor(st.team) });
+            const key = st.teamId != null ? 'id:' + st.teamId : 'nm:' + st.team;
+            const t = teamAgg[key] || (teamAgg[key] = { school: st.team, score: 0, logo: logoOf(st.teamId, st.team) });
             t.score = round(t.score + (st.score || 0));
         });
         const teams = Object.values(teamAgg);
@@ -225,7 +225,7 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
             (entry.scoreByTeam || []).forEach(st => {
                 const u = st.gameId != null ? upsetByGameId[st.gameId] : null;
                 if (u && u.winner === st.team && (!upset || u.margin > upset.margin)) {
-                    upset = { team: st.team, loser: u.loser, loserRank: u.loserRank, margin: u.margin, fantasy: round(st.score || 0), logo: logoFor(st.team) };
+                    upset = { team: st.team, loser: u.loser, loserRank: u.loserRank, margin: u.margin, fantasy: round(st.score || 0), logo: logoOf(st.teamId, st.team) };
                 }
             });
         }

--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -184,7 +184,9 @@ function teamTotals(users) {
             let total = 0;
             weekly(u).forEach(wk => {
                 (wk.scoreByTeam || []).forEach(st => {
-                    if (st.team === team.school) total += (st.score || 0);
+                    // Match by stable teamId (rename-safe); fall back to the school
+                    // string for any legacy entry stored without a teamId.
+                    if (Number(st.teamId) === Number(team.id) || st.team === team.school) total += (st.score || 0);
                 });
             });
             totals.push({ team: team.mascot, school: team.school, owner: initialName(u), logo: ccLogo(team.logos), score: total });

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -784,7 +784,7 @@ function bestTeam(season) {
     let best = null;
     (season.teams || []).forEach(t => {
         let total = 0;
-        weekly.forEach(w => (w.scoreByTeam || []).forEach(st => { if (st.team === t.school) total += (st.score || 0); }));
+        weekly.forEach(w => (w.scoreByTeam || []).forEach(st => { if (Number(st.teamId) === Number(t.id) || st.team === t.school) total += (st.score || 0); }));
         if (!best || total > best.total) best = { team: t, total };
     });
     return best;
@@ -973,9 +973,11 @@ function weeklyColumns(season) {
 }
 
 // The points a team banked in one column (bye / not yet played -> null).
-function columnTeamScore(entry, teamSchool) {
+// Matches by stable teamId (rename-safe), falling back to the school string for
+// any legacy entry stored without a teamId. `team` is the roster team {id, school}.
+function columnTeamScore(entry, team) {
     if (!entry) return null;
-    const games = (entry.scoreByTeam || []).filter(o => o.team === teamSchool);
+    const games = (entry.scoreByTeam || []).filter(o => Number(o.teamId) === Number(team.id) || o.team === team.school);
     if (!games.length) return null;
     return games.reduce((s, g) => s + (g.score || 0), 0);
 }
@@ -999,7 +1001,7 @@ function displayTeams(data) {
     // Highlight the season's best single team-game and best week (top weekly
     // total) — the standout cells, tie-inclusive.
     let bestGame = 0;
-    teams.forEach(t => columns.forEach(c => { const s = columnTeamScore(c.entry, t.school); if (s != null && s > bestGame) bestGame = s; }));
+    teams.forEach(t => columns.forEach(c => { const s = columnTeamScore(c.entry, t); if (s != null && s > bestGame) bestGame = s; }));
     let bestWeek = 0;
     columns.forEach(c => { if (c.entry && (c.entry.score || 0) > bestWeek) bestWeek = c.entry.score || 0; });
 
@@ -1008,7 +1010,7 @@ function displayTeams(data) {
         let totalScore = 0;
         let cells = '';
         columns.forEach(c => {
-            const s = columnTeamScore(c.entry, team.school);
+            const s = columnTeamScore(c.entry, team);
             if (!c.entry) { cells += '<td class="cell-future"></td>'; return; }   // week not played yet
             if (s == null) { cells += '<td class="cell-bye">–</td>'; return; }    // bye / no game
             totalScore += s;

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const fs = require('fs');
 const path = require('path');
 const Team = require('../models/team');
+const User = require('../models/user');
+const Draft = require('../models/draft');
 const { parseOdds, americanToProb, buildTeamMatcher } = require('../modules/cfp-odds');
+const { logosById, applyLogos } = require('../modules/team-refresh');
 
 //Getting All
 router.get('/', async (req, res) => {
@@ -482,9 +485,36 @@ router.post('/refresh', async (req, res) => {
             console.log("Refreshing " + refreshedTeams.length + " teams and adding " + newTeams.length + " new teams");
             const newCreatedTeams = await Team.insertMany(newTeams);
 
+            // Propagate the fresh logos into the denormalized copies the app
+            // actually renders from — user rosters (seasons[].teams[]) and draft
+            // picks (picks[].team) — otherwise Standings / My Team / Draft Room
+            // keep showing the old logos even though the teams collection updated.
+            // Global (not year-scoped): a team's logo is the same across seasons.
+            const map = logosById(allTeams);
+
+            let rostersSynced = 0;
+            const users = await User.find({ 'seasons.teams.0': { $exists: true } });
+            for (const u of users) {
+                let changed = 0;
+                (u.seasons || []).forEach(s => { changed += applyLogos(s.teams, map); });
+                if (changed) { await u.save(); rostersSynced++; }
+            }
+
+            let draftsSynced = 0;
+            const drafts = await Draft.find({ 'picks.0': { $exists: true } });
+            for (const d of drafts) {
+                // picks[].team is Mixed, so mutate the team objects then flag the
+                // path for mongoose to persist.
+                const changed = applyLogos((d.picks || []).map(p => p.team), map);
+                if (changed) { d.markModified('picks'); await d.save(); draftsSynced++; }
+            }
+            console.log(`Logo propagation: ${rostersSynced} rosters, ${draftsSynced} drafts updated`);
+
             var returnedTeams = {
                 newTeams: newCreatedTeams,
-                refreshedTeams: refreshedTeams
+                refreshedTeams: refreshedTeams,
+                rostersSynced: rostersSynced,
+                draftsSynced: draftsSynced
             };
 
             return res.status(201).json(returnedTeams);

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -6,7 +6,7 @@ const Team = require('../models/team');
 const User = require('../models/user');
 const Draft = require('../models/draft');
 const { parseOdds, americanToProb, buildTeamMatcher } = require('../modules/cfp-odds');
-const { logosById, applyLogos } = require('../modules/team-refresh');
+const { teamsById, applyTeamFields } = require('../modules/team-refresh');
 
 //Getting All
 router.get('/', async (req, res) => {
@@ -485,18 +485,20 @@ router.post('/refresh', async (req, res) => {
             console.log("Refreshing " + refreshedTeams.length + " teams and adding " + newTeams.length + " new teams");
             const newCreatedTeams = await Team.insertMany(newTeams);
 
-            // Propagate the fresh logos into the denormalized copies the app
-            // actually renders from — user rosters (seasons[].teams[]) and draft
-            // picks (picks[].team) — otherwise Standings / My Team / Draft Room
-            // keep showing the old logos even though the teams collection updated.
-            // Global (not year-scoped): a team's logo is the same across seasons.
-            const map = logosById(allTeams);
+            // Propagate the fresh team fields (logos, school, mascot, colors, …)
+            // into the denormalized copies the app actually renders from — user
+            // rosters (seasons[].teams[]) and draft picks (picks[].team) —
+            // otherwise Standings / My Team / Draft Room keep showing stale team
+            // info even though the teams collection updated. Display fields are
+            // global (same across seasons); see modules/team-refresh.js for which
+            // are synced and why conference is deliberately excluded.
+            const map = teamsById(allTeams);
 
             let rostersSynced = 0;
             const users = await User.find({ 'seasons.teams.0': { $exists: true } });
             for (const u of users) {
                 let changed = 0;
-                (u.seasons || []).forEach(s => { changed += applyLogos(s.teams, map); });
+                (u.seasons || []).forEach(s => { changed += applyTeamFields(s.teams, map); });
                 if (changed) { await u.save(); rostersSynced++; }
             }
 
@@ -505,10 +507,10 @@ router.post('/refresh', async (req, res) => {
             for (const d of drafts) {
                 // picks[].team is Mixed, so mutate the team objects then flag the
                 // path for mongoose to persist.
-                const changed = applyLogos((d.picks || []).map(p => p.team), map);
+                const changed = applyTeamFields((d.picks || []).map(p => p.team), map);
                 if (changed) { d.markModified('picks'); await d.save(); draftsSynced++; }
             }
-            console.log(`Logo propagation: ${rostersSynced} rosters, ${draftsSynced} drafts updated`);
+            console.log(`Team propagation: ${rostersSynced} rosters, ${draftsSynced} drafts updated`);
 
             var returnedTeams = {
                 newTeams: newCreatedTeams,

--- a/tests/TeamRefresh.spec.js
+++ b/tests/TeamRefresh.spec.js
@@ -1,0 +1,63 @@
+const { logosById, applyLogos, sameLogos } = require('../modules/team-refresh');
+
+describe('logosById', () => {
+    test('maps team id -> logos array', () => {
+        const map = logosById([
+            { id: 333, logos: ['a', 'b'] },
+            { id: 239, logos: ['c'] }
+        ]);
+        expect(map).toEqual({ 333: ['a', 'b'], 239: ['c'] });
+    });
+    test('skips teams without an id or a logos array', () => {
+        expect(logosById([{ id: 1 }, { logos: ['x'] }, null])).toEqual({});
+    });
+});
+
+describe('sameLogos', () => {
+    test('true only when arrays match element-for-element', () => {
+        expect(sameLogos(['a', 'b'], ['a', 'b'])).toBe(true);
+        expect(sameLogos(['a', 'b'], ['a', 'c'])).toBe(false);
+        expect(sameLogos(['a'], ['a', 'b'])).toBe(false);
+        expect(sameLogos(undefined, ['a'])).toBe(false);
+    });
+});
+
+describe('applyLogos', () => {
+    const NEW_333 = ['https://cdn.collegefootballdata.com/logos-dark/500/333.png'];
+
+    test('overwrites embedded logos from the map and counts changes', () => {
+        const teams = [
+            { id: 333, logos: ['http://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png'] },
+            { id: 239, logos: ['old-239'] }
+        ];
+        const map = { 333: NEW_333, 239: ['old-239'] };   // 239 already current
+        const changed = applyLogos(teams, map);
+        expect(changed).toBe(1);                            // only 333 changed
+        expect(teams[0].logos).toEqual(NEW_333);
+        expect(teams[1].logos).toEqual(['old-239']);
+    });
+
+    test('re-running is a no-op (idempotent)', () => {
+        const teams = [{ id: 333, logos: NEW_333.slice() }];
+        expect(applyLogos(teams, { 333: NEW_333 })).toBe(0);
+    });
+
+    test('leaves teams not in the map untouched', () => {
+        const teams = [{ id: 999, logos: ['keep'] }];
+        expect(applyLogos(teams, { 333: NEW_333 })).toBe(0);
+        expect(teams[0].logos).toEqual(['keep']);
+    });
+
+    test('copies the array (no shared reference back to the map)', () => {
+        const teams = [{ id: 333, logos: ['old'] }];
+        const src = ['x', 'y'];
+        applyLogos(teams, { 333: src });
+        expect(teams[0].logos).toEqual(src);
+        expect(teams[0].logos).not.toBe(src);   // defensive copy
+    });
+
+    test('handles empty / missing inputs', () => {
+        expect(applyLogos([], { 333: NEW_333 })).toBe(0);
+        expect(applyLogos(undefined, {})).toBe(0);
+    });
+});

--- a/tests/TeamRefresh.spec.js
+++ b/tests/TeamRefresh.spec.js
@@ -1,63 +1,73 @@
-const { logosById, applyLogos, sameLogos } = require('../modules/team-refresh');
+const { teamsById, applyTeamFields, sameArray } = require('../modules/team-refresh');
 
-describe('logosById', () => {
-    test('maps team id -> logos array', () => {
-        const map = logosById([
-            { id: 333, logos: ['a', 'b'] },
-            { id: 239, logos: ['c'] }
-        ]);
-        expect(map).toEqual({ 333: ['a', 'b'], 239: ['c'] });
+describe('teamsById', () => {
+    test('maps team id -> source team object', () => {
+        const map = teamsById([{ id: 333, school: 'Alabama' }, { id: 239, school: 'Baylor' }]);
+        expect(map[333].school).toBe('Alabama');
+        expect(map[239].school).toBe('Baylor');
     });
-    test('skips teams without an id or a logos array', () => {
-        expect(logosById([{ id: 1 }, { logos: ['x'] }, null])).toEqual({});
+    test('skips teams without an id', () => {
+        expect(teamsById([{ school: 'x' }, null])).toEqual({});
     });
 });
 
-describe('sameLogos', () => {
+describe('sameArray', () => {
     test('true only when arrays match element-for-element', () => {
-        expect(sameLogos(['a', 'b'], ['a', 'b'])).toBe(true);
-        expect(sameLogos(['a', 'b'], ['a', 'c'])).toBe(false);
-        expect(sameLogos(['a'], ['a', 'b'])).toBe(false);
-        expect(sameLogos(undefined, ['a'])).toBe(false);
+        expect(sameArray(['a', 'b'], ['a', 'b'])).toBe(true);
+        expect(sameArray(['a', 'b'], ['a', 'c'])).toBe(false);
+        expect(sameArray(['a'], ['a', 'b'])).toBe(false);
+        expect(sameArray(undefined, ['a'])).toBe(false);
     });
 });
 
-describe('applyLogos', () => {
-    const NEW_333 = ['https://cdn.collegefootballdata.com/logos-dark/500/333.png'];
+describe('applyTeamFields', () => {
+    const NEW_LOGOS = ['https://cdn.collegefootballdata.com/logos-dark/500/333.png'];
+    const src333 = {
+        id: 333, school: 'Louisiana State', mascot: 'Tigers', abbreviation: 'LSU',
+        color: '#461D7C', alt_color: '#FDD023', twitter: '@LSUfootball',
+        logos: NEW_LOGOS, alternateNames: ['LSU', 'Louisiana State']
+    };
 
-    test('overwrites embedded logos from the map and counts changes', () => {
-        const teams = [
-            { id: 333, logos: ['http://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png'] },
-            { id: 239, logos: ['old-239'] }
-        ];
-        const map = { 333: NEW_333, 239: ['old-239'] };   // 239 already current
-        const changed = applyLogos(teams, map);
-        expect(changed).toBe(1);                            // only 333 changed
-        expect(teams[0].logos).toEqual(NEW_333);
-        expect(teams[1].logos).toEqual(['old-239']);
+    test('overwrites the synced display fields, including a renamed school', () => {
+        const teams = [{ id: 333, school: 'Louisiana St.', mascot: 'Tigers', logos: ['old.png'] }];
+        const changed = applyTeamFields(teams, teamsById([src333]));
+        expect(changed).toBe(1);
+        expect(teams[0].school).toBe('Louisiana State');   // rename flows through
+        expect(teams[0].logos).toEqual(NEW_LOGOS);
+        expect(teams[0].abbreviation).toBe('LSU');
+        expect(teams[0].alternateNames).toEqual(['LSU', 'Louisiana State']);
     });
 
     test('re-running is a no-op (idempotent)', () => {
-        const teams = [{ id: 333, logos: NEW_333.slice() }];
-        expect(applyLogos(teams, { 333: NEW_333 })).toBe(0);
+        const teams = [{ id: 333, school: 'Louisiana State', mascot: 'Tigers', abbreviation: 'LSU',
+            color: '#461D7C', alt_color: '#FDD023', twitter: '@LSUfootball',
+            logos: NEW_LOGOS.slice(), alternateNames: ['LSU', 'Louisiana State'] }];
+        expect(applyTeamFields(teams, teamsById([src333]))).toBe(0);
+    });
+
+    test('does NOT touch conference/division/id (year-sensitive or the join key)', () => {
+        const teams = [{ id: 333, school: 'Old', conference: 'SEC (2024)', division: 'West' }];
+        applyTeamFields(teams, teamsById([{ id: 333, school: 'New', conference: 'SEC', division: 'None' }]));
+        expect(teams[0].id).toBe(333);
+        expect(teams[0].conference).toBe('SEC (2024)');
+        expect(teams[0].division).toBe('West');
     });
 
     test('leaves teams not in the map untouched', () => {
-        const teams = [{ id: 999, logos: ['keep'] }];
-        expect(applyLogos(teams, { 333: NEW_333 })).toBe(0);
-        expect(teams[0].logos).toEqual(['keep']);
+        const teams = [{ id: 999, school: 'Keep' }];
+        expect(applyTeamFields(teams, teamsById([src333]))).toBe(0);
+        expect(teams[0].school).toBe('Keep');
     });
 
-    test('copies the array (no shared reference back to the map)', () => {
+    test('copies arrays (no shared reference back to the source)', () => {
         const teams = [{ id: 333, logos: ['old'] }];
-        const src = ['x', 'y'];
-        applyLogos(teams, { 333: src });
-        expect(teams[0].logos).toEqual(src);
-        expect(teams[0].logos).not.toBe(src);   // defensive copy
+        applyTeamFields(teams, teamsById([src333]));
+        expect(teams[0].logos).toEqual(NEW_LOGOS);
+        expect(teams[0].logos).not.toBe(NEW_LOGOS);
     });
 
     test('handles empty / missing inputs', () => {
-        expect(applyLogos([], { 333: NEW_333 })).toBe(0);
-        expect(applyLogos(undefined, {})).toBe(0);
+        expect(applyTeamFields([], teamsById([src333]))).toBe(0);
+        expect(applyTeamFields(undefined, {})).toBe(0);
     });
 });


### PR DESCRIPTION
## The bug this started from

You refreshed teams, Mongo's `teams` collection had the new CFBD logos — but Standings still showed ESPN. Not caching: the app renders team info from **denormalized snapshots** taken at draft time (`users.seasons[].teams[]` and `drafts.picks[].team`), and `/teams/refresh` only updated the source collection.

## What it does now

After refreshing the `teams` collection, propagate the **full safe display set** into those embedded copies (matched by team id):

`school`, `mascot`, `abbreviation`, `color`, `alt_color`, `twitter`, `logos`, `alternateNames`.

Deliberately **not** synced: `id` (the join key) and `conference` / `division` (year-sensitive — a global overwrite would mislabel past seasons for teams that changed leagues). Idempotent: only changed fields save, so re-running is a cheap no-op. Draft `picks[].team` is `Mixed`, so it's `markModified`'d. Response reports `rostersSynced` / `draftsSynced`.

## Why `school` needed a refactor first

`school` isn't just a label — `scoreByTeam` stores the school *string* at scoring time, and several point-sums matched on it (`st.team === team.school`). Overwriting a rosterʼs `school` on a rename (`Louisiana St.` → `Louisiana State`) would strand that teamʼs already-scored points, because the stored strings still said the old name.

So those aggregations now match by the **stable `teamId`, with a school fallback** for any legacy entry lacking one — a strict superset that never sums *less*:

- `standings-insights` team totals
- `userHome` `bestTeam` + `columnTeamScore` (+ callers)
- `weekly-recap` MVP aggregation, logo lookup (`metaById`), and upset logo

With that in place, `school` is safe to sync, so a CFBD rename now flows into rosters on refresh without dropping points anywhere.

## How to use (after deploy)

Run admin **Refresh** (year 2025 is fine). It re-syncs the teams collection and propagates into rosters + drafts. Standings/My Team/Draft Room then show the crisp `logos-dark/500` logos (and any corrected names). `pickLogo` (#249) is already live, so the new arrays render as dark-500, not the blurry 16px.

## Testing

- `tests/TeamRefresh.spec.js` — field set incl. a renamed `school`, idempotent re-run, excluded `conference`/`division`/`id`, defensive array copy, empty inputs.
- Existing `WeeklyRecap` tests still green with the teamId-based MVP/logo lookup.
- Full suite **270/270**. `node --check` clean.
- The propagation + client aggregations run behind auth + data, so they're covered via the pure helpers/tests rather than an in-app screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)