### PR TITLE
Preseason polish: My Team, Standings & Team pages

### DIFF
--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -42,6 +42,9 @@ export function rankedRows(users) {
     }
 
     const leader = sorted.length ? cum(sorted[0]) : 0;
+    // Preseason: nobody has scored yet, so there's no real leader or ranking —
+    // rows render as a flat tie (no crown, no medals) instead of an arbitrary #1.
+    const preseason = leader <= 0;
     return sorted.map((u, i) => ({
         rank: i + 1,
         id: u._id,
@@ -53,6 +56,7 @@ export function rankedRows(users) {
         teams: season(u).teams || [],
         score: cum(u),
         gap: i === 0 ? 0 : leader - cum(u),
+        preseason: preseason,
         delta: (prevRankById && prevRankById[u._id] != null) ? (prevRankById[u._id] - i) : null
     }));
 }
@@ -104,7 +108,7 @@ export function standingsHeadHtml(h2h) {
         return `<tr>
             <th class="team-header"></th>
             <th class="team-header"></th>
-            <th class="team-header h2h-teams-head" style="text-align: center;">Teams</th>
+            <th class="team-header h2h-teams-head teams-col" style="text-align: center;">Teams</th>
             <th class="team-header rec-head">Record</th>
             <th class="team-header score-head">Total</th>
             <th class="team-header h2h-caret-head"></th>
@@ -113,13 +117,14 @@ export function standingsHeadHtml(h2h) {
     return `<tr>
         <th class="sticky-header team-header"></th>
         <th class="sticky-header team-header"></th>
-        <th class="team-header" style="text-align: center;">Teams</th>
+        <th class="team-header teams-col" style="text-align: center;">Teams</th>
         <th class="sticky-header-score team-header">Score</th>
     </tr>`;
 }
 
 // The leader/movement/gap treatment is shared; only the middle differs.
 function gapHtml(r) {
+    if (r.preseason) return '<span class="gap">Tied</span>';
     return r.rank === 1
         ? '<span class="gap leader">Leader</span>'
         : (r.gap === 0 ? '<span class="gap">Tied</span>' : `<span class="gap">-${r.gap} back</span>`);
@@ -139,7 +144,7 @@ function inlineTeamLogos(teams) {
 // team-logo strip filling the middle · score. This is the original layout — the
 // logos are what make the wide row read as full, not empty.
 function classicRowHtml(r) {
-    const medal = r.rank <= 3 ? ` medal-${r.rank}` : '';
+    const medal = (!r.preseason && r.rank <= 3) ? ` medal-${r.rank}` : '';
     return `<tr class="standings-row${medal}">
         <th class="sticky-header rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</th>
         <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${stdAvatarHtml(r)}<span class="std-name">${escapeHtml(r.franchise || r.name)}</span></a></th>
@@ -153,7 +158,7 @@ function classicRowHtml(r) {
 // Reuses the classic `.standings-row.medal-1` / `.rank-num` / `.score-num`
 // classes so the leader animation and score count-up carry over.
 function h2hRowHtml(r) {
-    const medal = r.rank <= 3 ? ` medal-${r.rank}` : '';
+    const medal = (!r.preseason && r.rank <= 3) ? ` medal-${r.rank}` : '';
     const logos = (r.teams || []).map(teamLogoLink).join('');
     const who = escapeHtml(r.franchise || r.name);
     return `<tr class="standings-row${medal}">

--- a/public/standings.css
+++ b/public/standings.css
@@ -861,3 +861,11 @@
     .mode-h2h .standings-row .score-cell,
     .fl-table.mode-h2h thead th.score-head { padding-right: 1.6rem; }
 }
+
+/* Preseason / undrafted: no rosters yet, so the Teams column (and its mobile
+   expand caret) would be empty — hide the whole column until the draft fills
+   it. The table carries .std-no-teams when no manager has any teams. */
+.std-no-teams .teams-col,
+.std-no-teams .team-item,
+.std-no-teams .h2h-caret-head,
+.std-no-teams .expand-cell { display: none; }

--- a/public/standings.js
+++ b/public/standings.js
@@ -132,9 +132,13 @@ async function getUsers() {
             loadProjections(leagueCode, data[0]?.seasons?.[0]?.season);
             displaySchedule(data);
             seedUserIdFromEmail(userMetadata, usersData);
-            // Chart is responsive now, so show it on mobile too.
-            setChartData(data);
-            document.querySelector('[chart-container]').removeAttribute("style");
+            // Chart is responsive now, so show it on mobile too — but only once
+            // the season has scored weeks. Preseason has nothing to plot, so the
+            // chart stays hidden instead of showing an empty axis.
+            if (latestWeek(data) > 0) {
+                setChartData(data);
+                document.querySelector('[chart-container]').removeAttribute("style");
+            }
         }
     });
 }
@@ -197,7 +201,12 @@ function renderStandingsTable(rows, opts) {
     // middle); the points-only table has fewer columns, so it centres at its
     // content width instead of stretching name and score to opposite edges.
     const table = (head && head.closest('table')) || (body && body.closest('table'));
-    if (table) { table.classList.toggle('mode-h2h', h2h); table.classList.toggle('mode-plain', !h2h); }
+    if (table) {
+        table.classList.toggle('mode-h2h', h2h);
+        table.classList.toggle('mode-plain', !h2h);
+        // Preseason / undrafted: no rosters yet, so hide the empty Teams column.
+        table.classList.toggle('std-no-teams', !rows.some(r => (r.teams || []).length));
+    }
     if (head) head.innerHTML = standingsHeadHtml(h2h);
     if (body) {
         body.innerHTML = buildStandingsRowsHtml(rows, { h2h });
@@ -427,6 +436,7 @@ async function loadH2HMatchups(league, season, sim) {
 function h2hRows(d) {
     const managers = (d.managers || []).slice();
     const leader = managers.length ? managers[0].adjustedTotal : 0;
+    const preseason = leader <= 0;   // no points scored yet → flat tie, no crown
     const deltaById = {};
     try { rankedRows(usersData || []).forEach(r => { deltaById[r.id] = r.delta; }); } catch (e) { /* movement is best-effort */ }
     return managers.map((m, i) => ({
@@ -440,6 +450,7 @@ function h2hRows(d) {
         teams: m.teams || [],
         score: m.adjustedTotal,
         gap: i === 0 ? 0 : Math.round((leader - m.adjustedTotal) * 10) / 10,
+        preseason: preseason,
         delta: deltaById[m.userId] != null ? deltaById[m.userId] : null,
         record: m.record || '',
         base: Math.round((m.adjustedTotal - m.h2hBonus) * 10) / 10,

--- a/public/team.css
+++ b/public/team.css
@@ -754,6 +754,7 @@
 
 /* Outlook ratings as accent-tinted chips (SP+/FPI/talent/returning). */
 .outlook-chips { display: flex; flex-wrap: wrap; gap: 0.4em; margin-top: 0.35em; }
+.outlook-note { font-size: 0.72rem; color: #767D9C; margin: 0.5em 0 0; line-height: 1.4; }
 .outlook-chip {
     font-size: 0.8rem;
     font-weight: 700;

--- a/public/team.js
+++ b/public/team.js
@@ -480,18 +480,24 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
 
     // Win/loss form strip + expected-wins comparison.
     var form = computeForm(schedule, team.id);
+    var played = form.length;   // completed games — 0 means the season hasn't started
     var wins = record?.total?.wins ?? form.filter(f => f.win).length;
     var expected = seasonObj.expectedWins;
     var formStrip = form.slice(-6).map(f =>
         `<span class="form-dot ${f.win ? 'form-win' : 'form-loss'}" title="${f.us}-${f.them}">${f.win ? 'W' : 'L'}</span>`
     ).join('');
 
-    var expectedHtml = (expected != null)
-        ? `<p class="score expected-wins">${wins} actual vs ${Number(expected).toFixed(1)} expected
-             <span class="ew-delta ${wins - expected >= 0 ? 'ew-up' : 'ew-down'}">
-                ${wins - expected >= 0 ? '▲' : '▼'} ${Math.abs(wins - expected).toFixed(1)}
-             </span></p>`
-        : '';
+    // Preseason (no games yet): show the projection on its own — a red "actual vs
+    // expected" delta against zero wins reads as a shortfall the team hasn't had.
+    var expectedHtml = '';
+    if (expected != null) {
+        expectedHtml = (played === 0)
+            ? `<p class="score expected-wins">${Number(expected).toFixed(1)} projected wins</p>`
+            : `<p class="score expected-wins">${wins} actual vs ${Number(expected).toFixed(1)} expected
+                 <span class="ew-delta ${wins - expected >= 0 ? 'ew-up' : 'ew-down'}">
+                    ${wins - expected >= 0 ? '▲' : '▼'} ${Math.abs(wins - expected).toFixed(1)}
+                 </span></p>`;
+    }
 
     // "Drafted by" — ties the team back to its fantasy manager for the season.
     var ownerHtml = owner
@@ -501,8 +507,9 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
            </a>`
         : `<span class="team-owner team-owner--undrafted"><i class="fa-solid fa-user-slash"></i> Undrafted</span>`;
 
-    // National fantasy-scoring rank alongside the raw point total.
-    var rankHtml = fantasyRank
+    // National fantasy-scoring rank alongside the raw point total — only once the
+    // team has actually scored (a rank at 0 points is an arbitrary preseason tie).
+    var rankHtml = (fantasyRank && seasonScore > 0)
         ? `<span class="fantasy-rank">#<span data-countup="${fantasyRank.rank}">0</span> of ${fantasyRank.total}</span>`
         : '';
 
@@ -529,7 +536,13 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
     if (seasonObj.returningProduction != null) {
         outlookChips.push(`<span class="outlook-chip" title="Share of last season's production (PPA) returning">${seasonObj.returningProduction}% returning</span>`);
     }
-    var outlookHtml = outlookChips.length ? `<div><h4>${window.ccIcon ? window.ccIcon('chart', { size: 21 }) : ''} Outlook</h4><div class="outlook-chips">${outlookChips.join('')}</div></div>` : '';
+    // Preseason: SP+/talent/returning are season-fixed and land only once CFBD
+    // publishes them (FPI/coach arrive earlier). When they're still missing on a
+    // not-yet-started season, note it so the lone FPI chip doesn't read as broken.
+    var outlookNote = (played === 0 && seasonObj.spRank == null && outlookChips.length)
+        ? `<p class="outlook-note">SP+, talent &amp; returning production post closer to kickoff.</p>`
+        : '';
+    var outlookHtml = outlookChips.length ? `<div><h4>${window.ccIcon ? window.ccIcon('chart', { size: 21 }) : ''} Outlook</h4><div class="outlook-chips">${outlookChips.join('')}</div>${outlookNote}</div>` : '';
 
     // Set the tab title to the team being viewed.
     document.title = `${team.school} ${team.mascot} · Campus Clash`;

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -811,10 +811,10 @@ body.uh-drawer-open { overflow: hidden; }
 .uh-mode-h { display: flex; align-items: center; gap: 9px; font-size: 14px; font-weight: 700; color: #F4F6FB; }
 .uh-mode-i { width: 28px; height: 28px; border-radius: 8px; flex: none; display: flex; align-items: center; justify-content: center; font-size: 15px; font-weight: 800; }
 .uh-mode-i.cap { background: rgba(142,140,240,0.16); color: #8E8CF0; }
-.uh-mode-i.h2h { background: rgba(232,105,95,0.16); color: #E8695F; }
+.uh-mode-i.h2h { background: rgba(224,179,65,0.16); color: #E0B341; }
 .uh-mode-b { margin-left: auto; font-size: 12px; font-weight: 800; padding: 4px 8px; border-radius: 7px; font-variant-numeric: tabular-nums; }
 .uh-mode-b.cap { color: #8E8CF0; background: rgba(142,140,240,0.14); }
-.uh-mode-b.h2h { color: #E8695F; background: rgba(232,105,95,0.14); }
+.uh-mode-b.h2h { color: #E0B341; background: rgba(224,179,65,0.14); }
 .uh-mode-d { font-size: 12.5px; line-height: 1.5; color: #A4A9C2; margin-top: 10px; }
 .uh-mode-d b { color: #F4F6FB; font-weight: 600; }
 

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -752,3 +752,83 @@ body.uh-drawer-open { overflow: hidden; }
 /* Draft-grade card in the drawer: plain page-style border (no tier left-accent
    or "you" highlight — it's always your own grade on My Team). */
 .uh-drawer-body .gg-card { border-left: 1px solid #2A2E42; box-shadow: none; }
+
+/* ============================================================
+   Preseason My Team (feat/my-team-preseason)
+   Draft countdown · get-ready checklist · last season · new
+   game modes · franchise history. Tokens mirror the bento above
+   (#1A1F33 tile, #101322 inset, #2A2E42 border, #8E8CF0 purple,
+   #6C9BFF blue, #5BD08D green, #E0B341 gold).
+   ============================================================ */
+
+/* draft countdown */
+.uh-pre-draft { display: flex; flex-direction: column; background: linear-gradient(180deg, #1d2540, #1A1F33); border-color: rgba(108,155,255,0.28); }
+.uh-pre-draft .uh-tlabel { color: #6C9BFF; }
+.uh-pd-h { font-size: 19px; font-weight: 800; color: #F4F6FB; margin: 2px 0 0; text-wrap: balance; }
+.uh-pd-sub { font-size: 14px; color: #A4A9C2; margin: 8px 0 0; line-height: 1.5; }
+.uh-clock { display: flex; gap: 10px; margin: 16px 0 4px; }
+.uh-unit { flex: 1; background: #101322; border: 1px solid #2A2E42; border-radius: 12px; padding: 12px 6px; text-align: center; }
+.uh-unit-n { font-size: 28px; font-weight: 800; color: #fff; line-height: 1; font-variant-numeric: tabular-nums; }
+.uh-unit-l { font-size: 10px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: #767D9C; margin-top: 7px; }
+.uh-pd-meta { display: flex; flex-wrap: wrap; gap: 8px 16px; color: #A4A9C2; font-size: 12.5px; margin-top: 14px; }
+.uh-pd-meta b { color: #F4F6FB; font-weight: 600; }
+.uh-pd-cta { margin-top: 16px; display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 18px; border-radius: 12px; background: linear-gradient(180deg, #7aa2f5, #6C9BFF); color: #08122a; font-weight: 700; font-size: 14px; text-decoration: none; }
+.uh-pd-cta:hover { filter: brightness(1.05); }
+
+/* get draft-ready checklist */
+.uh-check-prog { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.uh-bar { flex: 1; height: 7px; border-radius: 99px; background: #2A2E42; overflow: hidden; }
+.uh-bar > i { display: block; height: 100%; border-radius: 99px; background: linear-gradient(90deg, #5BD08D, #8ee9bb); }
+.uh-check-prog b { font-size: 12px; font-weight: 700; color: #5BD08D; font-variant-numeric: tabular-nums; }
+.uh-checks { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+.uh-checks li { display: flex; align-items: center; gap: 12px; padding: 10px 2px; }
+.uh-checks li + li { border-top: 1px solid #2A2E42; }
+.uh-box { width: 22px; height: 22px; border-radius: 7px; flex: none; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 800; }
+.uh-box.done { background: #5BD08D; color: #08210f; }
+.uh-box.todo { border: 1.5px dashed #3A3F58; color: #767D9C; }
+.uh-ci { flex: 1; min-width: 0; }
+.uh-ci-t { display: block; font-size: 13.5px; font-weight: 600; color: #F4F6FB; }
+.uh-ci-d { display: block; font-size: 12px; color: #767D9C; margin-top: 1px; }
+.uh-checks li.is-done .uh-ci-t { color: #A4A9C2; }
+.uh-ci-go { font-size: 12px; font-weight: 700; color: #6C9BFF; white-space: nowrap; text-decoration: none; }
+.uh-ci-go:hover { text-decoration: underline; }
+
+/* last-season recap */
+.uh-pre-recap-stats { display: flex; gap: 12px; margin-bottom: 12px; }
+.uh-pre-stat { flex: 1; background: #101322; border: 1px solid #2A2E42; border-radius: 12px; padding: 11px 12px; }
+.uh-pre-stat-v { font-size: 20px; font-weight: 800; color: #F4F6FB; display: flex; align-items: center; gap: 6px; font-variant-numeric: tabular-nums; }
+.uh-pre-stat-v img { height: 18px; width: auto; }
+.uh-pre-stat-k { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: #767D9C; margin-top: 6px; }
+.uh-pre-spark { margin-top: 2px; }
+
+/* new game modes */
+.uh-pre-modes .uh-tlabel { color: #8E8CF0; }
+.uh-mode-only { margin-left: 8px; font-size: 9.5px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: #8E8CF0; background: rgba(142,140,240,0.14); border: 1px solid rgba(142,140,240,0.32); padding: 3px 6px; border-radius: 6px; }
+.uh-modes-intro { font-size: 13px; color: #A4A9C2; margin: 0 0 12px; }
+.uh-modes { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+@media (max-width: 560px) { .uh-modes { grid-template-columns: 1fr; } }
+.uh-mode { background: #101322; border: 1px solid #2A2E42; border-radius: 12px; padding: 14px; }
+.uh-mode-h { display: flex; align-items: center; gap: 9px; font-size: 14px; font-weight: 700; color: #F4F6FB; }
+.uh-mode-i { width: 28px; height: 28px; border-radius: 8px; flex: none; display: flex; align-items: center; justify-content: center; font-size: 15px; font-weight: 800; }
+.uh-mode-i.cap { background: rgba(142,140,240,0.16); color: #8E8CF0; }
+.uh-mode-i.h2h { background: rgba(232,105,95,0.16); color: #E8695F; }
+.uh-mode-b { margin-left: auto; font-size: 12px; font-weight: 800; padding: 4px 8px; border-radius: 7px; font-variant-numeric: tabular-nums; }
+.uh-mode-b.cap { color: #8E8CF0; background: rgba(142,140,240,0.14); }
+.uh-mode-b.h2h { color: #E8695F; background: rgba(232,105,95,0.14); }
+.uh-mode-d { font-size: 12.5px; line-height: 1.5; color: #A4A9C2; margin-top: 10px; }
+.uh-mode-d b { color: #F4F6FB; font-weight: 600; }
+
+/* franchise history */
+.uh-hist { display: flex; flex-direction: column; }
+.uh-hist-row { display: flex; align-items: baseline; gap: 14px; padding: 12px 2px; }
+.uh-hist-row + .uh-hist-row { border-top: 1px solid #2A2E42; }
+.uh-hist-year { font-size: 15px; font-weight: 800; color: #767D9C; width: 36px; flex: none; }
+.uh-hist-body { flex: 1; min-width: 0; }
+.uh-hist-fran { font-size: 12.5px; font-weight: 700; color: #F4F6FB; margin-bottom: 7px; }
+.uh-hist-none { color: #767D9C; font-weight: 600; font-style: italic; }
+.uh-hist-teams { display: flex; flex-wrap: wrap; gap: 6px; }
+.uh-hist-chip { font-size: 11.5px; font-weight: 600; padding: 5px 9px; border-radius: 7px; background: #101322; border: 1px solid #2A2E42; color: #A4A9C2; white-space: nowrap; }
+.uh-hist-chip.r1 { color: #F4F6FB; border-color: #3A3F58; }
+.uh-hist-star { color: #E0B341; font-size: 10px; margin-right: 2px; }
+.uh-hist-chip.more { color: #767D9C; background: transparent; border-style: dashed; }
+.uh-hist-note { font-size: 11.5px; color: #767D9C; margin: 12px 0 0; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -827,9 +827,13 @@ body.uh-drawer-open { overflow: hidden; }
 .uh-hist-fran { font-size: 12.5px; font-weight: 700; color: #F4F6FB; margin-bottom: 7px; }
 .uh-hist-none { color: #767D9C; font-weight: 600; font-style: italic; }
 .uh-hist-teams { display: flex; flex-wrap: wrap; gap: 6px; }
-.uh-hist-chip { font-size: 11.5px; font-weight: 600; padding: 5px 9px; border-radius: 7px; background: #101322; border: 1px solid #2A2E42; color: #A4A9C2; white-space: nowrap; }
+.uh-hist-chip { display: inline-flex; align-items: center; font-size: 11.5px; font-weight: 600; padding: 5px 9px; border-radius: 7px; background: #101322; border: 1px solid #2A2E42; color: #A4A9C2; white-space: nowrap; }
 .uh-hist-chip.r1 { color: #F4F6FB; border-color: #3A3F58; }
 .uh-hist-star { color: #E0B341; font-size: 10px; margin-right: 2px; }
 .uh-hist-pts { color: #5BD08D; font-weight: 700; font-variant-numeric: tabular-nums; margin-left: 4px; }
-.uh-hist-chip.more { color: #767D9C; background: transparent; border-style: dashed; }
+.uh-hist-extra { display: none; }
+.uh-hist-teams.is-open .uh-hist-extra { display: inline-flex; }
+.uh-hist-more { font: inherit; font-size: 11.5px; font-weight: 600; padding: 5px 9px; border-radius: 7px; background: transparent; border: 1px dashed #3A3F58; color: #767D9C; cursor: pointer; white-space: nowrap; }
+.uh-hist-more:hover { color: #C9CEE6; border-color: #4A4F68; }
+.uh-hist-more:focus-visible { outline: 2px solid #6C9BFF; outline-offset: 2px; }
 .uh-hist-note { font-size: 11.5px; color: #767D9C; margin: 12px 0 0; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -830,5 +830,6 @@ body.uh-drawer-open { overflow: hidden; }
 .uh-hist-chip { font-size: 11.5px; font-weight: 600; padding: 5px 9px; border-radius: 7px; background: #101322; border: 1px solid #2A2E42; color: #A4A9C2; white-space: nowrap; }
 .uh-hist-chip.r1 { color: #F4F6FB; border-color: #3A3F58; }
 .uh-hist-star { color: #E0B341; font-size: 10px; margin-right: 2px; }
+.uh-hist-pts { color: #5BD08D; font-weight: 700; font-variant-numeric: tabular-nums; margin-left: 4px; }
 .uh-hist-chip.more { color: #767D9C; background: transparent; border-style: dashed; }
 .uh-hist-note { font-size: 11.5px; color: #767D9C; margin: 12px 0 0; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -419,7 +419,7 @@ async function hydratePreseasonModes(user, activeYear) {
         <div class="uh-mode-d">Each week, name one of your teams captain — its points count <b>double</b>. A boom-or-bust roster swings games.</div>
     </div>`);
     if (eng.h2hEnabled) cards.push(`<div class="uh-mode">
-        <div class="uh-mode-h"><span class="uh-mode-i h2h">⚔</span>Head-to-head<span class="uh-mode-b h2h">+${eng.h2hWinBonus || 3}</span></div>
+        <div class="uh-mode-h"><span class="uh-mode-i h2h">${window.ccIcon ? window.ccIcon('swords', { size: 16 }) : '⚔'}</span>Head-to-head<span class="uh-mode-b h2h">+${eng.h2hWinBonus || 3}</span></div>
         <div class="uh-mode-d">You’re matched against a different manager every week. Outscore them for a <b>+${eng.h2hWinBonus || 3}</b> win bonus on top of your points.</div>
     </div>`);
 

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -247,6 +247,14 @@ function renderPreseason(bento, data, activeYear, ctx) {
         try { window.localStorage.setItem('cc_seen_rules_' + activeYear, '1'); } catch (e) { /* private mode */ }
     });
 
+    // Franchise history: expand/collapse the teams beyond the first four.
+    bento.querySelectorAll('.uh-hist-more').forEach(btn => btn.addEventListener('click', () => {
+        const teams = btn.closest('.uh-hist-teams');
+        if (!teams) return;
+        const open = teams.classList.toggle('is-open');
+        btn.textContent = open ? 'Show less' : btn.getAttribute('data-more');
+    }));
+
     hydratePreseasonDraft(data, activeYear);
     hydratePreseasonModes(data, activeYear);
 }
@@ -309,12 +317,15 @@ function preHistoryHtml(data, activeYear) {
         const bestId = (best && best.total > 0) ? best.team.id : null;
         const ordered = (bestId != null ? [best.team] : [])
             .concat(teams.filter(t => bestId == null || Number(t.id) !== Number(bestId)));
-        const chips = ordered.slice(0, 4).map(t => {
+        // Render every team; chips past the first 4 are hidden until the manager
+        // taps "+N more" (wired in renderPreseason to toggle the row open).
+        const chips = ordered.map((t, i) => {
             const isBest = bestId != null && Number(t.id) === Number(bestId);
             const pts = isBest ? ` <span class="uh-hist-pts num">${best.total}</span>` : '';
-            return `<span class="uh-hist-chip${isBest ? ' r1' : ''}">${isBest ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}${pts}</span>`;
+            return `<span class="uh-hist-chip${isBest ? ' r1' : ''}${i >= 4 ? ' uh-hist-extra' : ''}">${isBest ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}${pts}</span>`;
         }).join('');
-        const more = ordered.length > 4 ? `<span class="uh-hist-chip more">+${ordered.length - 4} more</span>` : '';
+        const moreN = ordered.length - 4;
+        const more = moreN > 0 ? `<button type="button" class="uh-hist-more" data-more="+${moreN} more">+${moreN} more</button>` : '';
         const fran = s.franchiseName ? escapeHtml(s.franchiseName) : `<span class="uh-hist-none">Unnamed franchise</span>`;
         return `<div class="uh-hist-row">
             <div class="uh-hist-year num">’${String(s.season).slice(2)}</div>

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -131,40 +131,16 @@ async function renderBento(data) {
     const own = currentUserId() && String(currentUserId()) === String(data._id);
     const pencil = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
 
-    // Preseason / undrafted window: the active season (APP_YEAR) hasn't been
-    // drafted for this manager yet — there's no season entry to key tiles off,
-    // so uhSeasonFor is only giving us a prior-season fallback. Rather than mix
-    // last season's data into a half-empty grid, show a dedicated empty state.
-    const hasActiveSeason = (data.seasons || []).some(s => String(s.season) === String(activeYear));
-    if (!hasActiveSeason) {
-        const prior = (data.seasons || [])
-            .filter(s => (s.weeklyScore || []).length)
-            .sort((a, b) => Number(b.season) - Number(a.season))[0];
-        let lastLine = '';
-        if (prior) {
-            const bt = bestTeam(prior);
-            lastLine = `<div class="uh-preseason-last">Last season · <b>${escapeHtml(prior.season)}</b> · ${prior.cumulativeScore || 0} pts`
-                + (bt && bt.total > 0 ? ` · best <b>${escapeHtml(bt.team.school)}</b> (${bt.total})` : '') + `</div>`;
-        }
-        const ball = window.ccIcon ? window.ccIcon('football', { size: 44 }) : '🏈';
-        bento.innerHTML =
-            `<div class="uh-tile span2 uh-hero">
-                <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
-                <div class="uh-hero-meta">
-                    <div class="uh-hero-name">${escapeHtml(franchise)}</div>
-                    <div class="uh-hero-sub">${escapeHtml(franchise ? ('Managed by ' + manager) : manager)}</div>
-                    <div class="uh-hero-stats"><span class="uh-preseason-pill">${escapeHtml(activeYear)} preseason</span></div>
-                </div>
-                ${own ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
-            </div>`
-            + `<div class="uh-tile span2 uh-preseason">
-                    <span class="uh-preseason-icon">${ball}</span>
-                    <h2 class="uh-preseason-h">The ${escapeHtml(activeYear)} season hasn’t kicked off yet</h2>
-                    <p class="uh-preseason-p">Your roster, matchups, and weekly recaps land here once your league’s draft is complete.</p>
-                    ${lastLine}
-                </div>`;
-        renderAvatar(document.getElementById('uh-hero-av'), data);
-        if (own) setupEditModal(data, season, false);   // no season yet → name locked
+    // Preseason: the active season (APP_YEAR) hasn't been *drafted* for this
+    // manager yet — either there's no season entry at all, or the Season Roster
+    // created one with an empty roster. Either way there's no roster or scoring to
+    // key the live tiles off, so render a dedicated preseason grid (draft
+    // countdown, get-ready checklist, last season, new game modes, franchise
+    // history) instead of a bento that silently empties itself.
+    const activeEntry = (data.seasons || []).find(s => String(s.season) === String(activeYear));
+    const isPreseason = !activeEntry || !((activeEntry.teams || []).length);
+    if (isPreseason) {
+        renderPreseason(bento, data, activeYear, { manager, own, pencil, activeEntry });
         return;
     }
 
@@ -214,6 +190,212 @@ async function renderBento(data) {
     hydrateRoster(data, activeYear);
     hydrateTrajectory(data, activeYear);
     hydrateGames(data, activeYear);
+}
+
+// ---------- Preseason My Team ----------
+// The active season exists but hasn't been drafted (empty roster) — or doesn't
+// exist yet. Instead of a self-emptying live grid, build a purposeful preseason
+// page from data we already have: a draft countdown, a get-ready checklist, last
+// season's recap, the league's new game modes (if any), and franchise history.
+var uhCountdownTimer = null;
+
+function renderPreseason(bento, data, activeYear, ctx) {
+    const { manager, own, pencil, activeEntry } = ctx;
+    const franchise = (activeEntry && activeEntry.franchiseName) || `${data.firstName || 'Unnamed'}'s Team`;
+    const hasName = !!(activeEntry && activeEntry.franchiseName);
+    const hasPhoto = !!(data.avatarUrl);
+
+    // Last completed season (with scores) for the recap tile.
+    const prior = (data.seasons || [])
+        .filter(s => String(s.season) !== String(activeYear) && (s.weeklyScore || []).length)
+        .sort((a, b) => Number(b.season) - Number(a.season))[0];
+
+    bento.innerHTML =
+        // identity
+        `<div class="uh-tile span2 uh-hero">
+            <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
+            <div class="uh-hero-meta">
+                <div class="uh-hero-name">${escapeHtml(franchise)}</div>
+                <div class="uh-hero-sub">Managed by ${escapeHtml(manager)}</div>
+                <div class="uh-hero-stats"><span class="uh-preseason-pill">${escapeHtml(activeYear)} preseason</span></div>
+            </div>
+            ${own ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
+        </div>`
+        // draft countdown (hydrated async)
+        + `<div class="uh-tile span2 uh-pre-draft" id="uh-pre-draft">
+                <span class="uh-tlabel">Your draft</span>
+                <div class="uh-pd-body"><p class="uh-stub">Checking the draft schedule…</p></div>
+            </div>`
+        // get draft-ready checklist
+        + preChecklistHtml(hasName, hasPhoto)
+        // last season recap
+        + preRecapHtml(prior)
+        // new game modes (hydrated async; hidden until confirmed on)
+        + `<div class="uh-tile span2 uh-pre-modes" id="uh-pre-modes" hidden></div>`
+        // franchise history
+        + preHistoryHtml(data, activeYear);
+
+    renderAvatar(document.getElementById('uh-hero-av'), data);
+    // Name is editable only once the manager has an active-season entry to write
+    // it onto; before that only the photo can be set.
+    if (own) setupEditModal(data, activeEntry || {}, !!activeEntry);
+
+    hydratePreseasonDraft(data, activeYear);
+    hydratePreseasonModes(data, activeYear);
+}
+
+function preChecklistHtml(hasName, hasPhoto) {
+    const done = (hasName ? 1 : 0) + (hasPhoto ? 1 : 0);
+    const pct = Math.round((done / 2) * 100);
+    const row = (isDone, title, desc, go) =>
+        `<li class="${isDone ? 'is-done' : ''}"><span class="uh-box ${isDone ? 'done' : 'todo'}">${isDone ? '✓' : '○'}</span>`
+        + `<span class="uh-ci"><span class="uh-ci-t">${title}</span><span class="uh-ci-d">${desc}</span></span>${go || ''}</li>`;
+    return `<div class="uh-tile uh-pre-check">
+        <span class="uh-tlabel">Get draft-ready</span>
+        <div class="uh-check-prog"><span class="uh-bar"><i style="width:${pct}%"></i></span><b>${done} / 2</b></div>
+        <ul class="uh-checks">
+            ${row(hasName, 'Name your franchise', hasName ? 'Set — you’re on the board.' : 'Stand out in the standings.')}
+            ${row(hasPhoto, 'Add a profile photo', hasPhoto ? 'Looking sharp.' : 'Put a face to the trash talk.')}
+            ${row(false, 'Review the scoring rules', 'Know how bonuses stack before you pick.', '<a class="uh-ci-go" href="/rules">Read ›</a>')}
+        </ul>
+    </div>`;
+}
+
+function preRecapHtml(prior) {
+    if (!prior) {
+        return `<div class="uh-tile uh-pre-recap">
+            <span class="uh-tlabel">Your history</span>
+            <p class="uh-stub">This is your first Campus Clash season — welcome. Your story starts at the draft.</p>
+        </div>`;
+    }
+    const bt = bestTeam(prior);
+    let cum = 0; const series = [];
+    weeklyColumns(prior).forEach(c => { if (!c.entry) return; cum += c.entry.score || 0; series.push(cum); });
+    const spark = series.length >= 2 ? `<div class="uh-pre-spark">${uhSpark(series, 240, 40, '#5BD08D')}</div>` : '';
+    const bestStat = (bt && bt.total > 0)
+        ? `<div class="uh-pre-stat"><span class="uh-pre-stat-v"><img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}</span><span class="uh-pre-stat-k">Best: ${escapeHtml(bt.team.school)}</span></div>`
+        : '';
+    return `<div class="uh-tile uh-pre-recap">
+        <span class="uh-tlabel">Your ${escapeHtml(prior.season)} season</span>
+        <div class="uh-pre-recap-stats">
+            <div class="uh-pre-stat"><span class="uh-pre-stat-v num">${prior.cumulativeScore || 0}</span><span class="uh-pre-stat-k">Total points</span></div>
+            ${bestStat}
+        </div>
+        ${spark}
+    </div>`;
+}
+
+function preHistoryHtml(data, activeYear) {
+    const past = (data.seasons || [])
+        .filter(s => String(s.season) !== String(activeYear) && (s.teams || []).length)
+        .sort((a, b) => Number(b.season) - Number(a.season));
+    if (!past.length) return '';
+    const rows = past.map(s => {
+        const teams = s.teams || [];
+        const chips = teams.slice(0, 4).map((t, i) =>
+            `<span class="uh-hist-chip${i === 0 ? ' r1' : ''}">${i === 0 ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}</span>`).join('');
+        const more = teams.length > 4 ? `<span class="uh-hist-chip more">+${teams.length - 4} more</span>` : '';
+        const fran = s.franchiseName ? escapeHtml(s.franchiseName) : `<span class="uh-hist-none">Unnamed franchise</span>`;
+        return `<div class="uh-hist-row">
+            <div class="uh-hist-year num">’${String(s.season).slice(2)}</div>
+            <div class="uh-hist-body"><div class="uh-hist-fran">${fran}</div><div class="uh-hist-teams">${chips}${more}</div></div>
+        </div>`;
+    }).join('');
+    return `<div class="uh-tile span2 uh-pre-hist">
+        <span class="uh-tlabel">Your franchise history</span>
+        <div class="uh-hist">${rows}</div>
+        <p class="uh-hist-note">★ marks your first pick that year</p>
+    </div>`;
+}
+
+// Draft countdown tile: fetch the league's draft for the active season, then
+// show a live countdown + format/pick meta + a Draft Room CTA (or a graceful
+// "not scheduled yet" state).
+async function hydratePreseasonDraft(user, activeYear) {
+    const wrap = document.getElementById('uh-pre-draft');
+    if (!wrap) return;
+    const body = wrap.querySelector('.uh-pd-body');
+    let draft = null;
+    try {
+        const r = await fetch(`/draft/${encodeURIComponent(user.league)}/${encodeURIComponent(activeYear)}`, { headers: { Accept: 'application/json' } });
+        if (r.ok) draft = await r.json();
+    } catch (e) { /* fall through to the not-scheduled state */ }
+
+    if (!draft || !draft._id) {
+        body.innerHTML = `<h2 class="uh-pd-h">Draft not scheduled yet</h2>
+            <p class="uh-pd-sub">Your commissioner hasn’t set the ${escapeHtml(activeYear)} draft date. Hang tight — it’ll show up here.</p>`;
+        return;
+    }
+
+    const order = (draft.draftOrder || []).map(String);
+    const myPick = order.indexOf(String(user._id));
+    const managers = order.length;
+    const when = draft.scheduledAt ? new Date(draft.scheduledAt) : null;
+    const fmtDate = when ? when.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' }) : null;
+    const meta = [
+        fmtDate ? `<span>📅 <b>${escapeHtml(fmtDate)}</b></span>` : '',
+        `<span>${draft.snake ? '🐍 <b>Snake</b>' : '<b>Linear</b>'} · ${draft.totalRounds || 10} rounds</span>`,
+        managers ? `<span>👥 <b>${managers}</b> managers</span>` : '',
+        myPick >= 0 ? `<span>🎯 You pick <b>${escapeHtml(ordinal(myPick + 1))}</b></span>` : ''
+    ].filter(Boolean).join('');
+    const cta = `<a class="uh-pd-cta" href="/draft-room">Enter the Draft Room →</a>`;
+
+    if (when && when.getTime() > Date.now()) {
+        body.innerHTML = `<h2 class="uh-pd-h">Draft night is almost here</h2>
+            <div class="uh-clock">
+                ${['Days', 'Hrs', 'Min', 'Sec'].map((l, i) => `<div class="uh-unit"><div class="uh-unit-n num" data-u="${i}">–</div><div class="uh-unit-l">${l}</div></div>`).join('')}
+            </div>
+            <div class="uh-pd-meta">${meta}</div>${cta}`;
+        startCountdown(when.getTime(), wrap);
+    } else {
+        body.innerHTML = `<h2 class="uh-pd-h">Your draft is set up</h2>
+            <div class="uh-pd-meta">${meta}</div>${cta}`;
+    }
+}
+
+function startCountdown(targetMs, wrap) {
+    if (uhCountdownTimer) { clearInterval(uhCountdownTimer); uhCountdownTimer = null; }
+    const set = (i, v) => { const el = wrap.querySelector(`[data-u="${i}"]`); if (el) el.textContent = v; };
+    const p2 = n => String(n).padStart(2, '0');
+    const tick = () => {
+        let s = Math.max(0, Math.floor((targetMs - Date.now()) / 1000));
+        set(0, Math.floor(s / 86400)); s %= 86400;
+        set(1, p2(Math.floor(s / 3600))); s %= 3600;
+        set(2, p2(Math.floor(s / 60)));
+        set(3, p2(s % 60));
+        if (targetMs - Date.now() <= 0 && uhCountdownTimer) { clearInterval(uhCountdownTimer); uhCountdownTimer = null; }
+    };
+    tick();
+    uhCountdownTimer = setInterval(tick, 1000);
+}
+
+// New game modes tile: only for leagues that have H2H and/or Captain on for the
+// active season. Reads the same per-season engagement config the scoring job and
+// standings use, so it stays in lockstep (and never shows for a classic league).
+async function hydratePreseasonModes(user, activeYear) {
+    const tile = document.getElementById('uh-pre-modes');
+    if (!tile || !user.league) return;
+    let eng = null;
+    try {
+        const r = await fetch(`/scoring-config/${encodeURIComponent(user.league)}?season=${encodeURIComponent(activeYear)}`, { headers: { Accept: 'application/json' } });
+        if (r.ok) { const c = await r.json(); eng = c.engagement || null; }
+    } catch (e) { /* stays hidden */ }
+    if (!eng || !(eng.h2hEnabled || eng.captainEnabled)) return;
+
+    const cards = [];
+    if (eng.captainEnabled) cards.push(`<div class="uh-mode">
+        <div class="uh-mode-h"><span class="uh-mode-i cap">©</span>Captain pick<span class="uh-mode-b cap">×${eng.captainMultiplier || 2}</span></div>
+        <div class="uh-mode-d">Each week, name one of your teams captain — its points count <b>double</b>. A boom-or-bust roster swings games.</div>
+    </div>`);
+    if (eng.h2hEnabled) cards.push(`<div class="uh-mode">
+        <div class="uh-mode-h"><span class="uh-mode-i h2h">⚔</span>Head-to-head<span class="uh-mode-b h2h">+${eng.h2hWinBonus || 3}</span></div>
+        <div class="uh-mode-d">You’re matched against a different manager every week. Outscore them for a <b>+${eng.h2hWinBonus || 3}</b> win bonus on top of your points.</div>
+    </div>`);
+
+    tile.innerHTML = `<span class="uh-tlabel">New in ${escapeHtml(activeYear)}<span class="uh-mode-only">This league</span></span>
+        <p class="uh-modes-intro">${cards.length > 1 ? 'Two new ways' : 'A new way'} to score this season — worth knowing before you draft.</p>
+        <div class="uh-modes">${cards.join('')}</div>`;
+    tile.hidden = false;
 }
 
 // Roster → Roster tile. Glance shows your top performer; drawer lists all teams

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -227,7 +227,7 @@ function renderPreseason(bento, data, activeYear, ctx) {
                 <div class="uh-pd-body"><p class="uh-stub">Checking the draft schedule…</p></div>
             </div>`
         // get draft-ready checklist
-        + preChecklistHtml(hasName, hasPhoto)
+        + preChecklistHtml(hasName, hasPhoto, activeYear)
         // last season recap
         + preRecapHtml(prior)
         // new game modes (hydrated async; hidden until confirmed on)
@@ -240,23 +240,34 @@ function renderPreseason(bento, data, activeYear, ctx) {
     // it onto; before that only the photo can be set.
     if (own) setupEditModal(data, activeEntry || {}, !!activeEntry);
 
+    // Mark the scoring rules as reviewed (per season) when the manager opens them
+    // — flips the checklist item to done on their next visit.
+    const rulesLink = document.getElementById('uh-rules-link');
+    if (rulesLink) rulesLink.addEventListener('click', () => {
+        try { window.localStorage.setItem('cc_seen_rules_' + activeYear, '1'); } catch (e) { /* private mode */ }
+    });
+
     hydratePreseasonDraft(data, activeYear);
     hydratePreseasonModes(data, activeYear);
 }
 
-function preChecklistHtml(hasName, hasPhoto) {
-    const done = (hasName ? 1 : 0) + (hasPhoto ? 1 : 0);
-    const pct = Math.round((done / 2) * 100);
+function preChecklistHtml(hasName, hasPhoto, activeYear) {
+    // "Reviewed the rules" is tracked per-season in localStorage, flipped on when
+    // the manager opens /rules from the Read link (wired in renderPreseason).
+    let seenRules = false;
+    try { seenRules = window.localStorage.getItem('cc_seen_rules_' + activeYear) === '1'; } catch (e) { /* private mode */ }
+    const done = (hasName ? 1 : 0) + (hasPhoto ? 1 : 0) + (seenRules ? 1 : 0);
+    const pct = Math.round((done / 3) * 100);
     const row = (isDone, title, desc, go) =>
         `<li class="${isDone ? 'is-done' : ''}"><span class="uh-box ${isDone ? 'done' : 'todo'}">${isDone ? '✓' : '○'}</span>`
         + `<span class="uh-ci"><span class="uh-ci-t">${title}</span><span class="uh-ci-d">${desc}</span></span>${go || ''}</li>`;
     return `<div class="uh-tile uh-pre-check">
         <span class="uh-tlabel">Get draft-ready</span>
-        <div class="uh-check-prog"><span class="uh-bar"><i style="width:${pct}%"></i></span><b>${done} / 2</b></div>
+        <div class="uh-check-prog"><span class="uh-bar"><i style="width:${pct}%"></i></span><b>${done} / 3</b></div>
         <ul class="uh-checks">
             ${row(hasName, 'Name your franchise', hasName ? 'Set — you’re on the board.' : 'Stand out in the standings.')}
             ${row(hasPhoto, 'Add a profile photo', hasPhoto ? 'Looking sharp.' : 'Put a face to the trash talk.')}
-            ${row(false, 'Review the scoring rules', 'Know how bonuses stack before you pick.', '<a class="uh-ci-go" href="/rules">Read ›</a>')}
+            ${row(seenRules, 'Review the scoring rules', seenRules ? 'Reviewed — you know how bonuses stack.' : 'Know how bonuses stack before you pick.', seenRules ? '' : '<a class="uh-ci-go" id="uh-rules-link" href="/rules">Read ›</a>')}
         </ul>
     </div>`;
 }
@@ -292,9 +303,18 @@ function preHistoryHtml(data, activeYear) {
     if (!past.length) return '';
     const rows = past.map(s => {
         const teams = s.teams || [];
-        const chips = teams.slice(0, 4).map((t, i) =>
-            `<span class="uh-hist-chip${i === 0 ? ' r1' : ''}">${i === 0 ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}</span>`).join('');
-        const more = teams.length > 4 ? `<span class="uh-hist-chip more">+${teams.length - 4} more</span>` : '';
+        // Star the season's top scorer (not the draft-order first pick). Lead with
+        // it (starred, with its points), then the rest in draft order.
+        const best = bestTeam(s);
+        const bestId = (best && best.total > 0) ? best.team.id : null;
+        const ordered = (bestId != null ? [best.team] : [])
+            .concat(teams.filter(t => bestId == null || Number(t.id) !== Number(bestId)));
+        const chips = ordered.slice(0, 4).map(t => {
+            const isBest = bestId != null && Number(t.id) === Number(bestId);
+            const pts = isBest ? ` <span class="uh-hist-pts num">${best.total}</span>` : '';
+            return `<span class="uh-hist-chip${isBest ? ' r1' : ''}">${isBest ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}${pts}</span>`;
+        }).join('');
+        const more = ordered.length > 4 ? `<span class="uh-hist-chip more">+${ordered.length - 4} more</span>` : '';
         const fran = s.franchiseName ? escapeHtml(s.franchiseName) : `<span class="uh-hist-none">Unnamed franchise</span>`;
         return `<div class="uh-hist-row">
             <div class="uh-hist-year num">’${String(s.season).slice(2)}</div>
@@ -304,7 +324,7 @@ function preHistoryHtml(data, activeYear) {
     return `<div class="uh-tile span2 uh-pre-hist">
         <span class="uh-tlabel">Your franchise history</span>
         <div class="uh-hist">${rows}</div>
-        <p class="uh-hist-note">★ marks your first pick that year</p>
+        <p class="uh-hist-note">★ marks your top scorer that year</p>
     </div>`;
 }
 


### PR DESCRIPTION
## Why

In preseason the app read as half-broken: **My Team** was a near-empty page, **Standings** crowned an arbitrary leader at 0–0 and showed an empty championship chart, and **Team** pages showed a red "underperformance" delta and a rank against zero points. This PR makes all three surfaces read correctly before the season starts.

## My Team

Root cause: the empty state only triggered when a manager had *no* active-season entry, but the **Season Roster** action *creates* an (empty-roster) entry — so rostered-but-undrafted managers fell through to the live bento, which self-hid every tile. Redefine preseason as **"active season not yet drafted"** and render a purpose-built grid:

- **Draft countdown** — live clock, format/rounds/managers, your pick slot, Draft Room CTA (graceful "not scheduled yet" fallback).
- **Get draft-ready checklist** — franchise name + photo (real state) + a completable "review the scoring rules" item (per-season `localStorage` flag set when `/rules` opens).
- **Last-season recap** — points, best team, weekly sparkline.
- **New in `<year>`** — Captain / Head-to-head explainer, shown **only** for leagues with those modes on (same `engagementForSeason` config the scoring job uses; classic leagues never see it). Uses the shared `ccIcon('swords')` glyph.
- **Franchise history** — past drafts with the season's **top scorer** starred (points shown); "+N more" expands the full roster.

## Standings (no scores yet)

- Drop the arbitrary "Leader" crown and medals — every row reads as a flat tie until someone has scored.
- Hide the empty "Teams" column (and its mobile expand caret) until rosters exist.
- Keep the "Path to the Championship" chart hidden until there's a scored week.

## Team page (season not started)

- Show expected wins as "N projected wins" instead of a red "0 actual vs N expected ▼N" shortfall.
- Suppress the national rank while the team is at 0 points.
- Keep the real FPI chip but note that SP+/talent/returning post closer to kickoff, so the lone chip doesn't look broken.

## Verification

Verified live in dev: My Team (modes-on league shows all five tiles incl. ×2/+3 badges + swords icon; classic league shows four, modes hidden, unscheduled-draft fallback; checklist 2/3 → 3/3; history expand/collapse), Standings (no crown, all tied, no medals, Teams column + chart hidden), and Team pages (2026 = projected wins / no rank / FPI + note; **2025 in-season unchanged** — delta, rank, full outlook). **270 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)