### PR TITLE
Preseason follow-ups: silent recap popup + honest Standings

### DIFF
--- a/public/standings.js
+++ b/public/standings.js
@@ -26,6 +26,16 @@ function latestWeek(users) {
     return max;
 }
 
+// True once the season has REAL scoring — some manager has banked non-zero
+// points. The nightly scoring job seeds a zero-point weekly entry as soon as a
+// week's games exist (even with undrafted, 0-team rosters), so "a weekly entry
+// exists" fires too early. The highlights panel and the points chart gate on
+// this instead, so they stay hidden until the season is actually underway.
+function seasonHasScoring(users) {
+    return (users || []).some(u => ((u.seasons && u.seasons[0] && u.seasons[0].weeklyScore) || [])
+        .some(w => (w.score || 0) !== 0));
+}
+
 function detectMobile() {
     if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/.test(navigator.userAgent)){
         // true for mobile device
@@ -128,14 +138,17 @@ async function getUsers() {
             displayLastUpdated(data);
             displayHighlights(data);
             maybeCelebrateWeeklyWin(data);
-            loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
+            // Server "advanced" highlights append to the same panel — skip them
+            // too until there's real scoring, or they'd re-populate the panel
+            // displayHighlights just hid.
+            if (seasonHasScoring(data)) loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
             loadProjections(leagueCode, data[0]?.seasons?.[0]?.season);
             displaySchedule(data);
             seedUserIdFromEmail(userMetadata, usersData);
             // Chart is responsive now, so show it on mobile too — but only once
-            // the season has scored weeks. Preseason has nothing to plot, so the
-            // chart stays hidden instead of showing an empty axis.
-            if (latestWeek(data) > 0) {
+            // the season has real scoring. A zero-point week the nightly job seeds
+            // has nothing to plot, so the chart stays hidden until points land.
+            if (seasonHasScoring(data)) {
                 setChartData(data);
                 document.querySelector('[chart-container]').removeAttribute("style");
             }
@@ -333,9 +346,10 @@ function displayHighlights(users) {
     const container = document.querySelector('.highlights-container');
     const header = document.querySelector('.highlights-header');
     // Hide the whole section (header + its leading divider) when there's nothing
-    // to show yet — e.g. preseason, before any games are scored — so we don't
-    // leave a bare "League Highlights" heading over empty space.
-    if (!cards.length) {
+    // to show yet — e.g. preseason, before any real points are scored — so we
+    // don't leave a bare "League Highlights" heading over empty space (or worse,
+    // "winners" and "streaks" computed from all-zero weeks the nightly job seeds).
+    if (!cards.length || !seasonHasScoring(users)) {
         if (header) header.style.display = 'none';
         if (container) container.style.display = 'none';
         const hr = header && header.previousElementSibling;

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -205,17 +205,21 @@ router.get('/recap/:league/:season/:userId', async (req, res) => {
         const league = req.params.league;
         const userId = req.params.userId;
 
-        // `latest` (used by the weekly popup) resolves to the most recent season
-        // the manager actually has weekly scores for — so the popup works during
-        // the season and shows last season's finish in the offseason.
+        // `latest` (used by the weekly popup) resolves to the ACTIVE season only
+        // (process.env.YEAR). Until that season has a scored week there's nothing
+        // to recap, so return empty and the popup stays silent through the
+        // preseason — it fires once the season actually starts. (Previously this
+        // fell back to the most recent scored season, which surfaced last year's
+        // finish during the new preseason.)
         let season = req.params.season;
         if (season === 'latest') {
+            season = String(process.env.YEAR);
             const target = await User.findById(userId);
-            const played = ((target && target.seasons) || [])
-                .filter(s => (s.weeklyScore || []).length > 0)
-                .sort((a, b) => Number(b.season) - Number(a.season));
-            if (!played.length) return res.json({ league, season: null, userId, recaps: [] });
-            season = String(played[0].season);
+            const active = ((target && target.seasons) || [])
+                .find(s => String(s.season) === season);
+            if (!active || !((active.weeklyScore || []).length)) {
+                return res.json({ league, season: null, userId, recaps: [] });
+            }
         }
         const seasonNum = Number(season);
 


### PR DESCRIPTION
Two preseason-correctness fixes found after #251 shipped.

## 1. Weekly recap popup fires in the preseason

The popup's `latest` recap resolved to the most recent season **with scores**, so in a new preseason it surfaced *last* season's finish. Now `latest` resolves to the **active season** (`process.env.YEAR`) and returns empty recaps until it has a scored week — the popup stays silent through the preseason and fires only once the season is actually underway. (`routes/standings.js`)

## 2. Standings highlights + chart leak on zero-point weeks

The nightly `daily-scores` job seeds a **zero-point weekly entry** for each manager as soon as a week's games exist — even with undrafted, 0-team rosters. That made `latestWeek(data) > 0` true in the preseason, so:
- the "Path to the Championship" points chart un-hid over an empty axis, and
- the "League Highlights" panel (never gated) computed Big Winner / Hot Streak / Season High cards from all-zero weeks.

Added `seasonHasScoring(users)` — true only when some manager has banked non-zero points — and gated both on it (plus skipping the server "advanced highlights" fetch so it can't refill the panel). The standings **table** already gated on points (`leader <= 0`), so it was correct; the **team page** gates on *completed* games, so it's unaffected. (`public/standings.js`)

## Verification

- Recap: replicated against dev data — active 2026 (0 scored weeks) → empty/silent; the prior 2025 season (17 weeks) is no longer surfaced.
- Highlights/chart: replicated `seasonHasScoring` against **prod** graham-league data — all week-1 zeros → chart/highlights **hidden**; inject one real score → **shown**.
- 270 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)