### PR TITLE
Preseason polish: H2H padding, crisp draft logos, franchise history

### DIFF
--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -157,7 +157,7 @@ function buildPool(teams, recruiting) {
             var r = recruiting.filter(o => o.team == t.school || (t.alternateNames || []).includes(o.team))[0];
             if (r) rank = r.rank;
         }
-        return { id: t.id, name: t.school, logo: (t.logos || []).at(-1), conf, score, xwins, rank, sp, spRank, scoreYear: prev ? prev.season : null };
+        return { id: t.id, name: t.school, logo: (t.logos || []).length ? ccLogo(t.logos) : '', conf, score, xwins, rank, sp, spRank, scoreYear: prev ? prev.season : null };
     });
     var xw = pool.map(p => p.xwins).filter(v => v > 0);
     xwMin = xw.length ? Math.min(...xw) : 0;

--- a/public/standings.css
+++ b/public/standings.css
@@ -869,3 +869,9 @@
 .std-no-teams .team-item,
 .std-no-teams .h2h-caret-head,
 .std-no-teams .expand-cell { display: none; }
+
+/* With the expand caret hidden, the H2H Total column becomes the last cell, and
+   the mobile `.fl-table td` rule zeroes its right padding — so "0 Tied" jams the
+   card edge. Restore the right gutter the caret column used to provide. */
+.mode-h2h.std-no-teams .standings-row .score-cell,
+.fl-table.mode-h2h.std-no-teams thead th.score-head { padding-right: 1.25em; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -326,10 +326,12 @@ function preHistoryHtml(data, activeYear) {
         }).join('');
         const moreN = ordered.length - 4;
         const more = moreN > 0 ? `<button type="button" class="uh-hist-more" data-more="+${moreN} more">+${moreN} more</button>` : '';
-        const fran = s.franchiseName ? escapeHtml(s.franchiseName) : `<span class="uh-hist-none">Unnamed franchise</span>`;
+        // Seasons before franchise naming existed have no name — show nothing
+        // rather than a hollow "Unnamed franchise" label.
+        const franHtml = s.franchiseName ? `<div class="uh-hist-fran">${escapeHtml(s.franchiseName)}</div>` : '';
         return `<div class="uh-hist-row">
             <div class="uh-hist-year num">’${String(s.season).slice(2)}</div>
-            <div class="uh-hist-body"><div class="uh-hist-fran">${fran}</div><div class="uh-hist-teams">${chips}${more}</div></div>
+            <div class="uh-hist-body">${franHtml}<div class="uh-hist-teams">${chips}${more}</div></div>
         </div>`;
     }).join('');
     return `<div class="uh-tile span2 uh-pre-hist">


### PR DESCRIPTION
Three small follow-up fixes found on prod after the preseason work.

## 1. H2H Total column jams the card edge

Hiding the expand-caret column in the undrafted (`.std-no-teams`) state makes the H2H **Total** column the last cell. On mobile the `.fl-table td` rule zeroes its right padding, so "0 Tied" sat flush against the card edge. Added a right gutter to the H2H score cell/header in that state. Verified on the live prod mobile H2H table: `padding-right` 0 → 13.5px. (`public/standings.css`)

## 2. Blurry draft-room logos

The draft pool cards built the logo with `(t.logos||[]).at(-1)`, which after the new many-size CFBD logo array grabs the **16px** variant — blurry at the 30px render size. Switched to `ccLogo(t.logos)` (highest-res dark variant, ~500px) like the rest of the app. Verified: pool logos now 500×500 natural, crisp. (`public/draftRoom.js`)

## 3. "Unnamed franchise" in history

Franchise history showed a hollow "Unnamed franchise" label for seasons before franchise naming existed (2023–24). Omit the name line entirely when there's no name — the row reads as year + starred teams. (`public/userHome.js`)

270 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)