### PR TITLE
Nav: collapse to hamburger below 1024px (fix iPad/tablet UX)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -274,7 +274,12 @@ body {
     transform: translateY(-9px) rotate(-45deg);
 }
 
-@media (max-width: 600px) {
+/* Collapse the horizontal nav to a hamburger below the desktop content
+   breakpoint (64em / 1024px). The full row of links needs ~716px, so on tablet
+   portrait (768–1023px) and in iPad Split View it would otherwise overflow or
+   crowd the edge (Logout got cut off). This keeps nav + content switching to
+   "desktop mode" at the same width. */
+@media (max-width: 63.99em) {
     .toggle-button {
         display: flex;
     }


### PR DESCRIPTION
## Problem

On iPad (a couple of league members use them), the app didn't display well in either orientation. Diagnosed live on the prod instance:

- The horizontal nav only collapsed to a hamburger at **≤600px**. From 601px up it rendered the **full row of links**, which needs ~**716px**.
- So on **tablet portrait (768–1023px)** and in **iPad Split View** the nav either **overflowed** (the page scrolled sideways and "Logout" was cut off) or crowded the right edge.
- An overflow probe on prod confirmed `.navbar-links` was the **only** element overflowing at tablet widths — the navbar was the whole horizontal problem.

Root cause: the nav breakpoint (600px) and the content breakpoint (`64em` / 1024px) were misaligned, leaving a 601–1023px band that showed a desktop-width nav over phone-width content.

## Fix

Move the navbar's hamburger breakpoint to **`max-width: 63.99em`** (just under 1024px), matching the desktop content breakpoint:

- **< 1024px** (tablet portrait, Split View, narrow laptops) → hamburger.
- **≥ 1024px** (iPad landscape, iPad Pro portrait, desktop) → full horizontal nav, which fits with room to spare.

It reuses the existing, already-working hamburger styles — only the breakpoint value changed (one media query). Nav and content now switch to "desktop mode" at the same width.

## Verified

Built a faithful harness (real `styles.css` + the navbar markup) and checked true iPad viewports:

- **768px** → hamburger shown, links collapsed, **no horizontal overflow**.
- **1024px** → full nav returns, all 8 items fit comfortably, hamburger hidden.

## Note / possible follow-up

This fixes the navbar (the sole cause of horizontal scrolling/cut-off at tablet widths, in both orientations below 1024). Separately, **content** at tablet portrait (768–1023px) still uses the phone layout — it's functional and doesn't overflow, but a dedicated tablet content pass (a mid breakpoint for Standings/My Team/team pages) could use the space better. Happy to do that as a follow-up if it still feels off after this.

Verified against the prod instance (viewport was locked ~683px there, which is itself the Split-View case that overflowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)