### PR TITLE
Standings: compact preseason table (fix wide-screen empty gap)

### DIFF
--- a/public/standings.css
+++ b/public/standings.css
@@ -875,3 +875,18 @@
    card edge. Restore the right gutter the caret column used to provide. */
 .mode-h2h.std-no-teams .standings-row .score-cell,
 .fl-table.mode-h2h.std-no-teams thead th.score-head { padding-right: 1.25em; }
+
+/* Preseason, before any team is drafted, the table has only rank/name/record/
+   total columns. But .fl-table is width:100% of the 1200px wrapper, so on wide
+   screens (iPad landscape, desktop) the browser dumped the leftover ~700px into
+   the Total column — flinging "Total" to the far edge with a big empty gap.
+   Cap it to a compact, left-aligned card and let the name column take the slack
+   so Total stays snug. Automatically reverts once the draft fills the teams
+   column and .std-no-teams drops. :has() left-aligns the whole card cleanly; the
+   table max-width is the fallback where :has isn't supported. */
+.fl-table.std-no-teams,
+.fl-table.mode-h2h.std-no-teams { max-width: 600px; }
+.table-wrapper:has(.std-no-teams) { max-width: 600px; margin-left: 0; margin-right: auto; }
+
+/* The empty "Teams" header lingered even though its column is hidden. */
+.fl-table.std-no-teams .h2h-teams-head { display: none; }


### PR DESCRIPTION
## What you were actually seeing

The screenshot at iPad Pro 1366 wasn't the navbar (that's #256, and it only changes in *portrait*). It was the **standings table**: bunched left, a big empty middle, and "Total" flung to the far edge.

## Root cause

Before the draft, the table carries `.std-no-teams` and has only rank / name / record / total columns (the teams + expand columns are hidden). But `.fl-table` is `width: 100%` of the 1200px wrapper, so on wide screens the browser had ~700px of leftover width and **dumped it into the Total column** (measured live: Total column = **898px**). In-season this never happens — the teams column fills with logos — so it only looks sparse preseason.

## Fix

- Cap the preseason table to a compact **~600px, left-aligned** card and let the **name column** absorb the slack so Total stays snug on the right.
- `:has(.std-no-teams)` left-aligns the whole card cleanly under the heading; a table `max-width` is the fallback where `:has` isn't supported (older iPadOS) — it still compacts, just centered rather than flush-left.
- Also hide the stray empty **"Teams" header** that lingered even though its column was hidden.
- Reverts automatically once the draft fills the teams column and `.std-no-teams` drops.

## Verified

Injected this exact CSS on the live iPad-landscape (1366) prod instance and measured: **Total column 898px → 124px**, **table 1200px → 600px**, name column absorbs the slack — tidy compact card aligned with the heading.

Scoped to `.std-no-teams` (preseason) only; in-season standings are untouched. `public/standings.css` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)