### PR TITLE
Standings: keep teams column fully hidden preseason on desktop (real gap fix)

### DIFF
--- a/public/standings.css
+++ b/public/standings.css
@@ -845,13 +845,19 @@
 .fl-table.mode-h2h thead th.h2h-teams-head { display: none; }
 
 @media only screen and (min-width: 64em) {
-    .mode-h2h .h2h-teams-cell,
-    .fl-table.mode-h2h thead th.h2h-teams-head { display: table-cell; }
+    /* Only re-show the teams column and shrink the name when teams actually
+       exist. Preseason (.std-no-teams) has no logo strip to fill the middle, so
+       re-showing the teams HEADER (while its body cell stays hidden) shifted the
+       columns and stranded "Total" in a wide empty column. Excluding
+       .std-no-teams keeps the teams column fully hidden and lets the name cell
+       absorb the slack, so Total stays snug. */
+    .mode-h2h:not(.std-no-teams) .h2h-teams-cell,
+    .fl-table.mode-h2h:not(.std-no-teams) thead th.h2h-teams-head { display: table-cell; }
     .mode-h2h .expand-cell,
     .fl-table.mode-h2h thead th.h2h-caret-head { display: none; }
     /* Shrink the name so the team-logo strip takes the slack in the middle. */
-    .fl-table.mode-h2h .standings-row .name-cell { width: 1%; white-space: nowrap; }
-    .mode-h2h .h2h-teams-cell { width: auto; }
+    .fl-table.mode-h2h:not(.std-no-teams) .standings-row .name-cell { width: 1%; white-space: nowrap; }
+    .mode-h2h:not(.std-no-teams) .h2h-teams-cell { width: auto; }
 
     /* Desktop has room: bump the Total sub-line (gap + base/bonus) up a touch,
        and give the Total column a gutter so the numbers aren't flush to the


### PR DESCRIPTION
## Why #257 didn't fix it

You were right — #257 capped the table width but the empty gap stayed. I'd "verified" it by injecting CSS that got appended last in the cascade, which isn't how the deployed rule behaves. Inspecting the **deployed** page found the actual cause:

At desktop (`≥64em`, iPad landscape) there are `@media` rules that, in H2H mode, **re-show the teams column and shrink the name cell** so the team-logo strip fills the middle in-season. Preseason (`.std-no-teams`) there's no logo strip, and:

- The teams **body** cell stays hidden, but the teams **header** got re-shown — its selector `.fl-table.mode-h2h thead th.h2h-teams-head` (specificity `0,3,2`) **out-specified** #257's hide (`0,3,0`).
- That one extra header column shifted the body columns left by one, and the name cell was shrunk to `width:1%`, so nothing absorbed the slack → **"Total" stranded in a ~300px empty column** (measured 298px live).

## Fix

Scope the desktop "show teams column / shrink name" rules to **`:not(.std-no-teams)`**. Preseason then keeps the teams column fully hidden (header *and* cell) and the name cell falls back to `width:auto`, absorbing the slack so Total stays snug and header/body align.

## Verified on the deployed page (properly this time)

Injected an override with **real specificity (`0,4,2`, no `!important`)** — exactly how the `:not` change wins in the real cascade — on your live 1366 instance:

- teams header → `display: none`
- name column → **430px (absorbs the slack)**
- Total → **56px (snug)** — no gap

Screenshot confirmed a clean, compact, aligned table. `:not(.std-no-teams)` removes the competing match entirely, so it's deterministic (not a specificity race). Scoped to preseason; in-season is untouched. `public/standings.css` only.