### PR TITLE
Standings: shrink preseason table to content width (kill the empty gap)

### DIFF
--- a/public/standings.css
+++ b/public/standings.css
@@ -892,7 +892,13 @@
    table max-width is the fallback where :has isn't supported. */
 .fl-table.std-no-teams,
 .fl-table.mode-h2h.std-no-teams { max-width: 600px; }
-.table-wrapper:has(.std-no-teams) { max-width: 600px; margin-left: 0; margin-right: auto; }
+/* Shrink the wrapper to the table's CONTENT width (not a fixed cap) so there's
+   no leftover space for a column to stretch into — that stray slack was what
+   left a big empty gap between the manager name and Record/Total. `fit-content`
+   makes it a tidy compact card at every width; max-width:100% keeps it from
+   overflowing on narrow screens. (:has ships broadly now; where it's missing,
+   the .fl-table max-width above still caps the table.) */
+.table-wrapper:has(.std-no-teams) { width: fit-content; max-width: 100%; margin-left: 0; margin-right: auto; }
 
 /* The empty "Teams" header lingered even though its column is hidden. */
 .fl-table.std-no-teams .h2h-teams-head { display: none; }


### PR DESCRIPTION
## Why the last two didn't do it

- **#257** capped the preseason table at a fixed **600px**.
- **#258** hid the stray teams header (a real bug) and let the name cell absorb the slack.

But the content is only ~285px wide, so at 600px there were still ~300px of slack — and "absorbing" it just made the **name column** go wide: `Garrett G.` … big empty space … `Record` / `Total`. The gap moved, it didn't leave.

## The actual fix

Change the wrapper from `max-width: 600px` to **`width: fit-content`**, at all widths. The wrapper (and the `width:100%` table inside it) shrinks to the table's real content width, so there's **no leftover space for any column to stretch into** — no gap, just a tidy compact card. `max-width: 100%` keeps it from overflowing on narrow screens.

## Verified properly on your deployed page

Injected this exact rule (no `!important`, real specificity) on the live 1366 iPad instance and at 683px:

- table width → **285px @ 1366 / 250px @ 683** (content width)
- name cell → **115px** (fits the name, no stretch)
- gap between name and Record → **0**

Screenshots confirmed a compact, aligned table in both cases. Scoped to `.std-no-teams` (preseason); in-season untouched, reverts once the draft fills the teams column.

Sorry this took three passes — I was verifying with injected CSS that won the cascade artificially, which masked the real problem. This one behaves exactly like the deployed cascade.