### PR TITLE
Revert standings iPad attempts (#257/#258/#259) back to baseline

### DIFF
--- a/public/standings.css
+++ b/public/standings.css
@@ -845,19 +845,13 @@
 .fl-table.mode-h2h thead th.h2h-teams-head { display: none; }
 
 @media only screen and (min-width: 64em) {
-    /* Only re-show the teams column and shrink the name when teams actually
-       exist. Preseason (.std-no-teams) has no logo strip to fill the middle, so
-       re-showing the teams HEADER (while its body cell stays hidden) shifted the
-       columns and stranded "Total" in a wide empty column. Excluding
-       .std-no-teams keeps the teams column fully hidden and lets the name cell
-       absorb the slack, so Total stays snug. */
-    .mode-h2h:not(.std-no-teams) .h2h-teams-cell,
-    .fl-table.mode-h2h:not(.std-no-teams) thead th.h2h-teams-head { display: table-cell; }
+    .mode-h2h .h2h-teams-cell,
+    .fl-table.mode-h2h thead th.h2h-teams-head { display: table-cell; }
     .mode-h2h .expand-cell,
     .fl-table.mode-h2h thead th.h2h-caret-head { display: none; }
     /* Shrink the name so the team-logo strip takes the slack in the middle. */
-    .fl-table.mode-h2h:not(.std-no-teams) .standings-row .name-cell { width: 1%; white-space: nowrap; }
-    .mode-h2h:not(.std-no-teams) .h2h-teams-cell { width: auto; }
+    .fl-table.mode-h2h .standings-row .name-cell { width: 1%; white-space: nowrap; }
+    .mode-h2h .h2h-teams-cell { width: auto; }
 
     /* Desktop has room: bump the Total sub-line (gap + base/bonus) up a touch,
        and give the Total column a gutter so the numbers aren't flush to the
@@ -881,24 +875,3 @@
    card edge. Restore the right gutter the caret column used to provide. */
 .mode-h2h.std-no-teams .standings-row .score-cell,
 .fl-table.mode-h2h.std-no-teams thead th.score-head { padding-right: 1.25em; }
-
-/* Preseason, before any team is drafted, the table has only rank/name/record/
-   total columns. But .fl-table is width:100% of the 1200px wrapper, so on wide
-   screens (iPad landscape, desktop) the browser dumped the leftover ~700px into
-   the Total column — flinging "Total" to the far edge with a big empty gap.
-   Cap it to a compact, left-aligned card and let the name column take the slack
-   so Total stays snug. Automatically reverts once the draft fills the teams
-   column and .std-no-teams drops. :has() left-aligns the whole card cleanly; the
-   table max-width is the fallback where :has isn't supported. */
-.fl-table.std-no-teams,
-.fl-table.mode-h2h.std-no-teams { max-width: 600px; }
-/* Shrink the wrapper to the table's CONTENT width (not a fixed cap) so there's
-   no leftover space for a column to stretch into — that stray slack was what
-   left a big empty gap between the manager name and Record/Total. `fit-content`
-   makes it a tidy compact card at every width; max-width:100% keeps it from
-   overflowing on narrow screens. (:has ships broadly now; where it's missing,
-   the .fl-table max-width above still caps the table.) */
-.table-wrapper:has(.std-no-teams) { width: fit-content; max-width: 100%; margin-left: 0; margin-right: auto; }
-
-/* The empty "Teams" header lingered even though its column is hidden. */
-.fl-table.std-no-teams .h2h-teams-head { display: none; }


### PR DESCRIPTION
## Purpose

My three preseason-standings PRs (#257, #258, #259) did not fix the iPad issue and **broke the laptop and iPhone views** — a tiny, left-aligned card stranded in the top-left with large empty space.

This restores `public/standings.css` to its state **before #257** (commit `efe25f9`, the #256 navbar merge) — the confirmed-good baseline where laptop and iPhone were fine and only iPad's preseason table needed work.

## Scope

- Reverts **only `public/standings.css`** — the sole file those three PRs touched.
- The navbar fix (#256, `styles.css`) is untouched and stays.
- Net effect vs current main: removes the `.std-no-teams` max-width/`:has`/`fit-content` block and the `:not(.std-no-teams)` desktop scoping — i.e. exactly and only my three PRs.

## After deploy

- Laptop + iPhone: back to fine.
- iPad: back to its *original* preseason issue (stretched table). That will be redone properly and verified at each breakpoint (iPhone / iPad portrait / iPad landscape / laptop) against the real deployed CSS — not screenshots — before anything else ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)