### PR TITLE
Preseason standings: cap the H2H card at 640px and center it

### DIFF
--- a/public/standings.css
+++ b/public/standings.css
@@ -875,3 +875,25 @@
    card edge. Restore the right gutter the caret column used to provide. */
 .mode-h2h.std-no-teams .standings-row .score-cell,
 .fl-table.mode-h2h.std-no-teams thead th.score-head { padding-right: 1.25em; }
+
+/* Preseason card. With the Teams column hidden, the H2H table only needs room
+   for rank / name / record / total — left unchecked it stretches the full
+   width of the wrapper and reads as a sparse, lopsided band on tablets and
+   desktops. Cap it and center it so it presents as a tidy card at every width
+   (below 640px it just fills the screen as before). */
+.fl-table.std-no-teams {
+    max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
+}
+/* On desktop the base .mode-h2h rules re-show the Teams header and shrink the
+   name-cell to a nub so a logo strip can fill the middle. There's no strip in
+   preseason, so beat both (extra .std-no-teams class = higher specificity):
+   keep the Teams header hidden and let the name-cell keep its width. */
+@media only screen and (min-width: 64em) {
+    .fl-table.mode-h2h.std-no-teams thead th.h2h-teams-head { display: none; }
+    .fl-table.mode-h2h.std-no-teams .standings-row .name-cell {
+        width: auto;
+        white-space: nowrap;
+    }
+}


### PR DESCRIPTION
## What

In preseason the Teams column is hidden, so the H2H standings table only carries **rank / name / record / total**. Left uncapped it stretched the full width of the wrapper — a sparse, lopsided band on iPad (portrait and landscape) and desktop.

This caps `.fl-table.std-no-teams` at **640px** and centers it with auto margins, so it reads as a tidy card at every width. Below 640px it still fills the screen exactly as before.

On desktop, two base `.mode-h2h` rules assume a team-logo strip fills the middle (they re-show the Teams header and shrink the name-cell to a nub). There's no strip in preseason, so this overrides both — the extra `.std-no-teams` class wins on specificity.

## Verification

Measured in the dev browser against the codified file (not injected CSS) — table width and margins via `getBoundingClientRect`:

| Viewport | Table width | Margins | Result |
|---|---|---|---|
| iPhone 375 | 335 | 20 / 20 | full-width, untouched |
| iPad portrait 820 | 640 | 90 / 90 | centered |
| iPad landscape 1180 | 640 | 270 / 270 | centered |
| Laptop 1440 | 640 | 400 / 400 | centered |
| Extra-wide 1920 | 640 | 640 / 640 | centered |

🤖 Generated with [Claude Code](https://claude.com/claude-code)