### PR TITLE
season-preview: let the hero headline wrap on mobile

### DIFF
--- a/docs/announcements/offseason-2026.html
+++ b/docs/announcements/offseason-2026.html
@@ -258,7 +258,7 @@
       </div>
 
       <div class="eyebrow anim d1">The Offseason Build</div>
-      <h1 class="title anim d2">The&nbsp;2026&nbsp;Season<br><span class="hl">Is Loaded.</span></h1>
+      <h1 class="title anim d2">The 2026 Season<br><span class="hl">Is Loaded.</span></h1>
       <p class="lede anim d3">We spent the whole offseason rebuilding the league from the turf up — new
         ways to play, new places to go, and a home screen that actually feels like game day.
         <strong>Here's everything worth knowing before kickoff.</strong></p>


### PR DESCRIPTION
## What

Follow-up to the 2026 retitle (#263). The new headline used non-breaking spaces (`The&nbsp;2026&nbsp;Season`), so the line couldn't wrap — on a phone it overflowed the hero's `overflow: hidden` and got clipped mid-word ("THE 2026 SEAS…"). The old "Season 2" was short enough to never hit the edge, so the bug was latent until the longer title shipped.

## Fix

Use normal spaces so the headline wraps to **"THE 2026 / SEASON / IS LOADED."** on narrow screens. Desktop is unchanged (still fits on one line).

Verified at 390px: `scrollWidth == clientWidth`, no overflow of the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)