### PR TITLE
season-preview: give the "10" stat a noun

### DIFF
--- a/docs/announcements/offseason-2026.html
+++ b/docs/announcements/offseason-2026.html
@@ -264,7 +264,7 @@
         <strong>Here's everything worth knowing before kickoff.</strong></p>
 
       <div class="board anim d4">
-        <div class="cell"><div class="num">10</div><div class="lab">New&nbsp;&amp;&nbsp;Upgraded</div></div>
+        <div class="cell"><div class="num">10</div><div class="lab">New&nbsp;&amp;&nbsp;Upgraded<br>Features</div></div>
         <div class="cell"><div class="num">2</div><div class="lab">Game&nbsp;Modes</div></div>
         <div class="cell"><div class="num">5</div><div class="lab">Fresh&nbsp;Screens</div></div>
       </div>


### PR DESCRIPTION
## What

The first scoreboard stat read **"10 / New & Upgraded"** — an adjective phrase with no noun, unlike its siblings ("Game Modes", "Fresh Screens"). It counts the **10 new/upgraded feature cards** below it, so it now reads **"New & Upgraded Features"**.

`Features` drops to a second label line; all three stat cells stay equal height (verified at 152px each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)