### PR TITLE
Identity-match guard: refuse logins that resolve to another member's team

### DIFF
--- a/modules/identity-guard.js
+++ b/modules/identity-guard.js
@@ -1,0 +1,147 @@
+// Identity-match guard.
+//
+// This app resolves "who you are" purely from an Auth0 login's custom claim
+// `user_metadata.metadata.userId`, which points at a Mongo user `_id` — there is
+// no lookup by the Auth0 `sub` or email. If that pointer is wrong (e.g. a second
+// Auth0 identity for the same person was provisioned against another member's
+// record), the app would silently render — and let you edit — someone else's
+// franchise. That actually happened: a member's Google identity pointed at a
+// different league's record, so logging in with Google showed the wrong league.
+//
+// This middleware is the seatbelt: on every authenticated request it compares
+// the email on the *login* against the email on the *franchise the pointer
+// resolves to*. A mismatch means the login and the record don't belong to the
+// same person, so we refuse rather than serve the data (a "hard gate" — the
+// whole app is paused for that session, with Log Out as the escape hatch, since
+// the league context that would scope any other page rides on the same
+// untrusted pointer). We fail OPEN — never lock anyone out — whenever there is
+// nothing to compare (no email on the record or the token) or the lookup itself
+// errors; we only fail CLOSED on a genuine, verifiable mismatch or a pointer
+// that resolves to nothing.
+//
+// Notes:
+// - We check the REAL identity (req.oidc.user), not the dev-spoofed effUser.
+//   Dev role-spoofing only overrides roles/league, never userId/email, so it can
+//   never trigger a false block.
+// - /login, /logout, /callback are handled by the express-openid-connect router
+//   mounted before this, so they never reach here — the escape hatch always works.
+
+const norm = (e) => String(e == null ? '' : e).trim().toLowerCase();
+
+// Pure decision, exported for testing. Given the pointer, the login's email, the
+// resolved record (or null), and whether the DB lookup errored, decide whether to
+// allow the request and why. `ok:true` proceeds; `ok:false` renders the block page.
+function decideIdentity({ userId, tokenEmail, record, lookupError }) {
+    if (lookupError) return { ok: true,  reason: 'lookup-error' };   // DB hiccup: don't lock people out
+    if (!userId)     return { ok: false, reason: 'no-pointer' };     // login not linked to any franchise
+    if (!record)     return { ok: false, reason: 'no-record' };      // pointer resolves to a deleted/missing user
+    if (!record.email)   return { ok: true, reason: 'unverifiable' };// record has no email to compare — allow + warn
+    if (!tokenEmail)     return { ok: true, reason: 'no-token-email' };// login carried no email — allow + warn
+    if (norm(tokenEmail) === norm(record.email)) return { ok: true, reason: 'match' };
+    return { ok: false, reason: 'mismatch' };                         // login email != franchise email — block
+}
+
+const ALLOW_EXT = /\.(?:css|js|mjs|map|png|jpe?g|svg|ico|webp|gif|woff2?|ttf|json|txt)$/i;
+// Public / asset paths that should never be gated even for an authenticated,
+// mismatched session (the block page is self-contained, but these keep other
+// tabs and the public marketing page from throwing 403s).
+const ALLOW_PATH = new Set(['/season-preview', '/favicon.ico', '/profile']);
+
+// Self-contained block page — inline styles only, since this runs before the
+// static middleware and we can't rely on styles.css loading.
+function renderBlockPage() {
+    return '<!DOCTYPE html><html lang="en"><head>'
+        + '<meta charset="utf-8">'
+        + '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        + '<meta name="robots" content="noindex">'
+        + '<title>Campus Clash — Login not linked</title>'
+        + '<style>'
+        + 'html,body{margin:0;height:100%;background:#101322;color:#f4f6fb;'
+        + "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;}"
+        + '.wrap{min-height:100%;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;}'
+        + '.card{width:100%;max-width:460px;background:#1a1f33;border:1px solid #2a2e42;border-radius:14px;'
+        + 'padding:32px 28px;box-shadow:0 12px 40px rgba(0,0,0,.5);text-align:center;}'
+        + '.dot{width:12px;height:12px;border-radius:50%;background:#ed5858;display:inline-block;'
+        + 'box-shadow:0 0 12px 2px rgba(237,88,88,.4);margin-bottom:18px;}'
+        + 'h1{font-size:1.4rem;margin:0 0 12px;}'
+        + 'p{color:#a4a9c2;line-height:1.55;margin:0 0 14px;font-size:.98rem;}'
+        + '.btn{display:inline-block;margin-top:10px;background:#ed5858;color:#fff;text-decoration:none;'
+        + 'font-weight:600;padding:12px 22px;border-radius:10px;}'
+        + '.hint{font-size:.82rem;color:#767d9c;margin-top:18px;}'
+        + '</style></head><body><div class="wrap"><div class="card">'
+        + '<span class="dot"></span>'
+        + '<h1>This login isn’t linked to your team</h1>'
+        + '<p>To keep accounts safe, we’ve paused this session because the login you used '
+        + 'doesn’t match a team we can verify as yours.</p>'
+        + '<p>Log out and sign back in with your original login — or reach out to your commissioner '
+        + 'to get this login linked.</p>'
+        + '<a class="btn" href="/logout">Log out</a>'
+        + '<div class="hint">If this keeps happening, tell your commissioner which email you’re using.</div>'
+        + '</div></div></body></html>';
+}
+
+// Middleware factory. `deps.User` is the Mongoose User model (injected for
+// testability). Returns an async Express middleware.
+function identityGuard(deps) {
+    const User = deps.User;
+    return async function identityGuardMw(req, res, next) {
+        try {
+            // Public / logged-out traffic is not gated.
+            if (!req.oidc || !req.oidc.isAuthenticated()) return next();
+
+            const p = req.path || '';
+            if (ALLOW_PATH.has(p) || ALLOW_EXT.test(p) || p.indexOf('/images') === 0) return next();
+
+            const user = req.oidc.user || {};
+            const innerMeta = (user.user_metadata && user.user_metadata.metadata) || {};
+            const userId = innerMeta.userId;
+            const tokenEmail = user.email;
+
+            let record = null;
+            let lookupError = false;
+            if (userId) {
+                try {
+                    record = await User.findById(userId, { email: 1 }).lean();
+                } catch (e) {
+                    lookupError = true; // transient DB error: fail open, don't lock out
+                }
+            }
+
+            const verdict = decideIdentity({ userId, tokenEmail, record, lookupError });
+            const recEmail = (record && record.email) || '∅';
+
+            if (verdict.ok) {
+                // Log the non-happy allow paths so a commissioner can spot records
+                // that need an email or logins that never carry one.
+                if (verdict.reason !== 'match') {
+                    console.warn('[identity-guard] allow (' + verdict.reason + ') '
+                        + 'login=' + (tokenEmail || '∅') + ' userId=' + (userId || '∅')
+                        + ' record=' + recEmail);
+                }
+                return next();
+            }
+
+            console.warn('[identity-guard] BLOCK (' + verdict.reason + ') '
+                + 'login=' + (tokenEmail || '∅') + ' userId=' + (userId || '∅')
+                + ' record=' + recEmail + ' path=' + p);
+
+            const wantsHtml = (req.headers.accept || '').indexOf('text/html') !== -1;
+            if (wantsHtml) {
+                return res.status(403).type('html').send(renderBlockPage());
+            }
+            return res.status(403).json({
+                error: 'account_not_linked',
+                message: 'This login is not linked to your team. Log out and sign in with your '
+                    + 'original login, or contact your commissioner.'
+            });
+        } catch (e) {
+            // A bug in the guard must never take the whole app down: log and pass.
+            console.error('[identity-guard] unexpected error, allowing request', e);
+            return next();
+        }
+    };
+}
+
+module.exports = identityGuard;
+module.exports.decideIdentity = decideIdentity;
+module.exports.renderBlockPage = renderBlockPage;

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const requireAuthOrToken = require('./modules/require-auth');
 const requireCommissioner = require('./modules/require-commissioner');
 const requireAdmin = require('./modules/require-admin');
 const devRole = require('./modules/dev-role');
+const identityGuard = require('./modules/identity-guard');
 const { leagueCodeFor, canManageLeague } = require('./modules/league-access');
 const ScoringConfig = require('./models/scoringConfig');
 const User = require('./models/user');
@@ -81,6 +82,11 @@ app.use((req, res, next) => {
     res.locals.spoof = devRole.readSpoof(req); // {roles, league} | null, for the dev widget
     next();
 });
+
+// Identity-match guard. Refuses to serve a session whose login email doesn't
+// match the franchise its Auth0 pointer resolves to (see modules/identity-guard).
+// Runs on the REAL identity so dev role-spoofing can't trigger a false block.
+app.use(identityGuard({ User }));
 
 // Per-request league display names (editable via /leagues) for the navbar
 // switcher — HTML GETs only, falling back to the hardcoded defaults.


### PR DESCRIPTION
## Why

Identity is resolved purely from the Auth0 claim `user_metadata.metadata.userId` (a Mongo `_id`) — never from `sub` or email — with no provisioning and no account linking. So a **wrong pointer silently renders, and lets you edit, someone else's franchise**.

This actually happened: a member's **Google** identity pointed at a **different league's** record, so logging in with Google dropped him into the wrong league (the email/password login was correct).

## What this does

On **every authenticated request**, compare the email on the **login** against the email on the **franchise its pointer resolves to**:

- **Match** → proceed as normal (invisible to everyone).
- **Verifiable mismatch**, or a pointer that resolves to **nothing** → **hard-gate** the session: a self-contained block page ("this login isn't linked… log out / contact your commissioner"), with **Log Out** as the escape hatch. It's a hard gate rather than "block one page" because the league context that would scope any *other* page rides on the same untrusted pointer.
- **Nothing to compare** (record or token has no email) or the **DB lookup errors** → **fail open** (allow + log a warning), so a valid user is never locked out.

### Design notes
- Checks the **real** identity (`req.oidc.user`), so dev role-spoofing — which only overrides roles/league, never `userId`/email — can't cause a false block.
- HTML clients get the block page; JSON/API clients get `403 { error: "account_not_linked" }`.
- Assets, `/season-preview`, and unauthenticated traffic pass straight through.
- `/logout` is handled by the auth router *before* this guard, so the escape hatch always works.

## Verification
- `decideIdentity` is a pure, exported function — tested across **all 8 branches** (match, case/space-insensitive match, mismatch, no-pointer, pointer→missing-record, record-without-email, token-without-email, lookup-error).
- **9-case middleware integration pass** against a bare Express app with a stubbed User model + faked Auth0 sessions: allow vs. block, HTML vs. JSON response, asset/public allowlist, fail-open. All green.
- Dev server boots clean; public paths (`/season-preview` 200, `styles.css` 200) unaffected.

## Relationship to the Cole fix
This is the **seatbelt**, not the cure. It catches wrong/mismatched pointers (like Cole's Google login). The actual duplicate-identity cleanup still happens in Auth0 (delete/block the stray identity, or set up verified-email account linking). Both together = belt and suspenders.

## Follow-up (not in this PR)
- Jest tests mirroring the two standalone suites above (kept out for now to avoid colliding with in-progress test-infra changes).
- Optional: make the block page **self-healing** — since we have the verified token email, offer a one-click "link this login to your team" (Auth0 suggested account linking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)