### PR TITLE
Team-color accents in the draft room (pool + board)

### DIFF
--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -157,7 +157,7 @@ function buildPool(teams, recruiting) {
             var r = recruiting.filter(o => o.team == t.school || (t.alternateNames || []).includes(o.team))[0];
             if (r) rank = r.rank;
         }
-        return { id: t.id, name: t.school, logo: (t.logos || []).length ? ccLogo(t.logos) : '', conf, score, xwins, rank, sp, spRank, scoreYear: prev ? prev.season : null };
+        return { id: t.id, name: t.school, color: t.color, logo: (t.logos || []).length ? ccLogo(t.logos) : '', conf, score, xwins, rank, sp, spRank, scoreYear: prev ? prev.season : null };
     });
     var xw = pool.map(p => p.xwins).filter(v => v > 0);
     xwMin = xw.length ? Math.min(...xw) : 0;
@@ -254,8 +254,10 @@ function renderPool() {
         var spCell = p.spRank == null
             ? '<span class="muted">—</span>'
             : `<span class="sp-badge" title="SP+ rating ${p.sp}">#${p.spRank}</span>`;
+        var accent = (p.color && window.ccTeamAccent) ? ccTeamAccent(p.color) : '';
+        var teamCellStyle = accent ? ` style="box-shadow: inset 3px 0 0 ${accent}"` : '';
         return `<tr class="${drafted ? 'drafted' : ''}">
-            <td><a class="team-link" href="/team?team=${p.id}" target="_blank" rel="noopener"><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></a></td>
+            <td${teamCellStyle}><a class="team-link" href="/team?team=${p.id}" target="_blank" rel="noopener"><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></a></td>
             <td>${escapeHtml(p.conf)}</td>
             <td class="num">${spCell}</td>
             <td class="num">${badge}</td>
@@ -282,7 +284,9 @@ function renderPool() {
                 ? `<img class="pc-conf-logo" src="${cl}" alt="${escapeHtml(p.conf)}" title="${escapeHtml(p.conf)}">`
                 : `<span class="pc-conf">${escapeHtml(p.conf)}</span>`;
             var ptsLabel = p.scoreYear ? `'${String(p.scoreYear).slice(-2)} pts` : 'pts';
-            return `<div class="pool-card${drafted ? ' drafted' : ''}">
+            var accent = (p.color && window.ccTeamAccent) ? ccTeamAccent(p.color) : '';
+            var cardStyle = accent ? ` style="border-left: 3px solid ${accent}"` : '';
+            return `<div class="pool-card${drafted ? ' drafted' : ''}"${cardStyle}>
                 ${action}
                 <div class="pool-card-main">
                     <a class="team-link" href="/team?team=${p.id}" target="_blank" rel="noopener"><span class="team-cell"><img src="${p.logo}" alt="${escapeHtml(p.name)}">${escapeHtml(p.name)}</span></a>
@@ -523,7 +527,12 @@ function renderBoard() {
             var cls = isClock ? 'draft-board-cell on-clock-cell' : 'draft-board-cell';
             if (pick) {
                 var freshCls = (justPickedKey === String(userId) + '-' + round) ? ' just-picked' : '';
-                bodyStr += `<td class="${cls}${freshCls}"><a href="/team?team=${pick.team.id}" target="_blank" rel="noopener" title="${escapeHtml(pick.team.school)}"><img src="${pick.team.logos ? ccLogo(pick.team.logos) : ''}" alt="${escapeHtml(pick.team.school)}"></a></td>`;
+                // Tint the cell in the drafted team's color so the board reads as a
+                // mosaic of everyone's rosters. Skip when it's the on-clock cell so
+                // the active-pick highlight isn't overridden.
+                var tint = (!isClock && pick.team.color && window.ccTeamTint) ? ccTeamTint(pick.team.color, 0.20) : '';
+                var cellStyle = tint ? ` style="background-color: ${tint}"` : '';
+                bodyStr += `<td class="${cls}${freshCls}"${cellStyle}><a href="/team?team=${pick.team.id}" target="_blank" rel="noopener" title="${escapeHtml(pick.team.school)}"><img src="${pick.team.logos ? ccLogo(pick.team.logos) : ''}" alt="${escapeHtml(pick.team.school)}"></a></td>`;
             } else {
                 bodyStr += `<td class="${cls}"></td>`;
             }

--- a/public/logo.js
+++ b/public/logo.js
@@ -11,8 +11,14 @@
 // becomes the dark-*16px* logo on the new one — blurry everywhere. pickLogo
 // chooses by variant + resolution instead, so it's correct on both shapes.
 (function (root, factory) {
-    if (typeof module === 'object' && module.exports) module.exports = factory();
-    else root.ccLogo = factory().pickLogo;
+    if (typeof module === 'object' && module.exports) { module.exports = factory(); }
+    else {
+        var cc = factory();
+        root.ccLogo = cc.pickLogo;
+        root.ccTeamColor = cc.teamColor;    // strong: legible as text on dark
+        root.ccTeamAccent = cc.teamAccent;  // hue-true: accent bars/tints
+        root.ccTeamTint = cc.teamTint;      // rgba wash of the accent color
+    }
 }(typeof self !== 'undefined' ? self : this, function () {
     // The pixel size from a logo URL — the path segment before the filename
     // (".../500/333.png" -> 500; ESPN's ".../500-dark/333.png" -> 500). 0 if none.
@@ -41,5 +47,44 @@
         return best.u;
     }
 
-    return { pickLogo: pickLogo, logoSize: logoSize };
+    // ---- Team colors ---------------------------------------------------------
+    // CFBD gives each team a `color`/`alt_color` hex (sometimes without the '#').
+    // The app is dark-themed, so a raw navy/black team color would disappear.
+    // teamColor() lightens very dark colors until they read on #101322 (mirrors
+    // team.js readableOnDark), and teamTint() returns an rgba wash of it. Used as
+    // an *accent* only (bars, tints) — never for body text or large fills.
+    function hexToRgb(hex) {
+        if (typeof hex !== 'string') return null;
+        var m = hex.trim().replace('#', '');
+        if (m.length === 3) m = m.split('').map(function (c) { return c + c; }).join('');
+        if (!/^[0-9a-fA-F]{6}$/.test(m)) return null;
+        return { r: parseInt(m.slice(0, 2), 16), g: parseInt(m.slice(2, 4), 16), b: parseInt(m.slice(4, 6), 16) };
+    }
+    function luminance(r, g, b) {
+        var a = [r, g, b].map(function (v) { v /= 255; return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); });
+        return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+    }
+    // Lighten toward white until the color clears `minLum`. A high floor makes a
+    // color readable as *text* (but desaturates strong-but-dark hues like scarlet
+    // into pink); a low floor just rescues near-black/navy while keeping saturated
+    // colors true — right for a decorative accent bar/tint.
+    function lift(hex, minLum, step) {
+        var rgb = hexToRgb(hex);
+        if (!rgb) return null;
+        var r = rgb.r, g = rgb.g, b = rgb.b, guard = 0;
+        while (luminance(r, g, b) < minLum && guard < 14) {
+            r = r + (255 - r) * step; g = g + (255 - g) * step; b = b + (255 - b) * step; guard++;
+        }
+        var h = function (v) { return Math.round(Math.max(0, Math.min(255, v))).toString(16).padStart(2, '0'); };
+        return '#' + h(r) + h(g) + h(b);
+    }
+    function teamColor(hex) { return lift(hex, 0.22, 0.18); }   // legible as text
+    function teamAccent(hex) { return lift(hex, 0.10, 0.12); }  // hue-true bar/tint
+    function teamTint(hex, alpha) {
+        var rgb = hexToRgb(teamAccent(hex));
+        if (!rgb) return '';
+        return 'rgba(' + rgb.r + ',' + rgb.g + ',' + rgb.b + ',' + (alpha == null ? 0.16 : alpha) + ')';
+    }
+
+    return { pickLogo: pickLogo, logoSize: logoSize, teamColor: teamColor, teamAccent: teamAccent, teamTint: teamTint };
 }));

--- a/public/standings.js
+++ b/public/standings.js
@@ -681,22 +681,22 @@ async function getRankings (week, seasonType, seasonYear) {
 
 async function parseTeamLogos (game, allTeamLogos) {
 
-        var awayTeamLogo = allTeamLogos.find((element) => element.id == game.awayId);
-        var homeTeamLogo = allTeamLogos.find((element) => element.id == game.homeId);
+        var awayTeamObj = allTeamLogos.find((element) => element.id == game.awayId);
+        var homeTeamObj = allTeamLogos.find((element) => element.id == game.homeId);
 
-        if (awayTeamLogo == null) {
-            awayTeamLogo = '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
-        } else {
-            awayTeamLogo = '<img src="' + ccLogo(awayTeamLogo.logos) + '" style="padding-right: 5px;">';
-        }
+        // Per-team color accent (see logo.js); '' when the team/color is missing.
+        var awayColor = (awayTeamObj && awayTeamObj.color && window.ccTeamAccent) ? ccTeamAccent(awayTeamObj.color) : '';
+        var homeColor = (homeTeamObj && homeTeamObj.color && window.ccTeamAccent) ? ccTeamAccent(homeTeamObj.color) : '';
 
-        if (homeTeamLogo == null) {
-            homeTeamLogo = '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
-        } else {
-            homeTeamLogo = '<img src="' + ccLogo(homeTeamLogo.logos) + '" style="padding-right: 5px;">';
-        }
+        var awayTeamLogo = awayTeamObj == null
+            ? '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>'
+            : '<img src="' + ccLogo(awayTeamObj.logos) + '" style="padding-right: 5px;">';
 
-        const logoResponse = {awayTeamLogo, homeTeamLogo};
+        var homeTeamLogo = homeTeamObj == null
+            ? '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>'
+            : '<img src="' + ccLogo(homeTeamObj.logos) + '" style="padding-right: 5px;">';
+
+        const logoResponse = {awayTeamLogo, homeTeamLogo, awayColor, homeColor};
         return logoResponse;
 }
 
@@ -926,6 +926,8 @@ async function displaySchedule(data) {
                     var teamLogos = await parseTeamLogos(game, allTeamLogos);
                     var awayImg = teamLogos.awayTeamLogo;
                     var homeImg = teamLogos.homeTeamLogo;
+                    var awayRowAccent = teamLogos.awayColor ? `; box-shadow: inset 3px 0 0 ${teamLogos.awayColor}; padding-left: 8px` : '';
+                    var homeRowAccent = teamLogos.homeColor ? `; box-shadow: inset 3px 0 0 ${teamLogos.homeColor}; padding-left: 8px` : '';
 
                     if (game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
                         var existObject = exists(otherUsers, game.homeId);
@@ -1028,13 +1030,13 @@ async function displaySchedule(data) {
                     var teamTable = '<td><table class="schedule-table game-table"><tbody><tr firstRow></tr>';
                     teamTable += `<tr id="awayUserRow"><td><strong>${awayUser}</strong></td></tr>`;
 
-                    teamTable += '<tr><td style="width: 250px;">';
-        
+                    teamTable += '<tr><td style="width: 250px;' + awayRowAccent + '">';
+
                     teamTable += awayImg + awayRank + awayTeam;
                     teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 70px;">' + topData;
                     teamTable += '</tr>';
-        
-                    teamTable += '<tr><td style="width: 250px;">';
+
+                    teamTable += '<tr><td style="width: 250px;' + homeRowAccent + '">';
                     teamTable += homeImg + homeRank + homeTeam;
                     teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                     teamTable += '</tr>';
@@ -1114,16 +1116,18 @@ async function displaySchedule(data) {
                         var teamLogos = await parseTeamLogos(game, allTeamLogos);
                         var awayImg = teamLogos.awayTeamLogo;
                         var homeImg = teamLogos.homeTeamLogo;
+                        var awayRowAccent = teamLogos.awayColor ? `; box-shadow: inset 3px 0 0 ${teamLogos.awayColor}; padding-left: 8px` : '';
+                        var homeRowAccent = teamLogos.homeColor ? `; box-shadow: inset 3px 0 0 ${teamLogos.homeColor}; padding-left: 8px` : '';
 
                         var teamTable = '<td><table class="schedule-table game-table"><tbody><tr></tr>';
                         teamTable += `<tr id="awayUserRow"><td><strong>${awayUser}</strong></td></tr>`;
 
-                        teamTable += '<tr><td style="width: 250px;">';
+                        teamTable += '<tr><td style="width: 250px;' + awayRowAccent + '">';
                         teamTable += awayImg + awayRank + awayTeam;
                         teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 70px;">' + topData;
                         teamTable += '</tr>';
-            
-                        teamTable += '<tr><td style="width: 250px;">';
+
+                        teamTable += '<tr><td style="width: 250px;' + homeRowAccent + '">';
                         teamTable += homeImg + homeRank + homeTeam;
                         teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                         teamTable += `<tr><td><strong>${homeUser}</strong></td></tr>`;

--- a/public/team.css
+++ b/public/team.css
@@ -193,6 +193,7 @@
         flex-direction: row;
         align-items: center;
         gap: 0.5em;
+        padding-left: 8px;   /* room for the per-team color accent bar */
     }
 
     .game-info {

--- a/public/team.js
+++ b/public/team.js
@@ -676,10 +676,19 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
                 }
             }
 
-            var homeLogo = ccLogo((logos.find((team) => team.id == game.homeId))?.logos);
+            var homeTeamObj = logos.find((team) => team.id == game.homeId);
+            var awayTeamObj = logos.find((team) => team.id == game.awayId);
+
+            // Per-team color accent bar on each schedule row (see logo.js).
+            var homeAccent = (homeTeamObj && homeTeamObj.color && window.ccTeamAccent) ? ccTeamAccent(homeTeamObj.color) : '';
+            var awayAccent = (awayTeamObj && awayTeamObj.color && window.ccTeamAccent) ? ccTeamAccent(awayTeamObj.color) : '';
+            var homeRowStyle = homeAccent ? ` style="box-shadow: inset 3px 0 0 ${homeAccent}"` : '';
+            var awayRowStyle = awayAccent ? ` style="box-shadow: inset 3px 0 0 ${awayAccent}"` : '';
+
+            var homeLogo = ccLogo(homeTeamObj?.logos);
             homeLogo = homeLogo ? `<img src="${homeLogo}" alt="${game.homeTeam}">` : '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
 
-            var awayLogo = ccLogo((logos.find((team) => team.id == game.awayId))?.logos);
+            var awayLogo = ccLogo(awayTeamObj?.logos);
             awayLogo = awayLogo ? `<img src="${awayLogo}" alt="${game.awayTeam}">` : '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
 
             var pollName = 'Playoff Committee Rankings';
@@ -759,10 +768,10 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
             html += `
                 <div class="game-row">
                     <div class="game-info">
-                        <div class="team-row">
+                        <div class="team-row"${awayRowStyle}>
                             <span class="team-vs">${awayTeamHTML}
                         </div>
-                        <div class="team-row">
+                        <div class="team-row"${homeRowStyle}>
                             <span class="team-vs">${homeTeamHTML}
                         </div>
                         <span class="game-date">${formatDate(game.startTimeTbd, game.startDate)}${game.outlet ? ` · <span class="game-tv">${window.ccIcon ? window.ccIcon('broadcast', { size: 14 }) : ''} ${game.outlet}</span>` : ''}</span>

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -461,16 +461,22 @@ function hydrateRoster(user, activeYear) {
     const g = document.getElementById('uh-glance-roster');
     if (g) {
         g.innerHTML = top && top.pts > 0
-            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => `<span class="uh-rg-row"><img src="${ccLogo(c.t.logos)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></span>`).join('')}</span>`
+            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => {
+                const acc = (c.t.color && window.ccTeamAccent) ? ccTeamAccent(c.t.color) : '';
+                return `<span class="uh-rg-row"${acc ? ` style="box-shadow: inset 3px 0 0 ${acc}; padding-left: 6px"` : ''}><img src="${ccLogo(c.t.logos)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></span>`;
+              }).join('')}</span>`
             : (uhOwns(user) ? 'Your 10 teams' : 'Their 10 teams');
     }
 
     uhDrawer.roster = (body) => {
         const max = (cards[0] && cards[0].pts) || 1;
-        const list = cards.map(c => `<a class="uh-rc" href="/team?team=${c.t.id}">
+        const list = cards.map(c => {
+            const acc = (c.t.color && window.ccTeamAccent) ? ccTeamAccent(c.t.color) : '';
+            return `<a class="uh-rc"${acc ? ` style="box-shadow: inset 3px 0 0 ${acc}; padding-left: 10px"` : ''} href="/team?team=${c.t.id}">
             <img src="${ccLogo(c.t.logos)}" alt="">
             <span class="uh-rc-meta"><span class="uh-rc-nm">${escapeHtml(c.t.school)}</span><span class="uh-rc-bar"><i style="width:${Math.round((c.pts / max) * 100)}%"></i></span></span>
-            <span class="uh-rc-pts num">${c.pts}</span></a>`).join('');
+            <span class="uh-rc-pts num">${c.pts}</span></a>`;
+        }).join('');
         body.innerHTML = `<div class="uh-seg">
                 <button type="button" class="uh-seg-btn active" data-view="cards">Sorted</button>
                 <button type="button" class="uh-seg-btn" data-view="grid">Week by week</button>
@@ -1604,14 +1610,23 @@ async function batchTeamLogos(games) {
         });
         if (res.status === 200) {
             (await res.json()).forEach(t => {
-                if (t && t.logos && t.logos.length) map[t.id] = '<img src="' + ccLogo(t.logos) + '" style="padding-right: 5px;">';
+                if (!t) return;
+                map[t.id] = {
+                    logo: (t.logos && t.logos.length) ? '<img src="' + ccLogo(t.logos) + '" style="padding-right: 5px;">' : '',
+                    color: (t.color && window.ccTeamAccent) ? ccTeamAccent(t.color) : ''
+                };
             });
         }
     } catch (e) { /* fall back to helmet icons */ }
     return map;
 }
 function logoHtmlFromMap(map, teamId) {
-    return map[teamId] || '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
+    var e = map[teamId];
+    return (e && e.logo) || '<i class="fa-solid fa-helmet-un" style="padding-right: 5px;"></i>';
+}
+function teamAccentFromMap(map, teamId) {
+    var e = map[teamId];
+    return (e && e.color) || '';
 }
 
 // Formats a kickoff time like "7:30PM" from a game's start date.
@@ -1678,9 +1693,13 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
         homeScore = (game.startTimeTbd ? 'TBD' : kickoffTime(d)) + '</td>';
     }
 
+    const teamTdStyle = (c) => c ? ` style="box-shadow: inset 3px 0 0 ${c}; padding-left: 8px"` : '';
+    const awayAccent = teamAccentFromMap(logoMap, game.awayId);
+    const homeAccent = teamAccentFromMap(logoMap, game.homeId);
+
     return '<div class="game-card"><table class="game-table"><tbody><tr></tr>'
-        + '<tr><td class="gc-team">' + awayCol + '</td><td class="gc-divider"></td><td class="gc-score">' + awayScore + '</tr>'
-        + '<tr><td class="gc-team">' + homeCol + '</td><td class="gc-divider"></td><td class="gc-score">' + homeScore + '</tr>'
+        + '<tr><td class="gc-team"' + teamTdStyle(awayAccent) + '>' + awayCol + '</td><td class="gc-divider"></td><td class="gc-score">' + awayScore + '</tr>'
+        + '<tr><td class="gc-team"' + teamTdStyle(homeAccent) + '>' + homeCol + '</td><td class="gc-divider"></td><td class="gc-score">' + homeScore + '</tr>'
         + (game.outlet ? '<tr><td class="game-broadcast">' + (window.ccIcon ? window.ccIcon('broadcast', { size: 15 }) : '') + ' ' + game.outlet + '</td></tr>' : '')
         + '<tr><td class="game-notes">' + (game.notes || '') + '</td></tr>'
         + '</tbody></table></div>';

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -26,7 +26,7 @@ router.post('/teamLogos', async (req, res) => {
         if (!Array.isArray(req.body.teams)) {
             return res.status(400).json({message: 'teams must be an array of team ids'});
         }
-        const teamLogos = await Team.find({id: {$in: req.body.teams}}, "id school logos");
+        const teamLogos = await Team.find({id: {$in: req.body.teams}}, "id school logos color alt_color");
 
         if (JSON.stringify(teamLogos) === '[]') {
             res.status(400).json({message: `No teams found with names ${req.body.teams}`});
@@ -42,7 +42,7 @@ router.post('/teamLogos', async (req, res) => {
 //Getting All Logos
 router.get('/teamLogos/all', async (req,res) => {
     try {
-        const teamLogos = await Team.find({}, "id logos");
+        const teamLogos = await Team.find({}, "id logos color alt_color");
 
         if (JSON.stringify(teamLogos) === '[]') {
             res.status(400).json({message: `Couldn't get all logos for all teams`});


### PR DESCRIPTION
Surfaces each school's real colors (stored in `models/team.js` / the user's roster, delivered via `/teams`) as an **accent layer only** — a left color bar/tint, never text or large fills — so the dark theme stays legible. From the UI/UX audit's team-color-theming idea (#6). Applied to all leagues (no per-league toggle yet — noted below). Client-side plus one backward-compatible projection tweak.

## Shared helper
- **`logo.js`** (app-wide): `ccTeamColor` / `ccTeamAccent` / `ccTeamTint`. `ccTeamAccent` keeps saturated hues true (scarlet stays scarlet) and only lifts genuinely-dark colors (navy/black) to be visible on `#101322`.

## Surfaces
- **Draft room** — pool rows/cards get a color bar; the live board tints each drafted cell (roster mosaic), skipping the on-clock cell.
- **Team detail page** — each schedule game row gets a per-team accent bar.
- **Standings** — schedule game cards get a per-team accent bar (both build paths).
- **My Team** — game cards get per-team accent bars; roster glance rows + roster drawer cards get the team's color accent.

## Server
- `routes/teams.js`: added `color`/`alt_color` to the `/teams/teamLogos` and `/teams/teamLogos/all` projections (extra fields; backward-compatible).

## Verification
Verified live on localhost: the **draft pool + board** and the **team detail page schedule** render true team-color accents (dark colors lifted to legible), no console errors. The **standings schedule**, **My Team game cards**, and **My Team roster** only render with in-season / active-roster data (empty in the 2026 preseason), so those were verified functionally (the builders emit the accents and `ccTeamAccent` resolves the real team/roster colors) rather than visually. They use the same helper + pattern as the verified surfaces.

## Not included (follow-ups)
- **Per-league toggle** so the Claunts league can stay classic (you chose "apply to all leagues for now").
- The conference mini-standings widget on the team page (left neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)