### PR TITLE
Draft pick confetti: radial burst from the drafted logo

### DIFF
--- a/public/confetti.js
+++ b/public/confetti.js
@@ -160,11 +160,11 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 		ctx.clearRect(0, 0, canvas.width, canvas.height);
 		for (var i = parts.length - 1; i >= 0; i--) {
 			var p = parts[i];
-			p.vy += 0.3;                 // gravity
+			p.vy += 0.12;                // gravity (lower = slower fall / more float)
 			p.vx *= 0.985; p.vy *= 0.985; // air drag
 			p.x += p.vx; p.y += p.vy;
 			p.rot += p.rotSpeed;
-			p.life -= 0.012;
+			p.life -= 0.007;             // fade slower so they linger while drifting down
 			if (p.life <= 0 || p.y > canvas.height + 40) { parts.splice(i, 1); continue; }
 			ctx.save();
 			ctx.globalAlpha = Math.max(0, Math.min(1, p.life));

--- a/public/confetti.js
+++ b/public/confetti.js
@@ -164,7 +164,7 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 			p.vx *= 0.837; p.vy *= 0.837; // air drag (lower = more float)
 			p.x += p.vx; p.y += p.vy;
 			p.rot += p.rotSpeed;
-			p.life -= 0.006;             // fade slower so they linger while drifting down
+			p.life -= 0.005;             // fade slower so they linger while drifting down
 			if (p.life <= 0 || p.y > canvas.height + 40) { parts.splice(i, 1); continue; }
 			ctx.save();
 			ctx.globalAlpha = Math.max(0, Math.min(1, p.life));

--- a/public/confetti.js
+++ b/public/confetti.js
@@ -132,3 +132,72 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 		}
 	}
 })();
+
+// ---------------------------------------------------------------------------
+// ccBurst(x, y, colors): a radial confetti *pop* that erupts outward from a
+// point (e.g. a freshly drafted logo on the board) and falls under gravity —
+// distinct from the rain above, which seeds across the top and falls straight
+// down. Its own fixed-position canvas, so (x, y) are viewport coordinates
+// (getBoundingClientRect). No-op under prefers-reduced-motion.
+// ---------------------------------------------------------------------------
+(function () {
+	var canvas, ctx, parts = [], raf = null;
+
+	function ensureCanvas() {
+		canvas = document.getElementById('confetti-burst-canvas');
+		if (!canvas) {
+			canvas = document.createElement('canvas');
+			canvas.id = 'confetti-burst-canvas';
+			canvas.setAttribute('style', 'position:fixed;left:0;top:0;display:block;z-index:999999;pointer-events:none;');
+			document.body.appendChild(canvas);
+		}
+		canvas.width = window.innerWidth;
+		canvas.height = window.innerHeight;
+		ctx = canvas.getContext('2d');
+	}
+
+	function loop() {
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+		for (var i = parts.length - 1; i >= 0; i--) {
+			var p = parts[i];
+			p.vy += 0.3;                 // gravity
+			p.vx *= 0.985; p.vy *= 0.985; // air drag
+			p.x += p.vx; p.y += p.vy;
+			p.rot += p.rotSpeed;
+			p.life -= 0.012;
+			if (p.life <= 0 || p.y > canvas.height + 40) { parts.splice(i, 1); continue; }
+			ctx.save();
+			ctx.globalAlpha = Math.max(0, Math.min(1, p.life));
+			ctx.translate(p.x, p.y);
+			ctx.rotate(p.rot);
+			ctx.fillStyle = p.color;
+			ctx.fillRect(-p.w / 2, -p.h / 2, p.w, p.h);
+			ctx.restore();
+		}
+		raf = parts.length ? requestAnimationFrame(loop) : null;
+		if (!parts.length) ctx.clearRect(0, 0, canvas.width, canvas.height);
+	}
+
+	window.ccBurst = function (x, y, colors) {
+		if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+		var palette = (colors && colors.length) ? colors : ['#ffffff', '#8E8CF0', '#22C37A', '#E0B341'];
+		ensureCanvas();
+		if (parts.length > 400) return; // guard against runaway if spammed
+		for (var i = 0; i < 110; i++) {
+			var angle = Math.random() * Math.PI * 2;   // full circle → radial eruption
+			var speed = 4 + Math.random() * 9;
+			parts.push({
+				x: x, y: y,
+				vx: Math.cos(angle) * speed,
+				vy: Math.sin(angle) * speed - 2,        // slight upward pop before gravity
+				w: 5 + Math.random() * 6,
+				h: 3 + Math.random() * 4,
+				rot: Math.random() * Math.PI,
+				rotSpeed: (Math.random() - 0.5) * 0.4,
+				life: 1 + Math.random() * 0.3,
+				color: palette[(Math.random() * palette.length) | 0]
+			});
+		}
+		if (raf === null) raf = requestAnimationFrame(loop);
+	};
+})();

--- a/public/confetti.js
+++ b/public/confetti.js
@@ -160,11 +160,11 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 		ctx.clearRect(0, 0, canvas.width, canvas.height);
 		for (var i = parts.length - 1; i >= 0; i--) {
 			var p = parts[i];
-			p.vy += 0.12;                // gravity (lower = slower fall / more float)
-			p.vx *= 0.985; p.vy *= 0.985; // air drag
+			p.vy += 0.102;               // gravity (lower = slower fall / more float)
+			p.vx *= 0.837; p.vy *= 0.837; // air drag (lower = more float)
 			p.x += p.vx; p.y += p.vy;
 			p.rot += p.rotSpeed;
-			p.life -= 0.007;             // fade slower so they linger while drifting down
+			p.life -= 0.006;             // fade slower so they linger while drifting down
 			if (p.life <= 0 || p.y > canvas.height + 40) { parts.splice(i, 1); continue; }
 			ctx.save();
 			ctx.globalAlpha = Math.max(0, Math.min(1, p.life));

--- a/public/confetti.js
+++ b/public/confetti.js
@@ -185,7 +185,7 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 		if (parts.length > 400) return; // guard against runaway if spammed
 		for (var i = 0; i < 110; i++) {
 			var angle = Math.random() * Math.PI * 2;   // full circle → radial eruption
-			var speed = 4 + Math.random() * 9;
+			var speed = 12 + Math.random() * 18;        // high initial pop → wide spread before drag slows it
 			parts.push({
 				x: x, y: y,
 				vx: Math.cos(angle) * speed,

--- a/public/confetti.js
+++ b/public/confetti.js
@@ -185,7 +185,7 @@ var removeConfetti; //call to stop the confetti animation and remove all confett
 		if (parts.length > 400) return; // guard against runaway if spammed
 		for (var i = 0; i < 110; i++) {
 			var angle = Math.random() * Math.PI * 2;   // full circle → radial eruption
-			var speed = 12 + Math.random() * 18;        // high initial pop → wide spread before drag slows it
+			var speed = 22 + Math.random() * 28;        // high initial pop → wide spread before drag slows it
 			parts.push({
 				x: x, y: y,
 				vx: Math.cos(angle) * speed,

--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -353,13 +353,21 @@ function onPickMade({ pick, state }) {
     justPickedKey = String(pick.userId) + '-' + pick.round;
     renderAll();
     // No per-pick toast — the board pick-reveal and the ticker already show it.
-    // Celebrate your own pick with a short confetti burst in white + the
-    // drafted team's colour.
-    if (String(pick.userId) === String(myUserId) && !ccReduced() && typeof startConfetti === 'function') {
-        var tc = pick.team && pick.team.color;
-        if (tc && tc.charAt(0) !== '#') tc = '#' + tc;
-        startConfetti(tc ? ['#ffffff', tc] : undefined);
-        setTimeout(function () { if (typeof stopConfetti === 'function') stopConfetti(); }, 2500);
+    // Celebrate your own pick with a confetti burst that erupts from the logo
+    // that just landed on the board, in white + the drafted team's colour.
+    if (String(pick.userId) === String(myUserId) && !ccReduced()) {
+        var raw = pick.team && pick.team.color;
+        var tc = (raw && window.ccTeamAccent) ? ccTeamAccent(raw) : (raw ? (raw.charAt(0) === '#' ? raw : '#' + raw) : null);
+        var colors = tc ? ['#ffffff', tc, tc] : undefined;   // weight toward the team color
+        // renderAll() above has already drawn the new pick's cell (.just-picked).
+        var cell = document.querySelector('#draft-board-body .draft-board-cell.just-picked');
+        if (cell && typeof window.ccBurst === 'function') {
+            var r = cell.getBoundingClientRect();
+            window.ccBurst(r.left + r.width / 2, r.top + r.height / 2, colors);
+        } else if (typeof startConfetti === 'function') {   // fallback: the old rain
+            startConfetti(colors);
+            setTimeout(function () { if (typeof stopConfetti === 'function') stopConfetti(); }, 2500);
+        }
     }
 }
 


### PR DESCRIPTION
On your own pick, confetti now **erupts from the drafted logo's cell on the board** and floats down, instead of raining straight down from the top of the screen.

## Changes (client-side only)
- **`confetti.js`**: new self-contained `ccBurst(x, y, colors)` on its own fixed-position canvas — particles spawn radially at a point, arc down under gravity + drag, and fade out. Shares one requestAnimationFrame loop across concurrent bursts, self-clears when empty, and is a no-op under `prefers-reduced-motion`. The existing full-screen rain (`startConfetti`) is untouched and still used for draft-complete.
- **`draftRoom.js`**: `onPickMade` fires `ccBurst` from the just-picked board cell's center (`getBoundingClientRect`), colored white + the drafted team's color. Falls back to the old rain if the cell or `ccBurst` isn't available.

## Tuning (feel)
Wide throw, slow floaty fall, gentle lingering fade — arrived at over a few iterations (initial speed 22–50 px/frame, gravity 0.102, drag 0.837, fade 0.005).

## Notes
- Independent of the team-color PR (#270). If that one merges too, the burst uses the legibility-adjusted `ccTeamAccent`; on its own it uses the raw team color (guarded, no error either way).

Verified live on localhost: burst erupts radially from the drafted cell and floats down; reduced-motion respected; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)