### PR TITLE
Standings: animated top-3 podium

### DIFF
--- a/public/standings.css
+++ b/public/standings.css
@@ -897,3 +897,61 @@
         white-space: nowrap;
     }
 }
+
+/* ---- Standings podium (top 3) ---------------------------------------------
+   Animated pedestal above the table, rendered by renderPodium() in
+   standings.js from the same ranked rows the table uses. Hidden in preseason
+   (no real leader). Pedestal heights are fixed by rank (1st tallest). */
+#standings-podium {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 10px;
+    max-width: 440px;
+    margin: 8px auto 24px;
+    padding: 0 10px;
+}
+.pod { display: flex; flex-direction: column; align-items: center; width: 31%; min-width: 0; }
+.pod-av {
+    width: 52px; height: 52px; border-radius: 50%; overflow: hidden; flex: 0 0 auto;
+    display: flex; align-items: center; justify-content: center;
+    border: 2px solid var(--cc-border); color: #fff; font-weight: 800; font-size: .9rem;
+    margin-bottom: 6px; opacity: 0; transform: translateY(10px) scale(.85);
+}
+.pod-av img { width: 100%; height: 100%; object-fit: cover; }
+.pod-1 .pod-av { width: 62px; height: 62px; border-color: var(--cc-amber); }
+.pod-bar {
+    width: 100%; height: 0; border-radius: 8px 8px 0 0;
+    background: var(--cc-surface); border: 1px solid var(--cc-border); border-bottom: none;
+    display: flex; align-items: flex-start; justify-content: center; padding-top: 8px;
+    font-weight: 800; color: var(--cc-muted);
+    transition: height .6s cubic-bezier(.3, 1.2, .4, 1);
+}
+.pod-1 .pod-bar { background: linear-gradient(180deg, rgba(224,179,65,.28), rgba(224,179,65,.04)); border-color: var(--cc-amber); color: var(--cc-amber); }
+.pod-2 .pod-bar { color: #cfd3e6; }
+.pod-3 .pod-bar { color: #c58a4e; }
+.pod-rank { font-family: Graduate, serif; font-size: 1rem; }
+.pod-nm {
+    font-size: .74rem; color: var(--cc-text); font-weight: 600; margin-top: 6px;
+    max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    opacity: 0; transform: translateY(6px);
+}
+.pod-pts { font-size: .72rem; color: var(--cc-muted); margin-top: 1px; opacity: 0; transform: translateY(6px); }
+
+#standings-podium.play .pod-bar { height: var(--h); }
+@media (prefers-reduced-motion: no-preference) {
+    #standings-podium.play .pod-av,
+    #standings-podium.play .pod-nm,
+    #standings-podium.play .pod-pts { animation: pod-in .45s ease forwards; }
+    #standings-podium.play .pod-1 .pod-av { animation-delay: .5s; }
+    #standings-podium.play .pod-1 .pod-nm, #standings-podium.play .pod-1 .pod-pts { animation-delay: .58s; }
+    #standings-podium.play .pod-2 .pod-av { animation-delay: .25s; }
+    #standings-podium.play .pod-2 .pod-nm, #standings-podium.play .pod-2 .pod-pts { animation-delay: .33s; }
+    #standings-podium.play .pod-3 .pod-av { animation-delay: .35s; }
+    #standings-podium.play .pod-3 .pod-nm, #standings-podium.play .pod-3 .pod-pts { animation-delay: .43s; }
+}
+@keyframes pod-in { to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) {
+    .pod-av, .pod-nm, .pod-pts { opacity: 1; transform: none; }
+    .pod-bar { transition: none; }
+}

--- a/public/standings.js
+++ b/public/standings.js
@@ -111,6 +111,10 @@ async function getUsers() {
         
         usersData = data;
 
+        // Preview: ?podium=demo seeds sample season points so the podium (and
+        // table) populate in the preseason. No-op without the query param.
+        if (new URLSearchParams(location.search).get('podium') === 'demo') seedDemoScores(data);
+
         if (data.length == 0) {
             document.querySelector('.no-data-message').removeAttribute('style');
             document.querySelector('.get-users-container').setAttribute('style', 'display: none;');
@@ -169,6 +173,11 @@ function displayUsers(data) {
 async function renderStandingsSection(data, league, season) {
     const params = new URLSearchParams(location.search);
     const preview = params.get('h2h') === '1' || !!params.get('h2hSim');
+
+    // Preview: force the classic points render so the seeded demo scores drive
+    // the table + podium (H2H rows come from matchup results, which are empty in
+    // the preseason).
+    if (params.get('podium') === 'demo') { displayUsers(data); return; }
 
     let enabled = false;
     if (league && season != null) {
@@ -231,6 +240,55 @@ function renderStandingsTable(rows, opts) {
         note.textContent = h2h ? 'Ranked by total points + H2H bonuses' : '';
         note.hidden = !h2h;
     }
+    renderPodium(rows);
+}
+
+// Small round avatar for a podium slot: uploaded photo (face-cropped) or a
+// colored initials fallback. Mirrors the ranked-row avatar.
+function podiumAvatar(r) {
+    if (r.avatarUrl) {
+        const src = r.avatarUrl.indexOf('/upload/') !== -1
+            ? r.avatarUrl.replace('/upload/', '/upload/c_fill,g_face,w_120,h_120,q_auto,f_auto/')
+            : r.avatarUrl;
+        return `<span class="pod-av"><img src="${src}" alt=""></span>`;
+    }
+    return `<span class="pod-av" style="background:${r.color || '#333'}">${escapeHtml(r.initials || '?')}</span>`;
+}
+
+// Top-3 podium above the table. Renders from the same ranked rows the table
+// uses, so it always matches the current mode. Hidden until the season has real
+// scoring (no arbitrary preseason podium). Pedestal heights are fixed by rank.
+function renderPodium(rows) {
+    const el = document.getElementById('standings-podium');
+    if (!el) return;
+    const top = (rows || []).filter(r => r.rank <= 3);
+    if (top.length < 3 || rows[0].preseason || !(rows[0].score > 0)) {
+        el.hidden = true; el.innerHTML = ''; el.classList.remove('play'); return;
+    }
+    const byRank = {};
+    rows.forEach(r => { byRank[r.rank] = r; });
+    const hByRank = { 1: 132, 2: 98, 3: 74 };
+    const order = [byRank[2], byRank[1], byRank[3]];   // visual order: 2nd · 1st · 3rd
+    el.hidden = false;
+    el.innerHTML = order.map(r => `
+        <div class="pod pod-${r.rank}">
+            ${podiumAvatar(r)}
+            <div class="pod-bar" style="--h:${hByRank[r.rank]}px"><span class="pod-rank">${r.rank}</span></div>
+            <div class="pod-nm">${escapeHtml(r.franchise || r.name)}</div>
+            <div class="pod-pts">${r.score} pts</div>
+        </div>`).join('');
+    requestAnimationFrame(() => { el.classList.remove('play'); void el.offsetWidth; el.classList.add('play'); });
+}
+
+// Preview only: ?podium=demo seeds sample season totals so the podium + table
+// populate in the preseason. Gated by the query param — never touches real data
+// otherwise.
+function seedDemoScores(users) {
+    const samples = [647, 612, 588, 551, 523, 498, 470, 452, 431, 410];
+    users.forEach((u, i) => {
+        if (!u.seasons || !u.seasons.length) u.seasons = [{}];
+        u.seasons[0].cumulativeScore = samples[i % samples.length];
+    });
 }
 
 // Each row's caret button toggles the hidden roster row that follows it. The

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -60,6 +60,7 @@
     </div>
     <div class="get-users-container" style="width: 100%;" get-users-container>
         <p class="standings-rank-note" standings-rank-note hidden></p>
+        <div id="standings-podium" hidden></div>
         <div class="table-wrapper">
             <table class="fl-table">
                 <thead user-table-head></thead>


### PR DESCRIPTION
Adds a **top-3 podium** above the Standings table — the first of the "moments" from the FX prototypes.

## What
- Gold **#1** elevated in the center, **silver/bronze** flanking; each slot shows the manager's avatar on top of the pedestal, name + points below.
- On load: pedestals **rise** and avatars/names **fade up** (staggered), reduced-motion aware.
- Renders from the **same ranked rows the table uses** (classic or H2H), so it always matches the current view.
- **Hidden in the preseason** (no real leader) — appears automatically once the season has scoring.

## Preview (how to see it now)
`/standings?podium=demo` seeds sample season totals **client-side only** (gated by the query param — never touches real data) so the podium + table populate in the preseason. Verified live on mobile: podium renders, avatars/names/points fade in, no console errors.

## Files
- `views/standings.ejs` — `#standings-podium` container above the table.
- `public/standings.js` — `renderPodium()` (called from `renderStandingsTable`), the demo seed, and a "demo forces classic" short-circuit so the seeded scores drive it.
- `public/standings.css` — podium styles + rise/fade animation.

## Note
The `?podium=demo` seed is a harmless, param-gated preview hook. Happy to strip it before merge if you'd rather it not ship, or keep it for future previews/screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)