### PR TITLE
Win reveal + commissioner-configurable H2H tie bonus

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -25,6 +25,7 @@ const scoringConfigSchema = new mongoose.Schema({
     engagement: {
         h2hEnabled: { type: Boolean, default: false },
         h2hWinBonus: { type: Number, default: 3 },
+        h2hTieBonus: { type: Number, default: 0 },
         captainEnabled: { type: Boolean, default: false },
         captainMultiplier: { type: Number, default: 2 }
     },

--- a/modules/h2h.js
+++ b/modules/h2h.js
@@ -44,14 +44,15 @@ function scheduleForWeeks(ids, weeks) {
 // Resolve one week's matchups. `totals` is { [id]: weeklyTotal } (missing → 0).
 // Returns { [id]: { result: 'W'|'L'|'T', bonus, opponent, for, against } } for
 // every manager who had a matchup that week (managers on a bye are omitted).
-function resolveWeek(pairs, totals, winBonus) {
+function resolveWeek(pairs, totals, winBonus, tieBonus) {
+    tieBonus = tieBonus || 0;   // default 0 keeps the original "ties push" behavior
     const out = {};
     (pairs || []).forEach(([a, b]) => {
         const fa = totals[a] || 0, fb = totals[b] || 0;
         let ra, rb, ba, bb;
         if (fa > fb) { ra = 'W'; rb = 'L'; ba = winBonus; bb = 0; }
         else if (fb > fa) { ra = 'L'; rb = 'W'; ba = 0; bb = winBonus; }
-        else { ra = rb = 'T'; ba = bb = 0; }   // ties push — no bonus
+        else { ra = rb = 'T'; ba = bb = tieBonus; }   // ties: each gets the tie bonus (0 = push)
         out[a] = { result: ra, bonus: ba, opponent: b, for: fa, against: fb };
         out[b] = { result: rb, bonus: bb, opponent: a, for: fb, against: fa };
     });
@@ -60,14 +61,14 @@ function resolveWeek(pairs, totals, winBonus) {
 
 // Full-season head-to-head standings. `totalsByIdWeek` is { [id]: { [week]: total } }.
 // Returns { [id]: { wins, losses, ties, bonus, pointsFor, pointsAgainst, weeks: [ {week, ...resolveWeek entry} ] } }.
-function seasonH2H(ids, weeks, totalsByIdWeek, winBonus) {
+function seasonH2H(ids, weeks, totalsByIdWeek, winBonus, tieBonus) {
     const schedule = scheduleForWeeks(ids, weeks);
     const acc = {};
     ids.forEach(id => { acc[id] = { wins: 0, losses: 0, ties: 0, bonus: 0, pointsFor: 0, pointsAgainst: 0, weeks: [] }; });
     weeks.forEach(w => {
         const totals = {};
         ids.forEach(id => { totals[id] = (totalsByIdWeek[id] && totalsByIdWeek[id][w]) || 0; });
-        const res = resolveWeek(schedule[w] || [], totals, winBonus);
+        const res = resolveWeek(schedule[w] || [], totals, winBonus, tieBonus);
         Object.keys(res).forEach(id => {
             const r = res[id], a = acc[id];
             if (r.result === 'W') a.wins++;

--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -194,7 +194,7 @@ function resolveConfig(league, overrides) {
 
 // Engagement (game modes) defaults: everything off, with the standard bonus /
 // multiplier values used when a mode is turned on.
-const ENGAGEMENT_DEFAULTS = { h2hEnabled: false, h2hWinBonus: 3, captainEnabled: false, captainMultiplier: 2 };
+const ENGAGEMENT_DEFAULTS = { h2hEnabled: false, h2hWinBonus: 3, h2hTieBonus: 0, captainEnabled: false, captainMultiplier: 2 };
 
 // Coerce a stored/partial engagement object into a complete, well-typed one.
 function normalizeEngagement(e) {
@@ -202,6 +202,7 @@ function normalizeEngagement(e) {
     return {
         h2hEnabled: !!e.h2hEnabled,
         h2hWinBonus: typeof e.h2hWinBonus === 'number' ? e.h2hWinBonus : ENGAGEMENT_DEFAULTS.h2hWinBonus,
+        h2hTieBonus: typeof e.h2hTieBonus === 'number' ? e.h2hTieBonus : ENGAGEMENT_DEFAULTS.h2hTieBonus,
         captainEnabled: !!e.captainEnabled,
         captainMultiplier: typeof e.captainMultiplier === 'number' ? e.captainMultiplier : ENGAGEMENT_DEFAULTS.captainMultiplier
     };

--- a/public/admin.js
+++ b/public/admin.js
@@ -1191,10 +1191,12 @@ async function loadEngagement() {
         var e = (cfg && cfg.engagement) || {};
         var h2h = document.querySelector('[eng-h2h-enabled]');
         var bonus = document.querySelector('[eng-h2h-bonus]');
+        var tieBonus = document.querySelector('[eng-h2h-tie-bonus]');
         var cap = document.querySelector('[eng-captain-enabled]');
         var mult = document.querySelector('[eng-captain-mult]');
         if (h2h) h2h.checked = !!e.h2hEnabled;
         if (bonus) bonus.value = (e.h2hWinBonus != null ? e.h2hWinBonus : 3);
+        if (tieBonus) tieBonus.value = (e.h2hTieBonus != null ? e.h2hTieBonus : 0);
         if (cap) cap.checked = !!e.captainEnabled;
         if (mult) mult.value = (e.captainMultiplier != null ? e.captainMultiplier : 2);
     } catch (e) { /* leave defaults */ }
@@ -1210,6 +1212,7 @@ if (engagementForm) {
             season: (seasonSel && seasonSel.value) || String(new Date().getFullYear()),
             h2hEnabled: document.querySelector('[eng-h2h-enabled]').checked,
             h2hWinBonus: Number(document.querySelector('[eng-h2h-bonus]').value),
+            h2hTieBonus: Number(document.querySelector('[eng-h2h-tie-bonus]').value),
             captainEnabled: document.querySelector('[eng-captain-enabled]').checked,
             captainMultiplier: Number(document.querySelector('[eng-captain-mult]').value)
         };
@@ -1222,7 +1225,7 @@ if (engagementForm) {
             const data = await res.json().catch(() => ({}));
             if (res.status === 200) {
                 successToast.options.text = `Game modes saved · ${data.season || body.season}`
-                    + (data.h2hEnabled ? ` · H2H +${data.h2hWinBonus}` : ' · H2H off')
+                    + (data.h2hEnabled ? ` · H2H +${data.h2hWinBonus}${data.h2hTieBonus ? '/+' + data.h2hTieBonus + ' tie' : ''}` : ' · H2H off')
                     + (data.captainEnabled ? ` · Captain ${data.captainMultiplier}×` : ' · Captain off');
                 successToast.showToast();
             } else {

--- a/public/standings.js
+++ b/public/standings.js
@@ -497,7 +497,7 @@ function renderH2HMatchups(d) {
 
     const preview = !d.enabled ? '<span class="h2h-preview-tag">preview</span>' : '';
     el.innerHTML = `<h2 class="h2h-panel-title">${window.ccIcon ? window.ccIcon('swords', { size: 22 }) : ''}This Week's Matchups${preview}</h2>
-        <p class="h2h-panel-note">Each week you face one rival — win the matchup for a <b>+${d.winBonus}</b> bonus (regular season only). Bonuses are folded into your <b>Total</b> in the standings above; see your full matchup log on My Team.</p>
+        <p class="h2h-panel-note">Each week you face one rival — win the matchup for a <b>+${d.winBonus}</b> bonus${d.tieBonus > 0 ? `, or <b>+${d.tieBonus}</b> each on a tie` : ''} (regular season only). Bonuses are folded into your <b>Total</b> in the standings above; see your full matchup log on My Team.</p>
         <div class="h2h-week-bar"><span class="h2h-week-cap">Matchups</span><select h2h-week aria-label="Matchup week">${weekOpts}</select></div>
         <div class="h2h-matches" h2h-matches></div>`;
     el.hidden = false;

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -206,9 +206,9 @@ function maybePreviewWinReveal() {
     if (!r || typeof window.ccWinReveal !== 'function') return;
     const result = r === 'loss' ? 'loss' : r === 'tie' ? 'tie' : 'win';
     const samples = {
-        win:  { oppLabel: 'Treyce W.', myScore: 142, oppScore: 130 },
+        win:  { oppLabel: 'Treyce W.', myScore: 142, oppScore: 130, bonus: 3 },
         loss: { oppLabel: 'Brock M.',  myScore: 118, oppScore: 141 },
-        tie:  { oppLabel: 'Cole W.',   myScore: 126, oppScore: 126 }
+        tie:  { oppLabel: 'Cole W.',   myScore: 126, oppScore: 126, bonus: 1 }
     };
     setTimeout(() => window.ccWinReveal(Object.assign({ result }, samples[result])), 500);
 }
@@ -450,7 +450,7 @@ async function hydratePreseasonModes(user, activeYear) {
     </div>`);
     if (eng.h2hEnabled) cards.push(`<div class="uh-mode">
         <div class="uh-mode-h"><span class="uh-mode-i h2h">${window.ccIcon ? window.ccIcon('swords', { size: 16 }) : '⚔'}</span>Head-to-head<span class="uh-mode-b h2h">+${eng.h2hWinBonus || 3}</span></div>
-        <div class="uh-mode-d">${own ? 'You’re' : 'Each manager is'} matched against a different manager every week. Outscore them for a <b>+${eng.h2hWinBonus || 3}</b> win bonus${own ? ' on top of your points' : ''}.</div>
+        <div class="uh-mode-d">${own ? 'You’re' : 'Each manager is'} matched against a different manager every week. Outscore them for a <b>+${eng.h2hWinBonus || 3}</b> win bonus${own ? ' on top of your points' : ''}.${eng.h2hTieBonus > 0 ? ` A tie earns <b>+${eng.h2hTieBonus}</b> each.` : ''}</div>
     </div>`);
 
     tile.innerHTML = `<span class="uh-tlabel">New in ${escapeHtml(activeYear)}<span class="uh-mode-only">This league</span></span>
@@ -734,7 +734,8 @@ async function hydrateH2H(user, activeYear) {
                         result: res,
                         oppLabel: (oppM && oppM.name) || 'your opponent',
                         myScore: iAmA ? g.aScore : g.bScore,
-                        oppScore: iAmA ? g.bScore : g.aScore
+                        oppScore: iAmA ? g.bScore : g.aScore,
+                        bonus: res === 'win' ? data.winBonus : res === 'tie' ? data.tieBonus : 0
                     }), 700);
                 }
             }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -194,6 +194,23 @@ async function renderBento(data) {
     hydrateRoster(data, activeYear);
     hydrateTrajectory(data, activeYear);
     hydrateGames(data, activeYear);
+
+    // Preview only: ?win=win|loss|tie plays a sample Win reveal so the moment
+    // can be previewed anytime. The real trigger lives in hydrateH2H (fires once
+    // when your weekly matchup goes final).
+    maybePreviewWinReveal();
+}
+
+function maybePreviewWinReveal() {
+    const r = new URLSearchParams(location.search).get('win');
+    if (!r || typeof window.ccWinReveal !== 'function') return;
+    const result = r === 'loss' ? 'loss' : r === 'tie' ? 'tie' : 'win';
+    const samples = {
+        win:  { oppLabel: 'Treyce W.', myScore: 142, oppScore: 130 },
+        loss: { oppLabel: 'Brock M.',  myScore: 118, oppScore: 141 },
+        tie:  { oppLabel: 'Cole W.',   myScore: 126, oppScore: 126 }
+    };
+    setTimeout(() => window.ccWinReveal(Object.assign({ result }, samples[result])), 500);
 }
 
 // ---------- Preseason My Team ----------
@@ -698,6 +715,31 @@ async function hydrateH2H(user, activeYear) {
     const mine = [];
     (data.schedule || []).forEach(s => { const g = s.games.find(x => x.aId === uid || x.bId === uid); if (g) mine.push({ week: s.week, final: s.final !== false, g }); });
     if (!mine.length) return hide();
+
+    // Win reveal: play the moment once when your latest matchup goes final —
+    // own profile only, skipped when a ?win= preview is already forcing it.
+    try {
+        if (uhOwns(user) && typeof window.ccWinReveal === 'function' && !new URLSearchParams(location.search).get('win')) {
+            const finals = mine.filter(x => x.final);
+            const latest = finals[finals.length - 1];
+            if (latest) {
+                const g = latest.g;
+                const iAmA = String(g.aId) === uid;
+                const res = g.winner === 'tie' ? 'tie' : ((g.winner === 'a') === iAmA ? 'win' : 'loss');
+                const oppM = byId[iAmA ? g.bId : g.aId];
+                const seenKey = 'cc_winreveal_' + season + '_wk' + latest.week;
+                if (window.localStorage.getItem(seenKey) !== '1') {
+                    window.localStorage.setItem(seenKey, '1');
+                    setTimeout(() => window.ccWinReveal({
+                        result: res,
+                        oppLabel: (oppM && oppM.name) || 'your opponent',
+                        myScore: iAmA ? g.aScore : g.bScore,
+                        oppScore: iAmA ? g.bScore : g.aScore
+                    }), 700);
+                }
+            }
+        }
+    } catch (e) { /* non-fatal — the reveal is a bonus */ }
 
     const me = byId[uid];
     // On your own profile your side reads "You"; on another manager's profile a

--- a/public/win-reveal.js
+++ b/public/win-reveal.js
@@ -78,6 +78,7 @@
         var head = result === 'win' ? 'You win!' : result === 'loss' ? 'Tough one' : 'All square';
         var opp = opts.oppLabel || 'your opponent';
         var sub = result === 'win' ? ('You beat ' + opp) : result === 'loss' ? (opp + ' got you') : ('Tied with ' + opp);
+        if (opts.bonus > 0 && result !== 'loss') sub += result === 'tie' ? (' · +' + opts.bonus + ' each') : (' · +' + opts.bonus + ' bonus');
         var hasScore = opts.myScore != null && opts.oppScore != null;
 
         var scrim = document.createElement('div');

--- a/public/win-reveal.js
+++ b/public/win-reveal.js
@@ -1,0 +1,123 @@
+// Win reveal: a transient full-screen "moment" that plays when your weekly H2H
+// matchup goes final — a slamming W (win), a quieter L (loss), or a T (tie),
+// with the score and confetti on a win. Self-contained: it injects its own
+// styles and confetti, so it works on any page that loads this one file.
+//
+//   ccWinReveal({ result:'win'|'loss'|'tie', oppLabel, myScore, oppScore, onDone })
+//
+// No-op-ish under prefers-reduced-motion (shows the card, skips the slam +
+// confetti). Auto-dismisses after ~2.8s; tap anywhere to dismiss early.
+(function () {
+    function reduced() {
+        return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
+    var styled = false;
+    function injectStyle() {
+        if (styled) return; styled = true;
+        var css =
+        '.cwr-scrim{position:fixed;inset:0;z-index:4000;display:flex;align-items:center;justify-content:center;' +
+        'background:rgba(16,19,34,.74);-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px);' +
+        'opacity:0;transition:opacity .3s ease;pointer-events:none}' +
+        '.cwr-scrim.show{opacity:1;pointer-events:auto}' +
+        '.cwr-card{display:flex;flex-direction:column;align-items:center;gap:8px;text-align:center;padding:0 24px}' +
+        '.cwr-stamp{font-family:Graduate,serif;font-weight:800;font-size:7.5rem;line-height:.9;' +
+        'color:var(--cc-success,#22C37A);text-shadow:0 8px 30px rgba(0,0,0,.5);opacity:0;transform:scale(2.8) rotate(-14deg)}' +
+        '.cwr-loss .cwr-stamp{color:var(--cc-danger,#B5423F)}.cwr-tie .cwr-stamp{color:var(--cc-muted,#8A90A8)}' +
+        '.cwr-stamp.slam{animation:cwr-slam .5s cubic-bezier(.3,1.5,.4,1) forwards}' +
+        '@keyframes cwr-slam{0%{opacity:0;transform:scale(2.8) rotate(-14deg)}' +
+        '60%{opacity:1;transform:scale(.92) rotate(-7deg)}100%{opacity:1;transform:scale(1) rotate(-7deg)}}' +
+        '.cwr-head{font-size:1.7rem;font-weight:800;color:var(--cc-text,#F4F6FB)}' +
+        '.cwr-sub{font-size:1rem;color:var(--cc-muted,#8A90A8)}' +
+        '.cwr-bar{width:min(280px,72vw);height:10px;border-radius:99px;background:rgba(0,0,0,.35);overflow:hidden;margin-top:6px}' +
+        '.cwr-bar i{display:block;height:100%;width:52%;border-radius:99px;background:var(--cc-success,#22C37A);transition:width .8s cubic-bezier(.4,0,.2,1)}' +
+        '.cwr-loss .cwr-bar i{background:var(--cc-danger,#B5423F)}.cwr-tie .cwr-bar i{background:var(--cc-muted,#8A90A8)}' +
+        '.cwr-score{font-size:1.5rem;font-weight:800;color:var(--cc-text,#F4F6FB);font-variant-numeric:tabular-nums}' +
+        '.cwr-tap{font-size:.72rem;color:var(--cc-muted,#8A90A8);margin-top:14px;opacity:.7}' +
+        '#cwr-burst{position:fixed;inset:0;z-index:4001;pointer-events:none}' +
+        '@media (prefers-reduced-motion:reduce){.cwr-stamp{opacity:1;transform:none}.cwr-bar i,.cwr-scrim{transition:none}}';
+        var s = document.createElement('style'); s.id = 'cwr-style'; s.textContent = css; document.head.appendChild(s);
+    }
+
+    // ---- self-contained confetti burst (the tuned draft burst) --------------
+    var cv, ctx, parts = [], raf = null;
+    function sizeCv() { cv.width = window.innerWidth; cv.height = window.innerHeight; ctx = cv.getContext('2d'); }
+    function ensureCv() {
+        cv = document.getElementById('cwr-burst');
+        if (!cv) { cv = document.createElement('canvas'); cv.id = 'cwr-burst'; document.body.appendChild(cv); }
+        sizeCv();
+    }
+    function loop() {
+        ctx.clearRect(0, 0, cv.width, cv.height);
+        for (var i = parts.length - 1; i >= 0; i--) {
+            var p = parts[i];
+            p.vy += 0.102; p.vx *= 0.837; p.vy *= 0.837; p.x += p.vx; p.y += p.vy; p.rot += p.rs; p.life -= 0.005;
+            if (p.life <= 0 || p.y > cv.height + 40) { parts.splice(i, 1); continue; }
+            ctx.save(); ctx.globalAlpha = Math.max(0, Math.min(1, p.life)); ctx.translate(p.x, p.y); ctx.rotate(p.rot);
+            ctx.fillStyle = p.c; ctx.fillRect(-p.w / 2, -p.h / 2, p.w, p.h); ctx.restore();
+        }
+        raf = parts.length ? requestAnimationFrame(loop) : null;
+        if (!parts.length) ctx.clearRect(0, 0, cv.width, cv.height);
+    }
+    function burst(x, y, cols) {
+        ensureCv();
+        for (var i = 0; i < 120; i++) {
+            var a = Math.random() * Math.PI * 2, s = 22 + Math.random() * 28;
+            parts.push({ x: x, y: y, vx: Math.cos(a) * s, vy: Math.sin(a) * s - 2, w: 5 + Math.random() * 6, h: 3 + Math.random() * 4,
+                rot: Math.random() * Math.PI, rs: (Math.random() - 0.5) * 0.4, life: 1 + Math.random() * 0.3, c: cols[(Math.random() * cols.length) | 0] });
+        }
+        if (raf === null) raf = requestAnimationFrame(loop);
+    }
+
+    window.ccWinReveal = function (opts) {
+        opts = opts || {};
+        var result = opts.result === 'loss' ? 'loss' : opts.result === 'tie' ? 'tie' : 'win';
+        injectStyle();
+
+        var stamp = result === 'win' ? 'W' : result === 'loss' ? 'L' : 'T';
+        var head = result === 'win' ? 'You win!' : result === 'loss' ? 'Tough one' : 'All square';
+        var opp = opts.oppLabel || 'your opponent';
+        var sub = result === 'win' ? ('You beat ' + opp) : result === 'loss' ? (opp + ' got you') : ('Tied with ' + opp);
+        var hasScore = opts.myScore != null && opts.oppScore != null;
+
+        var scrim = document.createElement('div');
+        scrim.className = 'cwr-scrim cwr-' + result;
+        scrim.innerHTML =
+            '<div class="cwr-card">' +
+                '<div class="cwr-stamp">' + stamp + '</div>' +
+                '<div class="cwr-head"></div>' +
+                '<div class="cwr-sub"></div>' +
+                (hasScore ? '<div class="cwr-bar"><i></i></div><div class="cwr-score"></div>' : '') +
+                '<div class="cwr-tap">tap to dismiss</div>' +
+            '</div>';
+        document.body.appendChild(scrim);
+        // textContent for the manager-supplied strings (names / franchise).
+        scrim.querySelector('.cwr-head').textContent = head;
+        scrim.querySelector('.cwr-sub').textContent = sub;
+        if (hasScore) scrim.querySelector('.cwr-score').textContent = opts.myScore + ' – ' + opts.oppScore;
+
+        var bar = scrim.querySelector('.cwr-bar i');
+        var isReduced = reduced();
+
+        requestAnimationFrame(function () {
+            scrim.classList.add('show');
+            if (!isReduced) scrim.querySelector('.cwr-stamp').classList.add('slam');
+            if (bar) setTimeout(function () { bar.style.width = result === 'win' ? '100%' : result === 'loss' ? '8%' : '50%'; }, 300);
+            if (result === 'win' && !isReduced) {
+                setTimeout(function () { burst(window.innerWidth / 2, window.innerHeight * 0.42, ['#ffffff', '#22C37A', '#8E8CF0', '#E0B341']); }, 380);
+            }
+        });
+
+        var done = false;
+        function close() {
+            if (done) return; done = true;
+            scrim.classList.remove('show');
+            setTimeout(function () { try { scrim.remove(); } catch (e) {} if (typeof opts.onDone === 'function') opts.onDone(); }, 320);
+        }
+        scrim.addEventListener('click', close);
+        setTimeout(close, opts.duration || 2800);
+        return close;
+    };
+
+    window.addEventListener('resize', function () { if (cv) sizeCv(); });
+})();

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -154,6 +154,7 @@ router.patch('/:league/engagement', async (req, res) => {
         const engagement = {
             h2hEnabled: !!b.h2hEnabled,
             h2hWinBonus: clamp(b.h2hWinBonus, 0, 20, 3),
+            h2hTieBonus: clamp(b.h2hTieBonus, 0, 20, 0),
             captainEnabled: !!b.captainEnabled,
             captainMultiplier: clamp(b.captainMultiplier, 1.5, 5, 2)
         };

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -297,6 +297,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // (a season with no entry is off), so one season's setting never leaks.
         const eng = engagementForSeason(cfgDoc && cfgDoc.engagementBySeason, season);
         const winBonus = eng.h2hWinBonus;
+        const tieBonus = eng.h2hTieBonus;
 
         // H2H matchups run the fantasy regular season only. Weeks 15+ (conf
         // championships, Army/Navy) and the postseason still count toward season
@@ -344,7 +345,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             caps[id] = {};
             (s.captains || []).forEach(c => { if (c && c.week != null) caps[id][c.week] = c.teamId; });
         });
-        if (!ids.length) return res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, weeks: [], managers: [], schedule: [] });
+        if (!ids.length) return res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, tieBonus, weeks: [], managers: [], schedule: [] });
 
         // Game status for in-progress weeks: whether each rostered team's game is
         // final / live / upcoming, and which weeks are fully complete. Pairings
@@ -429,7 +430,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const rec = {}; ids.forEach(id => { rec[id] = { wins: 0, losses: 0, ties: 0, bonus: 0, pointsFor: 0, pointsAgainst: 0 }; });
         finalWeeks.forEach(w => {
             const wt = {}; ids.forEach(id => { wt[id] = totals[id][w] || 0; });
-            const r = resolveWeek(scheduleAll[w] || [], wt, winBonus);
+            const r = resolveWeek(scheduleAll[w] || [], wt, winBonus, tieBonus);
             Object.keys(r).forEach(id => {
                 const a = rec[id], x = r[id];
                 if (x.result === 'W') a.wins++; else if (x.result === 'L') a.losses++; else a.ties++;
@@ -447,7 +448,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
 
         // Standings-only: the ranked table is ready; return before the matchup
         // win-prob build (which needs the projections skipped above).
-        if (standingsOnly) return res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, managers });
+        if (standingsOnly) return res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, tieBonus, managers });
 
         // Schedule payload: final weeks + the current in-progress week. Final
         // weeks show scored contributing teams; the current week shows each
@@ -567,7 +568,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             featuredWeek = w.week; currentWeekOut = w.week;
         }
 
-        res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, weeks: schedWeeks, featuredWeek, currentWeek: currentWeekOut, managers, schedule });
+        res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, tieBonus, weeks: schedWeeks, featuredWeek, currentWeek: currentWeekOut, managers, schedule });
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const { leagueCodeFor, canManageLeague } = require('./modules/league-access');
 const ScoringConfig = require('./models/scoringConfig');
 const User = require('./models/user');
 const League = require('./models/league');
-const { resolveConfig, fieldsForModel, LEAGUES } = require('./modules/scoring-defaults');
+const { resolveConfig, fieldsForModel, LEAGUES, engagementForSeason } = require('./modules/scoring-defaults');
 const draftToken = require('./modules/draft-token');
 const registerDraftSockets = require('./modules/draft-socket');
 const { cloudinaryConfig } = require('./modules/profile-update');
@@ -265,14 +265,17 @@ app.get('/rules', async (req, res) => {
         try {
             const doc = await ScoringConfig.findOne({ league: leagueCode });
             cfg = resolveConfig(leagueCode, doc
-                ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled }
+                ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, engagement: doc.engagement, engagementBySeason: doc.engagementBySeason }
                 : null);
         } catch (err) {
             cfg = resolveConfig(leagueCode, null);
         }
         const fields = fieldsForModel(cfg.model, cfg.disabled, cfg.enabled);
+        // Game-mode (H2H/Captain) settings for the active season, so the rules
+        // page can spell out the win/tie bonuses when the league runs H2H.
+        const engagement = engagementForSeason(cfg.engagementBySeason, Number(process.env.YEAR));
 
-        res.render('scoringRules', { user, userState, cfg, fields, leagueCode });
+        res.render('scoringRules', { user, userState, cfg, fields, leagueCode, engagement });
     } else {
         res.redirect("/login");
     }

--- a/tests/EngagementSeason.spec.js
+++ b/tests/EngagementSeason.spec.js
@@ -5,12 +5,12 @@ describe('normalizeEngagement', () => {
         expect(normalizeEngagement()).toEqual(ENGAGEMENT_DEFAULTS);
         expect(normalizeEngagement({})).toEqual(ENGAGEMENT_DEFAULTS);
         expect(normalizeEngagement({ h2hEnabled: 1, captainEnabled: 'yes' }))
-            .toEqual({ h2hEnabled: true, h2hWinBonus: 3, captainEnabled: true, captainMultiplier: 2 });
+            .toEqual({ h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0, captainEnabled: true, captainMultiplier: 2 });
     });
 
-    test('keeps provided numeric bonus / multiplier', () => {
-        expect(normalizeEngagement({ h2hEnabled: true, h2hWinBonus: 5, captainEnabled: true, captainMultiplier: 3 }))
-            .toEqual({ h2hEnabled: true, h2hWinBonus: 5, captainEnabled: true, captainMultiplier: 3 });
+    test('keeps provided numeric bonus / tie bonus / multiplier', () => {
+        expect(normalizeEngagement({ h2hEnabled: true, h2hWinBonus: 5, h2hTieBonus: 2, captainEnabled: true, captainMultiplier: 3 }))
+            .toEqual({ h2hEnabled: true, h2hWinBonus: 5, h2hTieBonus: 2, captainEnabled: true, captainMultiplier: 3 });
     });
 });
 
@@ -22,7 +22,7 @@ describe('engagementForSeason', () => {
 
     test('returns the exact season entry', () => {
         expect(engagementForSeason(bySeason, '2026'))
-            .toEqual({ h2hEnabled: true, h2hWinBonus: 3, captainEnabled: true, captainMultiplier: 2 });
+            .toEqual({ h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0, captainEnabled: true, captainMultiplier: 2 });
     });
 
     test('seasons are independent — 2027 has Captain off while 2026 has it on', () => {

--- a/tests/H2H.spec.js
+++ b/tests/H2H.spec.js
@@ -55,10 +55,15 @@ describe('resolveWeek', () => {
         expect(res.b).toMatchObject({ result: 'L', bonus: 0 });
         expect(res.d).toMatchObject({ result: 'W', bonus: 3, opponent: 'c' });
     });
-    test('ties push — no bonus to either side', () => {
+    test('ties push — no bonus to either side by default', () => {
         const res = resolveWeek([['a', 'b']], { a: 14, b: 14 }, 3);
         expect(res.a).toMatchObject({ result: 'T', bonus: 0 });
         expect(res.b).toMatchObject({ result: 'T', bonus: 0 });
+    });
+    test('a configured tie bonus is awarded to both sides on a tie', () => {
+        const res = resolveWeek([['a', 'b']], { a: 14, b: 14 }, 3, 1);
+        expect(res.a).toMatchObject({ result: 'T', bonus: 1 });
+        expect(res.b).toMatchObject({ result: 'T', bonus: 1 });
     });
     test('missing totals count as 0', () => {
         const res = resolveWeek([['a', 'b']], { a: 5 }, 3);

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -317,6 +317,7 @@
                         <div class="draft-field"><label>Season</label><select eng-season></select></div>
                         <div class="draft-field"><label><input type="checkbox" eng-h2h-enabled> Head-to-Head <span class="mode-hint">— weekly matchup vs one rival</span></label></div>
                         <div class="draft-field"><label>Win bonus (pts)</label><input type="number" eng-h2h-bonus min="0" max="20" step="1" value="3"></div>
+                        <div class="draft-field"><label>Tie bonus (pts) <span class="mode-hint">— each manager on a tie</span></label><input type="number" eng-h2h-tie-bonus min="0" max="20" step="1" value="0"></div>
                         <div class="draft-field"><label><input type="checkbox" eng-captain-enabled> Captain <span class="mode-hint">— double one team each week</span></label></div>
                         <div class="draft-field"><label>Captain multiplier</label><input type="number" eng-captain-mult min="1.5" max="5" step="0.5" value="2"></div>
                         <div><button type="submit">Save Game Modes</button></div>

--- a/views/scoringRules.ejs
+++ b/views/scoringRules.ejs
@@ -66,6 +66,27 @@
       </ul>
     </section>
 
+    <% if (engagement && (engagement.h2hEnabled || engagement.captainEnabled)) { %>
+    <section class="rules-section">
+      <h2 class="rule-header"><span data-icon="swords" data-icon-size="20"></span>Game Modes</h2>
+      <ul class="scoring-list">
+        <% if (engagement.h2hEnabled) { %>
+          <li><strong>Head-to-Head</strong> — each week you're matched against one rival. Outscore them for a <strong>+<%= engagement.h2hWinBonus %></strong> win bonus on top of your points.</li>
+          <li>
+            <% if (engagement.h2hTieBonus > 0) { %>
+              On a tie, <strong>both</strong> managers get <strong>+<%= engagement.h2hTieBonus %></strong> <%= engagement.h2hTieBonus === 1 ? 'pt' : 'pts' %>.
+            <% } else { %>
+              A tie is a <strong>push</strong> — no bonus for either manager.
+            <% } %>
+          </li>
+        <% } %>
+        <% if (engagement.captainEnabled) { %>
+          <li><strong>Captain</strong> — name one team each week; its points count <strong><%= engagement.captainMultiplier %>×</strong>.</li>
+        <% } %>
+      </ul>
+    </section>
+    <% } %>
+
     <section class="rules-section">
       <h2 class="rule-header"><span data-icon="chart" data-icon-size="20"></span>Rankings Used</h2>
       <p>Rankings are based on the <strong>AP Poll</strong> until the <strong>CFP Poll</strong> is released.</p>

--- a/views/scoringRules.ejs
+++ b/views/scoringRules.ejs
@@ -36,6 +36,27 @@
       </ul>
     </section>
 
+    <% if (engagement && (engagement.h2hEnabled || engagement.captainEnabled)) { %>
+    <section class="rules-section">
+      <h2 class="rule-header"><span data-icon="swords" data-icon-size="20"></span>Game Modes</h2>
+      <ul class="scoring-list">
+        <% if (engagement.h2hEnabled) { %>
+          <li><strong>Head-to-Head</strong> — each week you're matched against one rival. Outscore them for a <strong>+<%= engagement.h2hWinBonus %></strong> win bonus on top of your points.</li>
+          <li>
+            <% if (engagement.h2hTieBonus > 0) { %>
+              On a tie, <strong>both</strong> managers get <strong>+<%= engagement.h2hTieBonus %></strong> <%= engagement.h2hTieBonus === 1 ? 'pt' : 'pts' %>.
+            <% } else { %>
+              A tie is a <strong>push</strong> — no bonus for either manager.
+            <% } %>
+          </li>
+        <% } %>
+        <% if (engagement.captainEnabled) { %>
+          <li><strong>Captain</strong> — name one team each week; its points count <strong><%= engagement.captainMultiplier %>×</strong>.</li>
+        <% } %>
+      </ul>
+    </section>
+    <% } %>
+
     <section class="rules-section">
       <h2 class="rule-header"><span data-icon="football" data-icon-size="20"></span>Regular Season Scoring</h2>
       <p class="scoring-mode">
@@ -65,27 +86,6 @@
         <% }); %>
       </ul>
     </section>
-
-    <% if (engagement && (engagement.h2hEnabled || engagement.captainEnabled)) { %>
-    <section class="rules-section">
-      <h2 class="rule-header"><span data-icon="swords" data-icon-size="20"></span>Game Modes</h2>
-      <ul class="scoring-list">
-        <% if (engagement.h2hEnabled) { %>
-          <li><strong>Head-to-Head</strong> — each week you're matched against one rival. Outscore them for a <strong>+<%= engagement.h2hWinBonus %></strong> win bonus on top of your points.</li>
-          <li>
-            <% if (engagement.h2hTieBonus > 0) { %>
-              On a tie, <strong>both</strong> managers get <strong>+<%= engagement.h2hTieBonus %></strong> <%= engagement.h2hTieBonus === 1 ? 'pt' : 'pts' %>.
-            <% } else { %>
-              A tie is a <strong>push</strong> — no bonus for either manager.
-            <% } %>
-          </li>
-        <% } %>
-        <% if (engagement.captainEnabled) { %>
-          <li><strong>Captain</strong> — name one team each week; its points count <strong><%= engagement.captainMultiplier %>×</strong>.</li>
-        <% } %>
-      </ul>
-    </section>
-    <% } %>
 
     <section class="rules-section">
       <h2 class="rule-header"><span data-icon="chart" data-icon-size="20"></span>Rankings Used</h2>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -15,6 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
     <script defer src="draftGrades.js"></script>
+    <script src="win-reveal.js"></script>
     <script defer src="userHome.js"></script>
     <title>Campus Clash</title>
     <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>


### PR DESCRIPTION
A **transient** celebratory moment (no permanent page space — the thing the podium got wrong). When your weekly H2H matchup goes final:
- **Win** → a big **W** slams down on a dimmed My Team, "You beat <opp>", the win-prob bar snaps to 100%, and a confetti burst fires.
- **Loss** → a quieter red **L**, "<opp> got you", no confetti.
- **Tie** → a muted **T**.

Auto-dismisses after ~2.8s (tap to dismiss early). `prefers-reduced-motion` shows the card without the slam/confetti.

## Files
- `public/win-reveal.js` (new) — self-contained `ccWinReveal()`: injects its own styles + confetti, so it drops onto any page with one `<script>`.
- `views/userHome.ejs` — load `win-reveal.js`.
- `public/userHome.js` — real trigger in `hydrateH2H` (own profile only; fires **once per week** via `localStorage` when your latest matchup is final), plus a `?win=win|loss|tie` preview hook.

## Preview
- On your Mac (logged in): `/userHome?user=<id>&win=win` (or `&win=loss` / `&win=tie`).
- Phone: a static `_win-preview.html` (throwaway, not in this PR) with Win/Loss/Tie buttons, openable over Wi-Fi without login.

## Verification
Verified live on mobile: win reveal renders (stamp + prob bar + score + confetti), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)