### PR TITLE
Persist the H2H win bonus into cumulativeScore

### DIFF
--- a/docs/season-flip-runbook.md
+++ b/docs/season-flip-runbook.md
@@ -66,6 +66,13 @@ Admin → **Engagement**, pick season **2026** in the dropdown. Set H2H + Captai
 per league. *If skipped:* `engagementForSeason` returns OFF defaults, so both
 silently disable for 2026 until configured.
 
+> The H2H win/tie bonus is **banked into the weekly scores** by
+> `POST /scores/h2h-bonus`, which every scoring run calls between `updateScores`
+> and `updateCumulativeScores` — so it lands in `cumulativeScore` and the Hall of
+> Fame, My Team rank, weekly recap and projections all agree with the standings.
+> Nothing to run by hand: the pass re-derives from scratch each time, so turning
+> the mode on/off or changing the bonus mid-season self-corrects on the next run.
+
 ### 6. Configure the 2026 Draft (per league)
 Admin → **Configure Draft** (defaults to the active season). Sets pick order
 (reverse-2025-standings default, reorderable) and creates the `Draft` doc the

--- a/jest.config.json
+++ b/jest.config.json
@@ -12,6 +12,7 @@
     "coverageThreshold": {
         "./modules/scoring-detectors.js": { "statements": 95, "branches": 90, "functions": 100, "lines": 95 },
         "./modules/draft-grades.js": { "statements": 90, "branches": 70, "functions": 95, "lines": 95 },
+        "./modules/h2h.js": { "statements": 95, "branches": 85, "functions": 100, "lines": 100 },
         "./modules/internal-api.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./modules/job-runs-util.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./update-enrichment-job.js": { "statements": 80, "branches": 60, "functions": 60, "lines": 90 }

--- a/models/user.js
+++ b/models/user.js
@@ -89,7 +89,16 @@ const weeklyScoreSchema = new mongoose.Schema({
     // extra points it contributed (already included in `score`). Absent when
     // the league hasn't opted into Captain.
     captainTeamId: { type: Number },
-    captainBonus: { type: Number }
+    captainBonus: { type: Number },
+    // Head-to-head result for this week, written by the H2H bonus pass once the
+    // week settles. Like captainBonus, `h2hBonus` is ALREADY INCLUDED in `score`
+    // — that is what carries it into cumulativeScore and every surface that
+    // ranks by it. The pre-bonus total is score - h2hBonus (see
+    // modules/h2h.js baseWeekScore), which is what matchups resolve from.
+    // Absent when the league hasn't opted into H2H or the week hasn't settled.
+    h2hBonus: { type: Number },
+    h2hResult: { type: String, enum: ['W', 'L', 'T'] },
+    h2hOpponentId: { type: String }
 });
 
 const teamSchema = new mongoose.Schema({

--- a/modules/h2h.js
+++ b/modules/h2h.js
@@ -83,6 +83,170 @@ function seasonH2H(ids, weeks, totalsByIdWeek, winBonus, tieBonus) {
     return acc;
 }
 
+// H2H matchups run the fantasy regular season only. Weeks 15+ (conference
+// championships, Army/Navy) and the postseason still count toward season totals,
+// but their thin slates make for unfair matchups — so no H2H past this cap.
+// Shared by the standings read model and the scoring-time persistence pass so
+// they can never disagree on the range.
+const H2H_LAST_WEEK = 14;
+
+// The season subdocument for a user, tolerating both document shapes in use:
+// a full `seasons` array (routes querying by league) and a single-entry array
+// from an $elemMatch projection (GET /users/season/:year).
+function seasonEntry(user, season) {
+    return ((user && user.seasons) || []).find(s => String(s.season) === String(season)) || null;
+}
+
+// The BASE (pre-bonus) weekly total for a stored weeklyScore entry.
+//
+// The H2H win bonus is folded INTO entry.score once awarded (the same way the
+// Captain bonus is), so it reaches cumulativeScore and every surface that reads
+// it. That means matchups must always be resolved from the base — resolving from
+// entry.score would feed a week's own bonus back into deciding that week, and a
+// rescore would compound it. Subtracting the stored bonus is what makes the
+// whole pass idempotent.
+function baseWeekScore(entry) {
+    if (!entry) return 0;
+    return (entry.score || 0) - (entry.h2hBonus || 0);
+}
+
+// The bonus already folded into a season's stored scores. The standings read
+// model subtracts this from the bonus it computes, so it renders the same total
+// whether or not the scoring job has persisted the current values yet.
+function persistedBonus(season) {
+    return ((season && season.weeklyScore) || [])
+        .reduce((sum, e) => sum + (e.h2hBonus || 0), 0);
+}
+
+// The managers in a league+season's H2H, as a DETERMINISTIC id list.
+//
+// The pairing schedule is positional (circle-method round robin), so the id
+// ORDER decides who plays whom. Sorting by id makes that stable regardless of
+// document order — previously the list came back in Mongo's natural order, so
+// an unrelated write could in principle reshuffle a season's matchups. Managers
+// with no scored week yet are excluded (nothing to match up), which is what
+// keeps the preseason empty rather than a table of 0-0-0 rows.
+function h2hManagerIds(users, season) {
+    return (users || [])
+        .filter(u => {
+            const s = seasonEntry(u, season);
+            return !!(s && (s.weeklyScore || []).length);
+        })
+        .map(u => String(u._id))
+        .sort();
+}
+
+const round1 = (v) => Math.round(v * 10) / 10;
+
+// The single source of truth for "who won which H2H week, and what is it worth".
+// Used by BOTH the standings read model and the scoring-time persistence pass,
+// so the number shown in the standings and the number banked in cumulativeScore
+// come from the same computation.
+//
+// A week only settles once every game involving a drafted team is complete AND
+// somebody has been scored for it — an in-progress week has no decided winner.
+//
+// `users` are docs (or lean objects) carrying the season's teams + weeklyScore;
+// `games` are that season's regular-season games involving drafted teams.
+// Returns:
+//   awards      { [userId]: { [week]: { result, bonus, opponent, for, against } } }
+//   weekFinal   { [week]: bool }
+//   finalWeeks  settled weeks, ascending
+//   currentWeek the first week with games that hasn't settled (or null)
+function computeH2HAwards({ users, games, season, winBonus, tieBonus, lastWeek }) {
+    const last = lastWeek || H2H_LAST_WEEK;
+    const weeks = Array.from({ length: last }, (_, i) => i + 1);
+    const ids = h2hManagerIds(users, season);
+
+    const awards = {};
+    ids.forEach(id => { awards[id] = {}; });
+
+    // Base weekly totals + which weeks anyone has been scored for.
+    const totals = {}, scored = new Set(), drafted = new Set();
+    (users || []).forEach(u => {
+        const s = seasonEntry(u, season);
+        if (!s) return;
+        ((s.teams) || []).forEach(t => drafted.add(Number(t.id)));
+        const id = String(u._id);
+        if (!awards[id]) return;
+        const tw = {};
+        (s.weeklyScore || []).forEach(e => {
+            if (e.season === 'postseason' || e.week > last) return;
+            tw[e.week] = (tw[e.week] || 0) + baseWeekScore(e);
+            scored.add(e.week);
+        });
+        totals[id] = tw;
+    });
+
+    // A week's games, restricted to the ones that can gate it: regular season,
+    // in range, involving a drafted team.
+    const gamesByWeek = {};
+    (games || []).forEach(g => {
+        if (g.seasonType && g.seasonType !== 'regular') return;
+        if (g.week == null || g.week > last) return;
+        if (!drafted.has(Number(g.homeId)) && !drafted.has(Number(g.awayId))) return;
+        (gamesByWeek[g.week] = gamesByWeek[g.week] || []).push(g);
+    });
+
+    const weekFinal = {};
+    weeks.forEach(w => { weekFinal[w] = isWeekFinal(gamesByWeek[w]) && scored.has(w); });
+    const finalWeeks = weeks.filter(w => weekFinal[w]);
+    let currentWeek = null;
+    for (const w of weeks) {
+        if ((gamesByWeek[w] || []).length && !weekFinal[w]) { currentWeek = w; break; }
+    }
+
+    const schedule = scheduleForWeeks(ids, weeks);
+    finalWeeks.forEach(w => {
+        const wt = {};
+        ids.forEach(id => { wt[id] = (totals[id] && totals[id][w]) || 0; });
+        const res = resolveWeek(schedule[w] || [], wt, winBonus, tieBonus);
+        Object.keys(res).forEach(id => { awards[id][w] = res[id]; });
+    });
+
+    return { awards, weekFinal, finalWeeks, currentWeek, ids, schedule };
+}
+
+// Rebuild a season's weeklyScore with this manager's H2H awards folded in.
+// Pure: takes and returns PLAIN objects (the caller assigns the result onto the
+// document wholesale, which sidesteps subdocument-mutation quirks).
+//
+// Idempotent by construction — each entry's score is rebuilt from its base, so
+// running this twice, re-running after a rescore, changing the configured bonus,
+// or turning H2H off all converge on the right number instead of compounding.
+// Returns { weeklyScore, changed }.
+function applyAwards(weeklyScore, awardsForUser, lastWeek) {
+    const last = lastWeek || H2H_LAST_WEEK;
+    let changed = false;
+    const next = (weeklyScore || []).map(entry => {
+        const e = Object.assign({}, entry);
+        const inRange = e.season !== 'postseason' && e.week <= last;
+        const award = inRange ? ((awardsForUser || {})[e.week] || null) : null;
+
+        const base = baseWeekScore(e);
+        const bonus = award ? (award.bonus || 0) : 0;
+        const score = round1(base + bonus);
+        const result = award ? award.result : null;
+        const opponent = award ? String(award.opponent) : null;
+
+        const wasBonus = e.h2hBonus || 0;
+        const wasResult = e.h2hResult || null;
+        const wasOpponent = e.h2hOpponentId ? String(e.h2hOpponentId) : null;
+        if (wasBonus !== bonus || (e.score || 0) !== score || wasResult !== result || wasOpponent !== opponent) {
+            changed = true;
+        }
+
+        e.score = score;
+        // Absent rather than zeroed when there's no matchup, matching how the
+        // Captain fields are stored.
+        if (bonus) e.h2hBonus = bonus; else delete e.h2hBonus;
+        if (result) e.h2hResult = result; else delete e.h2hResult;
+        if (opponent) e.h2hOpponentId = opponent; else delete e.h2hOpponentId;
+        return e;
+    });
+    return { weeklyScore: next, changed };
+}
+
 // Classify a game's live state for in-progress matchup display.
 //   completed          -> 'final'
 //   kickoff passed     -> 'live'
@@ -143,4 +307,9 @@ function matchupWinProb(aEntries, bEntries) {
     return { a, b: 1 - a };
 }
 
-module.exports = { buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H, gameStatus, isWeekFinal, matchupWinProb };
+module.exports = {
+    buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H,
+    gameStatus, isWeekFinal, matchupWinProb,
+    H2H_LAST_WEEK, seasonEntry, baseWeekScore, persistedBonus,
+    h2hManagerIds, computeH2HAwards, applyAwards
+};

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -132,6 +132,10 @@ async function runFullUpdate({ withBetting = false } = {}) {
         }
         week = postWeeks[postWeeks.length - 1];   // report the latest for logging
 
+        // H2H bonuses are regular-season only, but the pass still runs here: a
+        // postseason update is often the first job after a late regular week
+        // settles, and the pass is a no-op once everything is already applied.
+        await scoringModule.applyH2HBonuses();
         await scoringModule.updateCumulativeScores();
         await teamScoringModule.updateAllTeamScores();
         await recordsModule.updateAllTeamRecords();
@@ -149,6 +153,9 @@ async function runFullUpdate({ withBetting = false } = {}) {
         console.log("number of returned existing games", gamesUpdated);
 
         await scoringModule.updateScores("regular", weekNumber);
+        // Between weekly scoring and cumulative totals: the bonus is folded into
+        // the weekly scores that updateCumulativeScores then sums.
+        await scoringModule.applyH2HBonuses();
         await scoringModule.updateCumulativeScores();
         await teamScoringModule.updateAllTeamScores();
         await recordsModule.updateAllTeamRecords();

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -42,6 +42,31 @@ module.exports= {
         }
     },
 
+    // Folds each league's head-to-head win/tie bonuses into the stored weekly
+    // scores. MUST run after updateScores (a week's result needs every manager's
+    // total) and before updateCumulativeScores (which sums the bonus into
+    // cumulativeScore). Goes through the API like every other scoring step so it
+    // works both in-process and from a standalone job run. See the handler in
+    // routes/scores.js for the idempotency guarantees.
+    applyH2HBonuses: async function() {
+        const response = await internalFetch(`${process.env.URL}/scores/h2h-bonus`, {
+            method: 'POST',
+            headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ season: process.env.YEAR }),
+        });
+
+        const data = await response.json();
+        if (response.status == 200) {
+            console.log("✅ H2H bonuses applied", JSON.stringify(data.leagues || []));
+        } else {
+            console.log("❌ H2H bonuses could not be applied" + " | " + response.status);
+        }
+        return data;
+    },
+
     updateScores: async function(season, week) {
         // One ranking cache per call: every game in the week shares its poll doc
         // instead of re-reading it from Mongo per game.

--- a/modules/weekly-recap.js
+++ b/modules/weekly-recap.js
@@ -7,6 +7,13 @@
 // AND so a future weekly-recap EMAIL job can reuse it verbatim — no rework.
 
 const { pickLogo } = require('../public/logo.js');
+// The H2H win bonus is folded into weeklyScore[].score (see modules/h2h.js).
+// That belongs in SEASON totals — cumThrough/rank below use the stored score
+// as-is — but not in a week's PERFORMANCE figures: comparing your week to the
+// league average or crowning the week's top score has to be about points your
+// teams actually scored, not about whether you happened to win your matchup.
+// So the per-week numbers here are measured on the base.
+const { baseWeekScore } = require('./h2h');
 
 function ordinal(n) {
     const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
@@ -152,7 +159,7 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
             // One sample PER MANAGER (summed across any games/entries that week),
             // so a manager with multiple entries in a week isn't double-counted.
             let sum = 0, played = false;
-            ls.weekly.forEach(e => { if (effWeek(e) === W) { sum += (e.score || 0); played = true; } });
+            ls.weekly.forEach(e => { if (effWeek(e) === W) { sum += baseWeekScore(e); played = true; } });
             if (played) arr.push(sum);
         });
         weekStats[W] = {
@@ -170,7 +177,7 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
         const W = effWeek(e);
         if (!byEff.has(W)) byEff.set(W, { week: e.week, season: e.season, score: 0, scoreByTeam: [] });
         const agg = byEff.get(W);
-        agg.score += (e.score || 0);
+        agg.score += baseWeekScore(e);
         (e.scoreByTeam || []).forEach(st => agg.scoreByTeam.push(st));
     });
     const myWeekly = [...byEff.values()].sort((a, b) => effWeek(a) - effWeek(b));

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const scoringModule = require('../modules/scoring.js');
 const User = require('../models/user');
 const Game = require('../models/game');
+const ScoringConfig = require('../models/scoringConfig');
 const { computeAdminStatus } = require('../modules/admin-status');
+const { engagementForSeason } = require('../modules/scoring-defaults');
+const { H2H_LAST_WEEK, seasonEntry, computeH2HAwards, applyAwards } = require('../modules/h2h');
 
 // Read-only status summary for the admin console: how far scoring/games have
 // progressed and whether any completed results are still unscored. Derived from
@@ -22,6 +25,87 @@ router.get('/status/:season', async (req, res) => {
     }
 });
 
+// Fold each league's head-to-head win/tie bonuses into the stored weekly scores.
+//
+// Why this is a separate pass: a week's H2H result depends on EVERY manager's
+// total for that week, so it can't be resolved inside updateScores' per-user
+// loop. It runs after scoring and before updateCumulativeScores, which then sums
+// the bonus into cumulativeScore for free — the same way the Captain bonus rides
+// along. That is what keeps the Hall of Fame champion, the My Team rank, the
+// weekly recap, and the projections agreeing with the standings table.
+//
+// Safe to run at any time, for any league, in any state:
+//   - only weeks that have SETTLED (every drafted team's game complete) award;
+//   - each entry's score is rebuilt from its base, so re-running, rescoring, or
+//     changing the configured bonus converges instead of compounding;
+//   - a league with H2H off has any stale bonus stripped back out.
+async function applyH2HBonuses(season) {
+    const seasonStr = String(season);
+    const seasonNum = Number(season);
+    const leagues = await User.distinct('league', { 'seasons.season': seasonStr });
+    const summary = [];
+
+    for (const league of leagues) {
+        if (!league) continue;
+        const users = await User.find({ league, 'seasons.season': seasonStr });
+        if (!users.length) continue;
+
+        const cfgDoc = await ScoringConfig.findOne({ league }).lean();
+        const eng = engagementForSeason(cfgDoc && cfgDoc.engagementBySeason, seasonStr);
+
+        // Only load games when there's a chance of awarding. With H2H off the
+        // award map stays empty, which still strips any previously-stored bonus.
+        let awards = {};
+        if (eng.h2hEnabled) {
+            const drafted = new Set();
+            users.forEach(u => {
+                const s = seasonEntry(u, seasonStr);
+                ((s && s.teams) || []).forEach(t => drafted.add(Number(t.id)));
+            });
+            const idList = [...drafted];
+            const games = idList.length ? await Game.find(
+                { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_LAST_WEEK },
+                  $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
+                { id: 1, week: 1, seasonType: 1, completed: 1, homeId: 1, awayId: 1, _id: 0 }
+            ).lean() : [];
+            awards = computeH2HAwards({
+                users, games, season: seasonStr,
+                winBonus: eng.h2hWinBonus, tieBonus: eng.h2hTieBonus
+            }).awards;
+        }
+
+        let updated = 0, awarded = 0;
+        for (const user of users) {
+            const s = seasonEntry(user, seasonStr);
+            if (!s) continue;
+            const plain = (s.weeklyScore || []).map(e => (e.toObject ? e.toObject() : e));
+            const next = applyAwards(plain, awards[String(user._id)], H2H_LAST_WEEK);
+            if (!next.changed) continue;
+            s.weeklyScore = next.weeklyScore;
+            user.markModified('seasons');
+            await user.save();
+            updated++;
+            awarded += next.weeklyScore.reduce((sum, e) => sum + (e.h2hBonus || 0), 0);
+        }
+        summary.push({ league, enabled: !!eng.h2hEnabled, managersUpdated: updated, bonusAwarded: awarded });
+        console.log(`H2H bonus · ${league}: ${eng.h2hEnabled ? 'on' : 'off'}, ${updated} manager(s) updated`);
+    }
+
+    return summary;
+}
+
+// Exposed so the scoring jobs can run the pass over the internal API, matching
+// how every other scoring step reaches the DB (see modules/scoring.js).
+router.post('/h2h-bonus', async (req, res) => {
+    try {
+        const season = (req.body && req.body.season) || process.env.YEAR;
+        const leagues = await applyH2HBonuses(season);
+        res.status(200).json({ season: String(season), leagues });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
 // Recalculating & Updating Scores
 router.post('/update', async (req, res) => {
     try {
@@ -29,6 +113,9 @@ router.post('/update', async (req, res) => {
         var weekNumber = req.body.week;
 
         await scoringModule.updateScores(seasonType, weekNumber);
+        // Before cumulative totals: the bonus is folded into the weekly scores
+        // that updateCumulativeScores then sums.
+        await applyH2HBonuses(process.env.YEAR);
         await scoringModule.updateCumulativeScores();
 
         res.status(200).json({"seasonType": seasonType, "weekNumber": weekNumber});

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -14,7 +14,8 @@ const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../m
 const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
-const { scheduleForWeeks, resolveWeek, gameStatus, isWeekFinal, matchupWinProb } = require('../modules/h2h');
+const { gameStatus, matchupWinProb, H2H_LAST_WEEK, baseWeekScore, persistedBonus,
+        h2hManagerIds, computeH2HAwards } = require('../modules/h2h');
 const { pickLogo } = require('../public/logo.js');
 
 // The scoring jobs that actually refresh standings data (see modules/score-job.js
@@ -299,24 +300,28 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const winBonus = eng.h2hWinBonus;
         const tieBonus = eng.h2hTieBonus;
 
-        // H2H matchups run the fantasy regular season only. Weeks 15+ (conf
-        // championships, Army/Navy) and the postseason still count toward season
-        // totals, but their thin slates make for unfair matchups — so no H2H past
-        // this cap. Named for easy adjustment.
-        const H2H_LAST_WEEK = 14;
-
         // .lean(): the handler only reads plain fields (no doc methods/virtuals),
         // so skip Mongoose hydration of these heavy weeklyScore docs.
         const users = await User.find({ league, 'seasons.season': season }).lean();
         const isRegular = w => w.season !== 'postseason' && w.week <= 16;
         const round = v => Math.round(v * 10) / 10;
-        const ids = [], meta = {}, totals = {}, teamDetail = {}, caps = {};
+        // Deterministic manager ordering — the pairing schedule is positional, so
+        // this must match what the scoring-time pass used (modules/h2h.js).
+        const ids = h2hManagerIds(users, season);
+        const idSet = new Set(ids);
+        const meta = {}, totals = {}, teamDetail = {}, caps = {}, banked = {};
         const draftedSet = new Set();
         users.forEach(u => {
             const s = (u.seasons || []).find(x => String(x.season) === String(season));
             if (!s || !(s.weeklyScore || []).length) return;
             const id = String(u._id);
-            ids.push(id);
+            if (!idSet.has(id)) return;
+            // How much H2H bonus is ALREADY folded into cumulativeScore. Subtracted
+            // from the bonus computed below so the total reads the same whether or
+            // not the scoring job has persisted the current values yet — which also
+            // keeps this route honest when previewing H2H on a historical season
+            // that was never scored with it.
+            banked[id] = persistedBonus(s);
             const logoBy = {}, abbrBy = {};
             const roster = (s.teams || []).map(t => { const logo = pickLogo(t.logos) || null; logoBy[t.id] = logo; abbrBy[t.id] = t.abbreviation || null; draftedSet.add(t.id); return { id: t.id, school: t.school, abbr: t.abbreviation || null, logo }; });
             meta[id] = {
@@ -332,7 +337,9 @@ router.get('/h2h/:league/:season', async (req, res) => {
             (s.weeklyScore || []).forEach(e => {
                 if (!isRegular(e) || e.week > H2H_LAST_WEEK) return;
                 const w = e.week;
-                tw[w] = (tw[w] || 0) + (e.score || 0);
+                // BASE total (score minus any bonus already banked into it), so a
+                // week's own bonus never feeds back into deciding that week.
+                tw[w] = (tw[w] || 0) + baseWeekScore(e);
                 const byTeam = twTeams[w] || (twTeams[w] = {});
                 (e.scoreByTeam || []).forEach(st => {
                     const k = st.teamId;
@@ -351,7 +358,6 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // final / live / upcoming, and which weeks are fully complete. Pairings
         // are computed over the FIXED regular-season range so a week's matchup is
         // stable whether or not it's been scored yet.
-        const allWeeks = Array.from({ length: H2H_LAST_WEEK }, (_, i) => i + 1);
         const draftedIds = [...draftedSet];
         const games = draftedIds.length ? await Game.find(
             { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_LAST_WEEK }, $or: [{ homeId: { $in: draftedIds } }, { awayId: { $in: draftedIds } }] },
@@ -407,9 +413,8 @@ router.get('/h2h/:league/:season', async (req, res) => {
             });
         }
 
-        const gamesByWeek = {}, gameTW = {};
+        const gameTW = {};
         games.forEach(g => {
-            (gamesByWeek[g.week] = gamesByWeek[g.week] || []).push(g);
             [g.homeId, g.awayId].forEach(tid => {
                 if (!draftedSet.has(tid)) return;
                 const m = gameTW[tid] || (gameTW[tid] = {});
@@ -417,25 +422,24 @@ router.get('/h2h/:league/:season', async (req, res) => {
             });
         });
         const now = Date.now();
-        const scoredSet = new Set(ids.flatMap(id => Object.keys(totals[id]).map(Number)));
-        const weekFinal = {};
-        allWeeks.forEach(w => { weekFinal[w] = isWeekFinal(gamesByWeek[w]) && scoredSet.has(w); });
-        let currentWeek = null;
-        for (const w of allWeeks) { if ((gamesByWeek[w] || []).length && !weekFinal[w]) { currentWeek = w; break; } }
+
+        // Which weeks have settled, the pairings, and each manager's result —
+        // from the SAME function the scoring job uses to bank the bonus, so the
+        // table and cumulativeScore can never tell different stories.
+        const { awards, weekFinal, finalWeeks, currentWeek, schedule: scheduleAll } = computeH2HAwards({
+            users, games, season, winBonus, tieBonus, lastWeek: H2H_LAST_WEEK
+        });
 
         // Records + win bonus count FINAL weeks only (an in-progress week has no
-        // decided winner yet). Stable pairings over all 14 weeks.
-        const scheduleAll = scheduleForWeeks(ids, allWeeks);
-        const finalWeeks = allWeeks.filter(w => weekFinal[w]);
-        const rec = {}; ids.forEach(id => { rec[id] = { wins: 0, losses: 0, ties: 0, bonus: 0, pointsFor: 0, pointsAgainst: 0 }; });
-        finalWeeks.forEach(w => {
-            const wt = {}; ids.forEach(id => { wt[id] = totals[id][w] || 0; });
-            const r = resolveWeek(scheduleAll[w] || [], wt, winBonus, tieBonus);
-            Object.keys(r).forEach(id => {
-                const a = rec[id], x = r[id];
+        // decided winner yet).
+        const rec = {};
+        ids.forEach(id => {
+            const a = { wins: 0, losses: 0, ties: 0, bonus: 0, pointsFor: 0, pointsAgainst: 0 };
+            Object.values(awards[id] || {}).forEach(x => {
                 if (x.result === 'W') a.wins++; else if (x.result === 'L') a.losses++; else a.ties++;
                 a.bonus += x.bonus; a.pointsFor += x.for; a.pointsAgainst += x.against;
             });
+            rec[id] = a;
         });
         const managers = ids.map(id => ({
             ...meta[id],
@@ -443,7 +447,9 @@ router.get('/h2h/:league/:season', async (req, res) => {
             record: `${rec[id].wins}-${rec[id].losses}-${rec[id].ties}`,
             h2hBonus: rec[id].bonus,
             pointsFor: round(rec[id].pointsFor), pointsAgainst: round(rec[id].pointsAgainst),
-            adjustedTotal: round(meta[id].cumulative + rec[id].bonus)   // cumulative already includes weeks 15+/postseason
+            // cumulative already includes weeks 15+/postseason AND whatever bonus
+            // the scoring job has banked so far; add only the not-yet-banked part.
+            adjustedTotal: round(meta[id].cumulative + rec[id].bonus - (banked[id] || 0))
         })).sort((a, b) => b.adjustedTotal - a.adjustedTotal).map((m, i) => ({ rank: i + 1, ...m }));
 
         // Standings-only: the ranked table is ready; return before the matchup

--- a/tests/H2H.spec.js
+++ b/tests/H2H.spec.js
@@ -1,4 +1,5 @@
-const { buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H, gameStatus, isWeekFinal, matchupWinProb } = require('../modules/h2h');
+const { buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H, gameStatus, isWeekFinal, matchupWinProb,
+        baseWeekScore, persistedBonus, h2hManagerIds, computeH2HAwards, applyAwards } = require('../modules/h2h');
 
 describe('buildRoundRobin', () => {
     test('6 managers → 5 rounds, everyone plays everyone exactly once, 3 pairs/round', () => {
@@ -144,6 +145,161 @@ describe('matchupWinProb', () => {
         const live = matchupWinProb([{ winProb: 1, pointsIfWin: 20 }], [{ winProb: 0.5, pointsIfWin: 20 }]);
         expect(live.a).toBeCloseTo(0.75, 10);
         expect(live.a).toBeGreaterThan(pre.a);
+    });
+});
+
+// --- persisting the win bonus into the weekly scores -------------------------
+// The bonus is folded INTO weeklyScore[].score so updateCumulativeScores sums it
+// into cumulativeScore (the number the Hall of Fame, My Team rank, the recap and
+// the projections all read). These cover the invariants that makes safe.
+
+describe('baseWeekScore / persistedBonus', () => {
+    test('base strips a banked bonus back out; a pre-bonus entry is unchanged', () => {
+        expect(baseWeekScore({ score: 25, h2hBonus: 3 })).toBe(22);
+        expect(baseWeekScore({ score: 25 })).toBe(25);
+        expect(baseWeekScore(null)).toBe(0);
+    });
+    test('persistedBonus sums what is already folded into the season', () => {
+        expect(persistedBonus({ weeklyScore: [{ h2hBonus: 3 }, {}, { h2hBonus: 3 }] })).toBe(6);
+        expect(persistedBonus({ weeklyScore: [] })).toBe(0);
+        expect(persistedBonus(null)).toBe(0);
+    });
+});
+
+describe('h2hManagerIds', () => {
+    const u = (id, season, weeks) => ({ _id: id, seasons: [{ season, weeklyScore: weeks }] });
+    test('is sorted, so pairings do not depend on document order', () => {
+        const forward = [u('c', 2026, [{ week: 1, score: 5 }]), u('a', 2026, [{ week: 1, score: 5 }]), u('b', 2026, [{ week: 1, score: 5 }])];
+        const reversed = forward.slice().reverse();
+        expect(h2hManagerIds(forward, 2026)).toEqual(['a', 'b', 'c']);
+        expect(h2hManagerIds(reversed, 2026)).toEqual(h2hManagerIds(forward, 2026));
+    });
+    test('excludes managers with no scored week, and other seasons', () => {
+        const users = [u('a', 2026, [{ week: 1, score: 5 }]), u('b', 2026, []), u('c', 2025, [{ week: 1, score: 5 }])];
+        expect(h2hManagerIds(users, 2026)).toEqual(['a']);
+    });
+    test('matches a season passed as a string or a number', () => {
+        const users = [u('a', 2026, [{ week: 1, score: 5 }])];
+        expect(h2hManagerIds(users, '2026')).toEqual(['a']);
+    });
+});
+
+describe('computeH2HAwards', () => {
+    // Two managers, one drafted team each, weeks 1-2.
+    const users = [
+        { _id: 'a', seasons: [{ season: 2026, teams: [{ id: 1 }], weeklyScore: [{ week: 1, score: 20 }, { week: 2, score: 10 }] }] },
+        { _id: 'b', seasons: [{ season: 2026, teams: [{ id: 2 }], weeklyScore: [{ week: 1, score: 14 }, { week: 2, score: 30 }] }] }
+    ];
+    const game = (week, homeId, completed) => ({ id: week * 10 + homeId, week, homeId, awayId: 99, completed });
+    const opts = { season: 2026, winBonus: 3, tieBonus: 0, lastWeek: 14 };
+
+    test('awards the higher base total once every drafted game is complete', () => {
+        const games = [game(1, 1, true), game(1, 2, true)];
+        const { awards, finalWeeks, currentWeek } = computeH2HAwards({ users, games, ...opts });
+        expect(finalWeeks).toEqual([1]);
+        expect(currentWeek).toBeNull();
+        expect(awards.a[1]).toMatchObject({ result: 'W', bonus: 3, opponent: 'b', for: 20, against: 14 });
+        expect(awards.b[1]).toMatchObject({ result: 'L', bonus: 0 });
+        expect(awards.a[2]).toBeUndefined();      // week 2 has no games loaded
+    });
+
+    test('a week with an unfinished game does not settle — it becomes the current week', () => {
+        const games = [game(1, 1, true), game(1, 2, false)];
+        const { awards, finalWeeks, currentWeek } = computeH2HAwards({ users, games, ...opts });
+        expect(finalWeeks).toEqual([]);
+        expect(currentWeek).toBe(1);
+        expect(awards.a[1]).toBeUndefined();
+    });
+
+    test('resolves from the BASE total, so an already-banked bonus never decides its own week', () => {
+        // a trails b on base (18 vs 20) but leads on the stored score (21 vs 20)
+        // because a's week-1 bonus is already folded in. b must still win.
+        const banked = [
+            { _id: 'a', seasons: [{ season: 2026, teams: [{ id: 1 }], weeklyScore: [{ week: 1, score: 21, h2hBonus: 3 }] }] },
+            { _id: 'b', seasons: [{ season: 2026, teams: [{ id: 2 }], weeklyScore: [{ week: 1, score: 20 }] }] }
+        ];
+        const games = [game(1, 1, true), game(1, 2, true)];
+        const { awards } = computeH2HAwards({ users: banked, games, ...opts });
+        expect(awards.b[1]).toMatchObject({ result: 'W', bonus: 3 });
+        expect(awards.a[1]).toMatchObject({ result: 'L', bonus: 0 });
+    });
+
+    test('postseason entries and weeks past the cap never award', () => {
+        const late = [
+            { _id: 'a', seasons: [{ season: 2026, teams: [{ id: 1 }], weeklyScore: [{ week: 15, score: 20 }, { week: 1, season: 'postseason', score: 30 }] }] },
+            { _id: 'b', seasons: [{ season: 2026, teams: [{ id: 2 }], weeklyScore: [{ week: 15, score: 10 }] }] }
+        ];
+        const games = [{ id: 1, week: 15, homeId: 1, awayId: 99, completed: true }];
+        const { awards, finalWeeks } = computeH2HAwards({ users: late, games, ...opts });
+        expect(finalWeeks).toEqual([]);
+        expect(awards.a).toEqual({});
+    });
+
+    test('fewer than two scored managers awards nothing', () => {
+        const solo = [users[0]];
+        const { awards } = computeH2HAwards({ users: solo, games: [game(1, 1, true)], ...opts });
+        expect(awards.a).toEqual({});
+    });
+});
+
+describe('applyAwards', () => {
+    const weekly = () => [{ week: 1, score: 20 }, { week: 2, score: 10 }, { week: 1, season: 'postseason', score: 30 }];
+
+    test('folds the bonus into score and records the result', () => {
+        const { weeklyScore, changed } = applyAwards(weekly(), { 1: { result: 'W', bonus: 3, opponent: 'b' } });
+        expect(changed).toBe(true);
+        expect(weeklyScore[0]).toMatchObject({ score: 23, h2hBonus: 3, h2hResult: 'W', h2hOpponentId: 'b' });
+        expect(weeklyScore[1]).toMatchObject({ score: 10 });
+        expect(weeklyScore[1].h2hBonus).toBeUndefined();
+        expect(weeklyScore[2].score).toBe(30);                    // postseason untouched
+    });
+
+    test('is idempotent — applying the same awards twice does not compound', () => {
+        const awards = { 1: { result: 'W', bonus: 3, opponent: 'b' } };
+        const once = applyAwards(weekly(), awards);
+        const twice = applyAwards(once.weeklyScore, awards);
+        expect(twice.weeklyScore[0].score).toBe(23);
+        expect(twice.changed).toBe(false);                        // nothing to write
+    });
+
+    test('a changed bonus value re-bases rather than stacking', () => {
+        const once = applyAwards(weekly(), { 1: { result: 'W', bonus: 3, opponent: 'b' } });
+        const again = applyAwards(once.weeklyScore, { 1: { result: 'W', bonus: 5, opponent: 'b' } });
+        expect(again.weeklyScore[0]).toMatchObject({ score: 25, h2hBonus: 5 });
+        expect(again.changed).toBe(true);
+    });
+
+    test('a flipped result on a rescore moves the bonus to the other side', () => {
+        const won = applyAwards(weekly(), { 1: { result: 'W', bonus: 3, opponent: 'b' } });
+        const lost = applyAwards(won.weeklyScore, { 1: { result: 'L', bonus: 0, opponent: 'b' } });
+        expect(lost.weeklyScore[0]).toMatchObject({ score: 20, h2hResult: 'L' });
+        expect(lost.weeklyScore[0].h2hBonus).toBeUndefined();
+    });
+
+    test('turning H2H off strips the bonus back out entirely', () => {
+        const on = applyAwards(weekly(), { 1: { result: 'W', bonus: 3, opponent: 'b' } });
+        const off = applyAwards(on.weeklyScore, {});
+        expect(off.changed).toBe(true);
+        expect(off.weeklyScore[0].score).toBe(20);
+        expect(off.weeklyScore[0].h2hBonus).toBeUndefined();
+        expect(off.weeklyScore[0].h2hResult).toBeUndefined();
+    });
+
+    test('a tie bonus is awarded and folded in like a win', () => {
+        const { weeklyScore } = applyAwards(weekly(), { 1: { result: 'T', bonus: 1, opponent: 'b' } });
+        expect(weeklyScore[0]).toMatchObject({ score: 21, h2hBonus: 1, h2hResult: 'T' });
+    });
+
+    test('does not mutate the entries it was given', () => {
+        const original = weekly();
+        applyAwards(original, { 1: { result: 'W', bonus: 3, opponent: 'b' } });
+        expect(original[0]).toEqual({ week: 1, score: 20 });
+    });
+
+    test('a fractional captain bonus stays clean after folding (no float drift)', () => {
+        const withCaptain = [{ week: 1, score: 20.5, captainBonus: 5.5 }];
+        const { weeklyScore } = applyAwards(withCaptain, { 1: { result: 'W', bonus: 3, opponent: 'b' } });
+        expect(weeklyScore[0].score).toBe(23.5);
     });
 });
 

--- a/tests/H2HBonusPersistence.spec.js
+++ b/tests/H2HBonusPersistence.spec.js
@@ -1,0 +1,237 @@
+// End-to-end cover for the H2H win bonus reaching the season total of record.
+//
+// The bonus used to be computed only at read time inside GET /standings/h2h, so
+// cumulativeScore — the number the Hall of Fame crowns a champion by, My Team
+// ranks by, and the projections bank from — silently excluded it. POST
+// /scores/h2h-bonus folds it into the stored weekly scores instead, exactly the
+// way the Captain bonus already rode along, so summing weeklyScore[].score picks
+// it up for free.
+//
+// Runs against an in-memory Mongo with the real models and the real route.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const ScoringConfig = require('../models/scoringConfig');
+const scoresRouter = require('../routes/scores');
+const standingsRouter = require('../routes/standings');
+
+const app = express();
+app.use(express.json());
+app.use('/scores', scoresRouter);
+app.use('/standings', standingsRouter);
+
+useMongo();
+
+const SEASON = 2026;
+const LEAGUE = 'graham-league';
+
+// Two rostered teams per manager so a week only settles once BOTH play out.
+function team(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+
+// A manager with one weekly entry per (week, score) pair given.
+async function manager(firstName, teams, weeks) {
+    return User.create({
+        firstName, lastName: 'Test', league: LEAGUE,
+        seasons: [{
+            season: SEASON,
+            teams,
+            weeklyScore: weeks.map(([week, score]) => ({ week, score })),
+            cumulativeScore: weeks.reduce((s, [, score]) => s + score, 0)
+        }]
+    });
+}
+
+function game(id, week, homeId, awayId, completed) {
+    return {
+        id, season: SEASON, week, seasonType: 'regular',
+        startDate: '2026-09-05T00:00:00.000Z', startTimeTbd: false,
+        neutralSite: false, conferenceGame: false,
+        homeId, homeTeam: 'Home', awayId, awayTeam: 'Away',
+        homePoints: completed ? 30 : null, awayPoints: completed ? 10 : null,
+        completed
+    };
+}
+
+async function enableH2H({ winBonus = 3, tieBonus = 0 } = {}) {
+    await ScoringConfig.create({
+        league: LEAGUE, model: 'graham', values: {},
+        engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: winBonus, h2hTieBonus: tieBonus } }
+    });
+}
+
+// Recompute cumulativeScore the way modules/scoring.js updateCumulativeScores
+// does — sum weeklyScore[].score. This is the seam the whole fix relies on.
+async function sumCumulative(userId) {
+    const u = await User.findById(userId).lean();
+    return (u.seasons[0].weeklyScore || []).reduce((s, e) => s + (e.score || 0), 0);
+}
+
+beforeEach(() => { jest.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { jest.restoreAllMocks(); });
+
+describe('POST /scores/h2h-bonus', () => {
+    test('folds the win bonus into the weekly score, so cumulativeScore picks it up', async () => {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        const b = await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+
+        const res = await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(res.status).toBe(200);
+
+        const winner = await User.findById(a._id).lean();
+        const loser = await User.findById(b._id).lean();
+        const wk = (u) => u.seasons[0].weeklyScore[0];
+
+        expect(wk(winner)).toMatchObject({ score: 23, h2hBonus: 3, h2hResult: 'W' });
+        expect(String(wk(winner).h2hOpponentId)).toBe(String(b._id));
+        expect(wk(loser).score).toBe(14);
+        expect(wk(loser).h2hBonus).toBeUndefined();
+
+        // The whole point: the season total of record now includes the bonus.
+        expect(await sumCumulative(a._id)).toBe(23);
+        expect(await sumCumulative(b._id)).toBe(14);
+    });
+
+    test('a week is not awarded until every drafted team has played', async () => {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon'), team(3, 'Iowa')], [[1, 20]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        // Ann's second team hasn't finished.
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true), game(103, 1, 3, 97, false)]);
+
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        const winner = await User.findById(a._id).lean();
+        expect(winner.seasons[0].weeklyScore[0].score).toBe(20);
+        expect(winner.seasons[0].weeklyScore[0].h2hBonus).toBeUndefined();
+    });
+
+    test('running it repeatedly does not compound the bonus', async () => {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        const third = await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        expect(await sumCumulative(a._id)).toBe(23);
+        // Third pass had nothing left to write.
+        expect(third.body.leagues[0].managersUpdated).toBe(0);
+    });
+
+    test('a rescore that flips the weekly result moves the bonus to the other manager', async () => {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        const b = await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(await sumCumulative(a._id)).toBe(23);
+
+        // A rescore lands: Bob's week is corrected upward past Ann's.
+        await User.updateOne({ _id: b._id }, { $set: { 'seasons.0.weeklyScore.0.score': 40 } });
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        expect(await sumCumulative(a._id)).toBe(20);   // bonus removed
+        expect(await sumCumulative(b._id)).toBe(43);   // bonus awarded
+    });
+
+    test('raising the configured win bonus re-bases instead of stacking', async () => {
+        await enableH2H({ winBonus: 3 });
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        await ScoringConfig.updateOne({ league: LEAGUE },
+            { $set: { 'engagementBySeason.2026.h2hWinBonus': 5 } });
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        expect(await sumCumulative(a._id)).toBe(25);
+    });
+
+    test('turning H2H off strips previously banked bonuses back out', async () => {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(await sumCumulative(a._id)).toBe(23);
+
+        await ScoringConfig.updateOne({ league: LEAGUE },
+            { $set: { 'engagementBySeason.2026.h2hEnabled': false } });
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        const back = await User.findById(a._id).lean();
+        expect(back.seasons[0].weeklyScore[0].score).toBe(20);
+        expect(back.seasons[0].weeklyScore[0].h2hBonus).toBeUndefined();
+    });
+
+    test('a classic league with no config is left completely untouched', async () => {
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+
+        const res = await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(res.body.leagues[0]).toMatchObject({ enabled: false, managersUpdated: 0 });
+        expect(await sumCumulative(a._id)).toBe(20);
+    });
+
+    test('the Captain bonus already in the weekly score is preserved', async () => {
+        await enableH2H();
+        const a = await User.create({
+            firstName: 'Ann', lastName: 'Test', league: LEAGUE,
+            seasons: [{ season: SEASON, teams: [team(1, 'Oregon')],
+                weeklyScore: [{ week: 1, score: 26, captainTeamId: 1, captainBonus: 6 }] }]
+        });
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        const wk = (await User.findById(a._id).lean()).seasons[0].weeklyScore[0];
+        expect(wk).toMatchObject({ score: 29, captainBonus: 6, h2hBonus: 3 });
+    });
+});
+
+describe('GET /standings/h2h agrees with what was persisted', () => {
+    // The read model subtracts the bonus already banked into cumulativeScore, so
+    // the ranked total is the same before and after the scoring pass runs — and
+    // never double-counts once it has.
+    async function seed() {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        const b = await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+        return { a, b };
+    }
+    const totalsOf = (body) => body.managers.reduce((m, x) => (m[x.name.split(' ')[0]] = x.adjustedTotal, m), {});
+
+    test('the ranked total is identical before and after the bonus is banked', async () => {
+        const { a } = await seed();
+
+        const before = await request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}?standingsOnly=1`);
+        expect(totalsOf(before.body)).toEqual({ Ann: 23, Bob: 14 });
+
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        // Mirror updateCumulativeScores, which runs right after the pass.
+        await User.updateOne({ _id: a._id }, { $set: { 'seasons.0.cumulativeScore': await sumCumulative(a._id) } });
+
+        const after = await request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}?standingsOnly=1`);
+        expect(totalsOf(after.body)).toEqual({ Ann: 23, Bob: 14 });
+        expect(after.body.managers.find(m => m.name.startsWith('Ann'))).toMatchObject({ record: '1-0-0', h2hBonus: 3 });
+    });
+});

--- a/tests/ModelSchemas.spec.js
+++ b/tests/ModelSchemas.spec.js
@@ -85,6 +85,37 @@ describe('User schema', () => {
         expect(found.seasons[0].weeklyScore[0].score).toBe(20);
         expect(found.seasons[0].weeklyScore[0].scoreByTeam[0].team).toBe('Oregon');
     });
+
+    // The scoring job rewrites the WHOLE weeklyScore array each run (see
+    // modules/scoring.js updateUser -> PATCH /users/:id). Any bonus field the
+    // schema doesn't declare gets silently stripped on that write, so an earlier
+    // week's banked H2H bonus would vanish the next time a later week is scored.
+    test('H2H bonus fields survive a full weeklyScore rewrite', async () => {
+        const u = await User.create({
+            firstName: 'Ann', lastName: 'Adams', league: 'graham-league',
+            seasons: [{ season: 2026, weeklyScore: [{ week: 1, score: 23, h2hBonus: 3, h2hResult: 'W', h2hOpponentId: 'abc123' }] }]
+        });
+        // Rewrite the array the way the job does — week 1 untouched, week 2 added.
+        const doc = await User.findById(u._id);
+        doc.seasons[0].weeklyScore = [
+            doc.seasons[0].weeklyScore[0].toObject(),
+            { week: 2, score: 11 }
+        ];
+        doc.markModified('seasons');
+        await doc.save();
+
+        const found = await User.findById(u._id).lean();
+        expect(found.seasons[0].weeklyScore[0]).toMatchObject({ score: 23, h2hBonus: 3, h2hResult: 'W', h2hOpponentId: 'abc123' });
+        expect(found.seasons[0].weeklyScore[1].h2hBonus).toBeUndefined();
+    });
+
+    test('h2hResult is constrained to the W/L/T enum', () => {
+        const err = new User({
+            firstName: 'Ann', lastName: 'Adams',
+            seasons: [{ season: 2026, weeklyScore: [{ week: 1, score: 5, h2hResult: 'X' }] }]
+        }).validateSync();
+        expect(err.errors['seasons.0.weeklyScore.0.h2hResult']).toBeDefined();
+    });
 });
 
 describe('Game schema', () => {

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -1,5 +1,63 @@
 const { postseasonWeeksToScore } = require('../modules/score-update');
 
+// --- pipeline ordering -------------------------------------------------------
+// The H2H win bonus is folded into weeklyScore[].score, and updateCumulativeScores
+// then SUMS those scores into cumulativeScore. So applyH2HBonuses must run after
+// updateScores (a week's result needs every manager's total) and before
+// updateCumulativeScores. Reorder these and the bonus silently stops reaching the
+// season total of record — exactly the bug this replaced. Hence the assertion.
+
+jest.mock('../modules/cfbd-calendar', () => ({ getCalendar: jest.fn(async () => null) }));
+jest.mock('../modules/internal-api', () => ({
+    internalFetch: jest.fn(async () => ({ status: 200, json: async () => ({}) }))
+}));
+jest.mock('../modules/retrieve-games.js', () => ({
+    retrieveTeams: jest.fn(async () => []),
+    massRetrieveGames: jest.fn(async () => ({ newGames: [], existingGames: [], remainingCalls: 900 }))
+}));
+jest.mock('../modules/team-scoring.js', () => ({ updateAllTeamScores: jest.fn(async () => {}) }));
+jest.mock('../modules/records.js', () => ({ updateAllTeamRecords: jest.fn(async () => {}) }));
+jest.mock('../modules/betting.js', () => ({ updateAllBettingLines: jest.fn(async () => {}) }));
+jest.mock('../modules/scoring.js', () => {
+    const calls = [];
+    return {
+        _calls: calls,
+        updateScores: jest.fn(async () => { calls.push('updateScores'); }),
+        applyH2HBonuses: jest.fn(async () => { calls.push('applyH2HBonuses'); }),
+        updateCumulativeScores: jest.fn(async () => { calls.push('updateCumulativeScores'); })
+    };
+});
+
+describe('runFullUpdate scoring order', () => {
+    const { runFullUpdate } = require('../modules/score-update');
+    const scoringModule = require('../modules/scoring.js');
+    const retrieveGames = require('../modules/retrieve-games.js');
+
+    beforeEach(() => {
+        scoringModule._calls.length = 0;
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+    afterEach(() => { jest.restoreAllMocks(); });
+
+    it('applies H2H bonuses between weekly scoring and cumulative totals (regular season)', async () => {
+        await runFullUpdate({ withBetting: false });
+        expect(scoringModule._calls).toEqual(['updateScores', 'applyH2HBonuses', 'updateCumulativeScores']);
+    });
+
+    it('also applies them on a postseason run, before cumulative totals', async () => {
+        retrieveGames.massRetrieveGames.mockResolvedValueOnce({
+            newGames: [{ week: 1 }], existingGames: [], remainingCalls: 900
+        });
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce([
+            { week: 1, seasonType: 'postseason', firstGameStart: '2000-01-01', lastGameStart: '2100-01-01' }
+        ]);
+        await runFullUpdate({ withBetting: false });
+        const calls = scoringModule._calls;
+        expect(calls.indexOf('applyH2HBonuses')).toBeGreaterThan(calls.indexOf('updateScores'));
+        expect(calls.indexOf('applyH2HBonuses')).toBeLessThan(calls.indexOf('updateCumulativeScores'));
+    });
+});
+
 describe('postseasonWeeksToScore', () => {
     const g = (week) => ({ week });
 

--- a/tests/WeeklyRecap.spec.js
+++ b/tests/WeeklyRecap.spec.js
@@ -296,3 +296,34 @@ describe('narrate (pure)', () => {
         expect(s).toContain('below the league average');
     });
 });
+
+// The H2H win bonus rides inside weeklyScore[].score so it reaches the season
+// total (modules/h2h.js). A week's PERFORMANCE figures must still be measured on
+// the base — otherwise winning your matchup inflates your "vs league average"
+// and could hand you "top score of the week" on the bonus alone.
+describe('H2H bonus is excluded from weekly performance figures', () => {
+    const user = (id, weeks) => ({
+        _id: id,
+        seasons: [{ season: 2026, teams: [], weeklyScore: weeks }]
+    });
+
+    test('vs-league-average and week-high read the base, not the banked score', () => {
+        // Ann's raw week is 20; she won her matchup so 3 is banked into score.
+        // Bob actually outscored her 22. Bob owns the week high, not Ann.
+        const ann = user('a', [{ week: 1, score: 23, h2hBonus: 3, scoreByTeam: [] }]);
+        const bob = user('b', [{ week: 1, score: 22, scoreByTeam: [] }]);
+        const out = buildWeeklyRecaps({ user: ann, leagueUsers: [ann, bob], season: 2026 });
+        const wk = out.recaps[0];
+        expect(wk.score).toBe(20);              // base, not 23
+        expect(wk.vsLeagueAvg).toBe(-1);        // 20 vs an avg of 21
+        expect(wk.weekHigh).toBe(false);        // Bob's 22 is the real high
+    });
+
+    test('season rank still counts the banked bonus', () => {
+        // Base 20 vs 22 puts Ann second; the +3 she banked puts her first.
+        const ann = user('a', [{ week: 1, score: 23, h2hBonus: 3, scoreByTeam: [] }]);
+        const bob = user('b', [{ week: 1, score: 22, scoreByTeam: [] }]);
+        const out = buildWeeklyRecaps({ user: ann, leagueUsers: [ann, bob], season: 2026 });
+        expect(out.recaps[0].rank).toBe(1);
+    });
+});


### PR DESCRIPTION
## The problem

The head-to-head win/tie bonus was computed **only at read time**, inside `GET /standings/h2h`, as `adjustedTotal`. Nothing else saw it:

| Surface | Ranked by | Included the bonus? |
|---|---|---|
| Standings (H2H mode) | `adjustedTotal` | ✅ |
| Hall of Fame champion | `s.cumulativeScore` | ❌ |
| My Team hero rank | `seasons[0].cumulativeScore` | ❌ |
| Projected finish + title odds | `s.cumulativeScore` | ❌ |
| Weekly Recap rank + movement | cumulative-through-week | ❌ |
| Path to the Championship chart | summed weekly scores | ❌ |

With H2H on for the Graham league in 2026, a season decided by a bonus would have **crowned a different champion in the Hall of Fame than the standings showed all year**, and title odds would have been computed against the wrong baseline every week.

## The fix

Fold the bonus into `weeklyScore[].score`, exactly the way the Captain bonus already rode along. `updateCumulativeScores` sums those scores, so it reaches `cumulativeScore` — and every surface downstream — for free.

**One computation, two consumers.** `computeH2HAwards()` in `modules/h2h.js` decides which weeks have settled, the pairings, and each manager's result. The standings read model and the scoring job both call it, so they can't drift apart again.

**A pass between scoring and totals.** A week's result depends on *every* manager's total, so it can't live inside `updateScores`' per-user loop. `POST /scores/h2h-bonus` runs after scoring, before cumulative totals — wired into both branches of `runFullUpdate` and into `POST /scores/update`.

**Idempotent by construction.** Each entry's score is rebuilt from its base (`score - h2hBonus`), never incremented. Re-running, rescoring, changing the configured bonus, or turning H2H off all converge instead of compounding. Matchups resolve from the base too, so a week's own bonus never feeds back into deciding that week.

## Three things this surfaced

- **`h2hBonus` had to go in the schema.** The scoring job rewrites the *whole* `weeklyScore` array each run, so an undeclared field is silently stripped — week 3's banked bonus would vanish the next time week 5 was scored.
- **Manager ordering is now deterministic** (sorted by id). Pairings are positional, so they previously depended on Mongo's natural document order, and the two call sites had to agree on it.
- **The weekly recap now measures performance on base points.** Otherwise winning your matchup inflates "vs league average" and could hand you "top score of the week" on the bonus alone. Season rank still counts it.

## Compatibility

`adjustedTotal` subtracts whatever is already banked, so the ranked total reads **identically before and after** the job runs — which also keeps H2H previews on historical seasons working, and means no client change was needed.

**No migration.** 2026 has no scored weeks yet; the first scoring run backfills. A classic league with no H2H config is left completely untouched (covered by a test).

## Tests — 382 green

New `H2HBonusPersistence.spec.js` runs the real route against in-memory Mongo and proves the bonus reaches `cumulativeScore`, plus: repeated runs don't compound, a rescore that flips a result moves the bonus, raising the configured bonus re-bases, turning H2H off strips it back out, a classic league is untouched, and the Captain bonus is preserved alongside it.

`H2H.spec.js` covers the new pure functions. `ScoreUpdate.spec.js` locks the pipeline ordering — reorder those three calls and the bonus silently stops reaching the total, which is exactly the bug this replaces. `ModelSchemas.spec.js` covers the array-rewrite round-trip. New coverage floor on `modules/h2h.js`.

## Reviewer notes

- `routes/standings.js` is the largest diff but is mostly deletion — the local `weekFinal`/`currentWeek`/`resolveWeek` block is replaced by the shared call.
- Worth a look: `adjustedTotal: round(cumulative + rec[id].bonus - banked[id])` is what makes the before/after equivalence hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
