### PR TITLE
Season readiness panel: catch silent preseason data gaps before draft night

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -13,6 +13,7 @@
         "./modules/scoring-detectors.js": { "statements": 95, "branches": 90, "functions": 100, "lines": 95 },
         "./modules/draft-grades.js": { "statements": 90, "branches": 70, "functions": 95, "lines": 95 },
         "./modules/h2h.js": { "statements": 95, "branches": 85, "functions": 100, "lines": 100 },
+        "./modules/season-readiness.js": { "statements": 100, "branches": 85, "functions": 100, "lines": 100 },
         "./modules/internal-api.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./modules/job-runs-util.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./update-enrichment-job.js": { "statements": 80, "branches": 60, "functions": 60, "lines": 90 }

--- a/modules/season-readiness.js
+++ b/modules/season-readiness.js
@@ -1,0 +1,171 @@
+// Pure, DB-free "is this season ready to draft?" check.
+//
+// Sibling of modules/admin-status.js, which answers the IN-SEASON question ("is
+// scoring caught up?"). This one answers the PRESEASON question, because that is
+// where the dangerous failures live: per docs/season-flip-runbook.md, skipping
+// the schedule ingest makes every projection and draft grade compute from
+// postseason points only — "a full, convincing-but-wrong payload with no error
+// and no empty state". Same for CFP odds (falls back to an SP+-rank proxy) and
+// preseason enrichment (silently reuses last year's ratings).
+//
+// None of those announce themselves. This turns all of them into one screen.
+//
+// Kept free of Mongoose/Express so it's unit-testable; routes/scores.js gathers
+// the counts and hands them here. Reads only — no writes, no CFBD calls.
+
+// Coverage thresholds. A season-wide data load either lands for essentially
+// every FBS team or didn't run, so anything short of near-total coverage means
+// a partial/failed load worth looking at rather than a healthy state.
+const COVERAGE_READY = 0.9;
+
+// Odds boards only list contenders, so coverage is the wrong lens — a couple of
+// dozen priced teams is a fully-loaded board.
+const ODDS_MIN_TEAMS = 15;
+
+function pct(n, total) {
+    if (!total) return 0;
+    return n / total;
+}
+
+// One check row. `required` marks a check the draft actually depends on;
+// informational rows report state but never hold the season back.
+function check(key, label, status, detail, opts) {
+    return Object.assign({ key, label, status, detail, required: true }, opts || {});
+}
+
+// Coverage-style check: ready at >=90% of teams, partial if any, missing at 0.
+function coverageCheck(key, label, have, total, opts) {
+    const ratio = pct(have, total);
+    const status = ratio >= COVERAGE_READY ? 'ready' : (have > 0 ? 'partial' : 'missing');
+    const detail = total
+        ? `${have} of ${total} teams`
+        : 'No teams loaded';
+    return check(key, label, status, detail, opts);
+}
+
+// Platform-wide data loads — shared by every league.
+//
+//   teamTotal        FBS teams on file
+//   teamsWith        { talent, spRating, expectedWins, cfpOdds } counts for the season
+//   scheduledTeams   distinct teams with >=1 regular-season game
+//   gameCount        regular-season games loaded
+function platformChecks({ season, teamTotal, teamsWith, scheduledTeams, gameCount }) {
+    const w = teamsWith || {};
+    return [
+        // The runbook's most-forgotten step, and the one that fails most quietly.
+        Object.assign(
+            coverageCheck('schedule', 'Full schedule ingested', scheduledTeams, teamTotal, {
+                fix: 'Ingest Full Schedule',
+                whyItMatters: 'Without it every projection and draft grade computes from postseason points only — wrong, with no error shown.'
+            }),
+            { detail: gameCount ? `${gameCount} games · ${scheduledTeams} of ${teamTotal} teams` : 'No games loaded' }
+        ),
+        coverageCheck('enrichment', 'Preseason enrichment', w.talent || 0, teamTotal, {
+            fix: 'Refresh Ratings & Broadcasts',
+            whyItMatters: 'Talent, returning production and coaches are pulled once preseason. Missing, the pool and grades silently reuse last season.'
+        }),
+        coverageCheck('expectedWins', 'Expected wins', w.expectedWins || 0, teamTotal, {
+            fix: 'Refresh Expected Wins',
+            whyItMatters: 'Feeds the projection engine behind draft grades.'
+        }),
+        // Only contenders get priced, so this is a presence check, not coverage.
+        check('cfpOdds', 'CFP odds',
+            (w.cfpOdds || 0) >= ODDS_MIN_TEAMS ? 'ready' : ((w.cfpOdds || 0) > 0 ? 'partial' : 'missing'),
+            (w.cfpOdds || 0) ? `${w.cfpOdds} teams priced` : 'No odds loaded',
+            {
+                fix: 'Update CFP Odds',
+                whyItMatters: 'Missing, the CFP factor falls back to an SP+-rank proxy — degraded, and not obviously so.'
+            }),
+        // SP+ legitimately lags: CFBD doesn't publish the new season's ratings
+        // until close to kickoff, and the engine falls back to the prior year in
+        // the meantime. So this reports state without ever blocking.
+        Object.assign(
+            coverageCheck('spPlus', `SP+ ratings (${season})`, w.spRating || 0, teamTotal, {
+                required: false,
+                fix: 'Refresh Ratings & Broadcasts',
+                whyItMatters: 'CFBD publishes these close to kickoff; until then the engine falls back to last season. Not a blocker.'
+            }),
+            { note: (w.spRating || 0) === 0 ? 'Not published yet — using last season' : null }
+        )
+    ];
+}
+
+// Per-league setup.
+//
+//   members    managers with an entry for this season
+//   draft      the season's Draft doc (or null)
+//   engagement resolved game modes for the season (or null)
+function leagueChecks({ members, draft, engagement }) {
+    const order = (draft && draft.draftOrder) || [];
+    let draftStatus, draftDetail;
+    if (!draft) {
+        draftStatus = 'missing';
+        draftDetail = 'No draft configured';
+    } else if (order.length < 2) {
+        draftStatus = 'partial';
+        draftDetail = 'Configured, but no pick order set';
+    } else if (!draft.scheduledAt) {
+        draftStatus = 'partial';
+        draftDetail = `${order.length} managers in order · no date set`;
+    } else {
+        draftStatus = 'ready';
+        draftDetail = `${order.length} managers · ${draft.snake ? 'snake' : 'linear'} · ${draft.totalRounds || 10} rounds`;
+    }
+
+    const modes = [];
+    if (engagement && engagement.h2hEnabled) modes.push(`H2H +${engagement.h2hWinBonus}${engagement.h2hTieBonus ? '/+' + engagement.h2hTieBonus + ' tie' : ''}`);
+    if (engagement && engagement.captainEnabled) modes.push(`Captain ×${engagement.captainMultiplier}`);
+
+    return [
+        check('roster', 'Season roster', members >= 2 ? 'ready' : (members === 1 ? 'partial' : 'missing'),
+            members ? `${members} manager${members === 1 ? '' : 's'}` : 'Nobody added yet',
+            {
+                fix: 'Season Roster',
+                whyItMatters: 'Written against the ACTIVE season, so it only works after YEAR is flipped. Missing, Standings and My Team are empty.'
+            }),
+        check('draft', 'Draft configured', draftStatus, draftDetail, {
+            fix: 'Configure Draft',
+            whyItMatters: 'The draft room reads this doc — without it the room shows "no draft scheduled".'
+        }),
+        // Genuinely optional: a classic league runs neither mode. Never a blocker.
+        check('gameModes', 'Game modes', modes.length ? 'ready' : 'off',
+            modes.length ? modes.join(' · ') : 'Classic scoring (no game modes)',
+            {
+                required: false,
+                fix: 'Game Modes',
+                whyItMatters: 'Per season and off by default — a season with no entry runs classic.'
+            })
+    ];
+}
+
+// The whole picture. `leagues` is [{ code, name, members, draft, engagement }].
+// `seasonUnderway` (a real result has landed) is echoed back so the client can
+// retire the panel without having to consult a second endpoint for the answer.
+function computeSeasonReadiness({ season, teamTotal, teamsWith, scheduledTeams, gameCount, leagues, seasonUnderway }) {
+    const platform = platformChecks({ season, teamTotal, teamsWith, scheduledTeams, gameCount });
+    const leagueRows = (leagues || []).map(l => ({
+        league: l.code,
+        name: l.name || l.code,
+        checks: leagueChecks(l)
+    }));
+
+    const all = platform.concat(...leagueRows.map(l => l.checks));
+    const blocking = all.filter(c => c.required && c.status !== 'ready');
+
+    return {
+        season: String(season),
+        seasonUnderway: !!seasonUnderway,
+        platform,
+        leagues: leagueRows,
+        // Every required miss, for the "N steps outstanding" count. Keys repeat
+        // when several leagues miss the same thing — two leagues without a
+        // roster genuinely is two steps, so the duplication is the point.
+        blocking: blocking.map(c => c.key),
+        ready: blocking.length === 0
+    };
+}
+
+module.exports = {
+    computeSeasonReadiness, platformChecks, leagueChecks,
+    COVERAGE_READY, ODDS_MIN_TEAMS
+};

--- a/public/admin.css
+++ b/public/admin.css
@@ -423,6 +423,85 @@
 .admin-status.warn .ss-note { color: var(--cc-amber); }
 .admin-status .ss-note a { color: inherit; font-weight: 500; text-decoration: underline; cursor: pointer; }
 
+/* --- Preseason readiness panel -------------------------------------------
+   Same card shell as .admin-status (above) so the two read as one family; the
+   body is a labelled grid of checks rather than a stat row. */
+.readiness {
+    width: auto;
+    max-width: 1100px;
+    margin: 0 16px 1.75em;
+    /* Matches .admin-status literally rather than using --cc-surface-2 (#171B31):
+       the two cards stack, and a near-but-not-equal background reads as a bug. */
+    background: #141A2E;
+    border: 1px solid var(--cc-border);
+    border-radius: 12px;
+    padding: 14px 16px;
+    color: var(--cc-text);
+}
+@media (min-width: 1132px) {
+    .readiness { margin-left: auto; margin-right: auto; }
+}
+.readiness[hidden] { display: none; }
+.readiness .ss-head {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.13em;
+    color: var(--cc-muted-2); margin-bottom: 11px;
+}
+.rd-summary { display: flex; flex-direction: column; gap: 3px; margin-bottom: 14px; }
+.rd-state { font-size: 1.05rem; font-weight: 600; }
+.rd-state.ok { color: var(--cc-success); }
+.rd-state.warn { color: var(--cc-amber); }
+.rd-sub { color: var(--cc-muted-2); font-size: 0.78rem; }
+
+.rd-group { margin-top: 14px; padding-top: 11px; border-top: 1px solid #222741; }
+.rd-group > small {
+    display: block; color: var(--cc-muted-2); font-size: 0.68rem;
+    text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 9px;
+}
+
+/* dot | label | detail | fix — the why/note lines span the full width beneath. */
+.rd-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 4px 10px;
+    padding: 6px 0;
+    font-size: 0.85rem;
+}
+.rd-row .dot { width: 7px; height: 7px; border-radius: 50%; }
+.rd-row .dot.g { background: var(--cc-success); }
+.rd-row .dot.b { background: var(--cc-info); }
+.rd-row .dot.a { background: var(--cc-amber); }
+.rd-row .dot.r { background: var(--cc-danger); }
+.rd-label { font-weight: 500; }
+.rd-detail { color: var(--cc-muted-2); font-size: 0.8rem; text-align: right; }
+.rd-fix {
+    background: none; border: 1px solid var(--cc-border); border-radius: 6px;
+    color: var(--cc-muted-bright); font: inherit; font-size: 0.75rem;
+    padding: 3px 9px; cursor: pointer; white-space: nowrap;
+}
+.rd-fix:hover { border-color: var(--cc-info); color: var(--cc-text); }
+.rd-row.attn .rd-label { color: var(--cc-amber); }
+.rd-why, .rd-note {
+    grid-column: 2 / -1; margin: 2px 0 4px;
+    font-size: 0.78rem; color: var(--cc-muted-2); line-height: 1.45;
+}
+.rd-why { color: var(--cc-amber); opacity: 0.85; }
+
+/* Mobile: the detail has nowhere to go on one line. Switch to flex and use
+   `order` so the row reads dot · label · Fix, with the detail and the why-line
+   wrapping underneath — indented past the dot so they hang off the label.
+   (Grid with an explicit column here pushed Fix onto its own line, tripling the
+   row height.) */
+@media (max-width: 620px) {
+    .rd-row { display: flex; flex-wrap: wrap; align-items: center; gap: 3px 8px; }
+    .rd-row .dot { flex: none; }
+    .rd-label { flex: 1 1 auto; }
+    .rd-fix { flex: none; order: 3; }
+    .rd-detail { flex: 1 0 100%; order: 4; text-align: left; padding-left: 15px; }
+    .rd-why, .rd-note { flex: 1 0 100%; order: 5; padding-left: 15px; margin: 0; }
+}
+
 /* Highlight the Update Scores tool when results are waiting to be scored. */
 .function-container.attn .button-container button {
     box-shadow: inset 3px 0 0 var(--cc-amber), 0px 0px 2px 2px var(--cc-surface);

--- a/public/admin.js
+++ b/public/admin.js
@@ -328,6 +328,123 @@ function renderAdminStatus(el, s, api, year, jobs) {
     });
 }
 
+// --- Preseason readiness ----------------------------------------------------
+// Each season-flip data load that can fail silently, checked against what's
+// actually on file. See modules/season-readiness.js for why each one matters.
+
+// League display names are commissioner-editable, so they're escaped before
+// they're interpolated into innerHTML below.
+function escapeHtml(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+// Check key -> [container attribute, opener] for the admin tool that fixes it.
+// The openers are function declarations defined further down this file, so they
+// hoist and are already bound by the time this literal is evaluated.
+// See readinessRow() for when the affordance is actually rendered.
+var READINESS_FIX = {
+    schedule: ['schedule-container', displayScheduleContainer],
+    enrichment: ['enrichment-container', displayEnrichmentContainer],
+    spPlus: ['enrichment-container', displayEnrichmentContainer],
+    expectedWins: ['expected-wins-container', displayExpectedWinsContainer],
+    cfpOdds: ['cfp-odds-container', displayCfpOddsContainer],
+    roster: ['season-roster-container', displaySeasonRosterContainer],
+    draft: ['draft-config-container', displayDraftConfigContainer],
+    gameModes: ['engagement-container', displayEngagementContainer]
+};
+
+// 'off' is a legitimate resting state (a classic league runs no game modes), so
+// it reads as neutral rather than as a problem.
+function readinessDot(c) {
+    if (c.status === 'ready') return 'g';
+    if (c.status === 'off') return 'b';
+    if (c.status === 'partial') return 'a';
+    return c.required ? 'r' : 'a';
+}
+
+function readinessRow(c) {
+    var needsAttention = c.required && c.status !== 'ready';
+    // No action on a settled row: the panel's job is to point at what's
+    // outstanding, and a control on every line flattens that signal. The tools
+    // themselves are listed directly below if someone wants to re-run one.
+    // Also suppressed when the target tool isn't on the page — a League Manager
+    // doesn't get the platform-wide tools, so they see state without a dead button.
+    var target = c.status !== 'ready' && READINESS_FIX[c.key];
+    var canOpen = target && document.querySelector('[' + target[0] + ']');
+    // The button navigates — it opens the tool and scrolls to it, it doesn't run
+    // anything — so a real gap says "Fix" (where you go to fix it) and an
+    // optional row that's merely switched off says "Set up".
+    var action = canOpen
+        ? '<button type="button" class="rd-fix" data-rd-fix="' + escapeHtml(c.key) + '">'
+            + (c.required ? 'Fix' : 'Set up') + ' →</button>'
+        : '<span></span>';
+    return '<div class="rd-row' + (needsAttention ? ' attn' : '') + '">'
+        + '<span class="dot ' + readinessDot(c) + '"></span>'
+        + '<span class="rd-label">' + escapeHtml(c.label) + '</span>'
+        + '<span class="rd-detail">' + escapeHtml(c.detail || '') + '</span>'
+        + action
+        + (needsAttention && c.whyItMatters ? '<p class="rd-why">' + escapeHtml(c.whyItMatters) + '</p>' : '')
+        + (c.note ? '<p class="rd-note">' + escapeHtml(c.note) + '</p>' : '')
+        + '</div>';
+}
+
+function renderReadiness(el, r) {
+    var outstanding = (r.blocking || []).length;
+    var head = r.ready
+        ? '<span class="rd-state ok">Ready to draft</span>'
+        : '<span class="rd-state warn">' + outstanding + ' step' + (outstanding === 1 ? '' : 's') + ' outstanding</span>';
+
+    var leagueBlocks = (r.leagues || []).map(function (l) {
+        return '<div class="rd-group"><small>' + escapeHtml(l.name) + '</small>'
+            + l.checks.map(readinessRow).join('') + '</div>';
+    }).join('');
+
+    el.className = 'readiness ' + (r.ready ? 'ok' : 'warn');
+    el.innerHTML = '<div class="ss-head"><i class="fa-solid fa-clipboard-check"></i> Season readiness · ' + escapeHtml(r.season) + '</div>'
+        + '<div class="rd-summary">' + head
+        + '<span class="rd-sub">These loads fail quietly — stale or partial data instead of an error. Worth confirming before draft night.</span></div>'
+        + '<div class="rd-group"><small>Platform data</small>' + (r.platform || []).map(readinessRow).join('') + '</div>'
+        + leagueBlocks;
+    el.hidden = false;
+
+    el.querySelectorAll('[data-rd-fix]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var target = READINESS_FIX[btn.getAttribute('data-rd-fix')];
+            if (!target) return;
+            var c = document.querySelector('[' + target[0] + ']');
+            if (!c) return;
+            if (!c.classList.contains('open')) target[1]();
+            // Scroll the whole tool card into view, falling back to the container
+            // itself if the markup ever stops nesting one inside the other.
+            (c.closest('.function-container') || c).scrollIntoView({ behavior: 'smooth', block: 'center' });
+        });
+    });
+}
+
+// Preseason only — the panel retires itself once the season is underway rather
+// than becoming permanent furniture, since the roster/draft checks are moot by
+// then and the in-season status strip above covers what matters.
+//
+// The season-underway flag comes from the payload itself (a completed game with
+// points), so this stands alone: it doesn't ride on the status strip's fetch,
+// and it can't be hidden by a bare weeklyScore row — the nightly job writes an
+// empty Week 1 entry for everyone as soon as a season roster exists, which reads
+// as "scored through Week 1" in early August with no football played.
+async function loadReadiness() {
+    var el = document.querySelector('[season-readiness]');
+    if (!el) return;
+    var year = window.APP_YEAR || new Date().getFullYear();
+    try {
+        var res = await fetch('/scores/readiness/' + year, { headers: { 'Accept': 'application/json' } });
+        if (!res.ok) return;
+        var r = await res.json();
+        if (r.seasonUnderway) return;
+        renderReadiness(el, r);
+    } catch (e) { /* leave the panel hidden on error */ }
+}
+
 window.onload = async function() {
     // Hamburger toggle is owned by the navbar partial (views/partials/navbar.ejs).
     detectMobile();
@@ -337,6 +454,7 @@ window.onload = async function() {
     setSeasonTypeOptions();
     setWeekOptions();
     loadAdminStatus();
+    loadReadiness();
 };
 
 // League name: rename the active league (own-league enforced server-side).

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -4,8 +4,13 @@ const scoringModule = require('../modules/scoring.js');
 const User = require('../models/user');
 const Game = require('../models/game');
 const ScoringConfig = require('../models/scoringConfig');
+const Team = require('../models/team');
+const Draft = require('../models/draft');
+const League = require('../models/league');
 const { computeAdminStatus } = require('../modules/admin-status');
-const { engagementForSeason } = require('../modules/scoring-defaults');
+const { computeSeasonReadiness } = require('../modules/season-readiness');
+const { engagementForSeason, LEAGUES } = require('../modules/scoring-defaults');
+const { canManageLeague } = require('../modules/league-access');
 const { H2H_LAST_WEEK, seasonEntry, computeH2HAwards, applyAwards } = require('../modules/h2h');
 
 // Read-only status summary for the admin console: how far scoring/games have
@@ -20,6 +25,98 @@ router.get('/status/:season', async (req, res) => {
             { id: 1, week: 1, seasonType: 1, completed: 1, homeId: 1, awayId: 1, homePoints: 1, awayPoints: 1, _id: 0 }
         );
         res.json(computeAdminStatus(users, games, season));
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Preseason readiness: is this season actually ready to draft?
+//
+// The season-flip steps that feed draft grades and projections (schedule ingest,
+// preseason enrichment, expected wins, CFP odds) all fail SILENTLY — they produce
+// a plausible payload from stale or partial data rather than an error or an empty
+// state. See docs/season-flip-runbook.md. This endpoint reads what's actually on
+// file and reports it, so a missed step is visible before draft night instead of
+// after the season is underway.
+//
+// Read-only, derived entirely from existing data — no writes, no CFBD calls.
+// League rows are scoped to what the caller may manage (Admins: every league;
+// League Managers: their own), mirroring the /rules league gate.
+router.get('/readiness/:season', async (req, res) => {
+    try {
+        const season = req.params.season;
+        const seasonNum = Number(season);
+
+        // Only the readiness fields off each season subdoc — a bare `seasons: 1`
+        // drags every team's weeklyScore array along for no reason.
+        const teams = await Team.find({}, {
+            id: 1, 'seasons.season': 1, 'seasons.talent': 1, 'seasons.spRating': 1,
+            'seasons.expectedWins': 1, 'seasons.cfpMakeOdds': 1, 'seasons.cfpChampOdds': 1
+        }).lean();
+        const teamTotal = teams.length;
+        const fbsIds = new Set(teams.map(t => t.id));
+        const teamsWith = { talent: 0, spRating: 0, expectedWins: 0, cfpOdds: 0 };
+        teams.forEach(t => {
+            const s = (t.seasons || []).find(x => Number(x.season) === seasonNum);
+            if (!s) return;
+            if (s.talent != null) teamsWith.talent++;
+            if (s.spRating != null) teamsWith.spRating++;
+            if (s.expectedWins != null) teamsWith.expectedWins++;
+            if (s.cfpMakeOdds != null || s.cfpChampOdds != null) teamsWith.cfpOdds++;
+        });
+
+        // Schedule coverage: a full ingest reaches essentially every team, so
+        // distinct teams-with-a-game separates "loaded" from "partially loaded".
+        // Counted against FBS teams ONLY — the schedule is full of FCS and other
+        // non-FBS opponents whose ids never appear in the Team collection, so
+        // counting them raw gives more "scheduled teams" than teams that exist
+        // (350 of 138 on real 2026 data) and makes the ratio meaningless.
+        const games = await Game.find(
+            { season: seasonNum, seasonType: 'regular' },
+            { homeId: 1, awayId: 1, completed: 1, homePoints: 1, awayPoints: 1, _id: 0 }
+        ).lean();
+        const scheduled = new Set();
+        games.forEach(g => {
+            if (fbsIds.has(g.homeId)) scheduled.add(g.homeId);
+            if (fbsIds.has(g.awayId)) scheduled.add(g.awayId);
+        });
+
+        // Has the season actually started? Mirrors computeAdminStatus's
+        // gamesLoadedThroughWeek — a completed game with points on it. The client
+        // retires the panel on this, so it doesn't depend on a second endpoint
+        // (and can't be hidden by a mere weeklyScore row, which the nightly job
+        // creates for everyone the moment a season roster exists).
+        const seasonUnderway = games.some(g =>
+            g.completed && typeof g.homePoints === 'number' && (g.homePoints || g.awayPoints));
+
+        // Per-league setup. Only the fields needed — season rosters carry heavy
+        // weeklyScore arrays we don't read here.
+        const members = await User.find({ 'seasons.season': season }, { league: 1 }).lean();
+        const memberCount = {};
+        members.forEach(m => { memberCount[m.league] = (memberCount[m.league] || 0) + 1; });
+        const drafts = await Draft.find({ season: seasonNum }).lean();
+        const configs = await ScoringConfig.find({}, { league: 1, engagementBySeason: 1 }).lean();
+        const names = await League.find({}, { code: 1, name: 1, _id: 0 }).lean();
+        const nameByCode = {};
+        names.forEach(n => { nameByCode[n.code] = n.name; });
+
+        const visible = LEAGUES.filter(l => canManageLeague(req, l.code));
+        const leagues = visible.map(l => {
+            const cfg = configs.find(c => c.league === l.code);
+            return {
+                code: l.code,
+                name: nameByCode[l.code] || l.name,
+                members: memberCount[l.code] || 0,
+                draft: drafts.find(d => d.league === l.code) || null,
+                engagement: engagementForSeason(cfg && cfg.engagementBySeason, season)
+            };
+        });
+
+        res.json(computeSeasonReadiness({
+            season, teamTotal, teamsWith,
+            scheduledTeams: scheduled.size, gameCount: games.length,
+            leagues, seasonUnderway
+        }));
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/tests/SeasonReadiness.spec.js
+++ b/tests/SeasonReadiness.spec.js
@@ -1,0 +1,354 @@
+const { computeSeasonReadiness, platformChecks, leagueChecks } = require('../modules/season-readiness');
+
+const TEAMS = 134;
+const byKey = (checks) => checks.reduce((m, c) => (m[c.key] = c, m), {});
+
+// A fully-loaded season: every platform check satisfied.
+function loaded(over) {
+    return Object.assign({
+        season: 2026,
+        teamTotal: TEAMS,
+        teamsWith: { talent: TEAMS, spRating: TEAMS, expectedWins: TEAMS, cfpOdds: 30 },
+        scheduledTeams: TEAMS,
+        gameCount: 870
+    }, over || {});
+}
+function leagueReady(over) {
+    return Object.assign({
+        code: 'graham-league', name: 'Graham',
+        members: 10,
+        draft: { draftOrder: ['a', 'b', 'c'], scheduledAt: new Date('2026-08-15'), snake: true, totalRounds: 10 },
+        engagement: { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 1, captainEnabled: true, captainMultiplier: 2 }
+    }, over || {});
+}
+
+describe('platformChecks', () => {
+    test('a fully loaded season is all-ready', () => {
+        const c = byKey(platformChecks(loaded()));
+        ['schedule', 'enrichment', 'expectedWins', 'cfpOdds', 'spPlus'].forEach(k => {
+            expect(c[k].status).toBe('ready');
+        });
+    });
+
+    // The runbook's headline failure: no schedule means grades compute from
+    // postseason points only, with no error and no empty state.
+    test('a missing schedule is flagged as a required miss, with the game count', () => {
+        const c = byKey(platformChecks(loaded({ scheduledTeams: 0, gameCount: 0 })));
+        expect(c.schedule).toMatchObject({ status: 'missing', required: true });
+        expect(c.schedule.detail).toBe('No games loaded');
+        expect(c.schedule.whyItMatters).toMatch(/no error shown/);
+    });
+
+    test('a partially ingested schedule is partial, not ready', () => {
+        const c = byKey(platformChecks(loaded({ scheduledTeams: 40, gameCount: 120 })));
+        expect(c.schedule.status).toBe('partial');
+        expect(c.schedule.detail).toBe('120 games · 40 of 134 teams');
+    });
+
+    test('coverage just under the bar is partial; at the bar is ready', () => {
+        expect(byKey(platformChecks(loaded({ teamsWith: { talent: 120 } }))).enrichment.status).toBe('partial');
+        expect(byKey(platformChecks(loaded({ teamsWith: { talent: 121 } }))).enrichment.status).toBe('ready');
+    });
+
+    // Odds boards only price contenders, so coverage would be the wrong lens.
+    test('CFP odds are judged on absolute count, not team coverage', () => {
+        expect(byKey(platformChecks(loaded({ teamsWith: { cfpOdds: 30 } }))).cfpOdds.status).toBe('ready');
+        expect(byKey(platformChecks(loaded({ teamsWith: { cfpOdds: 4 } }))).cfpOdds.status).toBe('partial');
+        expect(byKey(platformChecks(loaded({ teamsWith: { cfpOdds: 0 } }))).cfpOdds.status).toBe('missing');
+    });
+
+    // CFBD publishes SP+ close to kickoff and the engine falls back to the prior
+    // year, so an empty SP+ in early August is expected — never a blocker.
+    test('missing SP+ is reported but never required', () => {
+        const c = byKey(platformChecks(loaded({ teamsWith: { spRating: 0 } })));
+        expect(c.spPlus).toMatchObject({ status: 'missing', required: false });
+        expect(c.spPlus.note).toMatch(/Not published yet/);
+    });
+
+    test('SP+ carries the season in its label, so a stale year is obvious', () => {
+        expect(byKey(platformChecks(loaded())).spPlus.label).toBe('SP+ ratings (2026)');
+    });
+
+    test('no teams on file at all degrades to missing rather than dividing by zero', () => {
+        const c = byKey(platformChecks(loaded({ teamTotal: 0, teamsWith: {}, scheduledTeams: 0, gameCount: 0 })));
+        expect(c.enrichment.status).toBe('missing');
+        expect(c.enrichment.detail).toBe('No teams loaded');
+    });
+});
+
+describe('leagueChecks', () => {
+    test('a configured league is all-ready', () => {
+        const c = byKey(leagueChecks(leagueReady()));
+        expect(c.roster.status).toBe('ready');
+        expect(c.draft.status).toBe('ready');
+        expect(c.draft.detail).toBe('3 managers · snake · 10 rounds');
+        expect(c.gameModes.detail).toBe('H2H +3/+1 tie · Captain ×2');
+    });
+
+    test('an empty season roster is a required miss', () => {
+        const c = byKey(leagueChecks(leagueReady({ members: 0 })));
+        expect(c.roster).toMatchObject({ status: 'missing', required: true });
+        expect(c.roster.whyItMatters).toMatch(/after YEAR is flipped/);
+    });
+
+    test('a draft with no doc, no order, or no date is distinguished', () => {
+        expect(byKey(leagueChecks(leagueReady({ draft: null }))).draft)
+            .toMatchObject({ status: 'missing', detail: 'No draft configured' });
+        expect(byKey(leagueChecks(leagueReady({ draft: { draftOrder: [] } }))).draft)
+            .toMatchObject({ status: 'partial', detail: 'Configured, but no pick order set' });
+        expect(byKey(leagueChecks(leagueReady({ draft: { draftOrder: ['a', 'b'] } }))).draft)
+            .toMatchObject({ status: 'partial', detail: '2 managers in order · no date set' });
+    });
+
+    // Claunts stays classic — no game modes is a valid resting state, not a gap.
+    test('a classic league reads as off, never as a failure', () => {
+        const c = byKey(leagueChecks(leagueReady({ engagement: { h2hEnabled: false, captainEnabled: false } })));
+        expect(c.gameModes).toMatchObject({ status: 'off', required: false });
+        expect(c.gameModes.detail).toBe('Classic scoring (no game modes)');
+    });
+
+    test('one mode on is described on its own', () => {
+        const c = byKey(leagueChecks(leagueReady({ engagement: { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0, captainEnabled: false } })));
+        expect(c.gameModes.detail).toBe('H2H +3');
+    });
+});
+
+describe('computeSeasonReadiness', () => {
+    test('everything loaded and configured → ready, nothing blocking', () => {
+        const r = computeSeasonReadiness(Object.assign(loaded(), { leagues: [leagueReady()] }));
+        expect(r.ready).toBe(true);
+        expect(r.blocking).toEqual([]);
+        expect(r.season).toBe('2026');
+    });
+
+    test('blocking lists every required miss across platform and leagues', () => {
+        const r = computeSeasonReadiness(Object.assign(
+            loaded({ scheduledTeams: 0, gameCount: 0, teamsWith: { talent: TEAMS, expectedWins: TEAMS, cfpOdds: 0 } }),
+            { leagues: [leagueReady({ draft: null })] }
+        ));
+        expect(r.ready).toBe(false);
+        expect(r.blocking).toEqual(['schedule', 'cfpOdds', 'draft']);
+    });
+
+    // The two never-required checks must not be able to hold a season back.
+    test('missing SP+ and a classic league alone still read as ready', () => {
+        const r = computeSeasonReadiness(Object.assign(
+            loaded({ teamsWith: { talent: TEAMS, spRating: 0, expectedWins: TEAMS, cfpOdds: 30 } }),
+            { leagues: [leagueReady({ engagement: { h2hEnabled: false, captainEnabled: false } })] }
+        ));
+        expect(r.ready).toBe(true);
+    });
+
+    test('each league gets its own row, keyed and named', () => {
+        const r = computeSeasonReadiness(Object.assign(loaded(), {
+            leagues: [leagueReady(), leagueReady({ code: 'claunts-league', name: 'Claunts', members: 0 })]
+        }));
+        expect(r.leagues.map(l => l.league)).toEqual(['graham-league', 'claunts-league']);
+        expect(r.leagues[1].name).toBe('Claunts');
+        expect(r.blocking).toContain('roster');
+    });
+
+    // The client retires the panel on this, so it must reflect real results
+    // rather than the mere existence of a weeklyScore row.
+    test('seasonUnderway is echoed back, defaulting to false', () => {
+        expect(computeSeasonReadiness(Object.assign(loaded(), { leagues: [] })).seasonUnderway).toBe(false);
+        expect(computeSeasonReadiness(Object.assign(loaded(), { leagues: [], seasonUnderway: true })).seasonUnderway).toBe(true);
+    });
+
+    test('blocking repeats a key when several leagues miss the same step', () => {
+        const r = computeSeasonReadiness(Object.assign(loaded(), {
+            leagues: [leagueReady({ members: 0 }), leagueReady({ code: 'claunts-league', members: 0 })]
+        }));
+        expect(r.blocking).toEqual(['roster', 'roster']);   // two leagues, two steps
+    });
+
+    test('no visible leagues still reports the platform data', () => {
+        const r = computeSeasonReadiness(Object.assign(loaded(), { leagues: [] }));
+        expect(r.leagues).toEqual([]);
+        expect(r.platform).toHaveLength(5);
+        expect(r.ready).toBe(true);
+    });
+});
+
+// --- route wiring ------------------------------------------------------------
+// The pure module is only as good as the fields the route reads. A renamed or
+// mistyped field would report "missing" forever — a silent failure inside the
+// panel built to catch silent failures. So this exercises GET
+// /scores/readiness/:season against real documents.
+
+process.env.INTERNAL_API_TOKEN = 'test-internal-token';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const Team = require('../models/team');
+const Game = require('../models/game');
+const User = require('../models/user');
+const Draft = require('../models/draft');
+const ScoringConfig = require('../models/scoringConfig');
+const League = require('../models/league');
+const scoresRouter = require('../routes/scores');
+
+const app = express();
+app.use(express.json());
+app.use('/scores', scoresRouter);
+
+useMongo();
+
+// The internal token is what makes every league visible (canManageLeague),
+// matching how a server-to-server caller sees the whole picture.
+const get = (season) => request(app)
+    .get(`/scores/readiness/${season}`)
+    .set('X-Internal-Token', 'test-internal-token');
+
+function teamDoc(id, seasonFields) {
+    return {
+        id, school: 'School' + id, mascot: 'M', abbreviation: 'S' + id,
+        conference: 'SEC', color: '#000', logos: ['l.png'],
+        location: { venue_id: id, name: 'V', city: 'C', state: 'ST', zip: '1', latitude: 1, longitude: 1, capacity: 1, grass: true, dome: false },
+        seasons: seasonFields ? [Object.assign({ season: 2026 }, seasonFields)] : []
+    };
+}
+
+describe('GET /scores/readiness/:season', () => {
+    test('reads enrichment, expected wins and CFP odds off the season subdoc', async () => {
+        await Team.create([
+            teamDoc(1, { talent: 900, spRating: 18.4, expectedWins: 9.1, cfpMakeOdds: -200 }),
+            teamDoc(2, { talent: 800, spRating: 12.0, expectedWins: 7.5 })
+        ]);
+        const body = (await get(2026)).body;
+        const c = byKey(body.platform);
+        expect(c.enrichment.detail).toBe('2 of 2 teams');
+        expect(c.expectedWins.detail).toBe('2 of 2 teams');
+        expect(c.spPlus.detail).toBe('2 of 2 teams');
+        expect(c.cfpOdds.detail).toBe('1 teams priced');
+    });
+
+    test('a season subdoc for another year does not count', async () => {
+        await Team.create([{ ...teamDoc(1), seasons: [{ season: 2025, talent: 900, expectedWins: 9 }] }]);
+        const c = byKey((await get(2026)).body.platform);
+        expect(c.enrichment.status).toBe('missing');
+        expect(c.enrichment.detail).toBe('0 of 1 teams');
+    });
+
+    test('schedule coverage counts distinct teams across home and away', async () => {
+        await Team.create([teamDoc(1), teamDoc(2), teamDoc(3)]);
+        await Game.create([{
+            id: 1, season: 2026, week: 1, seasonType: 'regular',
+            startDate: '2026-09-05T00:00:00.000Z', startTimeTbd: false,
+            neutralSite: false, conferenceGame: false,
+            homeId: 1, homeTeam: 'A', awayId: 2, awayTeam: 'B'
+        }]);
+        const c = byKey((await get(2026)).body.platform);
+        expect(c.schedule.detail).toBe('1 games · 2 of 3 teams');
+        expect(c.schedule.status).toBe('partial');
+    });
+
+    // Real 2026 data reported "350 of 138 teams" before this: the schedule is
+    // full of FCS opponents whose ids aren't in the Team collection, so counting
+    // them raw broke the ratio and would have hidden a partial ingest.
+    test('non-FBS opponents do not inflate schedule coverage', async () => {
+        await Team.create([teamDoc(1), teamDoc(2)]);
+        await Game.create([{
+            id: 1, season: 2026, week: 1, seasonType: 'regular',
+            startDate: '2026-09-05T00:00:00.000Z', startTimeTbd: false,
+            neutralSite: false, conferenceGame: false,
+            homeId: 1, homeTeam: 'FBS', awayId: 99999, awayTeam: 'Some FCS School'
+        }]);
+        const c = byKey((await get(2026)).body.platform);
+        expect(c.schedule.detail).toBe('1 games · 1 of 2 teams');
+        expect(c.schedule.status).toBe('partial');
+    });
+
+    // Drives whether the panel shows at all, so it has to key off a real result.
+    describe('seasonUnderway', () => {
+        const g = (o) => Object.assign({
+            id: 1, season: 2026, week: 1, seasonType: 'regular',
+            startDate: '2026-09-05T00:00:00.000Z', startTimeTbd: false,
+            neutralSite: false, conferenceGame: false,
+            homeId: 1, homeTeam: 'A', awayId: 2, awayTeam: 'B'
+        }, o);
+
+        test('false when the schedule is loaded but nothing has been played', async () => {
+            await Team.create([teamDoc(1), teamDoc(2)]);
+            await Game.create([g({ completed: false })]);
+            expect((await get(2026)).body.seasonUnderway).toBe(false);
+        });
+
+        test('true once a completed game has points on it', async () => {
+            await Team.create([teamDoc(1), teamDoc(2)]);
+            await Game.create([g({ completed: true, homePoints: 31, awayPoints: 20 })]);
+            expect((await get(2026)).body.seasonUnderway).toBe(true);
+        });
+
+        test('a completed game with no points recorded does not count', async () => {
+            await Team.create([teamDoc(1), teamDoc(2)]);
+            await Game.create([g({ completed: true })]);
+            expect((await get(2026)).body.seasonUnderway).toBe(false);
+        });
+    });
+
+    test('postseason games do not count toward the regular-season schedule', async () => {
+        await Team.create([teamDoc(1), teamDoc(2)]);
+        await Game.create([{
+            id: 1, season: 2026, week: 1, seasonType: 'postseason',
+            startDate: '2026-12-20T00:00:00.000Z', startTimeTbd: false,
+            neutralSite: true, conferenceGame: false,
+            homeId: 1, homeTeam: 'A', awayId: 2, awayTeam: 'B'
+        }]);
+        expect(byKey((await get(2026)).body.platform).schedule.status).toBe('missing');
+    });
+
+    test('counts season members per league and picks up the draft + game modes', async () => {
+        await Team.create([teamDoc(1)]);
+        await User.create([
+            { firstName: 'A', lastName: 'A', league: 'graham-league', seasons: [{ season: 2026 }] },
+            { firstName: 'B', lastName: 'B', league: 'graham-league', seasons: [{ season: 2026 }] },
+            { firstName: 'C', lastName: 'C', league: 'claunts-league', seasons: [{ season: 2025 }] }
+        ]);
+        await Draft.create({
+            league: 'graham-league', season: 2026,
+            draftOrder: [], scheduledAt: new Date('2026-08-15'), totalRounds: 10
+        });
+        await ScoringConfig.create({
+            league: 'graham-league', model: 'graham',
+            engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: 3, captainEnabled: true, captainMultiplier: 2 } }
+        });
+
+        const body = (await get(2026)).body;
+        const graham = body.leagues.find(l => l.league === 'graham-league');
+        const claunts = body.leagues.find(l => l.league === 'claunts-league');
+        const g = byKey(graham.checks), cl = byKey(claunts.checks);
+
+        expect(g.roster.detail).toBe('2 managers');
+        expect(g.draft.status).toBe('partial');          // no pick order yet
+        expect(g.gameModes.detail).toBe('H2H +3 · Captain ×2');
+        expect(cl.roster.status).toBe('missing');        // C is on 2025, not 2026
+        expect(cl.gameModes.status).toBe('off');
+    });
+
+    test('uses the commissioner-set league display name when present', async () => {
+        await League.create({ code: 'graham-league', name: 'The Gauntlet' });
+        const body = (await get(2026)).body;
+        expect(body.leagues.find(l => l.league === 'graham-league').name).toBe('The Gauntlet');
+    });
+
+    test('an empty database reports every required step as outstanding', async () => {
+        const body = (await get(2026)).body;
+        expect(body.ready).toBe(false);
+        expect(body.blocking).toEqual(
+            expect.arrayContaining(['schedule', 'enrichment', 'expectedWins', 'cfpOdds', 'roster', 'draft'])
+        );
+        expect(body.blocking).not.toContain('spPlus');
+        expect(body.blocking).not.toContain('gameModes');
+    });
+
+    // Without the token and without an Admin session, canManageLeague denies
+    // every league — the platform rows still render, the league rows don't.
+    test('league rows are scoped to what the caller may manage', async () => {
+        await Team.create([teamDoc(1)]);
+        const body = (await request(app).get('/scores/readiness/2026')).body;
+        expect(body.leagues).toEqual([]);
+        expect(body.platform).toHaveLength(5);
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -52,6 +52,12 @@
 
     <div class="admin-status" admin-status hidden></div>
 
+    <!-- Preseason readiness (docs/season-flip-runbook.md). The season-flip data
+         loads fail silently — stale/partial data rather than an error — so this
+         reports what's actually on file before draft night. Rendered by
+         renderReadiness(); hides itself once the season is scoring. -->
+    <div class="readiness" season-readiness hidden></div>
+
     <% /* Platform-wide groups: Admins only. League Managers see just League setup. */ %>
     <% if (isAdmin) { %>
     <section class="admin-group">


### PR DESCRIPTION
## The problem

The season-flip data loads all fail **quietly**. Per [`docs/season-flip-runbook.md`](docs/season-flip-runbook.md), skipping the schedule ingest makes every projection and draft grade compute from postseason points only — *"a full, convincing-but-wrong payload with no error and no empty state."* Missing CFP odds silently fall back to an SP+-rank proxy. Skipping preseason enrichment silently reuses last season's ratings.

None of them announce themselves, and all of them land on draft night. This turns the runbook into one screen on `/admin`.

## It found real problems immediately

Run against live 2026 data:

```
ready: false | seasonUnderway: false | blocking: [enrichment, roster, draft]

  [ready  ] Full schedule ingested   1638 games · 138 of 138 teams
  [MISSING] Preseason enrichment     0 of 138 teams
  [ready  ] Expected wins            138 of 138 teams
  [ready  ] CFP odds                 138 teams priced
  [ready  ] SP+ ratings (2026)       138 of 138 teams

  Claunts League          CFB Sickos
  [MISSING] Season roster       [ready] Season roster    6 managers
  [MISSING] Draft configured    [ready] Draft configured 6 managers · snake · 10 rounds
  [off    ] Game modes          [ready] Game modes       H2H +3/+1 tie · Captain ×2
```

**Preseason enrichment has not run for 2026** — zero of 138 teams have talent data. With the draft roughly a week out, the pool and every draft grade would have been computed on 2025 ratings, silently. Needs `node update-enrichment-job.js 2026 preseason` regardless of this PR.

**Claunts League has no 2026 roster and no draft** — intentional if they're sitting the year out, otherwise runbook steps 6 and 8.

## What's here

- **`modules/season-readiness.js`** (new) — pure, DB-free check computation. Sibling of `admin-status.js`, which answers the *in-season* question ("is scoring caught up?"); this answers the *preseason* one. Each row carries a status, the numbers behind it, and — for a required miss — what actually breaks if it's skipped.
- **`routes/scores.js`** — `GET /scores/readiness/:season`. Read-only, derived entirely from existing data; no writes, no CFBD calls. League rows are scoped to what the caller may manage, mirroring the `/rules` league gate.
- **`views/admin.ejs` + `public/admin.js` + `public/admin.css`** — the panel.

Only unsettled rows carry an action, so the eye goes to what's outstanding instead of a wall of identical buttons. The control **navigates** — it opens the matching tool below and scrolls to it, it doesn't run anything — so a real gap reads `Fix →` and an optional row that's merely switched off reads `Set up →`. It's suppressed entirely when the target tool isn't on the page, since a League Manager doesn't get the platform-wide tools and would otherwise see a dead button.

Two checks are deliberately **never blocking**: SP+ (CFBD publishes close to kickoff; the engine falls back to the prior year until then) and game modes (a classic league runs neither — a valid resting state, not a gap).

## Bugs caught while verifying against real data

Both were invisible to green tests, which is why this was run against live data before shipping:

- **Schedule coverage counted every id in the games collection**, so FCS opponents — who aren't in the `Team` collection — reported **"350 of 138 teams"**. Now intersected with the FBS list. A ratio over 100% would have masked a partial ingest, precisely the failure that row exists to catch.
- **The panel didn't render at all.** It gated on `scoredThroughWeek`, but the nightly job writes an empty Week 1 entry for everyone as soon as a season roster exists — so it read `1` in early August with no football played, hiding the panel exactly when it matters.

## From self-review before pushing

- **Decoupled the panel from the status strip.** It used to load only if `/scores/status` succeeded *and* `renderAdminStatus` didn't throw. The endpoint now returns `seasonUnderway` (a completed game with points), so the panel stands alone with no extra fetch.
- **Guarded `.closest('.function-container')`** — an unguarded null would have thrown on click if that nesting ever changed.
- **Narrowed the `Team` projection** to just the readiness fields; a bare `seasons: 1` dragged every team's `weeklyScore` array along on each admin page load. Verified the counts are byte-identical after the change.

## Tests — 414 green

Pure-module cases (coverage thresholds, the odds-count rule, non-blocking SP+, draft partial states, `seasonUnderway`) plus route-level cases against in-memory Mongo that **pin the real field names** — a renamed field would otherwise report "missing" forever inside the panel built to catch silent failures. New coverage floor on the module.

Verified in the browser at desktop and 375px: correct dot colors per state, the action opens the right tool, no console errors, no horizontal overflow. Mobile needed a layout fix — grid was pushing the action button onto its own line and tripling row height; flex + `order` now reads dot · label · action with the detail wrapping underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
