### PR TITLE
Commissioner roster correction: fix a team that landed on the wrong roster

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -14,6 +14,7 @@
         "./modules/draft-grades.js": { "statements": 90, "branches": 70, "functions": 95, "lines": 95 },
         "./modules/h2h.js": { "statements": 95, "branches": 85, "functions": 100, "lines": 100 },
         "./modules/season-readiness.js": { "statements": 100, "branches": 85, "functions": 100, "lines": 100 },
+        "./modules/roster-correction.js": { "statements": 95, "branches": 85, "functions": 100, "lines": 100 },
         "./modules/internal-api.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./modules/job-runs-util.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./update-enrichment-job.js": { "statements": 80, "branches": 60, "functions": 60, "lines": 90 }

--- a/models/draft.js
+++ b/models/draft.js
@@ -9,7 +9,12 @@ const draftPickSchema = new mongoose.Schema({
     userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
     team: { type: mongoose.Schema.Types.Mixed, required: true },
     pickedAt: { type: Date },
-    pickedByCommissioner: { type: Boolean, default: false }
+    pickedByCommissioner: { type: Boolean, default: false },
+    // Set when a commissioner corrected which team went in this slot after the
+    // fact (see modules/roster-correction.js). The round/overall/pickedAt of the
+    // pick are untouched — only the team was wrong — so this is the one marker
+    // that the board no longer shows what was originally entered.
+    correctedAt: { type: Date }
 }, { _id: false });
 
 const draftSchema = new mongoose.Schema({

--- a/modules/roster-correction.js
+++ b/modules/roster-correction.js
@@ -1,0 +1,146 @@
+// Commissioner roster correction: swap one team on a manager's season roster
+// for an undrafted one.
+//
+// Until now a completed draft was final — the only write path was
+// PATCH /users/draft/:id, which bulk-overwrites all ten teams and has no UI. So
+// a misclick on draft night (easy, since commissioners pick on behalf of absent
+// managers) was permanent. This is the narrow, auditable fix for that.
+//
+// A correction rewrites BOTH sides: the manager's seasons[].teams AND the
+// matching drafts.picks[] entry. Those are the two places a rostered team is
+// stored (see modules/team-refresh.js, which has to keep them in sync for the
+// same reason), and draft grades, the draft board, and the "Draft Steal"
+// highlight all read the picks. Correcting one and not the other would leave
+// them quietly disagreeing.
+//
+// Pure and DB-free so it's unit-testable; routes/users.js loads the documents
+// and applies the results.
+
+// CFBD's team.location uses `id`; the user schema's location requires
+// `venue_id`. modules/draft-socket.js does this same remap when it persists a
+// completed draft onto rosters — the two must agree, or a corrected team would
+// be shaped differently from a drafted one.
+function normalizeLocation(location) {
+    if (!location) return location;
+    const loc = Object.assign({}, location);
+    if (loc.id != null && loc.venue_id == null) loc.venue_id = loc.id;
+    delete loc.id;
+    return loc;
+}
+
+// The fields a roster team carries (models/user.js teamSchema). Copied
+// explicitly rather than spreading the whole Team document, which also holds
+// per-season ratings and scores that have no business on a roster entry.
+const ROSTER_TEAM_FIELDS = [
+    'id', 'school', 'mascot', 'abbreviation',
+    'alt_name1', 'alt_name2', 'alt_name3', 'alternateNames',
+    'conference', 'division', 'color', 'alt_color', 'logos', 'twitter'
+];
+
+// Build a roster-shaped team from a Team document.
+function rosterTeamFrom(teamDoc) {
+    if (!teamDoc) return null;
+    const out = {};
+    ROSTER_TEAM_FIELDS.forEach(f => { if (teamDoc[f] !== undefined) out[f] = teamDoc[f]; });
+    if (teamDoc.location) out.location = normalizeLocation(teamDoc.location);
+    return out;
+}
+
+// The user schema's location requires more fields than the team schema does
+// (zip, latitude, longitude, capacity, grass, dome), so a team with a thin
+// location record would fail validation on save with an opaque error. Checking
+// up front turns that into a message naming the team.
+const REQUIRED_LOCATION_FIELDS = ['venue_id', 'name', 'city', 'state', 'zip', 'latitude', 'longitude', 'capacity'];
+
+function missingLocationFields(team) {
+    const loc = (team && team.location) || null;
+    if (!loc) return ['location'];
+    return REQUIRED_LOCATION_FIELDS.filter(f => loc[f] == null);
+}
+
+// Validate a proposed correction. Returns { ok: true } or { ok: false, status,
+// message }. Every branch is a distinct HTTP status so the client can react
+// (409 = taken, 423 = locked) rather than parsing prose.
+//
+//   roster        the manager's current seasons[].teams
+//   targetTeam    the Team document for toTeamId (null if unknown)
+//   takenBy       { name } if another manager in the league already has it
+//   seasonUnderway  whether the season has scored games
+//   isAdmin       Admins may still correct a season that's underway
+function validateCorrection({ roster, fromTeamId, toTeamId, targetTeam, takenBy, seasonUnderway, isAdmin }) {
+    if (fromTeamId == null || toTeamId == null) {
+        return { ok: false, status: 400, message: 'Both the current team and the replacement are required.' };
+    }
+    if (Number(fromTeamId) === Number(toTeamId)) {
+        return { ok: false, status: 400, message: 'That manager already has this team.' };
+    }
+    // Locked once results exist: the roster is baked into every scored week, so
+    // a swap needs a full re-score to be meaningful. Admins can still proceed
+    // (and are told to re-score); League Managers are stopped. Mirrors the
+    // season-membership lock in routes/users.js.
+    if (seasonUnderway && !isAdmin) {
+        return { ok: false, status: 423, message: 'Rosters lock once the season is underway. Ask an admin — the change needs a full re-score.' };
+    }
+    const current = (roster || []).find(t => Number(t.id) === Number(fromTeamId));
+    if (!current) {
+        return { ok: false, status: 404, message: 'That team is not on this manager\'s roster.' };
+    }
+    // The manager's OWN roster, checked here rather than via the "taken by
+    // someone else" lookup — that query deliberately excludes this user, so
+    // without this a swap onto a team they already hold would sail through and
+    // leave the same team on the roster twice.
+    const dupe = (roster || []).find(t => Number(t.id) === Number(toTeamId));
+    if (dupe) {
+        return { ok: false, status: 409, message: `That manager already has ${dupe.school}.` };
+    }
+    if (!targetTeam) {
+        return { ok: false, status: 404, message: 'Could not find the replacement team.' };
+    }
+    if (takenBy) {
+        return { ok: false, status: 409, message: `${targetTeam.school} is already on ${takenBy.name}'s roster.` };
+    }
+    const missing = missingLocationFields(rosterTeamFrom(targetTeam));
+    if (missing.length) {
+        return {
+            ok: false, status: 422,
+            message: `${targetTeam.school} is missing venue details (${missing.join(', ')}) and can't be rostered. Run Refresh Teams for this season, then try again.`
+        };
+    }
+    return { ok: true, current };
+}
+
+// Swap the team on a roster, preserving order so the draft-order reading of a
+// roster (and anything rendering it) doesn't jump around after a correction.
+function replaceRosterTeam(teams, fromTeamId, nextTeam) {
+    let changed = false;
+    const out = (teams || []).map(t => {
+        if (!changed && Number(t.id) === Number(fromTeamId)) { changed = true; return nextTeam; }
+        return t;
+    });
+    return { teams: out, changed };
+}
+
+// Swap the team on the matching draft pick — the manager's pick of that team in
+// that draft. Keeps round/overall/pickedAt intact: the slot is unchanged, only
+// which team went in it was wrong.
+function replaceDraftPick(picks, userId, fromTeamId, nextTeam) {
+    let changed = false;
+    const out = (picks || []).map(p => {
+        if (changed) return p;
+        const sameUser = String(p.userId) === String(userId);
+        const sameTeam = p.team && Number(p.team.id) === Number(fromTeamId);
+        if (!sameUser || !sameTeam) return p;
+        changed = true;
+        const next = Object.assign({}, p.toObject ? p.toObject() : p);
+        next.team = nextTeam;
+        next.correctedAt = new Date();
+        return next;
+    });
+    return { picks: out, changed };
+}
+
+module.exports = {
+    normalizeLocation, rosterTeamFrom, missingLocationFields,
+    validateCorrection, replaceRosterTeam, replaceDraftPick,
+    ROSTER_TEAM_FIELDS, REQUIRED_LOCATION_FIELDS
+};

--- a/public/admin.css
+++ b/public/admin.css
@@ -423,6 +423,60 @@
 .admin-status.warn .ss-note { color: var(--cc-amber); }
 .admin-status .ss-note a { color: inherit; font-weight: 500; text-decoration: underline; cursor: pointer; }
 
+/* --- Correct a Roster ------------------------------------------------------
+   Manager picker, then one row per rostered team. A row swaps in place into an
+   edit state rather than opening a modal, so the rest of the roster stays
+   visible while you choose — you're usually checking you're fixing the right
+   one. */
+.roster-correction { display: flex; flex-direction: column; gap: 12px; width: 100%; }
+.rc-pick { display: flex; align-items: center; gap: 10px; }
+.rc-pick > span { color: var(--cc-muted-2); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; }
+.rc-pick select { flex: 1 1 auto; max-width: 380px; }
+
+.rc-rows { display: flex; flex-direction: column; }
+.rc-row {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    padding: 8px 0; border-top: 1px solid var(--cc-border);
+}
+.rc-row:first-child { border-top: 0; }
+.rc-team { display: flex; align-items: center; gap: 8px; flex: 1 1 auto; min-width: 0; font-size: 0.9rem; }
+.rc-team img { width: 22px; height: 22px; object-fit: contain; flex: none; }
+.rc-team i { width: 22px; text-align: center; color: var(--cc-muted-2); flex: none; }
+
+.rc-replace {
+    background: none; border: 1px solid var(--cc-border); border-radius: 6px;
+    color: var(--cc-muted-bright); font: inherit; font-size: 0.75rem;
+    padding: 3px 10px; cursor: pointer; flex: none;
+}
+.rc-replace:hover { border-color: var(--cc-info); color: var(--cc-text); }
+
+/* The row being edited gets a subtle wash so it's obvious which one is live. */
+.rc-row.is-editing { background: var(--cc-surface-2); border-radius: 8px; padding: 10px 12px; }
+.rc-arrow { color: var(--cc-muted-2); display: inline-flex; flex: none; }
+.rc-row select { flex: 1 1 200px; min-width: 0; }
+.rc-actions { display: flex; gap: 8px; flex: none; }
+.rc-cancel, .rc-save {
+    border-radius: 6px; font: inherit; font-size: 0.78rem; padding: 4px 12px; cursor: pointer;
+}
+.rc-cancel { background: none; border: 1px solid var(--cc-border); color: var(--cc-muted-bright); }
+.rc-save { background: var(--cc-info); border: 1px solid var(--cc-info); color: #0B0F1F; font-weight: 600; }
+.rc-save:disabled { background: none; border-color: var(--cc-border); color: var(--cc-muted-2); cursor: not-allowed; }
+
+.rc-empty { color: var(--cc-muted-2); font-size: 0.85rem; margin: 0; }
+/* Season underway but the caller is an Admin: allowed, with the re-score caveat. */
+.rc-warn {
+    display: flex; align-items: center; gap: 8px;
+    background: rgba(224, 179, 65, 0.1); border: 1px solid rgba(224, 179, 65, 0.35);
+    border-radius: 8px; padding: 9px 12px; color: var(--cc-amber); font-size: 0.82rem;
+}
+
+@media (max-width: 620px) {
+    .rc-pick { flex-direction: column; align-items: flex-start; gap: 5px; }
+    .rc-pick select { max-width: none; width: 100%; }
+    .rc-row select { flex-basis: 100%; }
+    .rc-actions { width: 100%; justify-content: flex-end; }
+}
+
 /* --- Preseason readiness panel -------------------------------------------
    Same card shell as .admin-status (above) so the two read as one family; the
    body is a labelled grid of checks rather than a stat row. */

--- a/public/admin.js
+++ b/public/admin.js
@@ -328,6 +328,161 @@ function renderAdminStatus(el, s, api, year, jobs) {
     });
 }
 
+// --- Correct a Roster --------------------------------------------------------
+// Swap one team on a manager's season roster for an undrafted one. Also rewrites
+// the matching draft pick server-side, so the board and grades stay in step —
+// see modules/roster-correction.js.
+
+var rosterFix = { data: null, managerId: null, editing: null };
+
+async function loadRosterCorrection() {
+    var body = document.querySelector('[roster-correction-body]');
+    if (!body) return;
+    body.textContent = 'Loading…';
+    var league = getDraftLeagueCode();
+    var year = window.APP_YEAR || new Date().getFullYear();
+    try {
+        var res = await fetch('/users/league/' + encodeURIComponent(league) + '/roster-teams?season=' + encodeURIComponent(year),
+            { headers: { 'Accept': 'application/json' } });
+        var data = await res.json();
+        if (!res.ok) { body.textContent = data.message || 'Could not load rosters.'; return; }
+        rosterFix.data = data;
+        // Keep the selected manager across a reload when they're still there.
+        if (!data.managers.some(function (m) { return m.userId === rosterFix.managerId; })) {
+            rosterFix.managerId = data.managers.length ? data.managers[0].userId : null;
+        }
+        rosterFix.editing = null;
+        renderRosterCorrection();
+    } catch (err) {
+        body.textContent = 'Could not load rosters.';
+    }
+}
+
+function renderRosterCorrection() {
+    var body = document.querySelector('[roster-correction-body]');
+    var d = rosterFix.data;
+    if (!body || !d) return;
+    if (!d.managers.length) {
+        body.innerHTML = '<p class="rc-empty">Nobody is in the ' + escapeHtml(d.season) + ' season yet. Add managers under Season Roster first.</p>';
+        return;
+    }
+
+    // Locked for a League Manager once results exist — a swap invalidates every
+    // scored week, so it needs an admin who can run the re-score.
+    var banner = d.locked
+        ? '<div class="scoring-locked"><span data-icon="lock" data-icon-size="16"></span>'
+            + 'Rosters lock once the season is underway. Ask an admin &mdash; the change needs a full re-score.</div>'
+        : (d.seasonUnderway
+            ? '<div class="rc-warn"><span data-icon="lock" data-icon-size="16"></span>'
+                + 'The season is underway. A correction now needs a full-season re-score to take effect.</div>'
+            : '');
+
+    var mgr = d.managers.filter(function (m) { return m.userId === rosterFix.managerId; })[0] || d.managers[0];
+    var options = d.managers.map(function (m) {
+        return '<option value="' + escapeHtml(m.userId) + '"' + (m.userId === mgr.userId ? ' selected' : '') + '>'
+            + escapeHtml(m.name) + (m.franchise ? ' — ' + escapeHtml(m.franchise) : '') + '</option>';
+    }).join('');
+
+    var rows = mgr.teams.length
+        ? mgr.teams.map(function (t) { return rosterFixRow(t, d); }).join('')
+        : '<p class="rc-empty">This manager has no teams for ' + escapeHtml(d.season) + ' yet.</p>';
+
+    body.innerHTML = banner
+        + '<label class="rc-pick"><span>Manager</span><select rc-manager>' + options + '</select></label>'
+        + '<div class="rc-rows">' + rows + '</div>';
+
+    // Icons are injected after load, so the auto-hydrator has already run.
+    if (window.ccHydrateIcons) window.ccHydrateIcons(body);
+
+    body.querySelector('[rc-manager]').addEventListener('change', function (e) {
+        rosterFix.managerId = e.target.value;
+        rosterFix.editing = null;
+        renderRosterCorrection();
+    });
+    wireRosterFixRows(body, mgr, d);
+}
+
+function rosterFixRow(t, d) {
+    var logo = t.logo ? '<img src="' + escapeHtml(t.logo) + '" alt="">' : '<i class="fa-solid fa-helmet-un"></i>';
+    if (rosterFix.editing !== t.id) {
+        return '<div class="rc-row">'
+            + '<span class="rc-team">' + logo + escapeHtml(t.school) + '</span>'
+            + (d.locked ? '<span></span>'
+                : '<button type="button" class="rc-replace" data-rc-edit="' + t.id + '">Replace</button>')
+            + '</div>';
+    }
+    // Editing this row: a picker of every team nobody in the league holds.
+    var opts = '<option value="">Choose a replacement…</option>' + d.available.map(function (a) {
+        return '<option value="' + a.id + '">' + escapeHtml(a.school) + (a.conference ? ' (' + escapeHtml(a.conference) + ')' : '') + '</option>';
+    }).join('');
+    return '<div class="rc-row is-editing">'
+        + '<span class="rc-team">' + logo + escapeHtml(t.school) + '</span>'
+        + '<span class="rc-arrow" data-icon="swords" data-icon-size="14"></span>'
+        + '<select rc-target>' + opts + '</select>'
+        + '<span class="rc-actions">'
+        +   '<button type="button" class="rc-cancel" data-rc-cancel>Cancel</button>'
+        +   '<button type="button" class="rc-save" data-rc-save="' + t.id + '" disabled>Save</button>'
+        + '</span>'
+        + '</div>';
+}
+
+function wireRosterFixRows(body, mgr, d) {
+    body.querySelectorAll('[data-rc-edit]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            rosterFix.editing = Number(btn.getAttribute('data-rc-edit'));
+            renderRosterCorrection();
+        });
+    });
+    var cancel = body.querySelector('[data-rc-cancel]');
+    if (cancel) cancel.addEventListener('click', function () { rosterFix.editing = null; renderRosterCorrection(); });
+
+    var select = body.querySelector('[rc-target]');
+    var save = body.querySelector('[data-rc-save]');
+    if (select && save) {
+        select.addEventListener('change', function () { save.disabled = !select.value; });
+        save.addEventListener('click', function () {
+            var fromId = Number(save.getAttribute('data-rc-save'));
+            var from = mgr.teams.filter(function (t) { return t.id === fromId; })[0];
+            var to = d.available.filter(function (a) { return String(a.id) === select.value; })[0];
+            if (!from || !to) return;
+            if (!window.confirm('Replace ' + from.school + ' with ' + to.school + ' on ' + mgr.name + "'s roster?\n\n"
+                + 'The draft record is corrected too, so the draft board and grades will show ' + to.school + '.')) return;
+            applyRosterCorrection(save, mgr.userId, fromId, to.id);
+        });
+    }
+}
+
+async function applyRosterCorrection(btn, userId, fromTeamId, toTeamId) {
+    btn.disabled = true;
+    try {
+        var res = await fetch('/users/' + encodeURIComponent(userId) + '/roster-team', {
+            method: 'PATCH',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ season: rosterFix.data.season, fromTeamId: fromTeamId, toTeamId: toTeamId })
+        });
+        var data = await res.json();
+        if (!res.ok) {
+            failToast.options.text = data.message || 'Could not correct the roster';
+            failToast.showToast();
+            btn.disabled = false;
+            return;
+        }
+        successToast.options.text = data.from.school + ' → ' + data.to.school
+            + (data.draftUpdated ? ' (draft record updated)' : '');
+        successToast.showToast();
+        if (data.rescoreNeeded) {
+            failToast.options.text = 'Scores are now stale — run Score All Weeks to apply this.';
+            failToast.showToast();
+        }
+        // Re-read: the available pool and the draft record both moved.
+        await loadRosterCorrection();
+    } catch (err) {
+        failToast.options.text = 'Could not correct the roster';
+        failToast.showToast();
+        btn.disabled = false;
+    }
+}
+
 // --- Preseason readiness ----------------------------------------------------
 // Each season-flip data load that can fail silently, checked against what's
 // actually on file. See modules/season-readiness.js for why each one matters.
@@ -1266,6 +1421,8 @@ function toggleSub(attr) {
 function displayCreateUserContainer() { toggleSub('create-user-container'); }
 
 function displaySeasonRosterContainer() { if (toggleSub('season-roster-container')) loadSeasonRoster(); }
+
+function displayRosterCorrectionContainer() { if (toggleSub('roster-correction-container')) loadRosterCorrection(); }
 
 function displayTeamContainer() { toggleSub('calculate-team-score-container'); }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -2,7 +2,11 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
 const Game = require('../models/game');
+const Team = require('../models/team');
+const Draft = require('../models/draft');
 const scoring = require('../modules/scoring');
+const rosterCorrection = require('../modules/roster-correction');
+const { pickLogo } = require('../public/logo.js');
 const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
 const { canManageLeague } = require('../modules/league-access');
 const { effectiveRoles } = require('../modules/dev-role');
@@ -399,6 +403,139 @@ router.post('/:id/season-membership', async (req, res) => {
         user.lastUpdated = new Date().toLocaleString("en-US", { timeZone: "America/Chicago" });
         await user.save();
         res.json({ inSeason: (user.seasons || []).some(s => Number(s.season) === year) });
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+// Everything the Correct a Roster tool needs in one read: each manager's teams
+// for the season, plus the FBS teams nobody in the league has. Also reports
+// whether the season is underway, so the UI can show the lock before a
+// commissioner picks a team and gets refused.
+router.get('/league/:league/roster-teams', async (req, res) => {
+    try {
+        const league = req.params.league;
+        const season = Number(req.query.season || process.env.YEAR);
+
+        const users = await User.find(
+            { league, 'seasons.season': season },
+            { firstName: 1, lastName: 1, color: 1, seasons: { $elemMatch: { season } } }
+        ).lean();
+
+        const taken = new Set();
+        const managers = users.map(u => {
+            const s = (u.seasons && u.seasons[0]) || {};
+            const teams = (s.teams || []).map(t => {
+                taken.add(Number(t.id));
+                return { id: t.id, school: t.school, logo: pickLogo(t.logos) || null };
+            });
+            return {
+                userId: String(u._id),
+                name: `${u.firstName || ''} ${u.lastName || ''}`.trim(),
+                franchise: s.franchiseName || null,
+                teams
+            };
+        }).sort((a, b) => a.name.localeCompare(b.name));
+
+        const allTeams = await Team.find({}, { id: 1, school: 1, conference: 1, logos: 1 }).lean();
+        const available = allTeams
+            .filter(t => !taken.has(Number(t.id)))
+            .map(t => ({ id: t.id, school: t.school, conference: t.conference || '', logo: pickLogo(t.logos) || null }))
+            .sort((a, b) => a.school.localeCompare(b.school));
+
+        const isAdmin = effectiveRoles(req).includes('Admin');
+        const seasonUnderway = await hasScoredGames(league, season);
+        res.json({
+            league, season: String(season), managers, available,
+            isAdmin, seasonUnderway,
+            locked: seasonUnderway && !isAdmin
+        });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Correct one team on a manager's season roster.
+//
+// A completed draft used to be final — the only write path bulk-overwrote all
+// ten teams and had no UI — so a draft-night misclick was permanent. This
+// rewrites BOTH the roster and the matching draft pick, because draft grades,
+// the draft board and the Draft Steal highlight all read the pick; correcting
+// one without the other would leave them quietly disagreeing.
+router.patch('/:id/roster-team', async (req, res) => {
+    try {
+        const user = await User.findById(req.params.id);
+        if (!user) return res.status(404).json({ message: 'Cannot find user' });
+        if (!canManageLeague(req, user.league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
+
+        const season = Number((req.body && req.body.season) || process.env.YEAR);
+        const fromTeamId = req.body && req.body.fromTeamId;
+        const toTeamId = req.body && req.body.toTeamId;
+
+        const seasonDoc = (user.seasons || []).find(s => Number(s.season) === season);
+        if (!seasonDoc) return res.status(404).json({ message: `No ${season} roster for that manager.` });
+
+        const targetTeam = toTeamId == null ? null : await Team.findOne({ id: Number(toTeamId) }).lean();
+
+        // Is the replacement already spoken for anywhere in this league?
+        let takenBy = null;
+        if (targetTeam) {
+            const holder = await User.findOne(
+                { league: user.league, _id: { $ne: user._id }, seasons: { $elemMatch: { season, 'teams.id': Number(toTeamId) } } },
+                { firstName: 1, lastName: 1 }
+            ).lean();
+            if (holder) takenBy = { name: `${holder.firstName || ''} ${holder.lastName || ''}`.trim() };
+        }
+
+        const isAdmin = effectiveRoles(req).includes('Admin');
+        const seasonUnderway = await hasScoredGames(user.league, season);
+        const check = rosterCorrection.validateCorrection({
+            roster: seasonDoc.teams, fromTeamId, toTeamId, targetTeam, takenBy, seasonUnderway, isAdmin
+        });
+        if (!check.ok) return res.status(check.status).json({ message: check.message });
+
+        const nextTeam = rosterCorrection.rosterTeamFrom(targetTeam);
+        const applied = rosterCorrection.replaceRosterTeam(seasonDoc.teams, fromTeamId, nextTeam);
+        if (!applied.changed) return res.status(404).json({ message: 'That team is not on this manager\'s roster.' });
+        seasonDoc.teams = applied.teams;
+        user.markModified('seasons');
+        user.lastUpdated = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+        try {
+            await user.save();
+        } catch (err) {
+            // Most likely the roster schema rejecting a thin location record.
+            return res.status(422).json({ message: `Could not roster ${targetTeam.school}: ${err.message}` });
+        }
+
+        // Keep the draft record in step. Absent for a season assembled without a
+        // live draft, which is fine — there's no pick to correct.
+        let draftUpdated = false;
+        const draft = await Draft.findOne({ league: user.league, season });
+        if (draft) {
+            const nextPicks = rosterCorrection.replaceDraftPick(draft.picks, user._id, fromTeamId, nextTeam);
+            if (nextPicks.changed) {
+                draft.picks = nextPicks.picks;
+                draft.markModified('picks');
+                draft.updatedAt = new Date();
+                await draft.save();
+                draftUpdated = true;
+            }
+        }
+
+        console.log(`Roster correction · ${user.league} ${season}: ${user.firstName} ${check.current.school} -> ${targetTeam.school}`
+            + (draftUpdated ? ' (draft pick updated)' : ' (no draft pick found)'));
+
+        res.json({
+            userId: String(user._id), season: String(season),
+            from: { id: check.current.id, school: check.current.school },
+            to: { id: nextTeam.id, school: nextTeam.school, logo: pickLogo(nextTeam.logos) || null },
+            draftUpdated,
+            // Every scored week was computed against the old roster, so the
+            // numbers are stale until a full-season re-score runs.
+            rescoreNeeded: seasonUnderway
+        });
     } catch (err) {
         res.status(400).json({ message: err.message });
     }

--- a/tests/RosterCorrection.spec.js
+++ b/tests/RosterCorrection.spec.js
@@ -1,0 +1,379 @@
+// Commissioner roster correction — the pure rules plus the two endpoints.
+//
+// A completed draft used to be final: the only write path bulk-overwrote all ten
+// teams and had no UI, so a draft-night misclick was permanent. The correction
+// rewrites BOTH the roster and the matching draft pick, since draft grades, the
+// draft board and the Draft Steal highlight all read the pick.
+
+process.env.YEAR = '2026';
+process.env.INTERNAL_API_TOKEN = 'test-internal-token';
+
+const {
+    normalizeLocation, rosterTeamFrom, missingLocationFields,
+    validateCorrection, replaceRosterTeam, replaceDraftPick
+} = require('../modules/roster-correction');
+
+// A complete location, as the user roster schema demands.
+const LOC = { venue_id: 7, name: 'Autzen', city: 'Eugene', state: 'OR', zip: '97401', latitude: 44, longitude: -123, capacity: 54000, grass: true, dome: false };
+const teamDoc = (o) => Object.assign({
+    id: 2483, school: 'Oregon', mascot: 'Ducks', abbreviation: 'ORE',
+    conference: 'Big Ten', color: '#154733', logos: ['a.png', 'b.png'], location: LOC
+}, o);
+
+describe('normalizeLocation', () => {
+    // CFBD sends `id`; the user schema requires `venue_id`. draft-socket does the
+    // same remap when persisting a draft, so a corrected team has to match.
+    test('maps CFBD id -> venue_id and drops id', () => {
+        const out = normalizeLocation({ id: 42, name: 'V' });
+        expect(out).toEqual({ venue_id: 42, name: 'V' });
+    });
+    test('leaves an existing venue_id alone', () => {
+        expect(normalizeLocation({ id: 42, venue_id: 7 })).toEqual({ venue_id: 7 });
+    });
+    test('does not mutate its input', () => {
+        const src = { id: 42 };
+        normalizeLocation(src);
+        expect(src).toEqual({ id: 42 });
+    });
+    test('passes through a missing location', () => {
+        expect(normalizeLocation(null)).toBeNull();
+    });
+});
+
+describe('rosterTeamFrom', () => {
+    test('copies the roster fields and normalizes the location', () => {
+        const t = rosterTeamFrom(teamDoc({ location: { id: 7, name: 'Autzen' } }));
+        expect(t).toMatchObject({ id: 2483, school: 'Oregon', mascot: 'Ducks', abbreviation: 'ORE', conference: 'Big Ten' });
+        expect(t.location).toEqual({ venue_id: 7, name: 'Autzen' });
+    });
+    // Team docs carry per-season ratings and scores that have no business on a
+    // roster entry.
+    test('drops fields that are not part of a roster team', () => {
+        const t = rosterTeamFrom(teamDoc({ seasons: [{ season: 2026, spRating: 18 }], _id: 'abc' }));
+        expect(t.seasons).toBeUndefined();
+        expect(t._id).toBeUndefined();
+    });
+});
+
+describe('missingLocationFields', () => {
+    test('a complete location is missing nothing', () => {
+        expect(missingLocationFields(rosterTeamFrom(teamDoc()))).toEqual([]);
+    });
+    test('names each field the roster schema would reject', () => {
+        const thin = rosterTeamFrom(teamDoc({ location: { venue_id: 1, name: 'V', city: 'C', state: 'S' } }));
+        expect(missingLocationFields(thin)).toEqual(['zip', 'latitude', 'longitude', 'capacity']);
+    });
+    test('no location at all', () => {
+        expect(missingLocationFields({})).toEqual(['location']);
+    });
+});
+
+describe('validateCorrection', () => {
+    const roster = [{ id: 1, school: 'Iowa' }, { id: 2, school: 'Duke' }];
+    const base = { roster, fromTeamId: 1, toTeamId: 2483, targetTeam: teamDoc(), takenBy: null, seasonUnderway: false, isAdmin: false };
+    const run = (o) => validateCorrection(Object.assign({}, base, o));
+
+    test('a clean swap passes and reports the outgoing team', () => {
+        const r = run();
+        expect(r.ok).toBe(true);
+        expect(r.current).toMatchObject({ id: 1, school: 'Iowa' });
+    });
+    test('missing ids are rejected', () => {
+        expect(run({ fromTeamId: null })).toMatchObject({ ok: false, status: 400 });
+        expect(run({ toTeamId: null })).toMatchObject({ ok: false, status: 400 });
+    });
+    test('swapping a team for itself is a no-op, not a write', () => {
+        expect(run({ fromTeamId: 2483, toTeamId: 2483 })).toMatchObject({ ok: false, status: 400 });
+    });
+    test('the outgoing team must actually be on the roster', () => {
+        expect(run({ fromTeamId: 999 })).toMatchObject({ ok: false, status: 404 });
+    });
+    test('an unknown replacement is rejected', () => {
+        expect(run({ targetTeam: null })).toMatchObject({ ok: false, status: 404 });
+    });
+    // Two managers holding the same team would double-count it in scoring.
+    test('a team already rostered in the league is a conflict', () => {
+        const r = run({ takenBy: { name: 'Bob Smith' } });
+        expect(r).toMatchObject({ ok: false, status: 409 });
+        expect(r.message).toBe("Oregon is already on Bob Smith's roster.");
+    });
+    // The "taken by someone else" lookup excludes this manager, so their own
+    // roster has to be checked here or the same team lands on it twice.
+    test('a team the manager already holds is a conflict, not a duplicate', () => {
+        const r = run({ toTeamId: 2, takenBy: null });
+        expect(r).toMatchObject({ ok: false, status: 409 });
+        expect(r.message).toBe('That manager already has Duke.');
+    });
+    // The user schema's location is stricter than the team schema's, so this
+    // would otherwise surface as an opaque validation error on save.
+    test('a team with a thin venue record is refused by name', () => {
+        const r = run({ targetTeam: teamDoc({ location: { venue_id: 1, name: 'V', city: 'C', state: 'S' } }) });
+        expect(r).toMatchObject({ ok: false, status: 422 });
+        expect(r.message).toMatch(/Oregon is missing venue details \(zip, latitude/);
+    });
+
+    describe('the season-underway lock', () => {
+        test('a League Manager is stopped once results exist', () => {
+            expect(run({ seasonUnderway: true })).toMatchObject({ ok: false, status: 423 });
+        });
+        test('an Admin may still proceed — they can run the re-score', () => {
+            expect(run({ seasonUnderway: true, isAdmin: true }).ok).toBe(true);
+        });
+        // The lock is checked before roster membership so a locked league gets
+        // the lock message rather than leaking whether a team is rostered.
+        test('the lock outranks the other failures', () => {
+            expect(run({ seasonUnderway: true, fromTeamId: 999 })).toMatchObject({ status: 423 });
+        });
+    });
+});
+
+describe('replaceRosterTeam', () => {
+    const roster = [{ id: 1, school: 'Iowa' }, { id: 2, school: 'Duke' }, { id: 3, school: 'Utah' }];
+    test('swaps in place, preserving draft order', () => {
+        const r = replaceRosterTeam(roster, 2, { id: 9, school: 'Oregon' });
+        expect(r.changed).toBe(true);
+        expect(r.teams.map(t => t.school)).toEqual(['Iowa', 'Oregon', 'Utah']);
+    });
+    test('reports no change when the team is not there', () => {
+        expect(replaceRosterTeam(roster, 99, { id: 9 }).changed).toBe(false);
+    });
+    test('does not mutate the original roster', () => {
+        replaceRosterTeam(roster, 2, { id: 9, school: 'Oregon' });
+        expect(roster[1].school).toBe('Duke');
+    });
+});
+
+describe('replaceDraftPick', () => {
+    const picks = [
+        { round: 1, overall: 1, userId: 'a', team: { id: 1, school: 'Iowa' }, pickedAt: new Date('2026-08-15') },
+        { round: 1, overall: 2, userId: 'b', team: { id: 2, school: 'Duke' } },
+        { round: 2, overall: 3, userId: 'a', team: { id: 3, school: 'Utah' } }
+    ];
+    test('replaces only that manager\'s pick of that team', () => {
+        const r = replaceDraftPick(picks, 'a', 3, { id: 9, school: 'Oregon' });
+        expect(r.changed).toBe(true);
+        expect(r.picks.map(p => p.team.school)).toEqual(['Iowa', 'Duke', 'Oregon']);
+    });
+    // The slot was right; only the team in it was wrong.
+    test('keeps round, overall and pickedAt, and stamps correctedAt', () => {
+        const r = replaceDraftPick(picks, 'a', 1, { id: 9, school: 'Oregon' });
+        expect(r.picks[0]).toMatchObject({ round: 1, overall: 1, userId: 'a' });
+        expect(r.picks[0].pickedAt).toEqual(new Date('2026-08-15'));
+        expect(r.picks[0].correctedAt).toBeInstanceOf(Date);
+    });
+    test('does not touch another manager who holds the same team id', () => {
+        const shared = [{ userId: 'b', team: { id: 5, school: 'X' } }, { userId: 'a', team: { id: 5, school: 'X' } }];
+        const r = replaceDraftPick(shared, 'a', 5, { id: 9, school: 'Oregon' });
+        expect(r.picks[0].team.school).toBe('X');
+        expect(r.picks[1].team.school).toBe('Oregon');
+    });
+    test('no matching pick is not a change', () => {
+        expect(replaceDraftPick(picks, 'a', 2, { id: 9 }).changed).toBe(false);
+        expect(replaceDraftPick([], 'a', 1, { id: 9 }).changed).toBe(false);
+    });
+});
+
+// --- endpoints ---------------------------------------------------------------
+// The whole point is that the roster and the draft record move together, so
+// these run both writes against real documents.
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Team = require('../models/team');
+const Draft = require('../models/draft');
+const usersRouter = require('../routes/users');
+
+const app = express();
+app.use(express.json());
+app.use('/users', usersRouter);
+
+// The internal token clears canManageLeague but is NOT an Admin session —
+// effectiveRoles() reads Auth0 roles, so a token-only caller is treated as a
+// plain commissioner. That matches the season-membership lock next door, and it
+// means the Admin override needs a real session to exercise.
+const adminApp = express();
+adminApp.use(express.json());
+adminApp.use((req, res, next) => {
+    req.oidc = { isAuthenticated: () => true, user: { user_metadata: { roles: ['Admin'] } } };
+    next();
+});
+adminApp.use('/users', usersRouter);
+
+useMongo();
+
+const LEAGUE = 'graham-league';
+const SEASON = 2026;
+
+function fullTeam(id, school, o) {
+    return Object.assign({
+        id, school, mascot: 'M', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'Big Ten', color: '#000', logos: [`${school}.png`],
+        location: { venue_id: id, name: 'V', city: 'C', state: 'ST', zip: '1', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    }, o);
+}
+const manager = (first, teams, extra) => User.create(Object.assign({
+    firstName: first, lastName: 'Test', league: LEAGUE,
+    seasons: [{ season: SEASON, teams }]
+}, extra || {}));
+
+// The internal token clears canManageLeague and reads as a commissioner.
+const patch = (id, body) => request(app)
+    .patch(`/users/${id}/roster-team`)
+    .set('X-Internal-Token', 'test-internal-token')
+    .send(body);
+
+beforeEach(() => { jest.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { jest.restoreAllMocks(); });
+
+describe('PATCH /users/:id/roster-team', () => {
+    test('swaps the roster team and the matching draft pick together', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(2, 'Duke'), fullTeam(9, 'Oregon')]);
+        const u = await manager('Ann', [fullTeam(1, 'Iowa'), fullTeam(2, 'Duke')]);
+        await Draft.create({
+            league: LEAGUE, season: SEASON, draftOrder: [u._id],
+            picks: [
+                { round: 1, overall: 1, userId: u._id, team: { id: 1, school: 'Iowa' } },
+                { round: 2, overall: 2, userId: u._id, team: { id: 2, school: 'Duke' } }
+            ]
+        });
+
+        const res = await patch(u._id, { fromTeamId: 2, toTeamId: 9 });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ draftUpdated: true, rescoreNeeded: false });
+        expect(res.body.from).toMatchObject({ id: 2, school: 'Duke' });
+        expect(res.body.to).toMatchObject({ id: 9, school: 'Oregon' });
+
+        const after = await User.findById(u._id).lean();
+        expect(after.seasons[0].teams.map(t => t.school)).toEqual(['Iowa', 'Oregon']);
+        const draft = await Draft.findOne({ league: LEAGUE, season: SEASON }).lean();
+        expect(draft.picks.map(p => p.team.school)).toEqual(['Iowa', 'Oregon']);
+        expect(draft.picks[1]).toMatchObject({ round: 2, overall: 2 });
+        expect(draft.picks[1].correctedAt).toBeInstanceOf(Date);
+    });
+
+    test('refuses a team another manager in the league already holds', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(2, 'Duke')]);
+        const ann = await manager('Ann', [fullTeam(1, 'Iowa')]);
+        await manager('Bob', [fullTeam(2, 'Duke')]);
+
+        const res = await patch(ann._id, { fromTeamId: 1, toTeamId: 2 });
+        expect(res.status).toBe(409);
+        expect(res.body.message).toBe("Duke is already on Bob Test's roster.");
+        const after = await User.findById(ann._id).lean();
+        expect(after.seasons[0].teams[0].school).toBe('Iowa');   // untouched
+    });
+
+    test('a team the manager already holds themselves is rejected, not duplicated', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(2, 'Duke')]);
+        const u = await manager('Ann', [fullTeam(1, 'Iowa'), fullTeam(2, 'Duke')]);
+        const res = await patch(u._id, { fromTeamId: 1, toTeamId: 2 });
+        expect(res.status).toBe(409);
+    });
+
+    test('succeeds without a draft doc — nothing to correct there', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(9, 'Oregon')]);
+        const u = await manager('Ann', [fullTeam(1, 'Iowa')]);
+        const res = await patch(u._id, { fromTeamId: 1, toTeamId: 9 });
+        expect(res.status).toBe(200);
+        expect(res.body.draftUpdated).toBe(false);
+        expect((await User.findById(u._id).lean()).seasons[0].teams[0].school).toBe('Oregon');
+    });
+
+    test('leaves other managers\' picks alone', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(9, 'Oregon')]);
+        const ann = await manager('Ann', [fullTeam(1, 'Iowa')]);
+        const bob = await manager('Bob', [fullTeam(9, 'Oregon')]);
+        await Draft.create({
+            league: LEAGUE, season: SEASON, draftOrder: [ann._id, bob._id],
+            picks: [
+                { round: 1, overall: 1, userId: ann._id, team: { id: 1, school: 'Iowa' } },
+                { round: 1, overall: 2, userId: bob._id, team: { id: 9, school: 'Oregon' } }
+            ]
+        });
+        // Free Oregon up first, then hand it to Ann.
+        await Team.create([fullTeam(3, 'Utah')]);
+        await patch(bob._id, { fromTeamId: 9, toTeamId: 3 });
+        const res = await patch(ann._id, { fromTeamId: 1, toTeamId: 9 });
+        expect(res.status).toBe(200);
+
+        const draft = await Draft.findOne({ league: LEAGUE, season: SEASON }).lean();
+        const byUser = (id) => draft.picks.filter(p => String(p.userId) === String(id)).map(p => p.team.school);
+        expect(byUser(ann._id)).toEqual(['Oregon']);
+        expect(byUser(bob._id)).toEqual(['Utah']);
+    });
+
+    test('a season the manager does not have is a 404', async () => {
+        await Team.create([fullTeam(9, 'Oregon')]);
+        const u = await manager('Ann', [fullTeam(1, 'Iowa')]);
+        const res = await patch(u._id, { season: 2099, fromTeamId: 1, toTeamId: 9 });
+        expect(res.status).toBe(404);
+    });
+
+    describe('once the season is underway', () => {
+        // hasScoredGames keys off a scoreByTeam entry, so seed one.
+        async function scored() {
+            await Team.create([fullTeam(1, 'Iowa'), fullTeam(9, 'Oregon')]);
+            return manager('Ann', [fullTeam(1, 'Iowa')], {
+                seasons: [{ season: SEASON, teams: [fullTeam(1, 'Iowa')],
+                    weeklyScore: [{ week: 1, score: 5, scoreByTeam: [{ team: 'Iowa', teamId: 1, gameId: 100, score: 5 }] }] }]
+            });
+        }
+
+        test('a commissioner without Admin is locked out', async () => {
+            const u = await scored();
+            const res = await request(app).patch(`/users/${u._id}/roster-team`)
+                .send({ fromTeamId: 1, toTeamId: 9 });
+            expect([403, 423]).toContain(res.status);
+            expect((await User.findById(u._id).lean()).seasons[0].teams[0].school).toBe('Iowa');
+        });
+
+        test('an Admin may proceed and is told a re-score is needed', async () => {
+            const u = await scored();
+            const res = await request(adminApp).patch(`/users/${u._id}/roster-team`)
+                .set('X-Internal-Token', 'test-internal-token')
+                .send({ fromTeamId: 1, toTeamId: 9 });
+            expect(res.status).toBe(200);
+            // Every scored week was computed against the old roster.
+            expect(res.body.rescoreNeeded).toBe(true);
+            expect((await User.findById(u._id).lean()).seasons[0].teams[0].school).toBe('Oregon');
+        });
+    });
+});
+
+describe('GET /users/league/:league/roster-teams', () => {
+    test('returns each manager\'s teams and the undrafted pool', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(2, 'Duke'), fullTeam(9, 'Oregon'), fullTeam(3, 'Utah')]);
+        await manager('Ann', [fullTeam(1, 'Iowa')]);
+        await manager('Bob', [fullTeam(2, 'Duke')]);
+
+        const res = await request(app).get(`/users/league/${LEAGUE}/roster-teams?season=${SEASON}`)
+            .set('X-Internal-Token', 'test-internal-token');
+        expect(res.status).toBe(200);
+        expect(res.body.managers.map(m => m.name)).toEqual(['Ann Test', 'Bob Test']);
+        expect(res.body.managers[0].teams[0]).toMatchObject({ id: 1, school: 'Iowa', logo: 'Iowa.png' });
+        // Drafted teams are excluded from the replacement pool.
+        expect(res.body.available.map(t => t.school)).toEqual(['Oregon', 'Utah']);
+        expect(res.body.seasonUnderway).toBe(false);
+        expect(res.body.locked).toBe(false);
+    });
+
+    test('reports the lock once the season is underway', async () => {
+        await Team.create([fullTeam(1, 'Iowa')]);
+        await manager('Ann', [fullTeam(1, 'Iowa')], {
+            seasons: [{ season: SEASON, teams: [fullTeam(1, 'Iowa')],
+                weeklyScore: [{ week: 1, score: 5, scoreByTeam: [{ team: 'Iowa', teamId: 1, gameId: 1, score: 5 }] }] }]
+        });
+        // No token and no session -> not an Admin, so the lock applies.
+        const res = await request(app).get(`/users/league/${LEAGUE}/roster-teams?season=${SEASON}`);
+        expect(res.body).toMatchObject({ seasonUnderway: true, locked: true });
+    });
+
+    test('a league with nobody in the season still returns the full pool', async () => {
+        await Team.create([fullTeam(1, 'Iowa')]);
+        const res = await request(app).get(`/users/league/${LEAGUE}/roster-teams?season=${SEASON}`);
+        expect(res.body.managers).toEqual([]);
+        expect(res.body.available).toHaveLength(1);
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -293,7 +293,7 @@
     <% } %>
 
     <section class="admin-group">
-        <div class="group-head"><h2>League setup</h2><span class="group-count">6</span></div>
+        <div class="group-head"><h2>League setup</h2><span class="group-count">7</span></div>
         <div class="admin-functions">
             <div class="function-container">
                 <div class="button-container">
@@ -454,6 +454,18 @@
                 <div class="sub-container" season-roster-container style="display: none">
                     <p class="function-description">Choose which managers are in the <span season-roster-year>current</span> season. Unchecking removes a manager from this season only &mdash; their past seasons, scores, and draft history are kept.</p>
                     <div season-roster-list class="season-roster-list"></div>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayRosterCorrectionContainer()">
+                        <i class="fa-solid fa-right-left" style="padding-right: 5px;"></i>
+                        Correct a Roster
+                    </button>
+                </div>
+                <div class="sub-container" roster-correction-container style="display: none">
+                    <p class="function-description">Fix a team that ended up on the wrong roster &mdash; a misclick on draft night, or a pick made for someone who wasn't there. The replacement must be a team nobody in the league has. This also corrects the <strong>draft record</strong>, so the draft board and draft grades match the roster.</p>
+                    <div roster-correction-body class="roster-correction"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## The problem

A completed draft was final. The only write path to a roster was `PATCH /users/draft/:id`, which bulk-overwrites all ten teams and has no UI — so a draft-night misclick was permanent.

That's a live risk here, not a hypothetical: commissioners are told to pick on behalf of absent managers (there's no pick clock), which is exactly when a wrong team gets entered. With the 2026 draft about a week out, this is the window where it matters.

## What's here

**Admin → League setup → Correct a Roster.** Pick a manager, pick the team that's wrong, choose any team nobody in the league holds.

A correction rewrites **both** sides — the manager's `seasons[].teams` *and* the matching `drafts.picks[]` entry. Those are the two places a rostered team lives (`modules/team-refresh.js` already has to keep them in sync for the same reason), and draft grades, the draft board, and the Draft Steal highlight all read the pick. Correcting one without the other would leave them quietly disagreeing — the class of silent mismatch the last two PRs were about.

The pick keeps its `round`/`overall`/`pickedAt` — the slot was right, the team in it wasn't — and gains a `correctedAt` stamp, so the board isn't silently rewritten history.

- **`modules/roster-correction.js`** (new) — pure validation + the two swaps.
- **`routes/users.js`** — `GET /users/league/:league/roster-teams` feeds the tool in one read (each manager's teams, the undrafted pool, the lock state); `PATCH /users/:id/roster-team` applies it.
- **`models/draft.js`** — `correctedAt` on a pick.
- **`views/admin.ejs` + `public/admin.js` + `public/admin.css`** — the tool. A row swaps in place into an edit state rather than opening a modal, so the rest of the roster stays visible while you choose; you're usually double-checking you're fixing the right one.

## Guardrails

Each its own status code, so the UI reacts rather than parsing prose:

| Status | Case |
|---|---|
| `409` | Replacement already rostered — by anyone, **including the manager themselves** |
| `404` | Outgoing team isn't on that roster, or the replacement doesn't exist |
| `422` | Team's venue record is too thin for the roster schema |
| `423` | Rosters lock once the season is underway; Admin-only past that |

Two of those are worth explaining:

**The self-conflict 409 is a bug a test caught.** The "already taken by someone else" lookup deliberately excludes the manager being edited — so swapping a team for one *they already hold* sailed straight through and put the same team on the roster twice. Now checked against their own roster in the pure validator.

**The 422 exists because the two schemas disagree.** `user.seasons[].teams[].location` requires `zip`, `latitude`, `longitude`, `capacity`; the `Team` schema doesn't. A team with a thin venue record would otherwise fail on `save()` with an opaque Mongoose error, so it's checked up front and named, with a pointer at Refresh Teams.

The `423` mirrors the existing season-membership lock. An Admin who proceeds is told scores are now stale and need a full re-score.

## Verification against real data

Loaded the live 2026 league — 6 managers, 138 available, unlocked, correctly showing the pre-draft empty state. Then rendered **2025's real rosters read-only** to exercise the row UI: 10 rows, 78 undrafted teams in the picker, Save gated on a choice, Cancel and manager-switch clean, and the amber "season underway" banner rather than the lock (Admin). No console errors.

**No writes were made to real data** — 2025 rosters confirmed intact afterward.

Caveat: browser screenshot capture stopped returning frames partway through, so the visual check is DOM + computed-style based rather than a picture. Worth an eyeball before merging.

## Tests — 452 green

38 new. The pure rules (location remap, roster-field selection, every validation branch *and its precedence*, both swaps' immutability) plus both endpoints against in-memory Mongo — including that the roster and draft pick move together, that another manager's identical pick is untouched, and that the Admin override needs a real session (the internal token is not an Admin, matching season-membership). New coverage floor on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
