### PR TITLE
Derive the H2H week range from the slate; stop a stray PATCH wiping scores

### DIFF
--- a/modules/h2h.js
+++ b/modules/h2h.js
@@ -83,12 +83,60 @@ function seasonH2H(ids, weeks, totalsByIdWeek, winBonus, tieBonus) {
     return acc;
 }
 
-// H2H matchups run the fantasy regular season only. Weeks 15+ (conference
-// championships, Army/Navy) and the postseason still count toward season totals,
-// but their thin slates make for unfair matchups — so no H2H past this cap.
-// Shared by the standings read model and the scoring-time persistence pass so
-// they can never disagree on the range.
-const H2H_LAST_WEEK = 14;
+// The widest week range H2H could ever cover. A bound for the game queries, not
+// the schedule itself — the actual range is derived per season by h2hWeekRange()
+// below. The postseason is a separate seasonType, so nothing past this is in
+// play here.
+const H2H_MAX_WEEK = 16;
+
+// A week is only an H2H week if it carries a real slate.
+//
+// H2H matchups run the fantasy regular season. Conference championship week and
+// Army/Navy involve a handful of rostered teams, so a matchup decided there
+// comes down to two or three games — which is why this range used to stop at a
+// hardcoded week 14.
+//
+// That hardcode was correct for 2025 (regular season through wk 14, titles wk
+// 15) and silently WRONG for 2026, whose calendar shifted a week: the last full
+// slate is wk 13 (Nov 29), conference championships land in wk 14, and
+// Army/Navy in wk 15. Cap-at-14 would have made championship week a scoring
+// matchup. So the range is derived from the slate instead of assumed, and a
+// future calendar shift can't move it again.
+//
+// `gamesByWeek` is { [week]: Game[] } for THIS league's rostered teams — the
+// same set the caller already has, so this costs no extra query. A week counts
+// when it holds at least `minShare` of the median week's slate: a normal week
+// puts most of the league's teams on the field, championship week a couple.
+// Returns the contiguous run from the first played week, because the thin weeks
+// mark the end of the regular season rather than a gap inside it.
+function h2hWeekRange(gamesByWeek, opts) {
+    const o = opts || {};
+    const maxWeek = o.maxWeek || H2H_MAX_WEEK;
+    const minShare = o.minShare == null ? 0.4 : o.minShare;
+
+    const counts = [];
+    for (let w = 1; w <= maxWeek; w++) counts.push({ week: w, n: ((gamesByWeek || {})[w] || []).length });
+    const played = counts.filter(c => c.n > 0);
+    if (played.length < 2) return played.map(c => c.week);
+
+    const sorted = played.map(c => c.n).sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const median = sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    const threshold = Math.max(1, median * minShare);
+
+    const out = [];
+    for (const c of counts) {
+        if (c.n === 0) {
+            // A gap before any real slate (nothing scheduled yet) isn't the end
+            // of the season; a gap after one is.
+            if (!out.length) continue;
+            break;
+        }
+        if (c.n < threshold) break;
+        out.push(c.week);
+    }
+    return out;
+}
 
 // The season subdocument for a user, tolerating both document shapes in use:
 // a full `seasons` array (routes querying by league) and a single-entry array
@@ -150,12 +198,12 @@ const round1 = (v) => Math.round(v * 10) / 10;
 // `games` are that season's regular-season games involving drafted teams.
 // Returns:
 //   awards      { [userId]: { [week]: { result, bonus, opponent, for, against } } }
+//   weeks       the derived H2H week range for this season
 //   weekFinal   { [week]: bool }
 //   finalWeeks  settled weeks, ascending
 //   currentWeek the first week with games that hasn't settled (or null)
-function computeH2HAwards({ users, games, season, winBonus, tieBonus, lastWeek }) {
-    const last = lastWeek || H2H_LAST_WEEK;
-    const weeks = Array.from({ length: last }, (_, i) => i + 1);
+function computeH2HAwards({ users, games, season, winBonus, tieBonus, maxWeek }) {
+    const bound = maxWeek || H2H_MAX_WEEK;
     const ids = h2hManagerIds(users, season);
 
     const awards = {};
@@ -171,7 +219,7 @@ function computeH2HAwards({ users, games, season, winBonus, tieBonus, lastWeek }
         if (!awards[id]) return;
         const tw = {};
         (s.weeklyScore || []).forEach(e => {
-            if (e.season === 'postseason' || e.week > last) return;
+            if (e.season === 'postseason' || e.week > bound) return;
             tw[e.week] = (tw[e.week] || 0) + baseWeekScore(e);
             scored.add(e.week);
         });
@@ -183,10 +231,13 @@ function computeH2HAwards({ users, games, season, winBonus, tieBonus, lastWeek }
     const gamesByWeek = {};
     (games || []).forEach(g => {
         if (g.seasonType && g.seasonType !== 'regular') return;
-        if (g.week == null || g.week > last) return;
+        if (g.week == null || g.week > bound) return;
         if (!drafted.has(Number(g.homeId)) && !drafted.has(Number(g.awayId))) return;
         (gamesByWeek[g.week] = gamesByWeek[g.week] || []).push(g);
     });
+
+    // Derived, not assumed — see h2hWeekRange.
+    const weeks = h2hWeekRange(gamesByWeek, { maxWeek: bound });
 
     const weekFinal = {};
     weeks.forEach(w => { weekFinal[w] = isWeekFinal(gamesByWeek[w]) && scored.has(w); });
@@ -204,7 +255,7 @@ function computeH2HAwards({ users, games, season, winBonus, tieBonus, lastWeek }
         Object.keys(res).forEach(id => { awards[id][w] = res[id]; });
     });
 
-    return { awards, weekFinal, finalWeeks, currentWeek, ids, schedule };
+    return { awards, weeks, weekFinal, finalWeeks, currentWeek, ids, schedule };
 }
 
 // Rebuild a season's weeklyScore with this manager's H2H awards folded in.
@@ -215,12 +266,16 @@ function computeH2HAwards({ users, games, season, winBonus, tieBonus, lastWeek }
 // running this twice, re-running after a rescore, changing the configured bonus,
 // or turning H2H off all converge on the right number instead of compounding.
 // Returns { weeklyScore, changed }.
-function applyAwards(weeklyScore, awardsForUser, lastWeek) {
-    const last = lastWeek || H2H_LAST_WEEK;
+function applyAwards(weeklyScore, awardsForUser, maxWeek) {
+    // `awardsForUser` is authoritative about which weeks earned a bonus, so the
+    // bound only has to exclude the postseason — a regular week with no award
+    // (including one outside the derived H2H range) gets any stale bonus
+    // stripped, which is what makes turning the mode off self-correcting.
+    const bound = maxWeek || H2H_MAX_WEEK;
     let changed = false;
     const next = (weeklyScore || []).map(entry => {
         const e = Object.assign({}, entry);
-        const inRange = e.season !== 'postseason' && e.week <= last;
+        const inRange = e.season !== 'postseason' && e.week <= bound;
         const award = inRange ? ((awardsForUser || {})[e.week] || null) : null;
 
         const base = baseWeekScore(e);
@@ -310,6 +365,6 @@ function matchupWinProb(aEntries, bEntries) {
 module.exports = {
     buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H,
     gameStatus, isWeekFinal, matchupWinProb,
-    H2H_LAST_WEEK, seasonEntry, baseWeekScore, persistedBonus,
+    H2H_MAX_WEEK, h2hWeekRange, seasonEntry, baseWeekScore, persistedBonus,
     h2hManagerIds, computeH2HAwards, applyAwards
 };

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -11,7 +11,7 @@ const { computeAdminStatus } = require('../modules/admin-status');
 const { computeSeasonReadiness } = require('../modules/season-readiness');
 const { engagementForSeason, LEAGUES } = require('../modules/scoring-defaults');
 const { canManageLeague } = require('../modules/league-access');
-const { H2H_LAST_WEEK, seasonEntry, computeH2HAwards, applyAwards } = require('../modules/h2h');
+const { H2H_MAX_WEEK, seasonEntry, computeH2HAwards, applyAwards } = require('../modules/h2h');
 
 // Read-only status summary for the admin console: how far scoring/games have
 // progressed and whether any completed results are still unscored. Derived from
@@ -161,7 +161,7 @@ async function applyH2HBonuses(season) {
             });
             const idList = [...drafted];
             const games = idList.length ? await Game.find(
-                { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_LAST_WEEK },
+                { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_MAX_WEEK },
                   $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
                 { id: 1, week: 1, seasonType: 1, completed: 1, homeId: 1, awayId: 1, _id: 0 }
             ).lean() : [];
@@ -176,7 +176,7 @@ async function applyH2HBonuses(season) {
             const s = seasonEntry(user, seasonStr);
             if (!s) continue;
             const plain = (s.weeklyScore || []).map(e => (e.toObject ? e.toObject() : e));
-            const next = applyAwards(plain, awards[String(user._id)], H2H_LAST_WEEK);
+            const next = applyAwards(plain, awards[String(user._id)], H2H_MAX_WEEK);
             if (!next.changed) continue;
             s.weeklyScore = next.weeklyScore;
             user.markModified('seasons');

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -14,7 +14,7 @@ const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../m
 const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
-const { gameStatus, matchupWinProb, H2H_LAST_WEEK, baseWeekScore, persistedBonus,
+const { gameStatus, matchupWinProb, H2H_MAX_WEEK, baseWeekScore, persistedBonus,
         h2hManagerIds, computeH2HAwards } = require('../modules/h2h');
 const { pickLogo } = require('../public/logo.js');
 
@@ -335,7 +335,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             };
             const tw = {}, twTeams = {};
             (s.weeklyScore || []).forEach(e => {
-                if (!isRegular(e) || e.week > H2H_LAST_WEEK) return;
+                if (!isRegular(e) || e.week > H2H_MAX_WEEK) return;
                 const w = e.week;
                 // BASE total (score minus any bonus already banked into it), so a
                 // week's own bonus never feeds back into deciding that week.
@@ -360,7 +360,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // stable whether or not it's been scored yet.
         const draftedIds = [...draftedSet];
         const games = draftedIds.length ? await Game.find(
-            { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_LAST_WEEK }, $or: [{ homeId: { $in: draftedIds } }, { awayId: { $in: draftedIds } }] },
+            { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_MAX_WEEK }, $or: [{ homeId: { $in: draftedIds } }, { awayId: { $in: draftedIds } }] },
             { id: 1, week: 1, startDate: 1, startTimeTbd: 1, completed: 1, homeId: 1, homeTeam: 1, homePoints: 1, awayId: 1, awayTeam: 1, awayPoints: 1, _id: 0 }
         ).lean() : [];
         // Opponent abbreviations (opponents aren't always rostered, so look them
@@ -427,7 +427,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // from the SAME function the scoring job uses to bank the bonus, so the
         // table and cumulativeScore can never tell different stories.
         const { awards, weekFinal, finalWeeks, currentWeek, schedule: scheduleAll } = computeH2HAwards({
-            users, games, season, winBonus, tieBonus, lastWeek: H2H_LAST_WEEK
+            users, games, season, winBonus, tieBonus, maxWeek: H2H_MAX_WEEK
         });
 
         // Records + win bonus count FINAL weeks only (an in-progress week has no

--- a/routes/users.js
+++ b/routes/users.js
@@ -329,11 +329,23 @@ router.patch('/:id', getUser, async (req, res) => {
     var centralTime = date.toLocaleString("en-US", {timeZone: "America/Chicago"});
     res.user.lastUpdated = centralTime;
 
+    // Exactly one score field is written per call, and only when present.
+    //
+    // The `!= null` guard on weeklyScore is the fix: this was a bare else, so ANY
+    // body without cumulativeScore assigned weeklyScore — a body of just
+    // { isUpdated: true } set it to undefined and wiped the season's scores. Both
+    // scoring callers happen to always send one, so it never fired, but nothing
+    // enforced that.
+    //
+    // They stay mutually exclusive on purpose. getUser projects `seasons` with
+    // $elemMatch, and Mongoose REFUSES to save a document that both edits a
+    // scalar and replaces an array wholesale under such a projection ("for your
+    // own good…") — so a body carrying both would throw and write NOTHING. Either
+    // one alone saves cleanly. Don't merge these into two independent ifs; the
+    // ScoringWrites spec pins the behavior.
     if (req.body.cumulativeScore != null) {
         res.user.seasons[0].cumulativeScore = req.body.cumulativeScore;
-    } 
-
-    else {
+    } else if (req.body.weeklyScore != null) {
         res.user.seasons[0].weeklyScore = req.body.weeklyScore;
     }
     if (req.body.isUpdated != null) {

--- a/tests/H2H.spec.js
+++ b/tests/H2H.spec.js
@@ -1,5 +1,89 @@
 const { buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H, gameStatus, isWeekFinal, matchupWinProb,
-        baseWeekScore, persistedBonus, h2hManagerIds, computeH2HAwards, applyAwards } = require('../modules/h2h');
+        baseWeekScore, persistedBonus, h2hManagerIds, computeH2HAwards, applyAwards,
+        h2hWeekRange } = require('../modules/h2h');
+
+// --- which weeks are H2H weeks ----------------------------------------------
+// This range used to be hardcoded to "through week 14". That was right for 2025
+// (regular season through wk 14, conference titles wk 15) and silently WRONG for
+// 2026, whose calendar shifted a week: last full slate wk 13, titles wk 14,
+// Army/Navy wk 15. Cap-at-14 would have made championship week — a couple of
+// rostered teams — decide a win bonus. So it's derived from the slate now.
+describe('h2hWeekRange', () => {
+    // n games in each of the listed weeks.
+    const slate = (spec) => Object.entries(spec).reduce((m, [w, n]) => {
+        m[w] = Array.from({ length: n }, (_, i) => ({ id: i }));
+        return m;
+    }, {});
+
+    test('2026 shape: stops before championship week', () => {
+        // Weeks 1-12 full, wk 13 rivalry (still full), wk 14 titles, wk 15 Army/Navy.
+        const spec = {};
+        for (let w = 1; w <= 13; w++) spec[w] = 45;
+        spec[14] = 4; spec[15] = 1;
+        expect(h2hWeekRange(slate(spec))).toEqual([1,2,3,4,5,6,7,8,9,10,11,12,13]);
+    });
+
+    test('2025 shape: the same rule keeps week 14', () => {
+        const spec = {};
+        for (let w = 1; w <= 14; w++) spec[w] = 45;
+        spec[15] = 6; spec[16] = 1;
+        expect(h2hWeekRange(slate(spec))).toEqual([1,2,3,4,5,6,7,8,9,10,11,12,13,14]);
+    });
+
+    // Championship week isn't scheduled until the matchups are known, which is
+    // the live 2026 state — the range must not run past the real slate.
+    test('an empty week after a real slate ends the range', () => {
+        const spec = {};
+        for (let w = 1; w <= 13; w++) spec[w] = 45;
+        expect(h2hWeekRange(slate(spec))).toEqual([1,2,3,4,5,6,7,8,9,10,11,12,13]);
+    });
+
+    test('a bye-heavy week is still a real week', () => {
+        const spec = { 1: 50, 2: 50, 3: 30, 4: 50, 5: 50 };   // wk 3 lighter, not thin
+        expect(h2hWeekRange(slate(spec))).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('handles a season that has barely started', () => {
+        expect(h2hWeekRange(slate({ 1: 40 }))).toEqual([1]);
+        expect(h2hWeekRange({})).toEqual([]);
+    });
+
+    test('a small league still separates a real week from championship week', () => {
+        // 2 managers, 20 teams: ~10 games a week, 1 in championship week.
+        const spec = { 1: 10, 2: 10, 3: 10, 4: 1 };
+        expect(h2hWeekRange(slate(spec))).toEqual([1, 2, 3]);
+    });
+
+    test('an even number of played weeks averages the middle two', () => {
+        // counts 10,10,40,40 -> median 25, threshold 10 -> all four qualify.
+        expect(h2hWeekRange(slate({ 1: 40, 2: 40, 3: 10, 4: 10 }))).toEqual([1, 2, 3, 4]);
+        // counts 4,40,40,40 -> median 40, threshold 16 -> wk 1 already too thin.
+        expect(h2hWeekRange(slate({ 1: 4, 2: 40, 3: 40, 4: 40 }))).toEqual([]);
+    });
+
+    test('the threshold never drops below one game', () => {
+        // A median of 1 would give a threshold of 0.4; the floor keeps it at 1 so
+        // an empty week can't sneak in as "above threshold".
+        expect(h2hWeekRange(slate({ 1: 1, 2: 1, 3: 1 }))).toEqual([1, 2, 3]);
+    });
+
+    test('minShare is tunable', () => {
+        const spec = { 1: 40, 2: 40, 3: 40, 4: 12 };
+        expect(h2hWeekRange(slate(spec))).toEqual([1, 2, 3]);                       // 0.4 default -> 16
+        expect(h2hWeekRange(slate(spec), { minShare: 0.2 })).toEqual([1, 2, 3, 4]); // -> 8, wk 4 counts
+    });
+
+    test('leading weeks with nothing scheduled are skipped, not treated as the end', () => {
+        expect(h2hWeekRange(slate({ 3: 40, 4: 40, 5: 40 }))).toEqual([3, 4, 5]);
+    });
+
+    test('never runs past the bound', () => {
+        const spec = {};
+        for (let w = 1; w <= 16; w++) spec[w] = 45;
+        expect(h2hWeekRange(slate(spec)).slice(-1)[0]).toBe(16);
+        expect(h2hWeekRange(slate(spec), { maxWeek: 12 }).slice(-1)[0]).toBe(12);
+    });
+});
 
 describe('buildRoundRobin', () => {
     test('6 managers → 5 rounds, everyone plays everyone exactly once, 3 pairs/round', () => {
@@ -224,15 +308,32 @@ describe('computeH2HAwards', () => {
         expect(awards.a[1]).toMatchObject({ result: 'L', bonus: 0 });
     });
 
-    test('postseason entries and weeks past the cap never award', () => {
+    // The end of the season, as 2026 actually lays out: full slates through wk
+    // 13, then a thin championship/Army-Navy week, then the postseason. Neither
+    // of the last two may decide a matchup.
+    test('postseason entries and thin end-of-season weeks never award', () => {
+        const weekly = (n) => {
+            const out = [];
+            for (let w = 1; w <= 13; w++) out.push({ week: w, score: n });
+            out.push({ week: 15, score: n });                          // Army/Navy
+            out.push({ week: 1, season: 'postseason', score: 30 });    // bowls
+            return out;
+        };
         const late = [
-            { _id: 'a', seasons: [{ season: 2026, teams: [{ id: 1 }], weeklyScore: [{ week: 15, score: 20 }, { week: 1, season: 'postseason', score: 30 }] }] },
-            { _id: 'b', seasons: [{ season: 2026, teams: [{ id: 2 }], weeklyScore: [{ week: 15, score: 10 }] }] }
+            { _id: 'a', seasons: [{ season: 2026, teams: [{ id: 1 }], weeklyScore: weekly(20) }] },
+            { _id: 'b', seasons: [{ season: 2026, teams: [{ id: 2 }], weeklyScore: weekly(10) }] }
         ];
-        const games = [{ id: 1, week: 15, homeId: 1, awayId: 99, completed: true }];
-        const { awards, finalWeeks } = computeH2HAwards({ users: late, games, ...opts });
-        expect(finalWeeks).toEqual([]);
-        expect(awards.a).toEqual({});
+        const games = [];
+        for (let w = 1; w <= 13; w++) {
+            for (let i = 0; i < 20; i++) games.push({ id: w * 100 + i, week: w, homeId: i % 2 ? 1 : 2, awayId: 99, completed: true });
+        }
+        games.push({ id: 9001, week: 15, homeId: 1, awayId: 2, completed: true });   // thin week
+
+        const { awards, weeks, finalWeeks } = computeH2HAwards({ users: late, games, ...opts });
+        expect(weeks).toEqual([1,2,3,4,5,6,7,8,9,10,11,12,13]);
+        expect(finalWeeks).toEqual(weeks);
+        expect(awards.a[15]).toBeUndefined();   // Army/Navy week is not a matchup
+        expect(awards.a[1]).toBeDefined();      // the real weeks still resolve
     });
 
     test('fewer than two scored managers awards nothing', () => {

--- a/tests/RosterCorrection.spec.js
+++ b/tests/RosterCorrection.spec.js
@@ -377,3 +377,62 @@ describe('GET /users/league/:league/roster-teams', () => {
         expect(res.body.available).toHaveLength(1);
     });
 });
+
+// --- PATCH /users/:id score writes -------------------------------------------
+// This handler used to be an if/else with a bare else: ANY body without
+// cumulativeScore assigned weeklyScore, so { isUpdated: true } set weeklyScore to
+// undefined and wiped the season. Both scoring callers happen to always send one,
+// so it never fired — but nothing enforced that.
+describe('PATCH /users/:id (score writes)', () => {
+    // Multiple seasons, so the $elemMatch projection is actually filtering —
+    // which is what makes the Mongoose array guard below reachable.
+    const scored = () => manager('Ann', [fullTeam(1, 'Iowa')], {
+        seasons: [
+            { season: 2025, cumulativeScore: 99, weeklyScore: [{ week: 1, score: 99 }] },
+            { season: SEASON, teams: [fullTeam(1, 'Iowa')], cumulativeScore: 12,
+              weeklyScore: [{ week: 1, score: 12, scoreByTeam: [{ team: 'Iowa', teamId: 1, gameId: 1, score: 12 }] }] }
+        ]
+    });
+    const send = (id, body) => request(app).patch(`/users/${id}`)
+        .set('X-Internal-Token', 'test-internal-token').send(body);
+    const season = async (id, yr) => (await User.findById(id).lean()).seasons.find(s => s.season === yr);
+
+    test('a body with neither score field leaves weeklyScore intact', async () => {
+        const u = await scored();
+        const res = await send(u._id, { isUpdated: true });
+        expect(res.status).toBe(200);
+        const s = await season(u._id, SEASON);
+        expect(s.weeklyScore).toHaveLength(1);
+        expect(s.weeklyScore[0].score).toBe(12);
+        expect((await User.findById(u._id).lean()).isUpdated).toBe(true);
+    });
+
+    test('weeklyScore alone writes, and leaves other seasons alone', async () => {
+        const u = await scored();
+        expect((await send(u._id, { weeklyScore: [{ week: 1, score: 20 }, { week: 2, score: 5 }] })).status).toBe(200);
+        expect((await season(u._id, SEASON)).weeklyScore.map(w => w.score)).toEqual([20, 5]);
+        expect((await season(u._id, 2025)).weeklyScore.map(w => w.score)).toEqual([99]);
+    });
+
+    test('cumulativeScore alone writes, and leaves weeklyScore alone', async () => {
+        const u = await scored();
+        expect((await send(u._id, { cumulativeScore: 40 })).status).toBe(200);
+        const s = await season(u._id, SEASON);
+        expect(s.cumulativeScore).toBe(40);
+        expect(s.weeklyScore).toHaveLength(1);
+    });
+
+    // Pins WHY the two branches are mutually exclusive. getUser projects seasons
+    // with $elemMatch, and Mongoose refuses to save a document that both edits a
+    // scalar and replaces an array wholesale under that projection — a body with
+    // both would throw and write nothing at all. Keeping them exclusive means
+    // cumulativeScore simply wins, which is the long-standing behavior.
+    test('sending both applies only cumulativeScore — never a failed no-op write', async () => {
+        const u = await scored();
+        const res = await send(u._id, { cumulativeScore: 40, weeklyScore: [{ week: 1, score: 77 }] });
+        expect(res.status).toBe(200);
+        const s = await season(u._id, SEASON);
+        expect(s.cumulativeScore).toBe(40);
+        expect(s.weeklyScore[0].score).toBe(12);   // untouched, not 77 and not wiped
+    });
+});


### PR DESCRIPTION
Two latent data bugs, both found by auditing rather than by anything breaking.

## 1. H2H ran "through week 14" — hardcoded

Right for 2025. **Silently wrong for 2026**, whose calendar shifted a week:

| | 2025 | 2026 |
|---|---|---|
| Last full slate | wk 14 | **wk 13** (Nov 29) |
| Conference titles | wk 15 | **wk 14** |
| Army–Navy | wk 16 | **wk 15** (Dec 12) |

Cap-at-14 would have made **championship week a scoring matchup** — decided by the two or three rostered teams still playing. Precisely what the cap existed to prevent, and it wouldn't have surfaced until December, once title matchups get ingested into week 14.

`h2hWeekRange()` now derives the range from the slate: a week counts when it holds at least 40% of the median week's rostered-team games, taking the contiguous run from the first played week. A normal week puts most of the league on the field; championship week a handful. `H2H_LAST_WEEK` is replaced by `H2H_MAX_WEEK` (16), which is now only a query bound — the range is computed, so the next calendar shift can't move it either.

**Verified on real data.** The derived range reproduces the old hardcode exactly where it was right, so historical seasons are untouched:

```
2024 slate | 1:46 2:39 … 13:41 14:40 15:8    -> weeks 1-14   (old: 1-14) ✓
2025 slate | 1:56 2:48 … 13:45 14:46 15:7    -> weeks 1-14   (old: 1-14) ✓
2026 slate | 1:52 2:47 … 13:46        15:1   -> weeks 1-13   (old: 1-14) ✗ fixed
2026 with championship week populated         -> weeks 1-13   wk 14 excluded ✓
```

(2026 isn't drafted yet, so that run used last season's 60 rostered teams as a stand-in against the real 2026 schedule.)

## 2. `PATCH /users/:id` could wipe a season's `weeklyScore`

It was an `if/else` with a bare `else`, so **any** body without `cumulativeScore` assigned `weeklyScore` — `{ isUpdated: true }` set it to `undefined` and dropped every weekly score for the season. Both scoring callers happen to always send one field, so it never fired; nothing enforced that. Now guarded on presence.

**The two branches stay mutually exclusive, and that turns out to matter.** `getUser` projects `seasons` with `$elemMatch`, and Mongoose *refuses* to save a document that both edits a scalar and replaces an array wholesale under such a projection — a body carrying both throws and writes nothing at all:

```
multi-season + weeklyScore only  -> SAVED
multi-season + cumulative only   -> SAVED
multi-season + both              -> THREW, nothing written
```

Either alone saves cleanly, which is why today's callers work. Making the two independent — the obvious "improvement", and my first attempt — would have introduced a silent no-op write, since `modules/scoring.js` logs a non-200 rather than raising. A comment and a test now pin that so nobody re-breaks it.

## Tests — 467 green

`h2hWeekRange` covers both calendar shapes, an unscheduled championship week, bye-heavy weeks, small leagues, median/threshold edges, and the bound. The existing "past the cap" case was rewritten to assert the real intent — thin end-of-season weeks never award — instead of the old constant. The PATCH cases run against a **multi-season** user so the `$elemMatch` projection is actually filtering, covering neither / either / both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
