### PR TITLE
Commissioner audit log: a trail for the changes that rewrite history

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,7 @@
 {
     "testRegex": "((\\.|/*.)(spec))\\.js?$",
+    "//testTimeout": "The in-memory-Mongo suites can exceed Jest's 5s default on a cold run — first connection, index builds and coverage instrumentation all land on the first DB-touching test, and several such suites now compete for workers. 20s absorbs that jitter without masking a genuinely hung test.",
+    "testTimeout": 20000,
     "collectCoverageFrom": [
         "modules/**/*.js",
         "routes/**/*.js",

--- a/jest.config.json
+++ b/jest.config.json
@@ -15,6 +15,7 @@
         "./modules/h2h.js": { "statements": 95, "branches": 85, "functions": 100, "lines": 100 },
         "./modules/season-readiness.js": { "statements": 100, "branches": 85, "functions": 100, "lines": 100 },
         "./modules/roster-correction.js": { "statements": 95, "branches": 85, "functions": 100, "lines": 100 },
+        "./modules/audit-log.js": { "statements": 100, "branches": 90, "functions": 100, "lines": 100 },
         "./modules/internal-api.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./modules/job-runs-util.js": { "statements": 100, "branches": 100, "functions": 100, "lines": 100 },
         "./update-enrichment-job.js": { "statements": 80, "branches": 60, "functions": 60, "lines": 90 }

--- a/models/auditLog.js
+++ b/models/auditLog.js
@@ -1,0 +1,37 @@
+const mongoose = require('mongoose');
+
+// A commissioner action that changed league data.
+//
+// Scheduled jobs already leave a trail (models/jobRun.js); commissioner actions
+// did not. Several of them quietly rewrite history — a roster correction edits
+// the draft record, a season-membership toggle drops a year's scores — and until
+// now the only evidence was the changed data itself. This is the trail.
+//
+// Append-only by construction: nothing in the app updates or deletes an entry.
+const auditLogSchema = new mongoose.Schema({
+    // Dotted verb, e.g. 'roster.correct'. See ACTIONS in modules/audit-log.js —
+    // the label shown in the admin panel is looked up from there, so an unknown
+    // action still renders (as its raw key) rather than vanishing.
+    action: { type: String, required: true },
+    league: { type: String },
+    season: { type: String },
+
+    // Who did it. Resolved from the session; a server-to-server call carrying
+    // the internal token records as system.
+    actorName: { type: String },
+    actorEmail: { type: String },
+    actorRole: { type: String },
+
+    // One human-readable line — what the admin panel actually shows.
+    summary: { type: String, required: true },
+    // Structured detail for anything that later wants to reconstruct the change.
+    meta: { type: mongoose.Schema.Types.Mixed },
+
+    createdAt: { type: Date, default: Date.now }
+});
+
+// The panel reads newest-first, either league-scoped or across the board.
+auditLogSchema.index({ createdAt: -1 });
+auditLogSchema.index({ league: 1, createdAt: -1 });
+
+module.exports = mongoose.model('AuditLog', auditLogSchema);

--- a/modules/audit-log.js
+++ b/modules/audit-log.js
@@ -1,0 +1,79 @@
+// Commissioner audit trail.
+//
+// Scheduled jobs already leave a record (modules/job-logger.js). Commissioner
+// actions did not — and several of them quietly rewrite history: a roster
+// correction edits the draft record, a season-membership toggle drops a year's
+// scores, a scoring-config change alters how every past game counts. The only
+// evidence was the changed data itself.
+//
+// Recording is BEST-EFFORT and never throws. An audit write failing must not
+// fail the action it was describing — same discipline as job-logger. That means
+// a missing entry is possible; the trail is for "who changed this and when",
+// not an accounting ledger.
+
+const AuditLog = require('../models/auditLog');
+const { effectiveRoles } = require('./dev-role');
+
+// Known actions -> the short label the admin panel shows. Kept here rather than
+// in the client so the vocabulary lives with the code that writes it; an
+// unrecognised action still renders as its raw key.
+const ACTIONS = {
+    'roster.correct': 'Roster',
+    'season.membership': 'Season roster',
+    'scoring.config': 'Scoring',
+    'scoring.engagement': 'Game modes',
+    'draft.config': 'Draft',
+    'draft.reset': 'Draft',
+    'league.rename': 'League',
+    'user.create': 'Manager'
+};
+
+function labelFor(action) {
+    return ACTIONS[action] || action;
+}
+
+// Who performed this. Reads the REAL session identity, not the dev role-spoof:
+// a spoof changes what an Admin can see, and the log should still say who they
+// actually are. A server-to-server call (internal token, no session) is system.
+function actorFrom(req) {
+    const user = req && req.oidc && req.oidc.user;
+    if (!user) return { actorName: 'system', actorEmail: null, actorRole: 'system' };
+    const roles = effectiveRoles(req) || [];
+    return {
+        actorName: user.name || user.email || 'unknown',
+        actorEmail: user.email || null,
+        actorRole: roles[0] || 'member'
+    };
+}
+
+// Append an entry. Fire-and-forget by design: callers `await` it so ordering is
+// predictable in tests, but it resolves to null instead of throwing on failure.
+async function record(req, entry) {
+    try {
+        if (!entry || !entry.action || !entry.summary) return null;
+        const doc = await AuditLog.create(Object.assign({
+            league: null, season: null, meta: null
+        }, actorFrom(req), entry));
+        return doc;
+    } catch (err) {
+        console.log('audit-log write failed:', err.message);
+        return null;
+    }
+}
+
+// Shape an entry for the panel. `label` is derived here so the client stays a
+// dumb renderer and the vocabulary can grow without a client change.
+function toRow(doc) {
+    return {
+        id: String(doc._id),
+        action: doc.action,
+        label: labelFor(doc.action),
+        league: doc.league || null,
+        season: doc.season || null,
+        actor: doc.actorName || 'unknown',
+        summary: doc.summary,
+        at: doc.createdAt
+    };
+}
+
+module.exports = { ACTIONS, labelFor, actorFrom, record, toRow };

--- a/public/admin.css
+++ b/public/admin.css
@@ -423,6 +423,40 @@
 .admin-status.warn .ss-note { color: var(--cc-amber); }
 .admin-status .ss-note a { color: inherit; font-weight: 500; text-decoration: underline; cursor: pointer; }
 
+/* --- Activity (commissioner audit trail) ------------------------------------
+   Deliberately dense: one line per change, so 25 entries read as a log rather
+   than a stack of cards. Collapsed by default, so it costs nothing until used. */
+.audit-log { width: 100%; }
+.al-rows { display: flex; flex-direction: column; }
+.al-row {
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr) auto;
+    align-items: baseline; gap: 4px 9px;
+    padding: 5px 0; border-top: 1px solid var(--cc-border);
+    font-size: 0.82rem; line-height: 1.35;
+}
+.al-row:first-child { border-top: 0; }
+.al-when { color: var(--cc-muted-2); font-size: 0.72rem; white-space: nowrap; min-width: 52px; }
+/* The action kind, e.g. Roster / Scoring / Draft. */
+.al-tag {
+    font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.07em;
+    color: var(--cc-muted-bright); border: 1px solid var(--cc-border);
+    border-radius: 4px; padding: 1px 6px; white-space: nowrap;
+}
+.al-league {
+    font-size: 0.66rem; color: var(--cc-info); border: 1px solid var(--cc-border);
+    border-radius: 4px; padding: 1px 5px; white-space: nowrap;
+}
+.al-summary { min-width: 0; overflow-wrap: anywhere; }
+.al-actor { color: var(--cc-muted-2); font-size: 0.74rem; white-space: nowrap; }
+.al-empty { color: var(--cc-muted-2); font-size: 0.85rem; margin: 0; }
+
+/* Mobile: the actor drops under the summary rather than squeezing it. */
+@media (max-width: 620px) {
+    .al-row { grid-template-columns: auto auto minmax(0, 1fr); }
+    .al-actor { grid-column: 2 / -1; }
+}
+
 /* --- Correct a Roster ------------------------------------------------------
    Manager picker, then one row per rostered team. A row swaps in place into an
    edit state rather than opening a modal, so the rest of the roster stays

--- a/public/admin.css
+++ b/public/admin.css
@@ -428,9 +428,11 @@
    than a stack of cards. Collapsed by default, so it costs nothing until used. */
 .audit-log { width: 100%; }
 .al-rows { display: flex; flex-direction: column; }
+/* when · kind · league · summary · actor. The league cell is always emitted
+   (empty when there's nothing to show) so the columns stay aligned. */
 .al-row {
     display: grid;
-    grid-template-columns: auto auto minmax(0, 1fr) auto;
+    grid-template-columns: auto auto auto minmax(0, 1fr) auto;
     align-items: baseline; gap: 4px 9px;
     padding: 5px 0; border-top: 1px solid var(--cc-border);
     font-size: 0.82rem; line-height: 1.35;
@@ -453,8 +455,14 @@
 
 /* Mobile: the actor drops under the summary rather than squeezing it. */
 @media (max-width: 620px) {
-    .al-row { grid-template-columns: auto auto minmax(0, 1fr); }
-    .al-actor { grid-column: 2 / -1; }
+    .al-row { grid-template-columns: auto auto auto minmax(0, 1fr); }
+    .al-actor { grid-column: 3 / -1; }
+}
+
+/* Tools sit two-up at 40% each on desktop (see the 64em block above). A log
+   needs the full row — five columns of it — so this one opts out. */
+@media only screen and (min-width: 64em) {
+    .function-container.is-wide { width: 84%; }
 }
 
 /* --- Correct a Roster ------------------------------------------------------

--- a/public/admin.js
+++ b/public/admin.js
@@ -335,8 +335,11 @@ function renderAdminStatus(el, s, api, year, jobs) {
 
 // Short league labels so a row stays on one line; Admins see both leagues, and
 // a League Manager only ever sees their own, so the tag is dropped for them.
+// Always emits a cell, even when there's nothing to show — the row is a grid, so
+// a conditionally-absent child would shift every later cell one column left
+// (which put the league chip on top of the summary).
 function auditLeagueTag(entry, multiLeague) {
-    if (!multiLeague || !entry.league) return '';
+    if (!multiLeague || !entry.league) return '<span></span>';
     var short = entry.league === 'graham-league' ? 'GG' : entry.league === 'claunts-league' ? 'CL' : entry.league;
     return '<span class="al-league">' + escapeHtml(short) + '</span>';
 }

--- a/public/admin.js
+++ b/public/admin.js
@@ -328,6 +328,46 @@ function renderAdminStatus(el, s, api, year, jobs) {
     });
 }
 
+// --- Activity (commissioner audit trail) ------------------------------------
+// Collapsed by default, so it costs one button row until someone opens it.
+// Entries are written server-side by the handlers that make the change
+// (modules/audit-log.js); this only reads.
+
+// Short league labels so a row stays on one line; Admins see both leagues, and
+// a League Manager only ever sees their own, so the tag is dropped for them.
+function auditLeagueTag(entry, multiLeague) {
+    if (!multiLeague || !entry.league) return '';
+    var short = entry.league === 'graham-league' ? 'GG' : entry.league === 'claunts-league' ? 'CL' : entry.league;
+    return '<span class="al-league">' + escapeHtml(short) + '</span>';
+}
+
+async function loadAuditLog() {
+    var body = document.querySelector('[audit-log-body]');
+    if (!body) return;
+    body.textContent = 'Loading…';
+    try {
+        var res = await fetch('/audit-log?limit=25', { headers: { 'Accept': 'application/json' } });
+        var data = await res.json();
+        if (!res.ok) { body.textContent = data.message || 'Could not load activity.'; return; }
+        if (!data.entries.length) {
+            body.innerHTML = '<p class="al-empty">No commissioner changes recorded yet.</p>';
+            return;
+        }
+        var multi = (data.scope || []).length > 1;
+        body.innerHTML = '<div class="al-rows">' + data.entries.map(function (e) {
+            return '<div class="al-row">'
+                + '<span class="al-when" title="' + escapeHtml(new Date(e.at).toLocaleString()) + '">' + escapeHtml(timeAgo(e.at)) + '</span>'
+                + '<span class="al-tag">' + escapeHtml(e.label) + '</span>'
+                + auditLeagueTag(e, multi)
+                + '<span class="al-summary">' + escapeHtml(e.summary) + '</span>'
+                + '<span class="al-actor">' + escapeHtml(e.actor) + '</span>'
+                + '</div>';
+        }).join('') + '</div>';
+    } catch (err) {
+        body.textContent = 'Could not load activity.';
+    }
+}
+
 // --- Correct a Roster --------------------------------------------------------
 // Swap one team on a manager's season roster for an undrafted one. Also rewrites
 // the matching draft pick server-side, so the board and grades stay in step —
@@ -1423,6 +1463,8 @@ function displayCreateUserContainer() { toggleSub('create-user-container'); }
 function displaySeasonRosterContainer() { if (toggleSub('season-roster-container')) loadSeasonRoster(); }
 
 function displayRosterCorrectionContainer() { if (toggleSub('roster-correction-container')) loadRosterCorrection(); }
+
+function displayAuditLogContainer() { if (toggleSub('audit-log-container')) loadAuditLog(); }
 
 function displayTeamContainer() { toggleSub('calculate-team-score-container'); }
 

--- a/routes/auditLog.js
+++ b/routes/auditLog.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const router = express.Router();
+const AuditLog = require('../models/auditLog');
+const { toRow } = require('../modules/audit-log');
+const { canManageLeague } = require('../modules/league-access');
+const { LEAGUES } = require('../modules/scoring-defaults');
+
+// Recent commissioner actions, newest first.
+//
+// Scoped to what the caller may manage — an Admin sees every league, a League
+// Manager only their own. Entries with no league (nothing does that today, but
+// the field is optional) are treated as platform-wide and shown to Admins only.
+// Read-only: entries are written server-side by the handlers that make the
+// change, never by a client.
+router.get('/', async (req, res) => {
+    try {
+        const limit = Math.min(Number(req.query.limit) || 25, 100);
+        const visible = LEAGUES.map(l => l.code).filter(code => canManageLeague(req, code));
+        if (!visible.length) return res.json({ entries: [], scope: [] });
+
+        // An Admin (every league visible) also sees league-less entries.
+        const seesAll = visible.length === LEAGUES.length;
+        const query = seesAll
+            ? {}
+            : { league: { $in: visible } };
+
+        const docs = await AuditLog.find(query, null, { sort: { createdAt: -1 }, limit }).lean();
+        res.json({ entries: docs.map(toRow), scope: visible });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const audit = require('../modules/audit-log');
 const Draft = require('../models/draft');
 const User = require('../models/user');
 const Team = require('../models/team');
@@ -103,6 +104,14 @@ router.post('/', async (req, res) => {
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
 
+        const when = draft.scheduledAt
+            ? new Date(draft.scheduledAt).toLocaleString('en-US', { timeZone: 'America/Chicago', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+            : 'no date';
+        await audit.record(req, {
+            action: 'draft.config', league, season: String(season),
+            summary: `Draft settings saved — ${when}, ${draft.snake ? 'snake' : 'linear'}, ${draft.totalRounds} rounds, ${(draft.draftOrder || []).length} managers`,
+            meta: { draftId: String(draft._id), scheduledAt: draft.scheduledAt, snake: draft.snake, totalRounds: draft.totalRounds, orderSize: (draft.draftOrder || []).length }
+        });
         res.status(200).json(draft);
     } catch (err) {
         res.status(400).json({ message: err.message });
@@ -154,6 +163,13 @@ router.post('/:id/reset', async (req, res) => {
             { $set: { status: 'pending', picks: [], currentOverall: 1, updatedAt: new Date() } },
             { new: true }
         );
+        // Wipes every pick. Rosters written by a previous completion are NOT
+        // rolled back (see the runbook), so this one especially wants a trail.
+        await audit.record(req, {
+            action: 'draft.reset', league: existing.league, season: String(existing.season),
+            summary: `Draft reset (${(existing.picks || []).length} picks cleared)`,
+            meta: { draftId: String(existing._id), picksCleared: (existing.picks || []).length }
+        });
         res.json(draft);
     } catch (err) {
         res.status(500).json({ message: err.message });

--- a/routes/leagues.js
+++ b/routes/leagues.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const audit = require('../modules/audit-log');
 const League = require('../models/league');
 const { LEAGUES } = require('../modules/scoring-defaults');
 const { canManageLeague } = require('../modules/league-access');
@@ -38,6 +39,11 @@ router.patch('/:code', async (req, res) => {
             { code, name },
             { new: true, upsert: true }
         );
+        await audit.record(req, {
+            action: 'league.rename', league: code,
+            summary: `League renamed to "${doc.name}"`,
+            meta: { name: doc.name }
+        });
         res.json({ code: doc.code, name: doc.name });
     } catch (err) {
         res.status(500).json({ message: err.message });

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -7,6 +7,7 @@ const { explainRegularWin, explainGame, getScoringConfig, getRankingsForGame } =
 const { canManageLeague } = require('../modules/league-access');
 const { effectiveRoles } = require('../modules/dev-role');
 const { hasScoredGames } = require('../modules/season-status');
+const audit = require('../modules/audit-log');
 
 // Attaches the ordered field metadata (for the admin form + rules page) and a
 // plain-language combine-mode `example` to a resolved config. `fields` reflect
@@ -124,6 +125,13 @@ router.post('/', async (req, res) => {
             } },
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
+        // Scoring changes how every past game counts, so the trail records the
+        // shape that was chosen, not just that something changed.
+        await audit.record(req, {
+            action: 'scoring.config', league, season: String(process.env.YEAR),
+            summary: `Scoring rules updated (${resolved.model === 'graham' ? 'stacking' : 'fixed'} win values)`,
+            meta: { model: resolved.model, combineMode: resolved.combineMode, disabled: resolved.disabled, enabled: resolved.enabled }
+        });
         res.json(withFields(resolveConfig(league, {
             model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled
         })));
@@ -166,6 +174,15 @@ router.patch('/:league/engagement', async (req, res) => {
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
         const saved = engagementForSeason(doc.engagementBySeason, season);
+        const modes = [
+            saved.h2hEnabled ? `H2H +${saved.h2hWinBonus}${saved.h2hTieBonus ? '/+' + saved.h2hTieBonus + ' tie' : ''}` : null,
+            saved.captainEnabled ? `Captain ×${saved.captainMultiplier}` : null
+        ].filter(Boolean);
+        await audit.record(req, {
+            action: 'scoring.engagement', league, season: String(season),
+            summary: modes.length ? `Game modes: ${modes.join(' · ')}` : 'Game modes: off (classic)',
+            meta: saved
+        });
         res.json(Object.assign({ season }, saved));
     } catch (err) {
         res.status(400).json({ message: err.message });

--- a/routes/users.js
+++ b/routes/users.js
@@ -6,6 +6,7 @@ const Team = require('../models/team');
 const Draft = require('../models/draft');
 const scoring = require('../modules/scoring');
 const rosterCorrection = require('../modules/roster-correction');
+const audit = require('../modules/audit-log');
 const { pickLogo } = require('../public/logo.js');
 const { sanitizeProfileUpdate, cloudinaryConfig } = require('../modules/profile-update');
 const { canManageLeague } = require('../modules/league-access');
@@ -316,6 +317,12 @@ router.post('/', async (req, res) => {
 
     try {
         const newUser = await user.save();
+        await audit.record(req, {
+            action: 'user.create',
+            league: newUser.league, season: String(process.env.YEAR),
+            summary: `Added ${newUser.firstName} ${newUser.lastName}`,
+            meta: { userId: String(newUser._id) }
+        });
         res.status(201).json(newUser);
     } catch (err) {
         res.status(400).json({message: err.message});
@@ -414,7 +421,18 @@ router.post('/:id/season-membership', async (req, res) => {
         }
         user.lastUpdated = new Date().toLocaleString("en-US", { timeZone: "America/Chicago" });
         await user.save();
-        res.json({ inSeason: (user.seasons || []).some(s => Number(s.season) === year) });
+        const inSeason = (user.seasons || []).some(s => Number(s.season) === year);
+        // Removing someone drops that year's scores, so this one is worth a trail
+        // even though it's reversible in principle.
+        if (has !== inSeason) {
+            await audit.record(req, {
+                action: 'season.membership',
+                league: user.league, season: String(year),
+                summary: `${inSeason ? 'Added' : 'Removed'} ${user.firstName} ${user.lastName}`,
+                meta: { userId: String(user._id), included: inSeason }
+            });
+        }
+        res.json({ inSeason });
     } catch (err) {
         res.status(400).json({ message: err.message });
     }
@@ -538,6 +556,14 @@ router.patch('/:id/roster-team', async (req, res) => {
 
         console.log(`Roster correction · ${user.league} ${season}: ${user.firstName} ${check.current.school} -> ${targetTeam.school}`
             + (draftUpdated ? ' (draft pick updated)' : ' (no draft pick found)'));
+
+        await audit.record(req, {
+            action: 'roster.correct',
+            league: user.league, season: String(season),
+            summary: `${user.firstName} ${user.lastName}: ${check.current.school} → ${targetTeam.school}`
+                + (draftUpdated ? ' (draft record too)' : ''),
+            meta: { userId: String(user._id), from: check.current.id, to: nextTeam.id, draftUpdated }
+        });
 
         res.json({
             userId: String(user._id), season: String(season),

--- a/server.js
+++ b/server.js
@@ -372,7 +372,7 @@ app.use('/teams', (req, res, next) => {
     if (req.method === 'GET' || (req.method === 'POST' && req.path === '/teamLogos')) return next();
     return requireAdmin(req, res, next);
 });
-app.use(['/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/job-runs'], (req, res, next) => {
+app.use(['/scores', '/records', '/games', '/betting', '/rankings', '/recruiting', '/job-runs', '/audit-log'], (req, res, next) => {
     if (req.method === 'GET') return next();
     return requireAdmin(req, res, next);
 });
@@ -437,6 +437,9 @@ app.post('/dev/spoof/reset', (req, res) => {
 
 const jobRunsRouter = require('./routes/jobRuns');
 app.use('/job-runs', requireAuthOrToken, jobRunsRouter);
+
+const auditLogRouter = require('./routes/auditLog');
+app.use('/audit-log', requireAuthOrToken, auditLogRouter);
 
 const standingsRouter = require('./routes/standings');
 app.use('/standings', requireAuthOrToken, standingsRouter);

--- a/tests/AuditLog.spec.js
+++ b/tests/AuditLog.spec.js
@@ -1,0 +1,219 @@
+// Commissioner audit trail.
+//
+// Scheduled jobs already leave a record; commissioner actions didn't — and
+// several of them quietly rewrite history (a roster correction edits the draft
+// record, a season-membership toggle drops a year's scores). These cover that
+// the trail is written, scoped to who may see it, and — the important part —
+// that a failing audit write can never take the action down with it.
+
+process.env.YEAR = '2026';
+process.env.INTERNAL_API_TOKEN = 'test-internal-token';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const AuditLog = require('../models/auditLog');
+const User = require('../models/user');
+const Team = require('../models/team');
+const League = require('../models/league');
+const audit = require('../modules/audit-log');
+const usersRouter = require('../routes/users');
+const leaguesRouter = require('../routes/leagues');
+const auditRouter = require('../routes/auditLog');
+
+// A session-bearing app, so entries record a real actor.
+function appAs(roles, oidcUser) {
+    const a = express();
+    a.use(express.json());
+    if (roles) {
+        a.use((req, res, next) => {
+            req.oidc = {
+                isAuthenticated: () => true,
+                user: Object.assign({ name: 'Dana Commish', email: 'dana@example.com', user_metadata: { roles } }, oidcUser || {})
+            };
+            next();
+        });
+    }
+    a.use('/users', usersRouter);
+    a.use('/leagues', leaguesRouter);
+    a.use('/audit-log', auditRouter);
+    return a;
+}
+const adminApp = appAs(['Admin']);
+const tokenApp = appAs(null);           // no session — server-to-server
+
+useMongo();
+
+const LEAGUE = 'graham-league';
+const SEASON = 2026;
+const TOKEN = { 'X-Internal-Token': 'test-internal-token' };
+
+function fullTeam(id, school) {
+    return {
+        id, school, mascot: 'M', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'Big Ten', color: '#000', logos: [`${school}.png`],
+        location: { venue_id: id, name: 'V', city: 'C', state: 'ST', zip: '1', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+const manager = (first, teams) => User.create({
+    firstName: first, lastName: 'Test', league: LEAGUE, seasons: [{ season: SEASON, teams }]
+});
+
+beforeEach(() => { jest.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { jest.restoreAllMocks(); });
+
+describe('actorFrom', () => {
+    test('reads the session identity', () => {
+        const req = { oidc: { isAuthenticated: () => true, user: { name: 'Dana', email: 'd@x.com', user_metadata: { roles: ['League Manager'] } } } };
+        expect(audit.actorFrom(req)).toEqual({ actorName: 'Dana', actorEmail: 'd@x.com', actorRole: 'League Manager' });
+    });
+    test('a server-to-server call records as system', () => {
+        expect(audit.actorFrom({}).actorName).toBe('system');
+        expect(audit.actorFrom(null).actorRole).toBe('system');
+    });
+    test('falls back to the email when there is no name', () => {
+        const req = { oidc: { isAuthenticated: () => true, user: { email: 'd@x.com', user_metadata: {} } } };
+        expect(audit.actorFrom(req).actorName).toBe('d@x.com');
+    });
+});
+
+describe('record', () => {
+    test('writes an entry', async () => {
+        await audit.record({}, { action: 'roster.correct', league: LEAGUE, season: '2026', summary: 'A → B' });
+        const rows = await AuditLog.find().lean();
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ action: 'roster.correct', summary: 'A → B', actorName: 'system' });
+        expect(rows[0].createdAt).toBeInstanceOf(Date);
+    });
+
+    test('ignores an entry with no action or summary', async () => {
+        expect(await audit.record({}, { action: 'x' })).toBeNull();
+        expect(await audit.record({}, { summary: 'y' })).toBeNull();
+        expect(await audit.record({}, null)).toBeNull();
+        expect(await AuditLog.countDocuments()).toBe(0);
+    });
+
+    // The whole point of best-effort: logging must never break the thing it logs.
+    test('a write failure resolves null instead of throwing', async () => {
+        jest.spyOn(AuditLog, 'create').mockRejectedValueOnce(new Error('mongo down'));
+        await expect(audit.record({}, { action: 'a.b', summary: 's' })).resolves.toBeNull();
+    });
+});
+
+describe('labelFor', () => {
+    test('known actions get a short label', () => {
+        expect(audit.labelFor('roster.correct')).toBe('Roster');
+        expect(audit.labelFor('scoring.engagement')).toBe('Game modes');
+    });
+    test('an unknown action still renders as its key rather than vanishing', () => {
+        expect(audit.labelFor('something.new')).toBe('something.new');
+    });
+});
+
+describe('entries are written by the actions themselves', () => {
+    test('a roster correction records both sides of the swap', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(9, 'Oregon')]);
+        const u = await manager('Ann', [fullTeam(1, 'Iowa')]);
+        const res = await request(adminApp).patch(`/users/${u._id}/roster-team`)
+            .set(TOKEN).send({ fromTeamId: 1, toTeamId: 9 });
+        expect(res.status).toBe(200);
+
+        const rows = await AuditLog.find({ action: 'roster.correct' }).lean();
+        expect(rows).toHaveLength(1);
+        expect(rows[0].summary).toBe('Ann Test: Iowa → Oregon');
+        expect(rows[0]).toMatchObject({ league: LEAGUE, season: '2026', actorName: 'Dana Commish', actorRole: 'Admin' });
+        expect(rows[0].meta).toMatchObject({ from: 1, to: 9 });
+    });
+
+    test('adding and removing a season member both record', async () => {
+        const u = await manager('Ann', []);
+        await request(adminApp).post(`/users/${u._id}/season-membership`).set(TOKEN).send({ included: false });
+        await request(adminApp).post(`/users/${u._id}/season-membership`).set(TOKEN).send({ included: true });
+        const rows = await AuditLog.find({ action: 'season.membership' }).sort({ createdAt: 1 }).lean();
+        expect(rows.map(r => r.summary)).toEqual(['Removed Ann Test', 'Added Ann Test']);
+    });
+
+    // A no-op toggle shouldn't clutter the trail.
+    test('a membership call that changes nothing records nothing', async () => {
+        const u = await manager('Ann', []);
+        await request(adminApp).post(`/users/${u._id}/season-membership`).set(TOKEN).send({ included: true });
+        expect(await AuditLog.countDocuments({ action: 'season.membership' })).toBe(0);
+    });
+
+    test('creating a manager records', async () => {
+        await request(adminApp).post('/users').set(TOKEN)
+            .send({ firstName: 'Bo', lastName: 'Nix', league: LEAGUE });
+        const rows = await AuditLog.find({ action: 'user.create' }).lean();
+        expect(rows[0].summary).toBe('Added Bo Nix');
+    });
+
+    test('renaming the league records the new name', async () => {
+        await League.create({ code: LEAGUE, name: 'Old' });
+        await request(adminApp).patch(`/leagues/${LEAGUE}`).set(TOKEN).send({ name: 'CFB Sickos' });
+        const rows = await AuditLog.find({ action: 'league.rename' }).lean();
+        expect(rows[0].summary).toBe('League renamed to "CFB Sickos"');
+    });
+
+    // Best-effort in practice: the action must still succeed and still persist.
+    test('the action succeeds even when the audit write fails', async () => {
+        await Team.create([fullTeam(1, 'Iowa'), fullTeam(9, 'Oregon')]);
+        const u = await manager('Ann', [fullTeam(1, 'Iowa')]);
+        jest.spyOn(AuditLog, 'create').mockRejectedValueOnce(new Error('mongo down'));
+
+        const res = await request(adminApp).patch(`/users/${u._id}/roster-team`)
+            .set(TOKEN).send({ fromTeamId: 1, toTeamId: 9 });
+        expect(res.status).toBe(200);
+        expect((await User.findById(u._id).lean()).seasons[0].teams[0].school).toBe('Oregon');
+        expect(await AuditLog.countDocuments()).toBe(0);
+    });
+});
+
+describe('GET /audit-log', () => {
+    const seed = () => AuditLog.create([
+        { action: 'roster.correct', league: 'graham-league', summary: 'G one', createdAt: new Date('2026-08-01') },
+        { action: 'scoring.config', league: 'claunts-league', summary: 'C one', createdAt: new Date('2026-08-02') },
+        { action: 'draft.reset', league: 'graham-league', summary: 'G two', createdAt: new Date('2026-08-03') }
+    ]);
+
+    test('newest first, with a display label per row', async () => {
+        await seed();
+        const res = await request(adminApp).get('/audit-log').set(TOKEN);
+        expect(res.status).toBe(200);
+        expect(res.body.entries.map(e => e.summary)).toEqual(['G two', 'C one', 'G one']);
+        expect(res.body.entries[0].label).toBe('Draft');
+        expect(res.body.entries[0].at).toBeTruthy();
+    });
+
+    test('an Admin sees every league', async () => {
+        await seed();
+        const res = await request(adminApp).get('/audit-log').set(TOKEN);
+        expect(res.body.scope).toHaveLength(2);
+        expect(res.body.entries).toHaveLength(3);
+    });
+
+    test('a League Manager sees only their own league', async () => {
+        await seed();
+        const lmApp = appAs(['League Manager'], { user_metadata: { roles: ['League Manager'], metadata: { league: 'gg' } } });
+        const res = await request(lmApp).get('/audit-log');
+        expect(res.body.scope).toEqual(['graham-league']);
+        expect(res.body.entries.map(e => e.summary)).toEqual(['G two', 'G one']);
+    });
+
+    test('someone who manages nothing sees nothing', async () => {
+        await seed();
+        const res = await request(appAs([])).get('/audit-log');
+        expect(res.body).toEqual({ entries: [], scope: [] });
+    });
+
+    test('limit is honored and capped', async () => {
+        await seed();
+        expect((await request(adminApp).get('/audit-log?limit=2').set(TOKEN)).body.entries).toHaveLength(2);
+        expect((await request(adminApp).get('/audit-log?limit=9999').set(TOKEN)).body.entries).toHaveLength(3);
+    });
+
+    test('an empty trail is an empty list, not an error', async () => {
+        const res = await request(adminApp).get('/audit-log').set(TOKEN);
+        expect(res.status).toBe(200);
+        expect(res.body.entries).toEqual([]);
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -293,7 +293,7 @@
     <% } %>
 
     <section class="admin-group">
-        <div class="group-head"><h2>League setup</h2><span class="group-count">7</span></div>
+        <div class="group-head"><h2>League setup</h2><span class="group-count">8</span></div>
         <div class="admin-functions">
             <div class="function-container">
                 <div class="button-container">
@@ -466,6 +466,18 @@
                 <div class="sub-container" roster-correction-container style="display: none">
                     <p class="function-description">Fix a team that ended up on the wrong roster &mdash; a misclick on draft night, or a pick made for someone who wasn't there. The replacement must be a team nobody in the league has. This also corrects the <strong>draft record</strong>, so the draft board and draft grades match the roster.</p>
                     <div roster-correction-body class="roster-correction"></div>
+                </div>
+            </div>
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayAuditLogContainer()">
+                        <i class="fa-solid fa-clock-rotate-left" style="padding-right: 5px;"></i>
+                        Activity
+                    </button>
+                </div>
+                <div class="sub-container" audit-log-container style="display: none">
+                    <p class="function-description">Recent commissioner changes &mdash; roster corrections, season roster edits, scoring and game-mode changes, draft settings. Scheduled jobs are logged separately in the status strip above.</p>
+                    <div audit-log-body class="audit-log"></div>
                 </div>
             </div>
         </div>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -468,7 +468,7 @@
                     <div roster-correction-body class="roster-correction"></div>
                 </div>
             </div>
-            <div class="function-container">
+            <div class="function-container is-wide">
                 <div class="button-container">
                     <button onclick="displayAuditLogContainer()">
                         <i class="fa-solid fa-clock-rotate-left" style="padding-right: 5px;"></i>


### PR DESCRIPTION
## Why

Scheduled jobs already leave a record (`models/jobRun.js`). Commissioner actions did not — and several of them quietly rewrite history:

- a **roster correction** edits the draft record
- a **season-membership** toggle drops a year's scores
- a **scoring config** change alters how every past game counts

The only evidence was the changed data itself.

## What records

Eight actions, each capturing who / when / what:

`roster.correct` · `season.membership` · `user.create` · `scoring.config` · `scoring.engagement` · `draft.config` · `draft.reset` · `league.rename`

- **`models/auditLog.js`** — append-only entries. Nothing in the app updates or deletes one.
- **`modules/audit-log.js`** — actor resolution, the write, row shaping. The action→label vocabulary lives here so the client stays a dumb renderer, and an unrecognised action renders as its key rather than vanishing.
- **`routes/auditLog.js`** — `GET /audit-log`, newest first, **scoped to the leagues the caller may manage**: an Admin sees both, a League Manager only their own. Read-only; entries are written by the handlers that make the change.

Two deliberate choices:

**Recording is best-effort and never throws** — same discipline as `job-logger`. An audit write failing must not fail the action it describes. A test asserts exactly that: with `AuditLog.create` stubbed to reject, the roster correction still returns 200 and still persists.

**The actor is the real session identity, not the dev role-spoof.** A spoof changes what an Admin can *see*; the log should still say who they actually are. A server-to-server call records as `system`.

## UI — kept small, as asked

"Activity" sits in League setup, collapsed like every other tool, so it costs **one button row** until someone opens it. Rows are deliberately dense — time · kind · league · summary · actor on a single line — so 25 entries read as a log rather than a stack of cards:

```
4m ago    ROSTER        GG   Cole Walker: Notre Dame → Oregon (draft record too)   Garrett Graham
3h ago    DRAFT         GG   Draft settings saved — Aug 15, 7:00 PM, snake, 10 rounds, 6 managers
1d ago    GAME MODES    GG   Game modes: H2H +3/+1 tie · Captain ×2
3d ago    SEASON ROSTER CL   Removed Michael Berry                                 Dana Commish
```

On mobile the actor drops under the summary rather than squeezing it.

## Verification — including what I could *not* check

**Verified live:** `GET /audit-log` returns correctly against the running app — empty trail, both leagues in scope for a server-to-server caller.

**Covered by tests, not live:** the write path. Recording a throwaway entry would have polluted the very log being built, so I left production data alone.

**Not verified:** the panel's rendered appearance. The browser session expired partway through, and signing in isn't something I'll do on the owner's behalf. The markup and CSS follow the readiness-panel pattern verified in #276, and behavior is covered — but **the visuals want an eyeball before merge**.

## Tests — 487 green

Actor resolution (session / system / name fallback), the best-effort contract, label lookup for known *and* unknown actions, an entry written by each of four real actions through their real routes, a no-op membership toggle recording nothing, and the read endpoint's ordering, scoping, limit cap and empty state. New coverage floor on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
