### PR TITLE
Add test coverage for the Standings page and its insights module

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,10 +1,17 @@
 {
     "testRegex": "((\\.|/*.)(spec))\\.js?$",
     "testTimeout": 20000,
+    "transform": {
+        "public[\\\\/].+\\.js$": "<rootDir>/tests/helpers/esm-transform.js",
+        "\\.[jt]sx?$": "babel-jest"
+    },
     "collectCoverageFrom": [
         "modules/**/*.js",
         "routes/**/*.js",
-        "*-job.js"
+        "*-job.js",
+        "public/standings-insights.js",
+        "public/standings.js",
+        "public/weekByWeek.js"
     ],
     "coveragePathIgnorePatterns": [
         "/node_modules/",
@@ -68,6 +75,24 @@
         "./modules/hall-of-fame.js": {
             "statements": 95,
             "branches": 85,
+            "functions": 100,
+            "lines": 100
+        },
+        "./public/standings-insights.js": {
+            "statements": 95,
+            "branches": 95,
+            "functions": 100,
+            "lines": 100
+        },
+        "./public/standings.js": {
+            "statements": 95,
+            "branches": 80,
+            "functions": 95,
+            "lines": 98
+        },
+        "./public/weekByWeek.js": {
+            "statements": 90,
+            "branches": 75,
             "functions": 100,
             "lines": 100
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "dotenv": "^16.5.0",
         "jest": "^29.7.0",
+        "jest-environment-jsdom": "^30.4.1",
         "mongodb-memory-server": "^11.2.0",
         "nodemon": "^3.0.1",
         "socket.io-client": "^4.8.3",
@@ -46,14 +47,37 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -248,10 +272,11 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -273,21 +298,6 @@
       "dependencies": {
         "@babel/template": "^7.25.0",
         "@babel/types": "^7.25.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -557,6 +567,121 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
@@ -673,76 +798,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/console/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/console/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/console/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@jest/console/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@jest/console/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/core": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
@@ -790,76 +845,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@jest/core/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -873,6 +858,230 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+      "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/expect": {
@@ -932,6 +1141,30 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
@@ -973,76 +1206,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@jest/reporters/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1127,76 +1290,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@jest/transform/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -1212,76 +1305,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@jest/types/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/types/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1552,6 +1575,18 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -1579,6 +1614,13 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -1603,10 +1645,11 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1682,15 +1725,18 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -1781,76 +1827,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/babel-jest/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/babel-jest/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/babel-jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-jest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -2291,17 +2267,40 @@
       }
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/char-regex": {
@@ -2419,19 +2418,22 @@
       "dev": true
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2551,76 +2553,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/create-jest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/create-jest/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/create-jest/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/create-jest/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/create-jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/create-jest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cron-parser": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.8.1.tgz",
@@ -2646,6 +2578,61 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2653,6 +2640,13 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2952,6 +2946,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3020,15 +3027,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -3668,6 +3666,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3693,6 +3704,45 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -3917,6 +3967,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4082,70 +4139,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jake/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jake/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jake/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jake/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/jake/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jake/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -4217,76 +4210,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-circus/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-circus/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-cli": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
@@ -4318,76 +4241,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-cli/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-config": {
@@ -4435,76 +4288,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-config/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -4518,76 +4301,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-diff/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-diff/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-docblock": {
@@ -4618,74 +4331,223 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-each/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+      "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@jest/environment": "30.4.1",
+        "@jest/environment-jsdom-abstract": "30.4.1",
+        "jsdom": "^26.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-each/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+    "node_modules/jest-environment-jsdom/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/jest-each/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+    "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.4"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-each/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-each/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -4767,76 +4629,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-matcher-utils/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -4855,76 +4647,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-message-util/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-mock": {
@@ -5000,76 +4722,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-resolve/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-resolve/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-runner": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
@@ -5102,64 +4754,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-runner/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-runner/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-runner/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-runner/node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -5168,18 +4762,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-runtime": {
@@ -5215,76 +4797,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-runtime/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
@@ -5316,76 +4828,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-snapshot/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -5401,76 +4843,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-util/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-util/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-util/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-util/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-validate": {
@@ -5490,21 +4862,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-validate/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -5515,61 +4872,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-validate/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-validate/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-validate/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-watcher": {
@@ -5589,76 +4891,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-watcher/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-worker": {
@@ -5730,7 +4962,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5743,6 +4976,73 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -6486,6 +5786,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6635,6 +5942,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6689,10 +6009,11 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6937,6 +6258,22 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -7040,6 +6377,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -7074,6 +6418,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -7783,6 +7140,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
@@ -7829,6 +7193,26 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -7880,6 +7264,19 @@
       },
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -8017,6 +7414,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -8032,6 +7442,43 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -8078,39 +7525,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8149,6 +7563,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "dotenv": "^16.5.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.4.1",
     "mongodb-memory-server": "^11.2.0",
     "nodemon": "^3.0.1",
     "socket.io-client": "^4.8.3",

--- a/tests/StandingsInsights.spec.js
+++ b/tests/StandingsInsights.spec.js
@@ -1,0 +1,744 @@
+// Coverage for public/standings-insights.js — the pure compute + HTML builders
+// behind the Standings view. The module is an ES module (standings.js imports
+// it as one); tests/helpers/esm-transform.js rewrites it for CommonJS so it can
+// be required here. No DOM: every assertion is on returned data or markup.
+
+// ccLogo is a browser global from logo.js. It's stubbed here (logos come
+// largest-first, so [0] is the pick) — logo selection itself is covered by
+// Logo.spec.js; this suite only cares that the chosen URL lands in the markup.
+global.ccLogo = (logos) => (logos && logos[0]) || '';
+
+const {
+    rankedRows,
+    standingsHeadHtml,
+    buildStandingsRowsHtml,
+    buildHighlights,
+    buildHighlightsHtml,
+    buildChartData
+} = require('../public/standings-insights.js');
+
+// Node test env has no `window`, which is the "page hasn't loaded icons" branch.
+// The icon test opts in by defining one.
+afterEach(() => { delete global.window; });
+
+// --- fixtures ----------------------------------------------------------------
+
+// Weekly entries from a list of scores. A plain number is a regular-season week;
+// an object is merged over the default so a test can mark one postseason or
+// attach scoreByTeam.
+function weeklyScore(list) {
+    return list.map((entry, i) => Object.assign(
+        { week: i + 1, season: 'regular', score: 0 },
+        typeof entry === 'number' ? { score: entry } : entry
+    ));
+}
+
+function user(id, firstName, lastName, scores, extra = {}) {
+    const { franchiseName, teams, ...top } = extra;
+    const weekly = weeklyScore(scores);
+    return Object.assign({ _id: id, firstName, lastName }, top, {
+        seasons: [{
+            franchiseName,
+            teams: teams || [],
+            weeklyScore: weekly,
+            cumulativeScore: weekly.reduce((s, w) => s + (w.score || 0), 0)
+        }]
+    });
+}
+
+const byTitle = (cards) => cards.reduce((acc, c) => Object.assign(acc, { [c.title]: c }), {});
+const titles = (cards) => cards.map(c => c.title);
+
+// --- rankedRows --------------------------------------------------------------
+
+describe('rankedRows', () => {
+    it('sorts by season total and reports rank plus gap to the leader', () => {
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [10, 20]),   // 30
+            user('b', 'Bob', 'Brown', [30, 20]),     // 50
+            user('c', 'Cara', 'Cole', [5, 5])        // 10
+        ]);
+        expect(rows.map(r => r.id)).toEqual(['b', 'a', 'c']);
+        expect(rows.map(r => r.rank)).toEqual([1, 2, 3]);
+        expect(rows.map(r => r.score)).toEqual([50, 30, 10]);
+        expect(rows.map(r => r.gap)).toEqual([0, 20, 40]);
+        expect(rows.every(r => r.preseason === false)).toBe(true);
+    });
+
+    it('reports movement against last week', () => {
+        // Week 1: Bob 50, Alice 10. Week 2 flips it.
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [10, 100]),  // 110
+            user('b', 'Bob', 'Brown', [50, 10])      // 60
+        ]);
+        expect(rows[0].id).toBe('a');
+        expect(rows[0].delta).toBe(1);   // climbed one spot
+        expect(rows[1].delta).toBe(-1);
+    });
+
+    it('reports zero movement when the order held', () => {
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [10, 10]),
+            user('b', 'Bob', 'Brown', [20, 20])
+        ]);
+        expect(rows.map(r => r.delta)).toEqual([0, 0]);
+    });
+
+    it('has no movement to report after a single week', () => {
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [10]),
+            user('b', 'Bob', 'Brown', [20])
+        ]);
+        expect(rows.map(r => r.delta)).toEqual([null, null]);
+    });
+
+    it('renders preseason as a flat tie rather than an arbitrary #1', () => {
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', []),
+            user('b', 'Bob', 'Brown', [])
+        ]);
+        expect(rows.every(r => r.preseason)).toBe(true);
+        expect(rows.every(r => r.score === 0 && r.gap === 0)).toBe(true);
+        expect(rows.every(r => r.delta === null)).toBe(true);
+    });
+
+    it('treats a scored-but-scoreless week as preseason too', () => {
+        const rows = rankedRows([user('a', 'Alice', 'Adams', [0])]);
+        expect(rows[0].preseason).toBe(true);
+    });
+
+    it('returns nothing for an empty league', () => {
+        expect(rankedRows([])).toEqual([]);
+    });
+
+    it('tolerates a manager with no season record at all', () => {
+        const [row] = rankedRows([{ _id: 'z', firstName: 'Zed', lastName: 'Zane' }]);
+        expect(row).toMatchObject({ score: 0, gap: 0, teams: [], preseason: true, delta: null });
+    });
+
+    it('carries the identity fields the row markup needs', () => {
+        const [row] = rankedRows([user('a', 'Alice', 'Adams', [10], {
+            franchiseName: 'Team Rocket',
+            avatarUrl: 'https://img/a.png',
+            color: '#123456',
+            teams: [{ id: 1, school: 'Indiana' }]
+        })]);
+        expect(row).toMatchObject({
+            id: 'a',
+            name: 'Alice A.',
+            franchise: 'Team Rocket',
+            avatarUrl: 'https://img/a.png',
+            initials: 'AA',
+            color: '#123456',
+            teams: [{ id: 1, school: 'Indiana' }]
+        });
+    });
+
+    it('falls back to null franchise and an empty roster', () => {
+        const [row] = rankedRows([user('a', 'Alice', 'Adams', [10])]);
+        expect(row.franchise).toBeNull();
+        expect(row.avatarUrl).toBeNull();
+        expect(row.teams).toEqual([]);
+    });
+
+    it('handles a manager with no last name', () => {
+        const [row] = rankedRows([user('a', 'Alice', '', [10])]);
+        expect(row.name).toBe('Alice .');
+        expect(row.initials).toBe('A');
+    });
+
+    it('hashes a stable fallback color when the user has none', () => {
+        const first = rankedRows([user('a', 'Alice', 'Adams', [10])])[0].color;
+        const again = rankedRows([user('a', 'Alice', 'Adams', [10])])[0].color;
+        expect(first).toMatch(/^hsl\(\d{1,3}, 45%, 45%\)$/);
+        expect(again).toBe(first);
+    });
+});
+
+// --- table markup ------------------------------------------------------------
+
+describe('standingsHeadHtml', () => {
+    it('keeps the classic points-only header', () => {
+        const html = standingsHeadHtml(false);
+        expect(html).toContain('>Score<');
+        expect(html).toContain('>Teams<');
+        expect(html).not.toContain('>Record<');
+        expect(html.match(/<th/g)).toHaveLength(4);
+    });
+
+    it('swaps in record + total and a caret column for H2H', () => {
+        const html = standingsHeadHtml(true);
+        expect(html).toContain('>Record<');
+        expect(html).toContain('>Total<');
+        expect(html).toContain('h2h-caret-head');
+        expect(html.match(/<th/g)).toHaveLength(6);
+    });
+});
+
+describe('buildStandingsRowsHtml (classic)', () => {
+    const rows = () => rankedRows([
+        user('a', 'Alice', 'Adams', [50], { teams: [{ id: 1, mascot: 'Hoosiers', logos: ['ind.png'] }] }),
+        user('b', 'Bob', 'Brown', [40]),
+        user('c', 'Cara', 'Cole', [30]),
+        user('d', 'Dan', 'Diaz', [20])
+    ]);
+
+    it('medals the top three and leaves fourth plain', () => {
+        const html = buildStandingsRowsHtml(rows(), {});
+        expect(html).toContain('standings-row medal-1');
+        expect(html).toContain('standings-row medal-2');
+        expect(html).toContain('standings-row medal-3');
+        expect(html.match(/medal-/g)).toHaveLength(3);
+    });
+
+    it('links the name to the manager page and shows the score', () => {
+        const html = buildStandingsRowsHtml(rows(), {});
+        expect(html).toContain('href="/userHome?user=a"');
+        expect(html).toContain('<span class="score-num" data-count="50">50</span>');
+        expect(html).toContain('<span class="std-name">Alice A.</span>');
+    });
+
+    it('prefers the franchise name over the manager name', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { franchiseName: 'Team Rocket' })
+        ]), {});
+        expect(html).toContain('<span class="std-name">Team Rocket</span>');
+        expect(html).not.toContain('Alice A.');
+    });
+
+    it('escapes a franchise name carrying markup', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { franchiseName: '<script>x</script>' })
+        ]), {});
+        expect(html).not.toContain('<script>');
+        expect(html).toContain('&lt;script&gt;x&lt;/script&gt;');
+    });
+
+    it('labels the leader, the gap, and a tie', () => {
+        // Gaps are measured to the leader, so "Tied" only shows for a manager
+        // level with first place.
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [50]),
+            user('b', 'Bob', 'Brown', [50]),
+            user('c', 'Cara', 'Cole', [30])
+        ]), {});
+        expect(html).toContain('<span class="gap leader">Leader</span>');
+        expect(html).toContain('<span class="gap">-20 back</span>');
+        expect(html).toContain('<span class="gap">Tied</span>');
+    });
+
+    it('renders every preseason row as tied with no medals', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', []),
+            user('b', 'Bob', 'Brown', [])
+        ]), {});
+        expect(html).not.toContain('medal-');
+        expect(html.match(/>Tied</g)).toHaveLength(2);
+        expect(html).not.toContain('Leader');
+    });
+
+    it('renders the arrows for rank movement', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10, 100]),
+            user('b', 'Bob', 'Brown', [50, 10])
+        ]), {});
+        expect(html).toContain('<span class="move up" title="Up 1">▲1</span>');
+        expect(html).toContain('<span class="move down" title="Down 1">▼1</span>');
+    });
+
+    it('renders a dash when the rank held and nothing before week two', () => {
+        const held = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [20, 20]),
+            user('b', 'Bob', 'Brown', [10, 10])
+        ]), {});
+        expect(held).toContain('<span class="move flat" title="No change">–</span>');
+
+        const week1 = buildStandingsRowsHtml(rankedRows([user('a', 'Alice', 'Adams', [20])]), {});
+        expect(week1).not.toContain('class="move');
+    });
+
+    it('face-crops a Cloudinary avatar and passes any other URL through', () => {
+        const cloudinary = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { avatarUrl: 'https://res.cloudinary.com/x/image/upload/v1/a.png' })
+        ]), {});
+        expect(cloudinary).toContain('/upload/c_fill,g_face,w_48,h_48,q_auto,f_auto/v1/a.png');
+
+        const plain = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { avatarUrl: 'https://img/a.png' })
+        ]), {});
+        expect(plain).toContain('<img src="https://img/a.png" alt="">');
+    });
+
+    it('falls back to a colored initials avatar', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { color: '#123456' })
+        ]), {});
+        expect(html).toContain('<span class="std-avatar std-avatar-initials" style="background:#123456">AA</span>');
+    });
+
+    it('shows a "?" avatar when the manager has no name to initial', () => {
+        const html = buildStandingsRowsHtml(rankedRows([user('a', '', '', [10])]), {});
+        expect(html).toContain('<span class="std-avatar std-avatar-initials" style="background:hsl(0, 45%, 45%)">?</span>');
+    });
+
+    it('renders the inline logo strip for both team shapes', () => {
+        const classic = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { teams: [{ id: 1, mascot: 'Hoosiers', logos: ['ind.png'] }] })
+        ]), {});
+        expect(classic).toContain('<a href="/team?team=1"><img src="ind.png" alt="Hoosiers"></a>');
+
+        const h2hShape = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { teams: [{ id: 2, school: 'Indiana', logo: 'ind2.png' }] })
+        ]), {});
+        expect(h2hShape).toContain('<a href="/team?team=2"><img src="ind2.png" alt="Indiana"></a>');
+    });
+
+    it('renders an empty logo strip for a team with no logos at all', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { teams: [{ id: 3, school: 'Indiana' }] })
+        ]), {});
+        expect(html).toContain('<img src="" alt="Indiana">');
+    });
+
+    it('still links a team carrying neither logo nor name', () => {
+        const rows = rankedRows([user('a', 'Alice', 'Adams', [10], { teams: [{ id: 9 }] })]);
+        expect(buildStandingsRowsHtml(rows, {}))
+            .toContain('<a href="/team?team=9"><img src="" alt=""></a>');
+        expect(buildStandingsRowsHtml(rows, { h2h: true }))
+            .toContain('<a class="std-team" href="/team?team=9" title=""><img src="" alt=""></a>');
+    });
+
+    it('tolerates a row built without a roster', () => {
+        const bare = {
+            rank: 1, id: 'a', name: 'Alice A.', franchise: null, initials: 'AA',
+            color: '#123456', score: 10, gap: 0, preseason: false, delta: null, base: 10, bonus: 0
+        };
+        expect(buildStandingsRowsHtml([bare], {})).toContain('<div class="team-logos"></div>');
+        expect(buildStandingsRowsHtml([bare], { h2h: true })).toContain('<div class="std-roster-logos"></div>');
+    });
+});
+
+describe('buildStandingsRowsHtml (h2h)', () => {
+    const h2hRows = () => rankedRows([
+        user('a', 'Alice', 'Adams', [50], { teams: [{ id: 1, school: 'Indiana', logo: 'ind.png' }] }),
+        user('b', 'Bob', 'Brown', [30])
+    ]).map((r, i) => Object.assign(r, i === 0
+        ? { record: '3-0', base: 50, bonus: 15 }
+        : { base: 30, bonus: 0 }));
+
+    it('emits a compact row plus a hidden roster row per manager', () => {
+        const html = buildStandingsRowsHtml(h2hRows(), { h2h: true });
+        expect(html.match(/class="standings-row/g)).toHaveLength(2);
+        expect(html.match(/class="std-roster-row" hidden/g)).toHaveLength(2);
+        expect(html).toContain('colspan="6"');
+    });
+
+    it('shows the record, or an em dash when there is none', () => {
+        const html = buildStandingsRowsHtml(h2hRows(), { h2h: true });
+        expect(html).toContain('<td class="rec-cell">3-0</td>');
+        expect(html).toContain('<td class="rec-cell">—</td>');
+    });
+
+    it('breaks the total into base plus bonus', () => {
+        const html = buildStandingsRowsHtml(h2hRows(), { h2h: true });
+        expect(html).toContain('<span class="score-math">50 <span class="bonus">+15</span></span>');
+    });
+
+    it('labels the expand caret with the escaped display name', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [10], { franchiseName: "O'Brien's" })
+        ]), { h2h: true });
+        expect(html).toContain('aria-expanded="false"');
+        expect(html).toContain('aria-label="Show O&#39;Brien&#39;s\'s teams"');
+    });
+
+    it('puts clickable team links in the roster drawer', () => {
+        const html = buildStandingsRowsHtml(h2hRows(), { h2h: true });
+        expect(html).toContain('<a class="std-team" href="/team?team=1" title="Indiana"><img src="ind.png" alt="Indiana"></a>');
+    });
+
+    it('resolves the drawer logo from the classic logos array too', () => {
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [10], { teams: [{ id: 4, mascot: 'Hoosiers', logos: ['ind.png'] }] })
+        ]);
+        const html = buildStandingsRowsHtml(rows, { h2h: true });
+        expect(html).toContain('<a class="std-team" href="/team?team=4" title="Hoosiers"><img src="ind.png" alt="Hoosiers"></a>');
+    });
+
+    it('keeps the medal and score classes so the shared animations carry over', () => {
+        const html = buildStandingsRowsHtml(h2hRows(), { h2h: true });
+        expect(html).toContain('standings-row medal-1');
+        expect(html).toContain('<span class="score-num" data-count="50">50</span>');
+    });
+
+    it('leaves a row outside the top three without a medal', () => {
+        const rows = rankedRows([50, 40, 30, 20].map((score, i) => user(`u${i}`, `M${i}`, 'Xu', [score])));
+        const html = buildStandingsRowsHtml(rows, { h2h: true });
+        expect(html.match(/medal-/g)).toHaveLength(3);
+        expect(html).toContain('<span class="rank-num">4</span>');
+    });
+
+    it('defaults to the classic layout when no opts are passed', () => {
+        expect(buildStandingsRowsHtml(rankedRows([user('a', 'Alice', 'Adams', [10])]))).toContain('team-item');
+        expect(buildStandingsRowsHtml(rankedRows([user('a', 'Alice', 'Adams', [10])]))).not.toContain('std-caret');
+    });
+
+    it('renders nothing for no rows', () => {
+        expect(buildStandingsRowsHtml([], { h2h: true })).toBe('');
+    });
+});
+
+// --- highlights --------------------------------------------------------------
+
+describe('buildHighlights', () => {
+    it('shows nothing before anyone has played', () => {
+        expect(buildHighlights([])).toEqual([]);
+        expect(buildHighlights([user('a', 'Alice', 'Adams', [])])).toEqual([]);
+    });
+
+    it('names the big winner and big loser of the latest week', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [10, 40]),
+            user('b', 'Bob', 'Brown', [50, 5])
+        ]));
+        expect(cards['Big Winner']).toMatchObject({ tag: 'Week 2', name: 'Alice A.', value: '+40', tone: 'good' });
+        expect(cards['Big Loser']).toMatchObject({ tag: 'Week 2', name: 'Bob B.', value: '+5', tone: 'bad' });
+    });
+
+    it('labels a postseason week as Postseason', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [10, { season: 'postseason', score: 40 }])
+        ]));
+        expect(cards['Big Winner'].tag).toBe('Postseason');
+    });
+
+    it('scores hot and cold streaks over the last two weeks', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [100, 1, 1]),   // hot early, cold now
+            user('b', 'Bob', 'Brown', [1, 50, 50])
+        ]));
+        expect(cards['Hot Streak']).toMatchObject({ tag: 'last 2 weeks', name: 'Bob B.', value: '+100' });
+        expect(cards['Cold Streak']).toMatchObject({ tag: 'last 2 weeks', name: 'Alice A.', value: '+2' });
+    });
+
+    it('calls out the biggest riser, with plural spots', () => {
+        const one = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [10, 100]),
+            user('b', 'Bob', 'Brown', [50, 10])
+        ]));
+        expect(one['Biggest Riser']).toMatchObject({ name: 'Alice A.', value: '▲ 1 spot' });
+
+        const two = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [1, 100]),
+            user('b', 'Bob', 'Brown', [50, 10]),
+            user('c', 'Cara', 'Cole', [40, 10])
+        ]));
+        expect(two['Biggest Riser'].value).toBe('▲ 2 spots');
+    });
+
+    it('skips the riser card when nobody climbed', () => {
+        const flat = buildHighlights([
+            user('a', 'Alice', 'Adams', [20, 20]),
+            user('b', 'Bob', 'Brown', [10, 10])
+        ]);
+        expect(titles(flat)).not.toContain('Biggest Riser');
+
+        const week1 = buildHighlights([
+            user('a', 'Alice', 'Adams', [20]),
+            user('b', 'Bob', 'Brown', [10])
+        ]);
+        expect(titles(week1)).not.toContain('Biggest Riser');
+    });
+
+    it('measures the closest race between first and second', () => {
+        const gap = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [30]),
+            user('b', 'Bob', 'Brown', [25]),
+            user('c', 'Cara', 'Cole', [1])
+        ]));
+        expect(gap['Closest Race']).toMatchObject({ name: 'Alice A. over Bob B.', value: '5 pts', tone: 'neutral' });
+
+        const onePoint = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [30]),
+            user('b', 'Bob', 'Brown', [29])
+        ]));
+        expect(onePoint['Closest Race'].value).toBe('1 pt');
+
+        const tied = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [30]),
+            user('b', 'Bob', 'Brown', [30])
+        ]));
+        expect(tied['Closest Race'].value).toBe('Tied!');
+    });
+
+    it('omits the closest race in a one-manager league', () => {
+        expect(titles(buildHighlights([user('a', 'Alice', 'Adams', [30])]))).not.toContain('Closest Race');
+    });
+
+    it('finds the season-high single week from any manager', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [10, 20]),
+            user('b', 'Bob', 'Brown', [77, 5])
+        ]));
+        expect(cards['Season High']).toMatchObject({ tag: 'Week 1', name: 'Bob B.', value: '+77' });
+    });
+
+    it('totals a drafted team across the season for Best Team', () => {
+        const teams = [{ id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] }];
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [
+                { score: 20, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 20 }] },
+                { score: 15, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 15 }] }
+            ], { teams })
+        ]));
+        expect(cards['Best Team'].name).toBe('<img src="ind.png" class="hl-logo">Hoosiers');
+        expect(cards['Best Team'].value).toBe('+35');
+    });
+
+    it('matches a legacy team entry stored without a teamId', () => {
+        const teams = [{ id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] }];
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [
+                { score: 20, scoreByTeam: [{ team: 'Indiana', score: 20 }] }
+            ], { teams })
+        ]));
+        expect(cards['Best Team'].value).toBe('+20');
+    });
+
+    it('totals teams through sparse weekly data', () => {
+        const teams = [
+            { id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] },
+            { id: 2, school: 'Purdue', mascot: 'Boilermakers', logos: ['pur.png'] }
+        ];
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [
+                { score: 20, scoreByTeam: [
+                    { teamId: 1, team: 'Indiana', score: 20 },
+                    { teamId: 2, team: 'Purdue' }        // played, no score recorded
+                ] },
+                { score: 0 }                             // bye week, no scoreByTeam at all
+            ], { teams }),
+            { _id: 'z', firstName: 'Zed', lastName: 'Zane' }   // joined late, no season record
+        ]));
+        expect(cards['Best Team'].name).toContain('Hoosiers');
+        expect(cards['Best Team'].value).toBe('+20');
+    });
+
+    it('skips Best Team when no drafted team has scored', () => {
+        const teams = [{ id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] }];
+        expect(titles(buildHighlights([
+            user('a', 'Alice', 'Adams', [{ score: 5, scoreByTeam: [{ teamId: 9, team: 'Purdue', score: 5 }] }], { teams })
+        ]))).not.toContain('Best Team');
+    });
+
+    it('names the single best team-game outright', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [{ score: 30, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 30 }] }]),
+            user('b', 'Bob', 'Brown', [{ score: 10, scoreByTeam: [{ teamId: 2, team: 'Purdue', score: 10 }] }])
+        ]));
+        expect(cards['Top Single Game']).toMatchObject({ tag: 'one game', value: '+30' });
+        expect(cards['Top Single Game'].name).toBe('Indiana <span class="hl-sub">(Alice A.)</span>');
+    });
+
+    it('still reads as one game when the same team ties its own high', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [
+                { score: 30, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 30 }] },
+                { score: 30, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 30 }] }
+            ])
+        ]));
+        expect(cards['Top Single Game'].tag).toBe('one game');
+        expect(cards['Top Single Game'].name).toContain('Indiana');
+    });
+
+    it('lists every team in a small tie', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [{ score: 30, scoreByTeam: [
+                { teamId: 1, team: 'Indiana', score: 30 },
+                { teamId: 2, team: 'Purdue', score: 30 }
+            ] }])
+        ]));
+        expect(cards['Top Single Game'].tag).toBe('2-way tie');
+        expect(cards['Top Single Game'].name).toBe('Indiana, Purdue');
+    });
+
+    it('truncates a big tie to four teams and hides the rest in a popover', () => {
+        const scoreByTeam = ['Indiana', 'Purdue', 'Ohio State', 'Michigan', 'Iowa', 'Illinois']
+            .map((team, i) => ({ teamId: i + 1, team, score: 30 }));
+        const card = byTitle(buildHighlights([user('a', 'Alice', 'Adams', [{ score: 180, scoreByTeam }])]))['Top Single Game'];
+
+        expect(card.tag).toBe('6-way tie');
+        expect(card.name).toContain('Indiana, Purdue, Ohio State, Michigan');
+        expect(card.name).toContain('<button type="button" class="hl-more" aria-expanded="false">+2</button>');
+        expect(card.name).toContain('All 6 tied teams');
+        expect(card.name).toContain('Iowa, Illinois');   // nothing is hidden for good
+    });
+
+    it('escapes team names in the tie list', () => {
+        const scoreByTeam = [
+            { teamId: 1, team: '<b>Indiana</b>', score: 30 },
+            { teamId: 2, team: 'Purdue', score: 30 }
+        ];
+        const card = byTitle(buildHighlights([user('a', 'Alice', 'Adams', [{ score: 60, scoreByTeam }])]))['Top Single Game'];
+        expect(card.name).not.toContain('<b>');
+        expect(card.name).toContain('&lt;b&gt;Indiana&lt;/b&gt;');
+    });
+
+    it('skips the top-game card when nobody scored', () => {
+        expect(titles(buildHighlights([
+            user('a', 'Alice', 'Adams', [{ score: 0, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 0 }] }])
+        ]))).not.toContain('Top Single Game');
+    });
+
+    it('crowns the steadiest manager as Mr. Reliable', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [10, 15]),   // sd 2.5, avg 12.5
+            user('b', 'Bob', 'Brown', [0, 40])       // sd 20
+        ]));
+        expect(cards['Mr. Reliable']).toMatchObject({
+            name: 'Alice A.',
+            value: '±2.5 pts/wk',
+            sub: 'avg 12.5/wk — smallest swing'
+        });
+    });
+
+    it('waits for a second week before naming Mr. Reliable', () => {
+        expect(titles(buildHighlights([
+            user('a', 'Alice', 'Adams', [10]),
+            user('b', 'Bob', 'Brown', [20])
+        ]))).not.toContain('Mr. Reliable');
+    });
+
+    it('treats a missing weekly score as zero', () => {
+        const cards = byTitle(buildHighlights([
+            user('a', 'Alice', 'Adams', [{ score: null }, { score: 20 }]),
+            user('b', 'Bob', 'Brown', [5, 5])
+        ]));
+        expect(cards['Big Winner'].value).toBe('+20');
+        expect(cards['Season High'].value).toBe('+20');
+        expect(cards['Mr. Reliable'].name).toBe('Bob B.');   // Alice swung 0 → 20
+    });
+
+    it('degrades to unlabelled cards when the first manager has no weeks yet', () => {
+        const cards = byTitle(buildHighlights([
+            user('z', 'Zed', 'Zane', []),
+            user('a', 'Alice', 'Adams', [10, 20])
+        ]));
+        expect(cards['Big Winner']).toMatchObject({ tag: '', name: 'Alice A.', value: '+0' });
+        expect(cards['Season High'].value).toBe('+20');
+    });
+});
+
+describe('buildHighlightsHtml', () => {
+    const card = {
+        icon: 'trophy', title: 'Big Winner', tag: 'Week 2',
+        name: 'Alice A.', value: '+40', tone: 'good'
+    };
+
+    it('renders a card with its title, tag, name and toned value', () => {
+        const html = buildHighlightsHtml([card]);
+        expect(html).toContain('Big Winner');
+        expect(html).toContain('<span class="hl-tag">Week 2</span>');
+        expect(html).toContain('<span class="hl-name">Alice A.</span>');
+        expect(html).toContain('<span class="hl-value good">+40</span>');
+    });
+
+    it('includes the detail line only when the card has one', () => {
+        expect(buildHighlightsHtml([card])).not.toContain('hl-detail');
+        expect(buildHighlightsHtml([Object.assign({}, card, { sub: 'avg 10/wk' })]))
+            .toContain('<span class="hl-detail">avg 10/wk</span>');
+    });
+
+    it('renders an empty tag rather than "undefined"', () => {
+        const html = buildHighlightsHtml([Object.assign({}, card, { tag: undefined })]);
+        expect(html).toContain('<span class="hl-tag"></span>');
+    });
+
+    it('escapes the title and tag', () => {
+        const html = buildHighlightsHtml([Object.assign({}, card, { title: '<b>x</b>', tag: '"y"' })]);
+        expect(html).not.toContain('<b>x</b>');
+        expect(html).toContain('&lt;b&gt;x&lt;/b&gt;');
+        expect(html).toContain('&quot;y&quot;');
+    });
+
+    it('passes name and value through unescaped so cards can carry markup', () => {
+        const html = buildHighlightsHtml([Object.assign({}, card, {
+            name: '<img src="ind.png" class="hl-logo">Hoosiers'
+        })]);
+        expect(html).toContain('<img src="ind.png" class="hl-logo">Hoosiers');
+    });
+
+    it('leaves the icon empty when the page has no icon helper', () => {
+        expect(buildHighlightsHtml([card])).toContain('<span class="hl-icon"></span>');
+
+        global.window = {};   // page loaded, ccIcon not registered
+        expect(buildHighlightsHtml([card])).toContain('<span class="hl-icon"></span>');
+    });
+
+    it('draws the icon through window.ccIcon when the page provides it', () => {
+        global.window = { ccIcon: (name, opts) => `<svg data-icon="${name}" data-size="${opts.size}"></svg>` };
+        expect(buildHighlightsHtml([card])).toContain('<svg data-icon="trophy" data-size="20"></svg>');
+    });
+
+    it('renders nothing for no cards', () => {
+        expect(buildHighlightsHtml([])).toBe('');
+    });
+});
+
+// --- chart data --------------------------------------------------------------
+
+describe('buildChartData', () => {
+    it('labels a Start point plus one entry per week', () => {
+        const data = buildChartData([
+            user('a', 'Alice', 'Adams', [10, 20]),
+            user('b', 'Bob', 'Brown', [50])
+        ]);
+        expect(data.labels).toEqual(['Start', 'Wk 1', 'Wk 2']);
+        expect(data.playerCount).toBe(2);
+    });
+
+    it('accumulates points from zero and holds the last value for missed weeks', () => {
+        const data = buildChartData([
+            user('a', 'Alice', 'Adams', [10, 20], { color: '#aaa' }),   // 30
+            user('b', 'Bob', 'Brown', [50], { color: '#bbb' })          // 50, only one week
+        ]);
+        expect(data.pointsDatasets.map(d => d.label)).toEqual(['Bob B.', 'Alice A.']);
+        expect(data.pointsDatasets[0].data).toEqual([0, 50, 50]);   // held flat through Wk 2
+        expect(data.pointsDatasets[1].data).toEqual([0, 10, 30]);
+    });
+
+    it('carries the per-manager line styling', () => {
+        const [set] = buildChartData([user('a', 'Alice', 'Adams', [10], { color: '#aaa' })]).pointsDatasets;
+        expect(set).toMatchObject({ fill: false, backgroundColor: '#aaa', borderColor: '#aaa', tension: 0.15 });
+    });
+
+    it('tracks rank week by week for the bump chart', () => {
+        const data = buildChartData([
+            user('a', 'Alice', 'Adams', [10, 100]),   // 110 — behind at Wk 1, ahead at Wk 2
+            user('b', 'Bob', 'Brown', [50, 10])       // 60
+        ]);
+        expect(data.rankDatasets.map(d => d.label)).toEqual(['Alice A.', 'Bob B.']);
+        expect(data.rankDatasets[0].data).toEqual([1, 2, 1]);
+        expect(data.rankDatasets[1].data).toEqual([2, 1, 2]);
+    });
+
+    it('treats a missing weekly score as zero in the series', () => {
+        const data = buildChartData([user('a', 'Alice', 'Adams', [{ score: null }, { score: 20 }])]);
+        expect(data.pointsDatasets[0].data).toEqual([0, 0, 20]);
+    });
+
+    it('keeps a manager with no weeks flat at zero', () => {
+        const data = buildChartData([
+            user('a', 'Alice', 'Adams', [10, 20]),
+            user('b', 'Bob', 'Brown', [])
+        ]);
+        expect(data.pointsDatasets[1].data).toEqual([0, 0, 0]);
+        expect(data.rankDatasets[1].data).toEqual([2, 2, 2]);
+    });
+
+    it('handles an empty league', () => {
+        expect(buildChartData([])).toEqual({
+            labels: ['Start'], pointsDatasets: [], rankDatasets: [], playerCount: 0
+        });
+    });
+});

--- a/tests/StandingsPage.spec.js
+++ b/tests/StandingsPage.spec.js
@@ -1,0 +1,1317 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Coverage for public/standings.js — the Standings page controller.
+ *
+ * The module exports nothing and wires itself up on import, so these are
+ * integration tests: tests/helpers/standings-dom.js stands up the page from
+ * views/standings.ejs, stubs the globals the view supplies (jQuery, Chart,
+ * ccIcon/ccH2H/ccLogo, userState), routes fetch, and runs window.onload. Every
+ * assertion is on the resulting DOM or on which endpoints were called.
+ */
+const { loadStandingsPage, resetStandingsPage, makeUser, respond } = require('./helpers/standings-dom');
+
+afterEach(resetStandingsPage);
+
+const scored = (id, first, last, weeks, extra = {}) => makeUser(Object.assign({
+    top: { _id: id, firstName: first, lastName: last, email: `${first}@example.com`.toLowerCase() },
+    weeklyScore: weeks
+}, extra));
+
+// --- bootstrap ---------------------------------------------------------------
+
+describe('empty league', () => {
+    it('shows the "no data" message and hides every populated section', async () => {
+        const page = await loadStandingsPage({ users: [] });
+
+        expect(page.q('.no-data-message').getAttribute('style')).toBeNull();
+        expect(page.q('.get-users-container').getAttribute('style')).toBe('display: none;');
+        expect(page.highlightsHeader().getAttribute('style')).toBe('display: none;');
+        expect(page.highlights().getAttribute('style')).toBe('display: none;');
+        expect(page.q('[poll-name]').getAttribute('style')).toBe('display: none;');
+        expect(page.q('.dropdownWeek').getAttribute('style')).toBe('display: none;');
+        expect(page.q('.game-content').getAttribute('style')).toBe('display: none;');
+        page.q('.hr-subtle');
+        document.querySelectorAll('.hr-subtle').forEach(hr => {
+            expect(hr.getAttribute('style')).toBe('display: none;');
+        });
+    });
+
+    it('never reaches the standings render', async () => {
+        const page = await loadStandingsPage({ users: [] });
+        expect(page.tableBody().innerHTML).toBe('');
+        expect(page.urls().some(u => u.includes('/standings/projections/'))).toBe(false);
+    });
+});
+
+describe('league + week bootstrap', () => {
+    it('defaults the schedule to the latest scored week', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20, 30])]
+        });
+        expect(window.localStorage.getItem('weekCode')).toBe('week-3');
+        expect(page.jquery.store['#dropdownMenuButtonWeek'].text).toBe('Week 3');
+    });
+
+    it('leaves a manually picked week alone', async () => {
+        await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20, 30])],
+            localStorage: { week: 'Week 2', weekCode: 'week-2' }
+        });
+        expect(window.localStorage.getItem('weekCode')).toBe('week-2');
+    });
+
+    it('ignores the postseason bucket when picking the latest week', async () => {
+        await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, { week: 2, score: 5 }, { season: 'postseason', week: 1, score: 40 }])]
+        });
+        expect(window.localStorage.getItem('weekCode')).toBe('week-2');
+    });
+
+    it('maps the league metadata onto a league code', async () => {
+        const page = await loadStandingsPage({
+            profile: { email: 'a@example.com', user_metadata: { metadata: { league: 'gg' } } }
+        });
+        expect(window.localStorage.getItem('leagueCode')).toBe('graham-league');
+        expect(page.urls().some(u => u.includes('/users/league/graham-league'))).toBe(true);
+    });
+
+    it('maps any other league to the Claunts code', async () => {
+        await loadStandingsPage({
+            profile: { email: 'a@example.com', user_metadata: { metadata: { league: 'cl' } } }
+        });
+        expect(window.localStorage.getItem('leagueCode')).toBe('claunts-league');
+    });
+
+    it('lets an admin override the league from storage', async () => {
+        const page = await loadStandingsPage({
+            userState: { user_metadata: { roles: ['Manager', 'Admin'], metadata: { league: 'gg', userId: 'a' } } },
+            localStorage: { leagueCode: 'claunts-league', week: 'Week 1', weekCode: 'week-1' }
+        });
+        expect(page.urls().some(u => u.includes('/users/league/claunts-league'))).toBe(true);
+        expect(page.jquery.store['#dropdownMenuButton']).toBeUndefined();   // no stored league label
+    });
+
+    it('shows the admin league label when one was picked this session', async () => {
+        window.sessionStorage.setItem('league', 'Claunts League');
+        const page = await loadStandingsPage({
+            userState: { user_metadata: { roles: ['Admin'], metadata: { league: 'gg', userId: 'a' } } },
+            localStorage: { leagueCode: 'claunts-league' }
+        });
+        expect(page.jquery.store['#dropdownMenuButton'].text).toBe('Claunts League');
+    });
+});
+
+// --- classic standings table -------------------------------------------------
+
+describe('classic standings table', () => {
+    const league = () => [
+        scored('a', 'Alice', 'Adams', [10, 20]),
+        scored('b', 'Bob', 'Brown', [40, 5])
+    ];
+
+    it('paints ranked rows and the points-only header', async () => {
+        const page = await loadStandingsPage({ users: league() });
+        expect(page.tableHead().innerHTML).toContain('>Score<');
+        expect(page.tableHead().innerHTML).not.toContain('>Record<');
+        expect(page.tableBody().querySelectorAll('tr.standings-row')).toHaveLength(2);
+        expect(page.tableBody().innerHTML.indexOf('Bob B.')).toBeLessThan(page.tableBody().innerHTML.indexOf('Alice A.'));
+    });
+
+    it('marks the table as points-only', async () => {
+        const page = await loadStandingsPage({ users: league() });
+        const table = page.tableBody().closest('table');
+        expect(table.classList.contains('mode-plain')).toBe(true);
+        expect(table.classList.contains('mode-h2h')).toBe(false);
+    });
+
+    it('hides the Teams column while no rosters exist', async () => {
+        const page = await loadStandingsPage({ users: league() });
+        expect(page.tableBody().closest('table').classList.contains('std-no-teams')).toBe(true);
+    });
+
+    it('keeps the Teams column once managers have drafted', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10], { teams: [{ id: 1, school: 'Indiana', logos: ['ind.png'] }] })]
+        });
+        expect(page.tableBody().closest('table').classList.contains('std-no-teams')).toBe(false);
+    });
+
+    it('leaves the ranking note empty and hidden', async () => {
+        const page = await loadStandingsPage({ users: league() });
+        expect(page.rankNote().hidden).toBe(true);
+        expect(page.rankNote().textContent).toBe('');
+    });
+});
+
+// --- head-to-head ------------------------------------------------------------
+
+const H2H_PAYLOAD = {
+    enabled: true,
+    managers: [
+        { userId: 'a', rank: 1, name: 'Alice A.', franchise: 'Rockets', initials: 'AA', color: '#111', adjustedTotal: 65.5, h2hBonus: 15, record: '2-0', teams: [{ id: 1, school: 'Indiana', logo: 'ind.png' }] },
+        { userId: 'b', rank: 2, name: 'Bob B.', initials: 'BB', color: '#222', adjustedTotal: 45.25, h2hBonus: 0, record: '0-2', teams: [] }
+    ]
+};
+
+describe('head-to-head standings', () => {
+    const users = () => [
+        scored('a', 'Alice', 'Adams', [10, 40]),
+        scored('b', 'Bob', 'Brown', [40, 5])
+    ];
+
+    it('renders the H2H table when the league has opted in', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        expect(page.tableHead().innerHTML).toContain('>Record<');
+        expect(page.tableHead().innerHTML).toContain('>Total<');
+        expect(page.tableBody().innerHTML).toContain('Rockets');
+        expect(page.tableBody().innerHTML).toContain('2-0');
+        expect(page.tableBody().closest('table').classList.contains('mode-h2h')).toBe(true);
+    });
+
+    it('explains the ranking above the table', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        expect(page.rankNote().hidden).toBe(false);
+        expect(page.rankNote().textContent).toBe('Ranked by total points + H2H bonuses');
+    });
+
+    it('splits the total into banked base and win bonus', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        // 65.5 total - 15 bonus = 50.5 base
+        expect(page.tableBody().innerHTML).toContain('50.5 <span class="bonus">+15</span>');
+    });
+
+    it('measures the gap against the adjusted leader', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        expect(page.tableBody().innerHTML).toContain('-20.3 back');
+    });
+
+    it('carries points-based movement over from the classic ranking', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        // Week 1: Bob 40, Alice 10. Week 2 flips it — Alice climbs one.
+        expect(page.tableBody().innerHTML).toContain('title="Up 1"');
+        expect(page.tableBody().innerHTML).toContain('title="Down 1"');
+    });
+
+    it('treats a scoreless H2H league as a flat tie', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [])],
+            h2hEnabled: true,
+            h2hStandings: { enabled: true, managers: [{ userId: 'a', rank: 1, name: 'Alice A.', initials: 'AA', adjustedTotal: 0, h2hBonus: 0, teams: [] }] }
+        });
+        expect(page.tableBody().innerHTML).not.toContain('medal-1');
+        expect(page.tableBody().innerHTML).toContain('Tied');
+    });
+
+    it('hides the unrelated legacy head-to-head schedule', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        expect(page.q('[poll-name]').closest('.header').style.display).toBe('none');
+        expect(page.q('.dropdownWeek').style.display).toBe('none');
+        expect(page.q('.game-content').style.display).toBe('none');
+        expect(document.querySelectorAll('.hr-subtle')[1].style.display).toBe('none');
+    });
+
+    it('renders in preview mode via ?h2h=1 even when disabled', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: false, search: '?h2h=1',
+            h2hStandings: Object.assign({}, H2H_PAYLOAD, { enabled: false })
+        });
+        expect(page.tableHead().innerHTML).toContain('>Record<');
+    });
+
+    it('passes a simulation key through to the API', async () => {
+        const page = await loadStandingsPage({
+            users: users(), search: '?h2hSim=wk3', h2hStandings: H2H_PAYLOAD
+        });
+        expect(page.urls().some(u => u.includes('h2hSim=wk3'))).toBe(true);
+    });
+
+    it('falls back to the classic table when the H2H fetch fails', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true,
+            routes: [[/standingsOnly=1/, () => { throw new Error('network'); }]]
+        });
+        expect(page.tableHead().innerHTML).toContain('>Score<');
+        expect(page.tableBody().innerHTML).toContain('Alice A.');
+    });
+
+    it('falls back to the classic table when the payload has no managers', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: { enabled: true, managers: [] }
+        });
+        expect(page.tableHead().innerHTML).toContain('>Score<');
+    });
+
+    it('falls back to classic when the enabled check times out', async () => {
+        const page = await loadStandingsPage({
+            users: users(),
+            routes: [[/\/enabled/, () => { throw new Error('abort'); }]]
+        });
+        expect(page.tableHead().innerHTML).toContain('>Score<');
+    });
+
+    it('shows a loading skeleton before the H2H payload lands', async () => {
+        const page = await loadStandingsPage({
+            users: users(), h2hEnabled: true, h2hStandings: H2H_PAYLOAD, autoLoad: false
+        });
+        const done = page.onload();
+        await new Promise(r => setTimeout(r, 0));
+        // The skeleton is painted synchronously once the H2H path is chosen.
+        const sawSkeleton = page.tableBody().innerHTML.includes('std-skel-row');
+        await done;
+        await page.flush();
+        expect(sawSkeleton || page.tableBody().innerHTML.includes('Rockets')).toBe(true);
+    });
+});
+
+describe('head-to-head matchups panel', () => {
+    const matchups = {
+        enabled: true,
+        winBonus: 5,
+        tieBonus: 2,
+        featuredWeek: 2,
+        managers: H2H_PAYLOAD.managers,
+        schedule: [
+            { week: 1, games: [{ id: 'g1' }] },
+            { week: 2, games: [{ id: 'g2' }, { id: 'g3' }] },
+            { week: 3, games: [] }
+        ]
+    };
+    const opts = () => ({
+        users: [scored('a', 'Alice', 'Adams', [10, 40]), scored('b', 'Bob', 'Brown', [40, 5])],
+        h2hEnabled: true, h2hStandings: H2H_PAYLOAD, h2hMatchups: matchups
+    });
+
+    it('renders the featured week with a card per game', async () => {
+        const page = await loadStandingsPage(opts());
+        expect(page.h2hPanel().hidden).toBe(false);
+        expect(page.h2hPanel().querySelectorAll('.h2h-card')).toHaveLength(2);
+        expect(page.h2hPanel().innerHTML).toContain("This Week's Matchups");
+    });
+
+    it('describes the win and tie bonuses', async () => {
+        const page = await loadStandingsPage(opts());
+        expect(page.h2hPanel().innerHTML).toContain('<b>+5</b>');
+        expect(page.h2hPanel().innerHTML).toContain('<b>+2</b> each on a tie');
+    });
+
+    it('omits the tie clause when there is no tie bonus', async () => {
+        const page = await loadStandingsPage(Object.assign(opts(), {
+            h2hMatchups: Object.assign({}, matchups, { tieBonus: 0 })
+        }));
+        expect(page.h2hPanel().innerHTML).not.toContain('each on a tie');
+    });
+
+    it('preselects the featured week in the picker', async () => {
+        const page = await loadStandingsPage(opts());
+        expect(page.h2hPanel().querySelector('[h2h-week]').value).toBe('2');
+    });
+
+    it('repaints when a different week is chosen', async () => {
+        const page = await loadStandingsPage(opts());
+        const select = page.h2hPanel().querySelector('[h2h-week]');
+        select.value = '1';
+        select.dispatchEvent(new window.Event('change'));
+        expect(page.h2hPanel().querySelectorAll('.h2h-card')).toHaveLength(1);
+    });
+
+    it('says so when a week has no matchups', async () => {
+        const page = await loadStandingsPage(opts());
+        const select = page.h2hPanel().querySelector('[h2h-week]');
+        select.value = '3';
+        select.dispatchEvent(new window.Event('change'));
+        expect(page.h2hPanel().innerHTML).toContain('No matchups this week.');
+    });
+
+    it('tags an unopted-in league as a preview', async () => {
+        const page = await loadStandingsPage(Object.assign(opts(), {
+            h2hEnabled: false, search: '?h2h=1',
+            h2hStandings: Object.assign({}, H2H_PAYLOAD, { enabled: false }),
+            h2hMatchups: Object.assign({}, matchups, { enabled: false })
+        }));
+        expect(page.h2hPanel().innerHTML).toContain('h2h-preview-tag');
+    });
+
+    it('leaves the panel hidden when the schedule is empty', async () => {
+        const page = await loadStandingsPage(Object.assign(opts(), {
+            h2hMatchups: { enabled: true, managers: [], schedule: [] }
+        }));
+        expect(page.h2hPanel().hidden).toBe(true);
+    });
+});
+
+// --- roster drawer + score animation ----------------------------------------
+
+describe('roster drawer', () => {
+    const open = async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 40]), scored('b', 'Bob', 'Brown', [40, 5])],
+            h2hEnabled: true, h2hStandings: H2H_PAYLOAD
+        });
+        return page;
+    };
+
+    it('expands the roster row when the caret is clicked', async () => {
+        const page = await open();
+        const caret = page.tableBody().querySelector('.std-caret');
+        const drawer = caret.closest('tr').nextElementSibling;
+
+        expect(drawer.hasAttribute('hidden')).toBe(true);
+        caret.click();
+        expect(drawer.hasAttribute('hidden')).toBe(false);
+        expect(caret.getAttribute('aria-expanded')).toBe('true');
+        expect(caret.classList.contains('open')).toBe(true);
+    });
+
+    it('collapses again on a second click', async () => {
+        const page = await open();
+        const caret = page.tableBody().querySelector('.std-caret');
+        const drawer = caret.closest('tr').nextElementSibling;
+        caret.click();
+        caret.click();
+        expect(drawer.hasAttribute('hidden')).toBe(true);
+        expect(caret.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('wires each caret only once', async () => {
+        const page = await open();
+        page.tableBody().querySelectorAll('.std-caret').forEach(btn => {
+            expect(btn.dataset.wired).toBe('1');
+        });
+    });
+});
+
+describe('score count-up', () => {
+    it('leaves the final score in place under reduced motion', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20])], reducedMotion: true
+        });
+        expect(page.tableBody().querySelector('.score-num').textContent).toBe('30');
+    });
+
+    it('animates from zero up to the score otherwise', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20])], reducedMotion: false
+        });
+        const el = page.tableBody().querySelector('.score-num');
+        expect(Number(el.textContent)).toBeLessThan(30);   // still counting up
+        await new Promise(r => setTimeout(r, 800));
+        expect(el.textContent).toBe('30');
+    });
+
+    it('skips the animation for a scoreless row', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [0])], reducedMotion: false
+        });
+        expect(page.tableBody().querySelector('.score-num').textContent).toBe('0');
+    });
+});
+
+// --- last updated badge ------------------------------------------------------
+
+describe('last updated badge', () => {
+    it('prefers the last successful scoring run', async () => {
+        const finishedAt = new Date(Date.now() - 2 * 3600 * 1000).toISOString();
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            lastUpdated: { finishedAt, week: 4 }
+        });
+        expect(page.lastUpdated().hidden).toBe(false);
+        expect(page.lastUpdated().innerHTML).toContain('Updated <b>2h ago</b>');
+        expect(page.lastUpdated().innerHTML).toContain('Last successful scoring update');
+        expect(page.lastUpdated().innerHTML).toContain('week 4');
+    });
+
+    it('falls back to startedAt when a run never finished', async () => {
+        const startedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], lastUpdated: { startedAt }
+        });
+        expect(page.lastUpdated().innerHTML).toContain('5m ago');
+        expect(page.lastUpdated().innerHTML).not.toContain('week');
+    });
+
+    it('falls back to the legacy per-user stamp with no run history', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10], { top: { _id: 'a', firstName: 'Alice', lastName: 'Adams', lastUpdated: new Date(Date.now() - 86400 * 1000).toISOString() } })],
+            lastUpdated: undefined
+        });
+        expect(page.lastUpdated().innerHTML).toContain('1d ago');
+        expect(page.lastUpdated().innerHTML).toContain('Last updated —');
+    });
+
+    it('hides the badge when nothing has ever been recorded', async () => {
+        const page = await loadStandingsPage({
+            users: [makeUser({ top: { _id: 'a', firstName: 'Alice', lastName: 'Adams', lastUpdated: undefined }, weeklyScore: [10] })]
+        });
+        expect(page.lastUpdated().hidden).toBe(true);
+    });
+
+    it('reads a very recent run as "just now"', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            lastUpdated: { finishedAt: new Date().toISOString() }
+        });
+        expect(page.lastUpdated().innerHTML).toContain('just now');
+    });
+
+    it.each([
+        ['3 weeks ago as "3w ago"', 21 * 86400, '3w ago'],
+        ['2 months ago as "2mo ago"', 70 * 86400, '2mo ago'],
+        ['a year ago as "1y ago"', 400 * 86400, '1y ago']
+    ])('formats %s', async (_label, seconds, expected) => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            lastUpdated: { finishedAt: new Date(Date.now() - seconds * 1000).toISOString() }
+        });
+        expect(page.lastUpdated().innerHTML).toContain(expected);
+    });
+
+    it('puts an absolute 12-hour stamp in the tooltip', async () => {
+        const when = new Date(2025, 8, 23, 0, 5);   // 12:05 AM, Sep 23
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            lastUpdated: { finishedAt: when.toISOString() }
+        });
+        expect(page.lastUpdated().innerHTML).toContain('9/23 at 12:05 AM');
+    });
+
+    it('renders an afternoon stamp as PM', async () => {
+        const when = new Date(2025, 8, 23, 15, 30);
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            lastUpdated: { finishedAt: when.toISOString() }
+        });
+        expect(page.lastUpdated().innerHTML).toContain('9/23 at 3:30 PM');
+    });
+
+    it('survives the endpoint erroring', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            routes: [['/standings/last-updated', () => { throw new Error('boom'); }]]
+        });
+        expect(page.lastUpdated().innerHTML).toContain('Last updated —');
+    });
+});
+
+// --- highlights --------------------------------------------------------------
+
+describe('highlights panel', () => {
+    it('renders the cards once the season has real scoring', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20]), scored('b', 'Bob', 'Brown', [40, 5])]
+        });
+        expect(page.highlights().innerHTML).toContain('Big Winner');
+        expect(page.highlightsHeader().style.display).toBe('');
+    });
+
+    it('hides the whole section while every week is still zero', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [0, 0]), scored('b', 'Bob', 'Brown', [0, 0])]
+        });
+        expect(page.highlightsHeader().style.display).toBe('none');
+        expect(page.highlights().style.display).toBe('none');
+        expect(document.querySelectorAll('.hr-subtle')[0].style.display).toBe('none');
+    });
+
+    it('hides the section in the preseason', async () => {
+        const page = await loadStandingsPage({ users: [scored('a', 'Alice', 'Adams', [])] });
+        expect(page.highlightsHeader().style.display).toBe('none');
+    });
+
+    it('appends the server-computed advanced cards', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20])],
+            advancedCards: [{ icon: 'medal', title: 'Overachiever', tag: 'season', name: 'Hoosiers', value: '+5 wins', tone: 'good' }]
+        });
+        expect(page.highlights().innerHTML).toContain('Big Winner');
+        expect(page.highlights().innerHTML).toContain('Overachiever');
+    });
+
+    it('skips the advanced fetch entirely before real scoring', async () => {
+        const page = await loadStandingsPage({ users: [scored('a', 'Alice', 'Adams', [0])] });
+        expect(page.urls().some(u => u.includes('/standings/highlights/'))).toBe(false);
+    });
+
+    it('ignores an advanced-highlights failure', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20])],
+            routes: [[/\/standings\/highlights\//, () => { throw new Error('boom'); }]]
+        });
+        expect(page.highlights().innerHTML).toContain('Big Winner');
+    });
+
+    it('ignores a non-OK advanced-highlights response', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20])],
+            routes: [[/\/standings\/highlights\//, respond(500, {})]]
+        });
+        expect(page.highlights().innerHTML).not.toContain('Overachiever');
+    });
+});
+
+describe('tie popover', () => {
+    // Five teams tied for the top single game gives buildHighlights a "+N" button.
+    const tied = () => [scored('a', 'Alice', 'Adams', [{
+        score: 150,
+        scoreByTeam: ['Indiana', 'Purdue', 'Ohio State', 'Michigan', 'Iowa'].map((team, i) => ({ teamId: i + 1, team, score: 30 }))
+    }])];
+
+    it('opens and closes on the "+N" button', async () => {
+        const page = await loadStandingsPage({ users: tied() });
+        const btn = page.highlights().querySelector('.hl-more');
+        const pop = btn.nextElementSibling;
+
+        expect(pop.hidden).toBe(true);
+        btn.click();
+        expect(pop.hidden).toBe(false);
+        expect(btn.getAttribute('aria-expanded')).toBe('true');
+        btn.click();
+        expect(pop.hidden).toBe(true);
+    });
+
+    it('closes on Escape', async () => {
+        const page = await loadStandingsPage({ users: tied() });
+        const btn = page.highlights().querySelector('.hl-more');
+        btn.click();
+        document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(btn.nextElementSibling.hidden).toBe(true);
+        expect(btn.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('closes on an outside click', async () => {
+        const page = await loadStandingsPage({ users: tied() });
+        const btn = page.highlights().querySelector('.hl-more');
+        btn.click();
+        document.body.click();
+        expect(btn.nextElementSibling.hidden).toBe(true);
+    });
+});
+
+// --- projections -------------------------------------------------------------
+
+describe('projected finish panel', () => {
+    const managers = [
+        { userId: 'a', name: 'Alice A.', franchise: 'Rockets', initials: 'AA', color: '#111', avatarUrl: 'https://res.cloudinary.com/x/image/upload/v1/a.png', banked: 50, projectedFinal: 120, titleOdds: 64 },
+        { userId: 'b', name: 'Bob B.', initials: 'BB', banked: 40, projectedFinal: 100, titleOdds: 150 }
+    ];
+
+    it('renders a row per manager', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], projections: { managers }
+        });
+        expect(page.projPanel().hidden).toBe(false);
+        expect(page.projPanel().querySelectorAll('.pp-row')).toHaveLength(2);
+        expect(page.projPanel().innerHTML).toContain('Projected Finish');
+    });
+
+    it('shows banked points projecting to a final total', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], projections: { managers }
+        });
+        expect(page.projPanel().innerHTML).toContain('<span class="pp-cur">50</span>');
+        expect(page.projPanel().innerHTML).toContain('<span class="pp-proj">120</span>');
+    });
+
+    it('shows the franchise name over the manager name', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], projections: { managers }
+        });
+        expect(page.projPanel().innerHTML).toContain('<span class="pp-name">Rockets</span>');
+        expect(page.projPanel().innerHTML).toContain('<span class="pp-sub">Alice A.</span>');
+    });
+
+    it('face-crops a Cloudinary avatar and falls back to initials', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], projections: { managers }
+        });
+        expect(page.projPanel().innerHTML).toContain('/upload/c_fill,g_face,w_48,h_48,q_auto,f_auto/v1/a.png');
+        expect(page.projPanel().innerHTML).toContain('pp-avatar-initials" style="background:#333">BB');
+    });
+
+    it('passes a non-Cloudinary avatar through untouched', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            projections: { managers: [Object.assign({}, managers[0], { avatarUrl: 'https://img/a.png' })] }
+        });
+        expect(page.projPanel().innerHTML).toContain('<img src="https://img/a.png" alt="">');
+    });
+
+    it('clamps the title-odds bar at 100%', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], projections: { managers }
+        });
+        expect(page.projPanel().innerHTML).toContain('width:100%');
+        expect(page.projPanel().innerHTML).toContain('width:64%');
+    });
+
+    it('stays hidden when the season has no games left to project', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])], projections: { managers: [] }
+        });
+        expect(page.projPanel().hidden).toBe(true);
+    });
+
+    it('stays hidden when the endpoint fails', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            routes: [[/\/standings\/projections\//, () => { throw new Error('boom'); }]]
+        });
+        expect(page.projPanel().hidden).toBe(true);
+    });
+});
+
+// --- chart -------------------------------------------------------------------
+
+describe('points chart', () => {
+    it('draws once the season has scoring', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20]), scored('b', 'Bob', 'Brown', [40, 5])]
+        });
+        expect(page.chartContainer().getAttribute('style')).toBeNull();
+        expect(page.charts).toHaveLength(1);
+        expect(page.charts[0].config.data.labels).toEqual(['Start', 'Wk 1', 'Wk 2']);
+    });
+
+    it('stays hidden while every seeded week is zero', async () => {
+        const page = await loadStandingsPage({ users: [scored('a', 'Alice', 'Adams', [0, 0])] });
+        expect(page.chartContainer().getAttribute('style')).toBe('display: none;');
+        expect(page.charts).toHaveLength(0);
+    });
+
+    it('redraws in rank mode when the toggle is used', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 20]), scored('b', 'Bob', 'Brown', [40, 5])]
+        });
+        page.q('[chart-mode-toggle] button[data-mode="rank"]').click();
+        expect(page.charts).toHaveLength(2);
+        expect(page.charts[1].config.options.scales.y.reverse).toBe(true);
+        expect(page.charts[1].config.options.scales.y.title.text).toBe('Rank');
+    });
+});
+
+// --- weekly win celebration --------------------------------------------------
+
+describe('weekly win celebration', () => {
+    const winner = () => [
+        scored('me', 'Alice', 'Adams', [10, 40]),
+        scored('b', 'Bob', 'Brown', [40, 5])
+    ];
+    const asMe = { user_metadata: { roles: ['Manager'], metadata: { league: 'gg', userId: 'me' } } };
+
+    beforeEach(() => { global.startConfetti = jest.fn(); global.stopConfetti = jest.fn(); });
+    afterEach(() => { delete global.startConfetti; delete global.stopConfetti; });
+
+    it('celebrates when you post the top score of the week', async () => {
+        const page = await loadStandingsPage({ users: winner(), userState: asMe, reducedMotion: false });
+        expect(page.q('.highlights-container .sub-highlight-container:first-child .hl-icon').classList.contains('celebrate')).toBe(true);
+        expect(global.startConfetti).toHaveBeenCalled();
+    });
+
+    it('only fires once per week', async () => {
+        await loadStandingsPage({ users: winner(), userState: asMe, reducedMotion: false });
+        expect(window.localStorage.getItem('weekWin-2025-2')).toBe('1');
+        global.startConfetti.mockClear();
+
+        const again = await loadStandingsPage({
+            users: winner(), userState: asMe, reducedMotion: false,
+            localStorage: { 'weekWin-2025-2': '1' }
+        });
+        expect(again.q('.highlights-container .sub-highlight-container:first-child .hl-icon').classList.contains('celebrate')).toBe(false);
+        expect(global.startConfetti).not.toHaveBeenCalled();
+    });
+
+    it('stays quiet when someone else won the week', async () => {
+        const page = await loadStandingsPage({
+            users: winner(),
+            userState: { user_metadata: { roles: ['Manager'], metadata: { league: 'gg', userId: 'b' } } },
+            reducedMotion: false
+        });
+        expect(page.q('.hl-icon').classList.contains('celebrate')).toBe(false);
+        expect(global.startConfetti).not.toHaveBeenCalled();
+    });
+
+    it('respects reduced motion', async () => {
+        const page = await loadStandingsPage({ users: winner(), userState: asMe, reducedMotion: true });
+        expect(page.q('.hl-icon').classList.contains('celebrate')).toBe(false);
+        expect(global.startConfetti).not.toHaveBeenCalled();
+    });
+
+    it('stays quiet when nobody scored', async () => {
+        await loadStandingsPage({
+            users: [scored('me', 'Alice', 'Adams', [0, 0])], userState: asMe, reducedMotion: false
+        });
+        expect(global.startConfetti).not.toHaveBeenCalled();
+    });
+});
+
+// --- profile setup nudge -----------------------------------------------------
+
+describe('profile setup nudge', () => {
+    const unprompted = () => [makeUser({
+        top: { _id: 'me', firstName: 'Alice', lastName: 'Adams' },
+        weeklyScore: [10], profilePrompted: false
+    })];
+    const asMe = { user_metadata: { roles: ['Manager'], metadata: { league: 'gg', userId: 'me' } } };
+
+    it('invites a manager who has never been prompted', async () => {
+        const page = await loadStandingsPage({ users: unprompted(), userState: asMe });
+        expect(page.welcomeModal().hidden).toBe(false);
+    });
+
+    it('stays closed for a manager already prompted', async () => {
+        const page = await loadStandingsPage({
+            users: [makeUser({ top: { _id: 'me', firstName: 'Alice', lastName: 'Adams' }, weeklyScore: [10] })],
+            userState: asMe
+        });
+        expect(page.welcomeModal().hidden).toBe(true);
+    });
+
+    it('records the prompt when dismissed with "maybe later"', async () => {
+        const page = await loadStandingsPage({ users: unprompted(), userState: asMe });
+        page.q('[welcome-later]').click();
+        await page.flush(5);
+
+        expect(page.welcomeModal().hidden).toBe(true);
+        const patch = page.fetchMock.calls.find(c => c.url === '/users/me/profile');
+        expect(patch.init.method).toBe('PATCH');
+        expect(JSON.parse(patch.init.body)).toEqual({ prompted: true });
+    });
+
+    it('records the prompt when the manager opts to set up', async () => {
+        const page = await loadStandingsPage({ users: unprompted(), userState: asMe });
+        page.q('[welcome-setup]').click();
+        await page.flush(5);
+
+        expect(page.welcomeModal().hidden).toBe(true);
+        expect(page.fetchMock.calls.some(c => c.url === '/users/me/profile')).toBe(true);
+    });
+
+    it('stays closed when the logged-in manager is not in this league', async () => {
+        const page = await loadStandingsPage({
+            users: unprompted(),
+            userState: { user_metadata: { roles: ['Manager'], metadata: { league: 'gg', userId: 'someone-else' } } }
+        });
+        expect(page.welcomeModal().hidden).toBe(true);
+    });
+});
+
+// --- legacy id backfill ------------------------------------------------------
+
+describe('legacy user id backfill', () => {
+    it('derives the id from the email when Auth0 has none', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            profile: { email: 'Alice@Example.com', user_metadata: { metadata: { league: 'gg' } } },
+            userState: { user_metadata: { roles: ['Manager'], metadata: { league: 'gg' } } }
+        });
+        expect(window.localStorage.getItem('userId')).toBe('a');
+        expect(page.q('[user-home]').getAttribute('href')).toBe('/userHome?user=a');
+    });
+
+    it('leaves things alone when Auth0 already has the id', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            userState: { user_metadata: { roles: ['Manager'], metadata: { league: 'gg', userId: 'u1' } } }
+        });
+        expect(window.localStorage.getItem('userId')).toBeNull();
+        expect(page.q('[user-home]').getAttribute('href')).toBe('/userHome?user=stale');
+    });
+
+    it('does nothing when no manager matches the email', async () => {
+        await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            profile: { email: 'nobody@example.com', user_metadata: { metadata: { league: 'gg' } } },
+            userState: { user_metadata: { roles: ['Manager'], metadata: { league: 'gg' } } }
+        });
+        expect(window.localStorage.getItem('userId')).toBeNull();
+    });
+});
+
+// --- score breakdown popover -------------------------------------------------
+
+describe('score breakdown', () => {
+    const withBadge = async (explain) => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10])],
+            localStorage: { leagueCode: 'graham-league' },
+            routes: explain ? [[/\/scoring-config\//, explain]] : []
+        });
+        // Same nesting displaySchedule produces: the game table lives in a cell
+        // of the schedule body, and the handler walks up to `table.game-table`.
+        page.scheduleBody().innerHTML = `<tr><td>
+            <table class="game-table"><tbody><tr><td>
+                <button type="button" class="score-explain" data-team="1" data-game="99" data-pts="7">+7</button>
+            </td></tr></tbody></table>
+        </td></tr>`;
+        return page;
+    };
+
+    it('reveals which rules earned the points', async () => {
+        const page = await withBadge({ matched: [{ points: 4, label: 'Win vs ranked' }, { points: 3, label: 'Road win' }], total: 7 });
+        page.q('.score-explain').click();
+        await page.flush(5);
+
+        const box = page.q('.gc-breakdown');
+        expect(box.innerHTML).toContain('Win vs ranked');
+        expect(box.innerHTML).toContain('Road win');
+        expect(page.q('.score-explain').classList.contains('is-open')).toBe(true);
+    });
+
+    it('flags a total that no longer matches what was banked', async () => {
+        const page = await withBadge({ matched: [{ points: 9, label: 'Win vs ranked' }], total: 9 });
+        page.q('.score-explain').click();
+        await page.flush(5);
+        expect(page.q('.gc-breakdown').innerHTML).toContain('differs from the banked +7');
+    });
+
+    it('collapses on a second tap', async () => {
+        const page = await withBadge({ matched: [{ points: 7, label: 'Win' }], total: 7 });
+        page.q('.score-explain').click();
+        await page.flush(5);
+        page.q('.score-explain').click();
+
+        expect(page.q('.gc-breakdown-row')).toBeNull();
+        expect(page.q('.score-explain').classList.contains('is-open')).toBe(false);
+    });
+
+    it('says so when the breakdown is unavailable', async () => {
+        const page = await withBadge({ matched: [] });
+        page.q('.score-explain').click();
+        await page.flush(5);
+        expect(page.q('.gc-breakdown').textContent).toBe('Breakdown unavailable.');
+    });
+
+    it('survives the endpoint erroring', async () => {
+        const page = await withBadge(() => { throw new Error('boom'); });
+        page.q('.score-explain').click();
+        await page.flush(5);
+        expect(page.q('.gc-breakdown').textContent).toBe('Breakdown unavailable.');
+    });
+
+    it('ignores clicks that are not on a badge', async () => {
+        const page = await withBadge({ matched: [], total: 0 });
+        page.scheduleBody().click();
+        await page.flush(2);
+        expect(page.q('.gc-breakdown-row')).toBeNull();
+    });
+});
+
+// --- schedule ----------------------------------------------------------------
+
+describe('schedule', () => {
+    const TEAMS = [{ id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] }];
+    const OPPONENT = [{ id: 2, school: 'Purdue', mascot: 'Boilermakers', logos: ['pur.png'] }];
+
+    const league = () => [
+        scored('a', 'Alice', 'Adams', [10], { teams: TEAMS }),
+        scored('b', 'Bob', 'Brown', [7], { teams: OPPONENT })
+    ];
+
+    const game = (over = {}) => Object.assign({
+        id: 'g1', awayId: 1, homeId: 2, awayTeam: 'Indiana', homeTeam: 'Purdue',
+        awayPoints: 28, homePoints: 21, completed: true, seasonType: 'regular',
+        startDate: '2025-09-06T16:00:00Z', notes: '', outlet: 'ESPN'
+    }, over);
+
+    it('renders a card for a game between two managers', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [game()],
+            teamLogos: [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }],
+            rankings: [{ week: 1, season: 2025, polls: [{ poll: 'AP Top 25', ranks: [{ school: 'Indiana', rank: 3 }] }] }]
+        });
+        const html = page.scheduleBody().innerHTML;
+        expect(html).toContain('game-table');
+        expect(html).toContain('Indiana');
+        expect(html).toContain('Purdue');
+        expect(html).toContain('Alice');
+        expect(html).toContain('Bob');
+    });
+
+    it('shows the rank and broadcast outlet', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [game()],
+            teamLogos: [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }],
+            rankings: [{ week: 1, season: 2025, polls: [{ poll: 'AP Top 25', ranks: [{ school: 'Indiana', rank: 3 }] }] }]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('>3</p>');
+        expect(page.scheduleBody().innerHTML).toContain('ESPN');
+    });
+
+    it('awards a points badge to the manager whose team won', async () => {
+        const users = league();
+        users[0].seasons[0].weeklyScore = [{
+            week: 1, season: 'regular', score: 10,
+            scoreByTeam: [{ teamId: 1, gameId: 'g1', team: 'Indiana', score: 10 }]
+        }];
+        const page = await loadStandingsPage({
+            users, games: [game()],
+            teamLogos: [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('class="score-explain"');
+        expect(page.scheduleBody().innerHTML).toContain('+10');
+    });
+
+    it('shows kickoff time for a game that has not been played', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [game({ completed: false })],
+            teamLogos: [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }]
+        });
+        expect(page.scheduleBody().innerHTML).toMatch(/\d{1,2}:\d{2}(AM|PM)/);
+    });
+
+    it('falls back to a helmet icon for a team with no stored logo', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [game()], teamLogos: []
+        });
+        expect(page.scheduleBody().innerHTML).toContain('fa-helmet-un');
+    });
+
+    it('shows a no-games message when nothing is scheduled', async () => {
+        const page = await loadStandingsPage({ users: league(), games: [] });
+        expect(page.q('#no-games-container').innerHTML).toContain('no-matchups-message');
+        expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(0);
+    });
+
+    it('hides the loader and reveals the table when done', async () => {
+        const page = await loadStandingsPage({ users: league(), games: [] });
+        expect(page.q('.football-loader').style.display).toBe('none');
+        expect(page.q('.schedule-table').style.display).toBe('flex');
+    });
+
+    it('switches to the postseason for week 17', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [],
+            localStorage: { week: 'Postseason', weekCode: 'week-17' }
+        });
+        expect(page.urls().some(u => u.includes('/games/seasonType/postseason/week/1/'))).toBe(true);
+    });
+
+    it('repaints when a different week is picked', async () => {
+        const page = await loadStandingsPage({ users: league(), games: [] });
+        page.jquery.store['#dropdownMenuButtonWeek'] = { text: 'Week 5', val: 'week-5' };
+        page.jquery.fire('.dropdown-menu-week a');
+        await page.flush(10);
+
+        expect(window.localStorage.getItem('week')).toBe('Week 5');
+        expect(window.localStorage.getItem('weekCode')).toBe('week-5');
+    });
+});
+
+describe('rankings selection', () => {
+    const league = () => [scored('a', 'Alice', 'Adams', [10], { teams: [{ id: 1, school: 'Indiana', logos: ['ind.png'] }] })];
+
+    it('prefers the playoff committee poll when it exists', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [],
+            rankings: [{ week: 1, season: 2025, polls: [
+                { poll: 'Playoff Committee Rankings', ranks: [{ school: 'Indiana', rank: 1 }] },
+                { poll: 'AP Top 25', ranks: [{ school: 'Indiana', rank: 9 }] }
+            ] }]
+        });
+        expect(page.urls().some(u => u.includes('/rankings/2025'))).toBe(true);
+    });
+
+    it('degrades to an empty ranking list when the week has none', async () => {
+        const page = await loadStandingsPage({ users: league(), games: [], rankings: [] });
+        expect(page.q('.football-loader').style.display).toBe('none');   // rendered without throwing
+    });
+});
+
+// --- schedule: game-card branch matrix --------------------------------------
+//
+// displaySchedule builds each card twice — once when a game is first seen, and
+// again when the second manager in the matchup reaches it — with separate
+// home/away paths in both passes. These drive the permutations.
+
+describe('schedule game cards', () => {
+    const INDIANA = { id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] };
+    const PURDUE = { id: 2, school: 'Purdue', mascot: 'Boilermakers', logos: ['pur.png'] };
+    const LOGOS = [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }];
+
+    // Bob owns the HOME team and is listed first, so the game is first seen from
+    // the home side and re-seen from the away side.
+    const homeFirst = () => [
+        makeUser({ top: { _id: 'b', firstName: 'Bob', lastName: 'Brown' }, teams: [PURDUE], weeklyScore: [{ week: 1, score: 7, scoreByTeam: [{ teamId: 2, gameId: 'g1', team: 'Purdue', score: 7 }] }] }),
+        makeUser({ top: { _id: 'a', firstName: 'Alice', lastName: 'Adams' }, teams: [INDIANA], weeklyScore: [{ week: 1, score: 10, scoreByTeam: [{ teamId: 1, gameId: 'g1', team: 'Indiana', score: 10 }] }] })
+    ];
+
+    const game = (over = {}) => Object.assign({
+        id: 'g1', awayId: 1, homeId: 2, awayTeam: 'Indiana', homeTeam: 'Purdue',
+        awayPoints: 28, homePoints: 21, completed: true, seasonType: 'regular',
+        startDate: '2025-09-06T16:00:00Z', notes: ''
+    }, over);
+
+    it('builds the card from the home side and re-resolves it from the away side', async () => {
+        const page = await loadStandingsPage({ users: homeFirst(), games: [game()], teamLogos: LOGOS });
+        const html = page.scheduleBody().innerHTML;
+        expect(html).toContain('Indiana');
+        expect(html).toContain('Purdue');
+        expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(1);
+    });
+
+    it('marks the winner when the home team wins', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ awayPoints: 14, homePoints: 31 })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('fa-caret-left');
+        expect(page.scheduleBody().innerHTML).toContain('+7');   // Bob's Purdue badge
+    });
+
+    it('renders a tie without a winner caret', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ awayPoints: 21, homePoints: 21 })]
+        });
+        expect(page.scheduleBody().innerHTML).not.toContain('fa-caret-left');
+    });
+
+    // Characterization test, not an endorsement. Both lookups run against the
+    // manager currently being iterated, but a team's points live only in its
+    // OWNER's weeklyScore — so the opponent always resolves to 0 and the card
+    // carries a badge for one side only.
+    it('scores each side of a playoff game independently', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ seasonType: 'postseason', notes: 'CFP Playoff Semifinal', awayPoints: 17, homePoints: 31 })]
+        });
+        const html = page.scheduleBody().innerHTML;
+        expect(html).toContain('CFP Playoff Semifinal');
+        expect(html).toContain('+7');    // Bob's Purdue — the card is built from his record
+        expect(html).not.toContain('+10');   // Alice's Indiana points are invisible here
+    });
+
+    it('flips the caret to the home row when the home team wins a playoff game', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ seasonType: 'postseason', notes: 'Playoff Final', awayPoints: 10, homePoints: 40 })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('fa-caret-left');
+    });
+
+    it('renders a dash when a completed game has no score recorded', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ awayPoints: null, homePoints: null })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('-');
+    });
+
+    it.each([
+        ['morning', 9, '9:00AM'],
+        ['noon', 12, '12:00PM'],
+        ['afternoon', 15, '3:00PM']
+    ])('formats a %s kickoff as %s', async (_label, hour, expected) => {
+        const local = new Date(2025, 8, 6, hour, 0);
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ completed: false, startDate: local.toISOString() })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain(expected);
+    });
+
+    it('skips a game whose kickoff time is still TBD on the second pass', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ startTimeTbd: true })]
+        });
+        expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(1);
+    });
+
+    it('shows the betting spread against the favoured team', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ completed: false })],
+            bettingLines: [{ homeTeam: 'Purdue', awayTeam: 'Indiana', lines: [{ provider: 'DraftKings', formattedSpread: 'Indiana -7.5' }] }]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('betting-line">-7.5');
+    });
+
+    it('falls back to the first provider when DraftKings has no line', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ completed: false })],
+            bettingLines: [{ homeTeam: 'Purdue', awayTeam: 'Indiana', lines: [{ provider: 'Bovada', formattedSpread: 'Purdue -3' }] }]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('betting-line">-3');
+    });
+
+    it('renders no spread when the game has no line', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ completed: false })], bettingLines: []
+        });
+        expect(page.scheduleBody().innerHTML).toContain('betting-line"></span>');
+    });
+
+    it('orders the cards by kickoff and wraps them into rows', async () => {
+        const games = [
+            game({ id: 'g1', startDate: '2025-09-06T23:00:00Z' }),
+            game({ id: 'g2', startDate: '2025-09-06T16:00:00Z' }),
+            game({ id: 'g3', startDate: '2025-09-06T20:00:00Z' }),
+            game({ id: 'g4', startDate: '2025-09-06T12:00:00Z' })
+        ];
+        const page = await loadStandingsPage({ users: homeFirst(), games, teamLogos: LOGOS });
+        expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(4);
+        expect(page.scheduleBody().querySelectorAll('tr').length).toBeGreaterThan(1);
+    });
+
+    it('stacks the cards one per row on mobile', async () => {
+        const page = await loadStandingsPage({
+            users: homeFirst(), teamLogos: LOGOS,
+            games: [game({ id: 'g1' }), game({ id: 'g2' })],
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)'
+        });
+        expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(2);
+    });
+});
+
+// --- upstream failures -------------------------------------------------------
+
+describe('degrading when upstream calls fail', () => {
+    const league = () => [makeUser({
+        top: { _id: 'a', firstName: 'Alice', lastName: 'Adams' },
+        teams: [{ id: 1, school: 'Indiana', logos: ['ind.png'] }], weeklyScore: [10]
+    })];
+
+    it('logs and skips games when the games endpoint errors', async () => {
+        const page = await loadStandingsPage({
+            users: league(),
+            routes: [[/^\/games\/seasonType\//, respond(500, { message: 'nope' })]]
+        });
+        expect(page.q('.football-loader').style.display).toBe('none');
+        expect(page.q('#no-games-container').innerHTML).toContain('no-matchups-message');
+    });
+
+    it('survives the team-logo endpoint erroring', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [],
+            routes: [['/teams/teamLogos/all', respond(500, { message: 'nope' })]]
+        });
+        expect(page.q('.football-loader').style.display).toBe('none');
+    });
+
+    it('renders with no spreads when the betting endpoint errors', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [],
+            routes: [[/^\/betting\//, respond(500, { message: 'nope' })]]
+        });
+        expect(page.q('.football-loader').style.display).toBe('none');
+    });
+
+    it('uses the postseason ranking bucket for week 17', async () => {
+        const page = await loadStandingsPage({
+            users: league(), games: [],
+            localStorage: { week: 'Postseason', weekCode: 'week-17' },
+            rankings: [{ week: 16, season: 2025, polls: [{ poll: 'Playoff Committee Rankings', ranks: [{ school: 'Indiana', rank: 2 }] }] }]
+        });
+        expect(page.urls().some(u => u.includes('/games/seasonType/postseason/'))).toBe(true);
+    });
+});
+
+describe('league selector', () => {
+    it('stores the picked league and reloads', async () => {
+        const page = await loadStandingsPage({
+            users: [makeUser({ top: { _id: 'a', firstName: 'Alice', lastName: 'Adams' }, weeklyScore: [10] })]
+        });
+        await new Promise(r => setTimeout(r, 300));   // the binding is deferred 200ms
+
+        page.jquery.store['#dropdownMenuButton'] = { text: 'Claunts League', val: 'claunts-league' };
+        page.jquery.fire('[league-selector] a');
+
+        expect(window.sessionStorage.getItem('league')).toBe('Claunts League');
+        expect(window.localStorage.getItem('leagueCode')).toBe('claunts-league');
+    });
+});
+
+describe('score breakdown league fallback', () => {
+    it('derives the league from Auth0 when storage has none', async () => {
+        const page = await loadStandingsPage({
+            users: [makeUser({ top: { _id: 'a', firstName: 'Alice', lastName: 'Adams' }, weeklyScore: [10] })],
+            localStorage: { leagueCode: 'undefined' },
+            routes: [[/\/scoring-config\//, { matched: [{ points: 7, label: 'Win' }], total: 7 }]]
+        });
+        page.scheduleBody().innerHTML = `<tr><td>
+            <table class="game-table"><tbody><tr><td>
+                <button type="button" class="score-explain" data-team="1" data-game="99" data-pts="7">+7</button>
+            </td></tr></tbody></table></td></tr>`;
+        page.q('.score-explain').click();
+        await page.flush(5);
+
+        expect(page.fetchMock.calls.some(c => c.url.includes('/scoring-config/graham-league/explain'))).toBe(true);
+    });
+});
+
+// The mirror of the block above: when the AWAY team's manager is listed first,
+// the first-sighting path takes its away branch and the second pass resolves
+// from the home side.
+describe('schedule game cards (away manager first)', () => {
+    const LOGOS = [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }];
+    const awayFirst = () => [
+        makeUser({ top: { _id: 'a', firstName: 'Alice', lastName: 'Adams' }, teams: [{ id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] }], weeklyScore: [{ week: 1, score: 10, scoreByTeam: [{ teamId: 1, gameId: 'g1', team: 'Indiana', score: 10 }] }] }),
+        makeUser({ top: { _id: 'b', firstName: 'Bob', lastName: 'Brown' }, teams: [{ id: 2, school: 'Purdue', mascot: 'Boilermakers', logos: ['pur.png'] }], weeklyScore: [{ week: 1, score: 7, scoreByTeam: [{ teamId: 2, gameId: 'g1', team: 'Purdue', score: 7 }] }] })
+    ];
+    const game = (over = {}) => Object.assign({
+        id: 'g1', awayId: 1, homeId: 2, awayTeam: 'Indiana', homeTeam: 'Purdue',
+        awayPoints: 28, homePoints: 21, completed: true, seasonType: 'regular',
+        startDate: '2025-09-06T16:00:00Z', notes: ''
+    }, over);
+
+    it('badges the away team in a playoff game it won', async () => {
+        const page = await loadStandingsPage({
+            users: awayFirst(), teamLogos: LOGOS,
+            games: [game({ seasonType: 'postseason', notes: 'Playoff Quarterfinal' })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('+10');
+        expect(page.scheduleBody().innerHTML).toContain('Playoff Quarterfinal');
+    });
+
+    // Characterization test, not an endorsement. The first-sighting path has an
+    // explicit tie branch (no winner caret), but the duplicate-game path only
+    // splits on `awayPoints > homePoints`, so a tie falls into the "home won"
+    // else and replaces the correct card with one that carets the home team.
+    // Low stakes in practice — FBS games go to overtime, so a completed regular
+    // game effectively never ties — but the two paths disagree.
+    it('renders a tie as a home win once the home manager re-resolves it', async () => {
+        const page = await loadStandingsPage({
+            users: awayFirst(), teamLogos: LOGOS,
+            games: [game({ awayPoints: 21, homePoints: 21 })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('fa-caret-left');
+        expect(page.scheduleBody().innerHTML).toContain('+7');
+    });
+
+    it('rebuilds the card from the home manager when the home team wins', async () => {
+        const page = await loadStandingsPage({
+            users: awayFirst(), teamLogos: LOGOS,
+            games: [game({ awayPoints: 14, homePoints: 35 })]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('+7');
+        expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(1);
+    });
+
+    it('ranks both teams when both are polled', async () => {
+        const page = await loadStandingsPage({
+            users: awayFirst(), teamLogos: LOGOS, games: [game()],
+            rankings: [
+                { week: 1, season: 2025, polls: [{ poll: 'AP Top 25', ranks: [{ school: 'Indiana', rank: 3 }, { school: 'Purdue', rank: 18 }] }] },
+                { week: 2, season: 2025, polls: [{ poll: 'AP Top 25', ranks: [] }] }
+            ]
+        });
+        expect(page.scheduleBody().innerHTML).toContain('>3</p>');
+        expect(page.scheduleBody().innerHTML).toContain('>18</p>');
+    });
+});

--- a/tests/helpers/esm-transform.js
+++ b/tests/helpers/esm-transform.js
@@ -1,0 +1,49 @@
+// Jest transform for the ES-module bundles under public/.
+//
+// Those files are real ES modules — standings.js and friends are loaded with
+// <script type="module"> and import each other by name — but this suite runs on
+// CommonJS Jest, so `require()` can't read them. This rewrites the `export`
+// keywords into a CommonJS `module.exports` so a spec can require the file
+// directly (see StandingsInsights.spec.js), leaving the source untouched.
+//
+// The rewrite is deliberately dumb because that's all these files need: named
+// imports, and named function/const exports — no default exports, no re-exports,
+// no namespace imports. Anything fancier should fail loudly rather than be
+// half-supported, so it's simply not matched here. The result is handed to
+// babel-jest so coverage instrumentation still runs — a hand-rolled loader would
+// leave the file reported at 0%.
+
+const babelJest = require('babel-jest').default;
+
+const babelTransformer = babelJest.createTransformer({ babelrc: false, configFile: false });
+
+const EXPORTED = /^export\s+(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z0-9_$]+)/gm;
+const EXPORT_KEYWORD = /^export\s+(?=(?:async\s+)?(?:function|class|const|let|var)\s)/gm;
+// import { a, b } from './x.js'  ->  const { a, b } = require('./x.js')
+const NAMED_IMPORT = /^import\s+(\{[^}]*\})\s+from\s+(['"][^'"]+['"]);?/gm;
+// import './x.js'  ->  require('./x.js')
+const BARE_IMPORT = /^import\s+(['"][^'"]+['"]);?/gm;
+
+function toCommonJs(src) {
+    let out = src
+        .replace(NAMED_IMPORT, 'const $1 = require($2);')
+        .replace(BARE_IMPORT, 'require($1);')
+        .replace(EXPORT_KEYWORD, '');
+
+    const names = [];
+    let match;
+    EXPORTED.lastIndex = 0;
+    while ((match = EXPORTED.exec(src)) !== null) names.push(match[1]);
+    if (names.length) out += `\nmodule.exports = { ${names.join(', ')} };\n`;
+    return out;
+}
+
+module.exports = {
+    canInstrument: true,
+    getCacheKey(sourceText, sourcePath, options) {
+        return babelTransformer.getCacheKey(toCommonJs(sourceText), sourcePath, options);
+    },
+    process(sourceText, sourcePath, options) {
+        return babelTransformer.process(toCommonJs(sourceText), sourcePath, options);
+    }
+};

--- a/tests/helpers/standings-dom.js
+++ b/tests/helpers/standings-dom.js
@@ -1,0 +1,309 @@
+// Harness for public/standings.js.
+//
+// That module exports nothing and runs side effects the moment it's imported
+// (delegated click handlers, jQuery bindings, a window.onload assignment), so
+// the only way to exercise it is to stand up the page it expects and load it.
+// This builds that page: the DOM hooks from views/standings.ejs, the globals the
+// view supplies via CDN/partials (jQuery, Chart, ccIcon, ccH2H, ccLogo,
+// userState), and a routing fetch mock for the dozen endpoints it calls.
+//
+// Usage:
+//   const page = await loadStandingsPage({ users: [...] });   // runs window.onload
+//   page.tableBody().innerHTML  →  assert on what rendered
+
+const DEFAULT_SEASON = 2025;
+
+// Mirrors the structural hooks standings.js queries in views/standings.ejs.
+// Element order matters: displayHighlights and hideLegacyH2HSchedule both reach
+// for a `.hr-subtle` via previousElementSibling.
+const FIXTURE = `
+<a user-home href="/userHome?user=stale"></a>
+<div class="welcome-backdrop" welcome-modal hidden>
+    <button type="button" welcome-later>Maybe later</button>
+    <button type="button" welcome-setup>Set up my profile</button>
+</div>
+<div class="header"><p last-updated class="last-updated"></p></div>
+<div class="no-data-message" style="display: none;"></div>
+<div class="get-users-container" get-users-container>
+    <p class="standings-rank-note" standings-rank-note hidden></p>
+    <table class="fl-table">
+        <thead user-table-head></thead>
+        <tbody user-table-body></tbody>
+    </table>
+</div>
+<section class="h2h-panel" id="h2h-panel" hidden></section>
+<section class="proj-panel" id="proj-panel" hidden></section>
+<hr class="hr-subtle">
+<h2 class="highlights-header">League Highlights</h2>
+<div class="highlights-container"></div>
+<hr class="hr-subtle">
+<div class="header"><div class="header-title" poll-name>Head to Head</div></div>
+<div class="dropdown dropdownWeek">
+    <button id="dropdownMenuButtonWeek"></button>
+    <div class="dropdown-menu dropdown-menu-week"><a class="dropdown-item" value="week-1">Week 1</a></div>
+</div>
+<div class="game-content">
+    <div class="football-loader"></div>
+    <div class="get-users-container">
+        <table class="schedule-table"><tbody schedule-body></tbody></table>
+        <div id="no-games-container"></div>
+    </div>
+</div>
+<div class="chart-container" chart-container style="display: none;">
+    <div class="chart-mode-toggle" chart-mode-toggle>
+        <button data-mode="points" class="active"></button>
+        <button data-mode="rank"></button>
+    </div>
+    <canvas id="week-by-week"></canvas>
+</div>`;
+
+// --- fixtures ----------------------------------------------------------------
+
+// A league manager in the shape /users/league/:code returns.
+function makeUser(over = {}) {
+    const weekly = (over.weeklyScore || []).map((w, i) => Object.assign(
+        { week: i + 1, season: 'regular', score: 0 },
+        typeof w === 'number' ? { score: w } : w
+    ));
+    return Object.assign({
+        _id: 'u1',
+        firstName: 'Alice',
+        lastName: 'Adams',
+        email: 'alice@example.com',
+        color: '#3355ff',
+        lastUpdated: '2025-09-01T12:00:00Z'
+    }, over.top || {}, {
+        avatarUrl: over.avatarUrl,
+        profilePrompted: over.profilePrompted !== false,
+        seasons: [{
+            season: over.season || DEFAULT_SEASON,
+            franchiseName: over.franchiseName,
+            teams: over.teams || [],
+            weeklyScore: weekly,
+            cumulativeScore: weekly.reduce((s, w) => s + (w.score || 0), 0)
+        }]
+    });
+}
+
+// --- fetch mock --------------------------------------------------------------
+
+const RESPONSE = Symbol('response');
+
+// Wrap a body to control the HTTP status (routes return bare bodies otherwise).
+function respond(status, body) {
+    return { [RESPONSE]: true, status, body };
+}
+
+function toResponse(value) {
+    const wrapped = value && value[RESPONSE];
+    const status = wrapped ? value.status : 200;
+    const body = wrapped ? value.body : value;
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => {
+            if (body === undefined) throw new SyntaxError('Unexpected end of JSON input');
+            return body;
+        }
+    };
+}
+
+// Routes are [matcher, handler] pairs checked in order, so the more specific
+// H2H paths must come before the general one. A handler that throws simulates a
+// network failure; the module treats that as "fall back".
+function makeFetch(routes) {
+    const calls = [];
+    const fetchMock = jest.fn(async (url, init) => {
+        const href = String(url);
+        calls.push({ url: href, init: init || {} });
+        for (const [matcher, handler] of routes) {
+            const hit = matcher instanceof RegExp ? matcher.test(href) : href.startsWith(matcher);
+            if (hit) return toResponse(typeof handler === 'function' ? await handler(href, init) : handler);
+        }
+        return toResponse(respond(404, { message: `unrouted: ${href}` }));
+    });
+    fetchMock.calls = calls;
+    return fetchMock;
+}
+
+// --- jQuery stub -------------------------------------------------------------
+
+// standings.js uses jQuery only for the week / league dropdown buttons. This
+// records .text()/.val() per selector and captures .click() handlers so a test
+// can fire them.
+function makeJquery() {
+    const store = {};
+    const handlers = {};
+    const $ = (selector) => {
+        const key = typeof selector === 'string' ? selector : '(node)';
+        store[key] = store[key] || {};
+        const chain = {
+            text: (v) => (v === undefined ? (store[key].text || '') : ((store[key].text = v), chain)),
+            val: (v) => (v === undefined ? (store[key].val || '') : ((store[key].val = v), chain)),
+            html: () => chain,
+            attr: () => undefined,
+            parents: () => chain,
+            find: () => chain,
+            click: (fn) => { (handlers[key] = handlers[key] || []).push(fn); return chain; }
+        };
+        return chain;
+    };
+    $.store = store;
+    $.handlers = handlers;
+    $.fire = (selector) => (handlers[selector] || []).forEach(fn => fn.call({}));
+    return $;
+}
+
+// --- page loader -------------------------------------------------------------
+
+// Document-level listeners survive a body reset, so they're tracked and removed
+// between tests — otherwise each re-import stacks another copy of the
+// score-explain and tie-popover handlers.
+let trackedListeners = [];
+let originalAddEventListener = null;
+
+function trackDocumentListeners() {
+    if (originalAddEventListener) return;
+    originalAddEventListener = document.addEventListener.bind(document);
+    document.addEventListener = (type, fn, opts) => {
+        trackedListeners.push([type, fn, opts]);
+        originalAddEventListener(type, fn, opts);
+    };
+}
+
+function resetStandingsPage() {
+    trackedListeners.forEach(([type, fn, opts]) => document.removeEventListener(type, fn, opts));
+    trackedListeners = [];
+    window.onload = null;
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    jest.restoreAllMocks();
+}
+
+// Settles the promise chain kicked off by window.onload. The module nests
+// several `await`s inside `.then()` callbacks, so a handful of macrotask turns
+// is the reliable way to let it finish.
+async function flush(turns = 40) {
+    for (let i = 0; i < turns; i++) await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/**
+ * Builds the page, installs globals, imports standings.js, and (unless
+ * `autoLoad: false`) runs window.onload to completion.
+ */
+async function loadStandingsPage(opts = {}) {
+    const {
+        users = [makeUser()],
+        profile = { email: 'alice@example.com', user_metadata: { metadata: { league: 'gg' } } },
+        season = DEFAULT_SEASON,
+        h2hEnabled = false,
+        h2hStandings,
+        h2hMatchups,
+        projections = { managers: [] },
+        advancedCards = [],
+        lastUpdated,
+        rankings = [],
+        teamLogos = [],
+        bettingLines = [],
+        games = [],
+        routes = [],
+        userState = { user_metadata: { roles: ['Manager'], metadata: { league: 'gg', userId: 'u1' } } },
+        reducedMotion = true,
+        search = '',
+        userAgent,
+        localStorage: seedStorage = {},
+        autoLoad = true
+    } = opts;
+
+    document.body.innerHTML = FIXTURE;
+    trackDocumentListeners();
+
+    // detectMobile() sniffs the UA to decide the schedule's grid wrapping.
+    if (userAgent) {
+        Object.defineProperty(window.navigator, 'userAgent', { value: userAgent, configurable: true });
+    }
+
+    Object.entries(seedStorage).forEach(([k, v]) => window.localStorage.setItem(k, v));
+
+    // Query string drives the ?h2h=1 / ?h2hSim preview branches.
+    window.history.replaceState({}, '', `/standings${search}`);
+
+    const defaultRoutes = [
+        ['/profile', profile],
+        [/^\/users\/league\//, users],
+        [/\/standings\/h2h\/[^/]+\/[^/]+\/enabled/, { enabled: h2hEnabled }],
+        [/\/standings\/h2h\/[^/?]+\/[^/?]+\?.*standingsOnly=1/, h2hStandings || { enabled: h2hEnabled, managers: [] }],
+        [/\/standings\/h2h\//, h2hMatchups || { enabled: h2hEnabled, managers: [], schedule: [] }],
+        ['/standings/last-updated', lastUpdated === undefined ? respond(404, undefined) : lastUpdated],
+        [/\/standings\/highlights\//, advancedCards],
+        [/\/standings\/projections\//, projections],
+        [/^\/rankings\//, rankings],
+        ['/teams/teamLogos/all', teamLogos],
+        [/^\/betting\//, bettingLines],
+        [/^\/games\/seasonType\//, games],
+        [/\/scoring-config\//, { matched: [], total: 0 }],
+        ['/users/me/profile', { ok: true }]
+    ];
+
+    const fetchMock = makeFetch([...routes, ...defaultRoutes]);
+    const jquery = makeJquery();
+    const charts = [];
+
+    global.fetch = fetchMock;
+    global.$ = jquery;
+    global.userState = userState;
+    global.ccLogo = (logos) => (logos && logos[0]) || '';
+    global.Chart = class {
+        constructor(canvas, config) { charts.push({ canvas, config }); this.destroyed = false; }
+        destroy() { this.destroyed = true; }
+    };
+    window.ccIcon = (name, o) => `<svg data-icon="${name}" data-size="${(o || {}).size}"></svg>`;
+    window.ccH2H = {
+        matchupCard: (g) => `<div class="h2h-card" data-game="${g.id}"></div>`,
+        wire: jest.fn()
+    };
+    window.matchMedia = (query) => ({ matches: reducedMotion && /reduce/.test(query), media: query });
+
+    // displaySchedule logs a render timing; jsdom reports the unimplemented
+    // navigation in the profile-setup flow. Neither is a test signal.
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    jest.resetModules();
+    require('../../public/standings.js');
+
+    // Detach the handler before jsdom's own load event fires, or the whole
+    // bootstrap runs a second time and append-style renders double up.
+    const onload = window.onload;
+    window.onload = null;
+
+    if (autoLoad) {
+        await onload();
+        await flush();
+    }
+
+    const q = (sel) => document.querySelector(sel);
+    return {
+        fetchMock,
+        jquery,
+        charts,
+        season,
+        flush,
+        onload,
+        urls: () => fetchMock.calls.map(c => c.url),
+        tableHead: () => q('[user-table-head]'),
+        tableBody: () => q('[user-table-body]'),
+        rankNote: () => q('[standings-rank-note]'),
+        highlights: () => q('.highlights-container'),
+        highlightsHeader: () => q('.highlights-header'),
+        projPanel: () => q('#proj-panel'),
+        h2hPanel: () => q('#h2h-panel'),
+        lastUpdated: () => q('[last-updated]'),
+        welcomeModal: () => q('[welcome-modal]'),
+        scheduleBody: () => q('[schedule-body]'),
+        chartContainer: () => q('[chart-container]'),
+        q
+    };
+}
+
+module.exports = { loadStandingsPage, resetStandingsPage, makeUser, respond, flush, FIXTURE };


### PR DESCRIPTION
Adds coverage for the two Standings browser modules, which had none. **No production code changes** — every file touched is a test, test helper, or Jest config.

## Coverage

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `public/standings-insights.js` | 99.5% | 98.0% | 100% | 100% |
| `public/standings.js` | 96.6% | 83.4% | 97.1% | 99.5% |
| `public/weekByWeek.js` | 92.3% | 78.6% | 100% | 100% |

Uncovered lines in all three are unreachable defensive guards — e.g. `stdev`'s `< 2` check on a list already filtered to `>= 2`, and a `'just now'` fallback the minutes branch always claims first. Per-file ratchets added to `jest.config.json` in line with the existing convention.

Suite goes from 616 to 744 tests.

## How the ESM modules are reached

Both files are real ES modules (`standings.js` is loaded with `<script type="module">`), but this suite is CommonJS Jest with no Babel presets installed. `tests/helpers/esm-transform.js` rewrites the `import`/`export` keywords for `public/*.js` and delegates to `babel-jest`, so coverage instrumentation still runs — a hand-rolled loader passed the tests but reported the file at 0%. No new npm dependency was needed for this; `@babel/core` and `babel-jest` already ship with Jest.

`standings.js` exports nothing and runs side effects on import, so it can't be unit-tested. `tests/helpers/standings-dom.js` builds the page from `views/standings.ejs`, stubs the globals the view supplies (jQuery, Chart, `ccIcon`/`ccH2H`/`ccLogo`, `userState`, `matchMedia`), routes `fetch`, and drives `window.onload`.

## Two characterization tests

These pin what the code does today, not what it should do. Both are commented as such, and both are addressed in the follow-up PR stacked on this one:

1. **Playoff cards show one badge, not two.** Both lookups resolve against the manager currently being iterated, but a team's points live only in its owner's `weeklyScore`, so the opponent always reads 0.
2. **A tie renders as a home win.** The duplicate-game path splits only on `awayPoints > homePoints`, so a tie falls into the "home won" branch and draws a winner caret. Unreachable in practice — FBS games go to overtime.

## Note

Adds `jest-environment-jsdom` as a devDependency — the only dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)