### PR TITLE
Resolve schedule card points against the roster owner

### DIFF
--- a/public/standings.js
+++ b/public/standings.js
@@ -820,6 +820,18 @@ async function displaySchedule(data) {
         usersAndTeams.push(userTeamObject);
     }
 
+    // Points a team earned in a game, resolved against that team's ROSTER OWNER.
+    // scoreByTeam entries live only in the owning manager's weeklyScore, so
+    // looking them up in whichever manager is currently being iterated returns 0
+    // for the opponent — which is why a head-to-head card used to carry a badge
+    // for only one of its two teams.
+    const weeklyByTeamId = {};
+    data.forEach(u => {
+        const season = u.seasons.at(-1);
+        (season.teams || []).forEach(t => { weeklyByTeamId[t.id] = season.weeklyScore; });
+    });
+    const pointsFor = (teamId, gameId) => teamGameScoreById(weeklyByTeamId[teamId], teamId, gameId);
+
     const scheduleContainer = document.querySelector('[schedule-body]');
     var str = '<tr>';
     var gameIds = [];
@@ -919,10 +931,9 @@ async function displaySchedule(data) {
 
                     var topData = '';
                     var bottomData = '';
-                    var scoreAdded = ''; // no badge unless this user's own team earned points
+                    var scoreAdded = ''; // no badge unless the winning team earned points
                     var awayTeam = '';
                     var homeTeam = '';
-                    var isAway = false;
                     var teamLogos = await parseTeamLogos(game, allTeamLogos);
                     var awayImg = teamLogos.awayTeamLogo;
                     var homeImg = teamLogos.homeTeamLogo;
@@ -937,7 +948,6 @@ async function displaySchedule(data) {
 
                         homeUser = oppName;
                         homeTeam = `<a href="/team?team=${game.homeId}">${game.homeTeam}<span class="betting-line">${homeLine ? '-' + homeLine : ''}</span></a>`;
-                        isAway = true;
 
                         if (doesExist) {
                             isHeadToHead = true;
@@ -962,14 +972,12 @@ async function displaySchedule(data) {
                     if (game.completed) {   
 
                         if (game.seasonType == "postseason" && game.notes && game.notes.toLowerCase().includes("playoff")) {
-                            shouldReplace = true;
-                            // Each team's own points (the old code showed one team's
-                            // score for both), found safely by (teamId, gameId).
-                            // Only the current user's own team earns points on this card; the
-                            // opponent's team lives in another user's data and resolves to 0 here,
-                            // so gate on >0 to avoid a spurious "+0" badge on the opponent's row.
-                            var awayPts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id);
-                            var homePts = teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id);
+                            // Both sides of a playoff game bank points, and each is
+                            // resolved against its own owner. scoreBadge renders
+                            // nothing at 0, so an unrostered or scoreless team still
+                            // gets no badge rather than a spurious "+0".
+                            var awayPts = pointsFor(game.awayId, game.id);
+                            var homePts = pointsFor(game.homeId, game.id);
                             var awayScoreAdded = scoreBadge(game.awayId, game.id, awayPts);
                             var homeScoreAdded = scoreBadge(game.homeId, game.id, homePts);
 
@@ -982,23 +990,16 @@ async function displaySchedule(data) {
                             }
 
                         } else if ( game.awayPoints > game.homePoints ) {
-                            if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                                scoreAdded = scoreBadge(game.awayId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id));
-                            }
+                            scoreAdded = scoreBadge(game.awayId, game.id, pointsFor(game.awayId, game.id));
                             topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                             bottomData = (game.homePoints != null ? game.homePoints : '-');
                         } else if (game.homePoints > game.awayPoints) {
-
-                            if(!isAway) {
-                                scoreAdded = scoreBadge(game.homeId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id));
-                            }
+                            scoreAdded = scoreBadge(game.homeId, game.id, pointsFor(game.homeId, game.id));
 
                             topData = (game.awayPoints != null ? game.awayPoints : '-');
                             bottomData = (game.homePoints != null ? game.homePoints : '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
                         } else {
-                            if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                                scoreAdded = scoreBadge(game.awayId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id));
-                            }
+                            // Tie: no winner caret and no badge cell on either row.
                             topData = (game.awayPoints != null ? game.awayPoints : '-');
                             bottomData = (game.homePoints != null ? game.homePoints : '-');
                         }
@@ -1054,98 +1055,12 @@ async function displaySchedule(data) {
                     if (isHeadToHead) {
                         gameTables.push(gameInfo);
                     }
-                } else {
-                    var isHeadToHead = false;
-                    if (!game.startTimeTbd) {
-
-                        var shouldReplace = false;
-        
-                        if (game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                            var existObject = exists(otherUsers, game.homeId);
-                            var doesExist = existObject.doesExist;
-                            oppName = existObject.name;
-
-                            awayUser = userData.firstName;
-                            awayTeam = `<a href="/team?team=${game.awayId}">${game.awayTeam}<span class="betting-line">${awayLine ? '-' + awayLine : ''}</span></a>`;
-
-                            homeUser = oppName;
-                            homeTeam = `<a href="/team?team=${game.homeId}">${game.homeTeam}<span class="betting-line">${homeLine ? '-' + homeLine : ''}</span></a>`;
-                            isAway = true;
-
-                            if (doesExist) {
-                                isHeadToHead = true;
-                            }
-                        } else {
-                            var existObject = exists(otherUsers, game.awayId);
-                            var doesExist = existObject.doesExist;
-                            oppName = existObject.name;
-
-                            awayUser = oppName;
-                            awayTeam = `<a href="/team?team=${game.awayId}">${game.awayTeam}<span class="betting-line">${awayLine ? '-' + awayLine : ''}</span></a>`;
-
-                            homeUser = userData.firstName;
-                            homeTeam = `<a href="/team?team=${game.homeId}">${game.homeTeam}<span class="betting-line">${homeLine ? '-' + homeLine : ''}</span></a>`;
-
-                            if (doesExist) {
-                                isHeadToHead = true;
-                            }
-                        }
-        
-                        if (game.completed) {
-                            if( game.awayPoints > game.homePoints ) {
-                                if(game.awayId == userData.seasons.at(-1).teams[iterNum].id) {
-                                    shouldReplace = true;
-                                    scoreAdded = scoreBadge(game.awayId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.awayId, game.id));
-                                }
-                                topData = (game.awayPoints != null ? game.awayPoints : '-') + '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
-                                bottomData = (game.homePoints != null ? game.homePoints : '-');
-                            } else {
-
-                                if(game.homeId == userData.seasons.at(-1).teams[iterNum].id) {
-                                    shouldReplace = true;
-                                    scoreAdded = scoreBadge(game.homeId, game.id, teamGameScoreById(userData.seasons.at(-1).weeklyScore, game.homeId, game.id));
-                                }
-
-                                topData = (game.awayPoints != null ? game.awayPoints : '-');
-                                bottomData = (game.homePoints != null ? game.homePoints : '-')+ '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i></td>' + '<td class="score-added">' + scoreAdded + '</td>';
-                            }
-                        }
-                        
-                        var teamLogos = await parseTeamLogos(game, allTeamLogos);
-                        var awayImg = teamLogos.awayTeamLogo;
-                        var homeImg = teamLogos.homeTeamLogo;
-
-                        var teamTable = '<td><table class="schedule-table game-table"><tbody><tr></tr>';
-                        teamTable += `<tr id="awayUserRow"><td><strong>${awayUser}</strong></td></tr>`;
-
-                        teamTable += '<tr><td style="width: 250px;">';
-                        teamTable += awayImg + awayRank + awayTeam;
-                        teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 70px;">' + topData;
-                        teamTable += '</tr>';
-            
-                        teamTable += '<tr><td style="width: 250px;">';
-                        teamTable += homeImg + homeRank + homeTeam;
-                        teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
-                        teamTable += `<tr><td><strong>${homeUser}</strong></td></tr>`;
-                        teamTable += `</tr>${game.outlet ? `<tr><td class="game-broadcast">${window.ccIcon ? window.ccIcon('broadcast', { size: 15 }) : ''} ${game.outlet}</td></tr>` : ''}<tr><td class="game-notes">`;
-                        teamTable += game.notes || '';
-                        teamTable += '</td></tr><tbody></table></td>';
-            
-                        var gameInfo = {
-                            id: game.id,
-                            table: teamTable,
-                            homeTeam: game.homeTeam,
-                            awayTeam: game.awayTeam,
-                            startDate: game.startDate || ''
-                        };
-
-                        if (shouldReplace && isHeadToHead) {
-                            var indexToReplace = gameTables.findIndex(x => x.id == game.id);
-                            gameTables.splice(indexToReplace, 1);
-                            gameTables.push(gameInfo);
-                        }
-                    }
                 }
+                // A game already in gameIds was built on its first sighting, by
+                // whichever manager rosters a team in it. That card resolves both
+                // teams through pointsFor, so a second pass has nothing to correct
+                // — it used to rebuild and swap the whole card just to attach the
+                // other manager's badge.
             } 
         }
     }

--- a/tests/StandingsPage.spec.js
+++ b/tests/StandingsPage.spec.js
@@ -1032,9 +1032,10 @@ describe('rankings selection', () => {
 
 // --- schedule: game-card branch matrix --------------------------------------
 //
-// displaySchedule builds each card twice — once when a game is first seen, and
-// again when the second manager in the matchup reaches it — with separate
-// home/away paths in both passes. These drive the permutations.
+// displaySchedule builds each card once, on first sighting, with separate
+// home/away paths. Points resolve through pointsFor against the roster owner,
+// so the card is complete no matter which manager reaches the game first.
+// These drive the permutations.
 
 describe('schedule game cards', () => {
     const INDIANA = { id: 1, school: 'Indiana', mascot: 'Hoosiers', logos: ['ind.png'] };
@@ -1054,11 +1055,12 @@ describe('schedule game cards', () => {
         startDate: '2025-09-06T16:00:00Z', notes: ''
     }, over);
 
-    it('builds the card from the home side and re-resolves it from the away side', async () => {
+    it('badges the away winner even though the home manager builds the card', async () => {
         const page = await loadStandingsPage({ users: homeFirst(), games: [game()], teamLogos: LOGOS });
         const html = page.scheduleBody().innerHTML;
         expect(html).toContain('Indiana');
         expect(html).toContain('Purdue');
+        expect(html).toContain('+10');   // Alice's Indiana, resolved from her record
         expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(1);
     });
 
@@ -1079,19 +1081,16 @@ describe('schedule game cards', () => {
         expect(page.scheduleBody().innerHTML).not.toContain('fa-caret-left');
     });
 
-    // Characterization test, not an endorsement. Both lookups run against the
-    // manager currently being iterated, but a team's points live only in its
-    // OWNER's weeklyScore — so the opponent always resolves to 0 and the card
-    // carries a badge for one side only.
-    it('scores each side of a playoff game independently', async () => {
+    it('badges both managers on a playoff game', async () => {
         const page = await loadStandingsPage({
             users: homeFirst(), teamLogos: LOGOS,
             games: [game({ seasonType: 'postseason', notes: 'CFP Playoff Semifinal', awayPoints: 17, homePoints: 31 })]
         });
         const html = page.scheduleBody().innerHTML;
         expect(html).toContain('CFP Playoff Semifinal');
-        expect(html).toContain('+7');    // Bob's Purdue — the card is built from his record
-        expect(html).not.toContain('+10');   // Alice's Indiana points are invisible here
+        expect(html).toContain('+10');   // Alice's Indiana
+        expect(html).toContain('+7');    // Bob's Purdue
+        expect(page.scheduleBody().querySelectorAll('td.score-added')).toHaveLength(2);
     });
 
     it('flips the caret to the home row when the home team wins a playoff game', async () => {
@@ -1123,7 +1122,7 @@ describe('schedule game cards', () => {
         expect(page.scheduleBody().innerHTML).toContain(expected);
     });
 
-    it('skips a game whose kickoff time is still TBD on the second pass', async () => {
+    it('renders a game with a TBD kickoff exactly once', async () => {
         const page = await loadStandingsPage({
             users: homeFirst(), teamLogos: LOGOS,
             games: [game({ startTimeTbd: true })]
@@ -1256,8 +1255,7 @@ describe('score breakdown league fallback', () => {
 });
 
 // The mirror of the block above: when the AWAY team's manager is listed first,
-// the first-sighting path takes its away branch and the second pass resolves
-// from the home side.
+// the card is built from its away branch instead.
 describe('schedule game cards (away manager first)', () => {
     const LOGOS = [{ id: 1, logos: ['ind.png'] }, { id: 2, logos: ['pur.png'] }];
     const awayFirst = () => [
@@ -1279,22 +1277,17 @@ describe('schedule game cards (away manager first)', () => {
         expect(page.scheduleBody().innerHTML).toContain('Playoff Quarterfinal');
     });
 
-    // Characterization test, not an endorsement. The first-sighting path has an
-    // explicit tie branch (no winner caret), but the duplicate-game path only
-    // splits on `awayPoints > homePoints`, so a tie falls into the "home won"
-    // else and replaces the correct card with one that carets the home team.
-    // Low stakes in practice — FBS games go to overtime, so a completed regular
-    // game effectively never ties — but the two paths disagree.
-    it('renders a tie as a home win once the home manager re-resolves it', async () => {
+    // Unreachable in practice (FBS games go to overtime), but the branch exists.
+    it('renders a tie with no winner caret and no badge', async () => {
         const page = await loadStandingsPage({
             users: awayFirst(), teamLogos: LOGOS,
             games: [game({ awayPoints: 21, homePoints: 21 })]
         });
-        expect(page.scheduleBody().innerHTML).toContain('fa-caret-left');
-        expect(page.scheduleBody().innerHTML).toContain('+7');
+        expect(page.scheduleBody().innerHTML).not.toContain('fa-caret-left');
+        expect(page.scheduleBody().querySelectorAll('td.score-added')).toHaveLength(0);
     });
 
-    it('rebuilds the card from the home manager when the home team wins', async () => {
+    it('badges the home winner even though the away manager builds the card', async () => {
         const page = await loadStandingsPage({
             users: awayFirst(), teamLogos: LOGOS,
             games: [game({ awayPoints: 14, homePoints: 35 })]


### PR DESCRIPTION
**Stacked on #282** — review that one first; this PR's diff is against it.

A game card between two managers only ever showed one manager's points badge. Both lookups ran against `userData`, the manager currently being iterated, but a team's `scoreByTeam` entries live only in its **owner's** `weeklyScore` — so the opponent always resolved to 0 and rendered nothing.

## The change

```js
const weeklyByTeamId = {};
data.forEach(u => {
    const season = u.seasons.at(-1);
    (season.teams || []).forEach(t => { weeklyByTeamId[t.id] = season.weeklyScore; });
});
const pointsFor = (teamId, gameId) => teamGameScoreById(weeklyByTeamId[teamId], teamId, gameId);
```

Because badges no longer depend on which manager reaches a game first, the first-sighting card is complete for both sides. That makes the second-pass rebuild redundant, so the duplicate-game branch is deleted along with the `shouldReplace` / `splice` dance it existed to drive — plus the now-unread `isAway` flag and a dead `scoreAdded` assignment in the tie branch.

**27 insertions, 112 deletions.** The deleted path also emitted subtly different markup (no `firstRow` marker, a missing `</tr>`), so every card now comes from one code path.

## Verification

Ran before and after against real 2025 CFP data in the dev tenant on a second server pinned to `YEAR=2025`, capturing a per-card digest — teams, scores, carets, badge team + points, cell counts, HTML hash.

| League | Cards | Playoff fixed | Markup only | Identical |
|---|---|---|---|---|
| claunts-league | 20 | 9 of 9 | 3 | 8 |
| graham-league | 17 | 7 of 7 | 4 | 6 |

Expected values were queried from the DB independently first; every badge matches. graham-league is the stronger case because its values are **asymmetric** — Cotton Bowl reads Miami +6 / Ohio State +12, Orange reads Oregon +6 / Texas Tech +12 — which proves each side resolves against its own owner rather than duplicating one number. The National Championship confirms zero-suppression: Miami banked 0 and still renders **no badge**, not a spurious "+0".

**No card lost a badge, changed a caret, or changed a score in either league.** The markup-only cards are bowl games previously built by the deleted path; they now match the other bowl cards byte-for-byte in structure. `firstRow` and `awayUserRow` are referenced in no CSS or view, so gaining those markers is inert.

## Worth knowing

In **graham-league this fix corrects markup nobody currently sees**: H2H mode calls `hideLegacyH2HSchedule()`, which sets `.game-content` to `display: none`, so those 17 cards are built but hidden. It's visible in claunts-league, which stays classic. Whether the postseason cards should survive the H2H hiding is a separate open question.

## Tie handling deliberately not fixed

The tie branch inconsistency noted in #282 is resolved incidentally — deleting the duplicate path removes the branch that mis-rendered a tie as a home win — but no new tie logic was added. FBS games go to overtime, so it stays unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)