### PR TITLE
Gate season-to-date UI on real scoring: Weekly Recap + My Team rank

### DIFF
--- a/modules/weekly-recap.js
+++ b/modules/weekly-recap.js
@@ -14,6 +14,9 @@ const { pickLogo } = require('../public/logo.js');
 // teams actually scored, not about whether you happened to win your matchup.
 // So the per-week numbers here are measured on the base.
 const { baseWeekScore } = require('./h2h');
+// "This week got scored" — shared with the Standings highlights + points chart
+// so the whole app agrees on when a season is genuinely underway.
+const { entryHasScoring } = require('../public/season-scoring.js');
 
 function ordinal(n) {
     const s = ['th', 'st', 'nd', 'rd'], v = n % 100;
@@ -122,7 +125,9 @@ function narrate({ score, rank, rankDelta, rankTie, vsLeagueAvg, mvp, upset }) {
     return `${lead}${avg}${place ? ` — holding at ${place}` : ''}.`;
 }
 
-// Build one recap object per week the manager has played, oldest → newest.
+// Build one recap object per week the LEAGUE has played, oldest → newest. A
+// season nobody has played yet yields no recaps at all — that empty list is what
+// keeps the popup and the My Team tile hidden (see playedWeeks below).
 //   user         — the profile user's full doc (all seasons)
 //   leagueUsers  — every user in the league (full docs) for rank + average
 //   season       — the season to recap (number or string)
@@ -130,6 +135,8 @@ function narrate({ score, rank, rankDelta, rankTie, vsLeagueAvg, mvp, upset }) {
 function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
     const mySeason = seasonOf(user, season);
     const result = { userId: String(user && user._id), season: Number(season), recaps: [] };
+    // Cheap short-circuit only — a manager with no entries at all has no weeks.
+    // Whether those entries represent PLAYED weeks is settled by playedWeeks below.
     if (!mySeason || !(mySeason.weeklyScore || []).length) return result;
 
     const leagueSeasons = (leagueUsers || [])
@@ -143,12 +150,22 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
     const metaOf = (teamId, school) => (teamId != null && metaById[teamId]) || metaBySchool[school] || null;
     const logoOf = (teamId, school) => { const m = metaOf(teamId, school); return (m && pickLogo(m.logos)) || null; };
 
-    // Distinct effective weeks across the whole league, ascending — so "the
-    // previous week" for rank movement is the real prior week, not W-1 (which
-    // may not exist).
-    const weekSet = new Set();
-    leagueSeasons.forEach(ls => ls.weekly.forEach(e => weekSet.add(effWeek(e))));
-    const weeksAsc = [...weekSet].sort((a, b) => a - b);
+    // Distinct effective weeks the league has actually PLAYED, ascending — so
+    // "the previous week" for rank movement is the real prior week, not W-1
+    // (which may not exist).
+    //
+    // Played means someone banked points, not merely that a weekly entry exists:
+    // the nightly scoring job seeds a zero-point entry for every manager as soon
+    // as a week's games exist — all through the preseason with undrafted, 0-team
+    // rosters, and again mid-week before a game goes final — so gating on
+    // existence recapped a week nobody had played (the popup fired a "Week 1 · 0
+    // points" story before kickoff). Unplayed weeks drop out here, which also
+    // makes an unstarted season return no recaps at all, so every caller — the
+    // popup, the My Team tile, a future recap email — inherits the gate.
+    const playedWeeks = new Set();
+    leagueSeasons.forEach(ls => ls.weekly.forEach(e => { if (entryHasScoring(e)) playedWeeks.add(effWeek(e)); }));
+    const weeksAsc = [...playedWeeks].sort((a, b) => a - b);
+    if (!weeksAsc.length) return result;   // season hasn't kicked off yet
 
     // Per-week league stats (average / high / low) so slides can call out
     // "top score of the week", the margin vs average, streaks, etc.
@@ -180,7 +197,12 @@ function buildWeeklyRecaps({ user, leagueUsers, season, upsetByGameId }) {
         agg.score += baseWeekScore(e);
         (e.scoreByTeam || []).forEach(st => agg.scoreByTeam.push(st));
     });
-    const myWeekly = [...byEff.values()].sort((a, b) => effWeek(a) - effWeek(b));
+    // Only weeks the league played (see playedWeeks) — a manager's own seeded
+    // zero for the in-progress week is not a week they've played, but their real
+    // 0-point week inside a week the league DID play still earns a quiet recap.
+    const myWeekly = [...byEff.values()]
+        .filter(e => playedWeeks.has(effWeek(e)))
+        .sort((a, b) => effWeek(a) - effWeek(b));
     // Running state for the "momentum" slide (season high, streaks, milestones).
     let runningMax = -Infinity, runningTotal = 0, aboveStreak = 0, belowStreak = 0, regularWeeksSeen = 0;
 

--- a/public/league-rank.js
+++ b/public/league-rank.js
@@ -1,0 +1,49 @@
+// Shared league placement by season total (client + server; UMD so both can load
+// this one file).
+//
+// Standard competition ranking: your rank is 1 + the managers strictly ahead of
+// you, so tied managers SHARE a placement and the caller can label it "T-3rd".
+// The same rule rankAt() in modules/weekly-recap.js applies to a single week —
+// this one works off the stored season total.
+//
+// The alternative — sort the league and read off each manager's index — silently
+// invents placements whenever scores tie, because Array#sort is stable and so
+// leaves equal entries in whatever order the DB returned them. Every manager sits
+// at 0 before the season starts, which turned that index into a confident-looking
+// "1st of 6" for whoever happened to be first in the collection. Nothing here
+// depends on input order, so there's no arbitrary tiebreak to leak. Gate the
+// unstarted-season case with ccSeasonScoring (public/season-scoring.js) — a rank
+// is meaningless before anyone has played, tie-aware or not.
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) module.exports = factory();
+    else root.ccLeagueRank = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+    // The season total to rank on. Reads seasons[0] — the payload shape of
+    // /users/league/:league, where routes/users.js $elemMatch's the active season
+    // so it's the only one present.
+    function seasonTotal(user) {
+        var seasons = (user && user.seasons) || [];
+        return (seasons[0] && seasons[0].cumulativeScore) || 0;
+    }
+
+    // { rank, tie, total } for userId among `users`, or null if they aren't in the
+    // league. `tie` means another manager holds the exact same total, so the
+    // caller can prefix "T-". `total` is the league size, for "3rd of 6".
+    function leagueRank(users, userId) {
+        var rows = (users || []).map(function (u) {
+            return { id: String(u && u._id), score: seasonTotal(u) };
+        });
+        var id = String(userId);
+        var mine = rows.filter(function (r) { return r.id === id; })[0];
+        if (!mine) return null;
+
+        var ahead = 0, shared = 0;
+        rows.forEach(function (r) {
+            if (r.score > mine.score) ahead += 1;
+            else if (r.score === mine.score && r.id !== id) shared += 1;
+        });
+        return { rank: ahead + 1, tie: shared > 0, total: rows.length };
+    }
+
+    return { leagueRank: leagueRank };
+}));

--- a/public/league-rank.js
+++ b/public/league-rank.js
@@ -26,24 +26,35 @@
         return (seasons[0] && seasons[0].cumulativeScore) || 0;
     }
 
+    // Competition ranks for `items`, highest scoreOf(item) first. Returns a
+    // parallel array of { rank, tie }, index-aligned with `items` — so the caller
+    // keeps whatever display order it already has (usually sorted by score) and
+    // just reads the placement off. Ties share a rank and consume the ones behind
+    // them: 1, 2, 2, 4.
+    function competitionRanks(items, scoreOf) {
+        var scores = (items || []).map(function (item, i) { return scoreOf(item, i); });
+        return scores.map(function (mine, i) {
+            var ahead = 0, shared = 0;
+            scores.forEach(function (s, j) {
+                if (s > mine) ahead += 1;
+                else if (s === mine && j !== i) shared += 1;
+            });
+            return { rank: ahead + 1, tie: shared > 0 };
+        });
+    }
+
     // { rank, tie, total } for userId among `users`, or null if they aren't in the
     // league. `tie` means another manager holds the exact same total, so the
     // caller can prefix "T-". `total` is the league size, for "3rd of 6".
     function leagueRank(users, userId) {
-        var rows = (users || []).map(function (u) {
-            return { id: String(u && u._id), score: seasonTotal(u) };
-        });
+        var rows = users || [];
         var id = String(userId);
-        var mine = rows.filter(function (r) { return r.id === id; })[0];
-        if (!mine) return null;
-
-        var ahead = 0, shared = 0;
-        rows.forEach(function (r) {
-            if (r.score > mine.score) ahead += 1;
-            else if (r.score === mine.score && r.id !== id) shared += 1;
-        });
-        return { rank: ahead + 1, tie: shared > 0, total: rows.length };
+        var idx = -1;
+        rows.forEach(function (u, i) { if (idx < 0 && String(u && u._id) === id) idx = i; });
+        if (idx < 0) return null;
+        var mine = competitionRanks(rows, seasonTotal)[idx];
+        return { rank: mine.rank, tie: mine.tie, total: rows.length };
     }
 
-    return { leagueRank: leagueRank };
+    return { competitionRanks: competitionRanks, leagueRank: leagueRank };
 }));

--- a/public/season-scoring.js
+++ b/public/season-scoring.js
@@ -1,0 +1,48 @@
+// Shared "has this season actually been played yet?" test (client + server; UMD
+// so both can load this one file).
+//
+// The nightly scoring job seeds a zero-point weeklyScore entry for every manager
+// as soon as a week's games EXIST — through the preseason with undrafted, 0-team
+// rosters, and again mid-week before a single game goes final. So "a weekly entry
+// exists" is a different question from "has anyone played", and every feature
+// that gated on the former showed empty week-one content during the preseason:
+// first the Standings highlights panel and points chart, then the Weekly Recap
+// (its popup fired a "Week 1 · 0 points" story before kickoff).
+//
+// The honest signal is banked points. Once any manager's week is non-zero, that
+// week got scored. Everything that decides whether to show season-to-date
+// content routes through here so the app can't disagree with itself about when
+// the season starts.
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) module.exports = factory();
+    else root.ccSeasonScoring = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+    // One weeklyScore entry that got scored. `score` is the BANKED number (it
+    // carries the H2H win bonus — see modules/h2h.js); any non-zero value means
+    // the week was played, which is all this asks.
+    function entryHasScoring(entry) {
+        return !!entry && (entry.score || 0) !== 0;
+    }
+
+    // The weeklyScore array for `season`. Omit `season` for the standings /
+    // profile payloads, where routes/users.js $elemMatch's the active season and
+    // seasons[0] is the only one present.
+    function weeklyScoreFor(user, season) {
+        var seasons = (user && user.seasons) || [];
+        var entry = season == null
+            ? seasons[0]
+            : seasons.filter(function (s) { return String(s.season) === String(season); })[0];
+        return (entry && entry.weeklyScore) || [];
+    }
+
+    // True once ANY manager in the league has banked points in `season`. Deliberately
+    // league-wide: a manager who scored 0 in a week the league really played still
+    // has a real (if quiet) week to show, so this can't be a per-manager check.
+    function seasonHasScoring(users, season) {
+        return (users || []).some(function (u) {
+            return weeklyScoreFor(u, season).some(entryHasScoring);
+        });
+    }
+
+    return { entryHasScoring: entryHasScoring, seasonHasScoring: seasonHasScoring };
+}));

--- a/public/season-scoring.js
+++ b/public/season-scoring.js
@@ -44,5 +44,22 @@
         });
     }
 
-    return { entryHasScoring: entryHasScoring, seasonHasScoring: seasonHasScoring };
+    // True once someone has banked real POSTSEASON points — the bowl/playoff slate
+    // has something on it. Same rule as above, narrowed to the postseason entries,
+    // and narrowed for the same reason: the scoring job writes a postseason entry
+    // whenever it runs for the postseason, so a bare one can sit at 0.
+    // (weeklyScore[].season doubles as a type tag — 'regular' or 'postseason'.)
+    function postseasonHasScoring(users, season) {
+        return (users || []).some(function (u) {
+            return weeklyScoreFor(u, season).some(function (w) {
+                return !!w && w.season === 'postseason' && entryHasScoring(w);
+            });
+        });
+    }
+
+    return {
+        entryHasScoring: entryHasScoring,
+        seasonHasScoring: seasonHasScoring,
+        postseasonHasScoring: postseasonHasScoring
+    };
 }));

--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -34,19 +34,24 @@ export function rankedRows(users) {
     const sorted = users.slice().sort((a, b) => cum(b) - cum(a));
     const weeks = sorted.length ? weekly(sorted[0]).length : 0;
 
-    let prevRankById = null;
-    if (weeks > 1) {
-        prevRankById = {};
-        users.slice().sort((a, b) => cumThrough(b, weeks - 1) - cumThrough(a, weeks - 1))
-            .forEach((u, i) => { prevRankById[u._id] = i; });
-    }
+    // Placements are competition-ranked, NOT each row's index in `sorted`: an
+    // index splits tied managers by whatever order the DB happened to return,
+    // which before kickoff is EVERY manager (all on 0). `sorted` still sets the
+    // display order, so the table reads top-to-bottom by points. Same rule My
+    // Team's hero rank uses — public/league-rank.js, a browser global here.
+    const now = ccLeagueRank.competitionRanks(sorted, cum);
+    // Movement compares like with like, competition rank then vs now, so losing a
+    // share of the lead reads as a slip instead of "no change".
+    const prev = weeks > 1 ? ccLeagueRank.competitionRanks(sorted, (u) => cumThrough(u, weeks - 1)) : null;
 
     const leader = sorted.length ? cum(sorted[0]) : 0;
-    // Preseason: nobody has scored yet, so there's no real leader or ranking —
-    // rows render as a flat tie (no crown, no medals) instead of an arbitrary #1.
+    // Preseason: nobody has scored yet, so there's no real leader — no crown, no
+    // medals. The ranking itself needs no special case, since everyone sitting on
+    // 0 simply ties for 1st.
     const preseason = leader <= 0;
     return sorted.map((u, i) => ({
-        rank: i + 1,
+        rank: now[i].rank,
+        tie: now[i].tie,
         id: u._id,
         name: initialName(u),
         franchise: franchiseName(u),
@@ -57,7 +62,7 @@ export function rankedRows(users) {
         score: cum(u),
         gap: i === 0 ? 0 : leader - cum(u),
         preseason: preseason,
-        delta: (prevRankById && prevRankById[u._id] != null) ? (prevRankById[u._id] - i) : null
+        delta: prev ? (prev[i].rank - now[i].rank) : null
     }));
 }
 
@@ -122,12 +127,22 @@ export function standingsHeadHtml(h2h) {
     </tr>`;
 }
 
+// The rank cell's number. "T-2" when the placement is shared, matching how the
+// Weekly Recap labels a tied week.
+function rankNumHtml(r) {
+    return `<span class="rank-num">${r.tie ? 'T-' : ''}${r.rank}</span>`;
+}
+
 // The leader/movement/gap treatment is shared; only the middle differs.
 function gapHtml(r) {
     if (r.preseason) return '<span class="gap">Tied</span>';
-    return r.rank === 1
-        ? '<span class="gap leader">Leader</span>'
-        : (r.gap === 0 ? '<span class="gap">Tied</span>' : `<span class="gap">-${r.gap} back</span>`);
+    // The gap is measured to the leader, so gap === 0 means you ARE leading —
+    // shared with anyone who matched you, which competition ranking reports as a
+    // tie at rank 1. (There's no "tied but not leading" case for this cell; two
+    // managers level on 80 behind an 90-pt leader are both "-10 back", and their
+    // shared placement shows in the rank cell.)
+    if (r.rank === 1) return `<span class="gap leader">${r.tie ? 'Co-leader' : 'Leader'}</span>`;
+    return `<span class="gap">-${r.gap} back</span>`;
 }
 
 // The inline team-logo strip (the classic middle column). Handles both team
@@ -146,7 +161,7 @@ function inlineTeamLogos(teams) {
 function classicRowHtml(r) {
     const medal = (!r.preseason && r.rank <= 3) ? ` medal-${r.rank}` : '';
     return `<tr class="standings-row${medal}">
-        <th class="sticky-header rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</th>
+        <th class="sticky-header rank-cell">${rankNumHtml(r)}${movementHtml(r.delta)}</th>
         <th class="sticky-header name-cell"><a href="/userHome?user=${r.id}">${stdAvatarHtml(r)}<span class="std-name">${escapeHtml(r.franchise || r.name)}</span></a></th>
         <td class="team-item"><div class="team-logos">${inlineTeamLogos(r.teams)}</div></td>
         <th class="sticky-header-score"><span class="score-num" data-count="${r.score}">${r.score}</span><br>${gapHtml(r)}</th>
@@ -162,7 +177,7 @@ function h2hRowHtml(r) {
     const logos = (r.teams || []).map(teamLogoLink).join('');
     const who = escapeHtml(r.franchise || r.name);
     return `<tr class="standings-row${medal}">
-        <td class="rank-cell"><span class="rank-num">${r.rank}</span>${movementHtml(r.delta)}</td>
+        <td class="rank-cell">${rankNumHtml(r)}${movementHtml(r.delta)}</td>
         <td class="name-cell"><a href="/userHome?user=${r.id}">${stdAvatarHtml(r)}<span class="std-name">${who}</span></a></td>
         <td class="team-item h2h-teams-cell"><div class="team-logos">${inlineTeamLogos(r.teams)}</div></td>
         <td class="rec-cell">${escapeHtml(r.record || '—')}</td>

--- a/public/standings.js
+++ b/public/standings.js
@@ -458,6 +458,7 @@ function h2hRows(d) {
     try { rankedRows(usersData || []).forEach(r => { deltaById[r.id] = r.delta; }); } catch (e) { /* movement is best-effort */ }
     return managers.map((m, i) => ({
         rank: m.rank != null ? m.rank : i + 1,
+        tie: !!m.tie,                     // competition-ranked server-side, so ties share a place
         id: m.userId,
         name: m.name,
         franchise: m.franchise,

--- a/public/standings.js
+++ b/public/standings.js
@@ -47,10 +47,10 @@ const seasonHasScoring = (users) => ccSeasonScoring.seasonHasScoring(users);
 // This is deliberately NOT the same moment as "the H2H schedule ran out".
 // Conference championship week and Army/Navy fall between the two, and they
 // carry rivalry games of their own — see revealRivalryGames.
-function postseasonHasScoring(users) {
-    return (users || []).some(u => ((u.seasons && u.seasons[0] && u.seasons[0].weeklyScore) || [])
-        .some(w => w.season === 'postseason' && (w.score || 0) !== 0));
-}
+//
+// Shares its "non-zero banked points" rule with seasonHasScoring above, from the
+// same place (public/season-scoring.js), so the two can't drift apart.
+const postseasonHasScoring = (users) => ccSeasonScoring.postseasonHasScoring(users);
 
 function detectMobile() {
     if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/.test(navigator.userAgent)){

--- a/public/standings.js
+++ b/public/standings.js
@@ -31,10 +31,13 @@ function latestWeek(users) {
 // week's games exist (even with undrafted, 0-team rosters), so "a weekly entry
 // exists" fires too early. The highlights panel and the points chart gate on
 // this instead, so they stay hidden until the season is actually underway.
-function seasonHasScoring(users) {
-    return (users || []).some(u => ((u.seasons && u.seasons[0] && u.seasons[0].weeklyScore) || [])
-        .some(w => (w.score || 0) !== 0));
-}
+//
+// The rule itself lives in public/season-scoring.js (loaded app-wide by the
+// navbar partial) because the Weekly Recap and the server need the same answer —
+// the two had drifted, and the recap was popping a zero-point week-one story
+// through the preseason. The users here carry one season each (routes/users.js
+// $elemMatch's the active one), which is the no-season-argument form.
+const seasonHasScoring = (users) => ccSeasonScoring.seasonHasScoring(users);
 
 function detectMobile() {
     if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/.test(navigator.userAgent)){

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -168,10 +168,12 @@ async function renderBento(data) {
     renderAvatar(document.getElementById('uh-hero-av'), data);
     const statsEl = document.getElementById('uh-hero-stats');
     let sh = '';
-    // Rank only once the active season has scores (preseason ties everyone at 0).
-    if ((season.weeklyScore || []).length) {
-        try { const rank = await computeRank(data); if (rank) sh += statTile(escapeHtml(ordinal(rank.rank)), `of ${rank.total} teams`); } catch (e) { /* rank optional */ }
-    }
+    // Rank only once the season has really been played, and share a placement on
+    // a tie ("T-3rd") — computeRank owns both calls, since both need the league.
+    try {
+        const rank = await computeRank(data);
+        if (rank) sh += statTile(escapeHtml((rank.tie ? 'T-' : '') + ordinal(rank.rank)), `of ${rank.total} teams`);
+    } catch (e) { /* rank optional */ }
     sh += statTile(String(season.cumulativeScore || 0), 'Total points');
     const bt = bestTeam(season);
     if (bt && bt.total > 0) sh += statTile(`<img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
@@ -1156,17 +1158,27 @@ function bestTeam(season) {
 }
 
 // League rank for the profile user, by current-season cumulative score.
+// { rank, tie, total } — or null when there's no honest answer.
+//
+// The season-underway gate lives here rather than at the call site because this
+// is where the whole league is in hand, and the question is league-wide: a single
+// manager's season entry can't tell you whether anyone has played. It has to be
+// asked, too — before the season starts every cumulativeScore is 0, and any
+// placement drawn from that is really just each manager's position in the DB
+// result order wearing a rank's clothes.
 async function computeRank(data) {
     try {
         if (!data.league) return null;
         const res = await fetch(`/users/league/${data.league}`, { headers: { 'Accept': 'application/json' } });
         if (!res.ok) return null;
         const users = await res.json();
-        const ranked = users
-            .map(u => ({ id: u._id, score: (u.seasons && u.seasons[0] && u.seasons[0].cumulativeScore) || 0 }))
-            .sort((a, b) => b.score - a.score);
-        const idx = ranked.findIndex(r => r.id === data._id);
-        return idx < 0 ? null : { rank: idx + 1, total: ranked.length };
+        // Not "does this manager have a weekly entry" — the nightly scoring job
+        // seeds zero-point weeks as soon as a week's games exist, so that fires
+        // before kickoff. See public/season-scoring.js.
+        if (!ccSeasonScoring.seasonHasScoring(users)) return null;
+        // Competition ranking, so mid-season ties share a placement instead of
+        // being split by document order. See public/league-rank.js.
+        return ccLeagueRank.leagueRank(users, data._id);
     } catch (e) { return null; }
 }
 

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -14,6 +14,9 @@ const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../m
 const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
 const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
+// Shared with the classic standings table and My Team, so a tied placement reads
+// the same everywhere.
+const { competitionRanks } = require('../public/league-rank.js');
 const { gameStatus, matchupWinProb, H2H_MAX_WEEK, baseWeekScore, persistedBonus,
         h2hManagerIds, computeH2HAwards } = require('../modules/h2h');
 const { pickLogo } = require('../public/logo.js');
@@ -446,7 +449,13 @@ router.get('/h2h/:league/:season', async (req, res) => {
             // cumulative already includes weeks 15+/postseason AND whatever bonus
             // the scoring job has banked so far; add only the not-yet-banked part.
             adjustedTotal: round(meta[id].cumulative + rec[id].bonus - (banked[id] || 0))
-        })).sort((a, b) => b.adjustedTotal - a.adjustedTotal).map((m, i) => ({ rank: i + 1, ...m }));
+        })).sort((a, b) => b.adjustedTotal - a.adjustedTotal);
+        // Competition ranking, so managers level on points share a placement (and
+        // the client can render "T-2") instead of being split by array position —
+        // which before kickoff, with everyone on 0, is just the DB's document
+        // order. The sort above still sets display order.
+        competitionRanks(managers, m => m.adjustedTotal)
+            .forEach((r, i) => Object.assign(managers[i], { rank: r.rank, tie: r.tie }));
 
         // Standings-only: the ranked table is ready; return before the matchup
         // win-prob build (which needs the projections skipped above).

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -207,21 +207,17 @@ router.get('/recap/:league/:season/:userId', async (req, res) => {
         const userId = req.params.userId;
 
         // `latest` (used by the weekly popup) resolves to the ACTIVE season only
-        // (process.env.YEAR). Until that season has a scored week there's nothing
-        // to recap, so return empty and the popup stays silent through the
-        // preseason — it fires once the season actually starts. (Previously this
-        // fell back to the most recent scored season, which surfaced last year's
-        // finish during the new preseason.)
+        // (process.env.YEAR) — never a fallback to the most recent scored season,
+        // which used to surface last year's finish during the new preseason.
+        //
+        // Whether that season has anything to recap is buildWeeklyRecaps' call: it
+        // only counts weeks the league has actually played, so the preseason
+        // returns an empty list and the popup stays silent until week one is in the
+        // books. Checking "the active season has a weeklyScore entry" here instead
+        // fired too early — the nightly job seeds a zero-point entry for every
+        // manager as soon as a week's games exist.
         let season = req.params.season;
-        if (season === 'latest') {
-            season = String(process.env.YEAR);
-            const target = await User.findById(userId);
-            const active = ((target && target.seasons) || [])
-                .find(s => String(s.season) === season);
-            if (!active || !((active.weeklyScore || []).length)) {
-                return res.json({ league, season: null, userId, recaps: [] });
-            }
-        }
+        if (season === 'latest') season = String(process.env.YEAR);
         const seasonNum = Number(season);
 
         // Whole league for the target season (need nested teams + weeklyScore

--- a/tests/LeagueRank.spec.js
+++ b/tests/LeagueRank.spec.js
@@ -5,11 +5,44 @@
 // stable, so tied managers kept whatever order the DB returned, and every manager
 // sits at 0 before the season starts. So the cases that matter here are ties and
 // order-independence.
-const { leagueRank } = require('../public/league-rank');
+const { competitionRanks, leagueRank } = require('../public/league-rank');
 
 // One manager with a season total, in the /users/league/:league payload shape
 // (routes/users.js $elemMatch's the active season, so seasons[0] is the only one).
 const mgr = (id, cumulativeScore) => ({ _id: id, seasons: [{ season: 2026, cumulativeScore }] });
+
+// The primitive the standings table and the H2H route rank through: an array of
+// { rank, tie } aligned with the input, so callers keep their own display order.
+describe('competitionRanks', () => {
+    const ranks = (scores) => competitionRanks(scores.map(s => ({ s })), (x) => x.s);
+
+    it('ranks highest-first and skips the placements a tie consumed', () => {
+        expect(ranks([50, 30, 30, 10]).map(r => r.rank)).toEqual([1, 2, 2, 4]);
+        expect(ranks([50, 30, 30, 10]).map(r => r.tie)).toEqual([false, true, true, false]);
+    });
+
+    it('does not care what order the items arrive in', () => {
+        // The property the old sort-index approach lacked.
+        expect(ranks([30, 50, 30]).map(r => r.rank)).toEqual([2, 1, 2]);
+    });
+
+    it('ties an all-equal field for 1st (the preseason shape)', () => {
+        expect(ranks([0, 0, 0])).toEqual([
+            { rank: 1, tie: true }, { rank: 1, tie: true }, { rank: 1, tie: true }
+        ]);
+    });
+
+    it('handles three-way ties and a single item', () => {
+        expect(ranks([20, 20, 20, 5]).map(r => r.rank)).toEqual([1, 1, 1, 4]);
+        expect(ranks([7])).toEqual([{ rank: 1, tie: false }]);
+    });
+
+    it('passes the index to the accessor and tolerates an empty list', () => {
+        expect(competitionRanks(['x', 'y'], (item, i) => i).map(r => r.rank)).toEqual([2, 1]);
+        expect(competitionRanks([], () => 0)).toEqual([]);
+        expect(competitionRanks(null, () => 0)).toEqual([]);
+    });
+});
 
 describe('leagueRank', () => {
     const league = [mgr('a', 120), mgr('b', 90), mgr('c', 90), mgr('d', 40)];

--- a/tests/LeagueRank.spec.js
+++ b/tests/LeagueRank.spec.js
@@ -1,0 +1,70 @@
+// Coverage for public/league-rank.js — league placement by season total.
+//
+// It replaced "sort the league, read off the index" in public/userHome.js's
+// computeRank. That approach leaked input order into the answer: Array#sort is
+// stable, so tied managers kept whatever order the DB returned, and every manager
+// sits at 0 before the season starts. So the cases that matter here are ties and
+// order-independence.
+const { leagueRank } = require('../public/league-rank');
+
+// One manager with a season total, in the /users/league/:league payload shape
+// (routes/users.js $elemMatch's the active season, so seasons[0] is the only one).
+const mgr = (id, cumulativeScore) => ({ _id: id, seasons: [{ season: 2026, cumulativeScore }] });
+
+describe('leagueRank', () => {
+    const league = [mgr('a', 120), mgr('b', 90), mgr('c', 90), mgr('d', 40)];
+
+    it('ranks by season total, 1 = best', () => {
+        expect(leagueRank(league, 'a')).toEqual({ rank: 1, tie: false, total: 4 });
+        expect(leagueRank(league, 'd')).toEqual({ rank: 4, tie: false, total: 4 });
+    });
+
+    it('tied managers share a placement and are flagged', () => {
+        expect(leagueRank(league, 'b')).toEqual({ rank: 2, tie: true, total: 4 });
+        expect(leagueRank(league, 'c')).toEqual({ rank: 2, tie: true, total: 4 });
+    });
+
+    it('skips the placements a tie consumed (competition ranking)', () => {
+        // a=1st, b and c share 2nd, so d is 4th — not 3rd.
+        expect(leagueRank(league, 'd').rank).toBe(4);
+    });
+
+    it('gives the same answer whatever order the league arrives in', () => {
+        // The old index-of-sorted approach handed the tied pair different ranks
+        // depending on document order; this must not.
+        const shuffled = [league[2], league[0], league[3], league[1]];
+        ['a', 'b', 'c', 'd'].forEach(id => {
+            expect(leagueRank(shuffled, id)).toEqual(leagueRank(league, id));
+        });
+    });
+
+    it('calls a whole-league tie a shared 1st, not an arbitrary winner', () => {
+        // The preseason shape. computeRank gates this case out with
+        // seasonHasScoring, but the ranking itself must not invent a leader.
+        const flat = [mgr('a', 0), mgr('b', 0), mgr('c', 0)];
+        expect(flat.map(m => leagueRank(flat, m._id)))
+            .toEqual([{ rank: 1, tie: true, total: 3 }, { rank: 1, tie: true, total: 3 }, { rank: 1, tie: true, total: 3 }]);
+    });
+
+    it('treats a missing total as 0', () => {
+        const users = [mgr('a', 10), { _id: 'b', seasons: [{ season: 2026 }] }, { _id: 'c' }];
+        expect(leagueRank(users, 'b')).toEqual({ rank: 2, tie: true, total: 3 });
+        expect(leagueRank(users, 'c')).toEqual({ rank: 2, tie: true, total: 3 });
+    });
+
+    it('matches ids across string/ObjectId-ish forms', () => {
+        const oid = { toString: () => '64f539d45cf0433f3b6a6a1e' };
+        expect(leagueRank([{ _id: oid, seasons: [{ cumulativeScore: 5 }] }], '64f539d45cf0433f3b6a6a1e'))
+            .toEqual({ rank: 1, tie: false, total: 1 });
+    });
+
+    it('is null for a manager outside the league, and for no league at all', () => {
+        expect(leagueRank(league, 'zz')).toBeNull();
+        expect(leagueRank([], 'a')).toBeNull();
+        expect(leagueRank(null, 'a')).toBeNull();
+    });
+
+    it('handles a one-manager league', () => {
+        expect(leagueRank([mgr('a', 30)], 'a')).toEqual({ rank: 1, tie: false, total: 1 });
+    });
+});

--- a/tests/SeasonScoring.spec.js
+++ b/tests/SeasonScoring.spec.js
@@ -6,7 +6,7 @@
 // included), so "a weekly entry exists" is not the same question. The Standings
 // highlights + points chart, the Weekly Recap module, and the recap route all
 // gate on this, and they must not drift apart.
-const { entryHasScoring, seasonHasScoring } = require('../public/season-scoring');
+const { entryHasScoring, seasonHasScoring, postseasonHasScoring } = require('../public/season-scoring');
 
 const user = (id, seasons) => ({ _id: id, seasons });
 
@@ -77,5 +77,50 @@ describe('seasonHasScoring', () => {
         expect(seasonHasScoring([{ _id: 'a' }])).toBe(false);
         expect(seasonHasScoring([user('a', [{ season: 2026 }])], 2026)).toBe(false);
         expect(seasonHasScoring([user('a', [{ season: 2025, weeklyScore: [{ score: 5 }] }])], 2026)).toBe(false);
+    });
+});
+
+// Drives the Rivalry Games reveal on the Standings page (revealRivalryGames in
+// public/standings.js): the bowl/playoff slate has points on it. Same rule as
+// seasonHasScoring, narrowed to the entries tagged 'postseason', because the
+// scoring job writes a postseason entry whenever it runs for the postseason —
+// so a bare one can sit at 0 just like a seeded regular week.
+describe('postseasonHasScoring', () => {
+    const wk = (season, week, score) => ({ season, week, score });
+
+    it('is false while only the regular season has scored', () => {
+        const users = [user('a', [{ season: 2025, weeklyScore: [wk('regular', 1, 30), wk('regular', 2, 20)] }])];
+        expect(postseasonHasScoring(users)).toBe(false);
+    });
+
+    it('is false for a postseason entry the job wrote at 0', () => {
+        const users = [user('a', [{ season: 2025, weeklyScore: [wk('regular', 1, 30), wk('postseason', 1, 0)] }])];
+        expect(postseasonHasScoring(users)).toBe(false);
+    });
+
+    it('is true once any manager banks postseason points', () => {
+        const users = [
+            user('a', [{ season: 2025, weeklyScore: [wk('postseason', 1, 0)] }]),
+            user('b', [{ season: 2025, weeklyScore: [wk('postseason', 1, 24)] }])
+        ];
+        expect(postseasonHasScoring(users)).toBe(true);
+    });
+
+    it('ignores a big regular-season week — the tag is what matters', () => {
+        const users = [user('a', [{ season: 2025, weeklyScore: [wk('regular', 16, 99)] }])];
+        expect(postseasonHasScoring(users)).toBe(false);
+    });
+
+    it('honours the season argument, and survives empty input', () => {
+        const users = [user('a', [
+            { season: 2025, weeklyScore: [wk('postseason', 1, 24)] },
+            { season: 2026, weeklyScore: [wk('regular', 1, 0)] }
+        ])];
+        expect(postseasonHasScoring(users, 2025)).toBe(true);
+        expect(postseasonHasScoring(users, 2026)).toBe(false);
+        expect(postseasonHasScoring(users)).toBe(true);           // seasons[0] form
+        expect(postseasonHasScoring([])).toBe(false);
+        expect(postseasonHasScoring(null)).toBe(false);
+        expect(postseasonHasScoring([user('a', [{ season: 2025, weeklyScore: [null] }])])).toBe(false);
     });
 });

--- a/tests/SeasonScoring.spec.js
+++ b/tests/SeasonScoring.spec.js
@@ -1,0 +1,81 @@
+// Coverage for public/season-scoring.js — the one shared answer to "has this
+// season actually been played yet?".
+//
+// It exists because the nightly scoring job seeds a zero-point weeklyScore entry
+// for every manager as soon as a week's games exist (preseason, undrafted rosters
+// included), so "a weekly entry exists" is not the same question. The Standings
+// highlights + points chart, the Weekly Recap module, and the recap route all
+// gate on this, and they must not drift apart.
+const { entryHasScoring, seasonHasScoring } = require('../public/season-scoring');
+
+const user = (id, seasons) => ({ _id: id, seasons });
+
+describe('entryHasScoring', () => {
+    it('is true for a week with banked points', () => {
+        expect(entryHasScoring({ week: 1, score: 12 })).toBe(true);
+    });
+
+    it('is false for the zero-point week the nightly job seeds', () => {
+        expect(entryHasScoring({ week: 1, score: 0 })).toBe(false);
+    });
+
+    it('is false for a missing score or a missing entry', () => {
+        expect(entryHasScoring({ week: 1 })).toBe(false);
+        expect(entryHasScoring(null)).toBe(false);
+        expect(entryHasScoring(undefined)).toBe(false);
+    });
+
+    it('counts a banked H2H win bonus — the week clearly got scored', () => {
+        // score carries the bonus (modules/h2h.js); any non-zero total means played.
+        expect(entryHasScoring({ week: 1, score: 3, h2hBonus: 3 })).toBe(true);
+    });
+});
+
+describe('seasonHasScoring', () => {
+    it('is false when every manager has only seeded zero weeks', () => {
+        const users = [
+            user('a', [{ season: 2026, teams: [], weeklyScore: [{ week: 1, score: 0 }] }]),
+            user('b', [{ season: 2026, teams: [], weeklyScore: [{ week: 1, score: 0 }] }])
+        ];
+        expect(seasonHasScoring(users, 2026)).toBe(false);
+    });
+
+    it('is true once ANY manager has banked points', () => {
+        const users = [
+            user('a', [{ season: 2026, weeklyScore: [{ week: 1, score: 0 }] }]),
+            user('b', [{ season: 2026, weeklyScore: [{ week: 1, score: 0 }, { week: 2, score: 18 }] }])
+        ];
+        expect(seasonHasScoring(users, 2026)).toBe(true);
+    });
+
+    it('asks about the season it was given, not any other', () => {
+        const users = [user('a', [
+            { season: 2025, weeklyScore: [{ week: 1, score: 40 }] },   // last year scored
+            { season: 2026, weeklyScore: [{ week: 1, score: 0 }] }     // this year seeded
+        ])];
+        expect(seasonHasScoring(users, 2025)).toBe(true);
+        expect(seasonHasScoring(users, 2026)).toBe(false);
+    });
+
+    it('matches a string season against a numeric one (route params arrive as strings)', () => {
+        const users = [user('a', [{ season: 2026, weeklyScore: [{ week: 1, score: 9 }] }])];
+        expect(seasonHasScoring(users, '2026')).toBe(true);
+    });
+
+    it('reads seasons[0] when no season is given (the $elemMatch payload shape)', () => {
+        // routes/users.js $elemMatch's the active season, so seasons[0] is the only one.
+        const scored = [user('a', [{ season: 2026, weeklyScore: [{ week: 1, score: 7 }] }])];
+        const seeded = [user('a', [{ season: 2026, weeklyScore: [{ week: 1, score: 0 }] }])];
+        expect(seasonHasScoring(scored)).toBe(true);
+        expect(seasonHasScoring(seeded)).toBe(false);
+    });
+
+    it('is false for an empty league, a missing list, or managers without seasons', () => {
+        expect(seasonHasScoring([])).toBe(false);
+        expect(seasonHasScoring(null)).toBe(false);
+        expect(seasonHasScoring([user('a', [])])).toBe(false);
+        expect(seasonHasScoring([{ _id: 'a' }])).toBe(false);
+        expect(seasonHasScoring([user('a', [{ season: 2026 }])], 2026)).toBe(false);
+        expect(seasonHasScoring([user('a', [{ season: 2025, weeklyScore: [{ score: 5 }] }])], 2026)).toBe(false);
+    });
+});

--- a/tests/StandingsInsights.spec.js
+++ b/tests/StandingsInsights.spec.js
@@ -7,6 +7,11 @@
 // largest-first, so [0] is the pick) — logo selection itself is covered by
 // Logo.spec.js; this suite only cares that the chosen URL lands in the markup.
 global.ccLogo = (logos) => (logos && logos[0]) || '';
+// ccLeagueRank is the other browser global the module reaches for (rankedRows
+// ranks through it). The REAL one, not a stub — placement and tie handling are
+// exactly what the row assertions below are about. LeagueRank.spec.js covers it
+// directly.
+global.ccLeagueRank = require('../public/league-rank.js');
 
 const {
     rankedRows,
@@ -65,6 +70,40 @@ describe('rankedRows', () => {
         expect(rows.every(r => r.preseason === false)).toBe(true);
     });
 
+    it('shares a placement between managers level on points, and skips what the tie consumed', () => {
+        // The old "index in the sorted array" rank gave the tied pair 2 and 3,
+        // decided by nothing but the order they arrived in.
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [50]),
+            user('b', 'Bob', 'Brown', [30]),
+            user('c', 'Cara', 'Cole', [30]),
+            user('d', 'Dan', 'Dole', [10])
+        ]);
+        expect(rows.map(r => r.rank)).toEqual([1, 2, 2, 4]);
+        expect(rows.map(r => r.tie)).toEqual([false, true, true, false]);
+    });
+
+    it('gives the same placements whatever order the league arrives in', () => {
+        const league = [
+            user('a', 'Alice', 'Adams', [30]),
+            user('b', 'Bob', 'Brown', [30]),
+            user('c', 'Cara', 'Cole', [50])
+        ];
+        const byId = (rows) => rows.reduce((acc, r) => Object.assign(acc, { [r.id]: r.rank }), {});
+        expect(byId(rankedRows(league))).toEqual(byId(rankedRows(league.slice().reverse())));
+        expect(byId(rankedRows(league))).toEqual({ a: 2, b: 2, c: 1 });
+    });
+
+    it('ties everyone for 1st before the season starts, instead of numbering by DB order', () => {
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [0]),
+            user('b', 'Bob', 'Brown', [0]),
+            user('c', 'Cara', 'Cole', [0])
+        ]);
+        expect(rows.map(r => r.rank)).toEqual([1, 1, 1]);
+        expect(rows.every(r => r.tie && r.preseason)).toBe(true);
+    });
+
     it('reports movement against last week', () => {
         // Week 1: Bob 50, Alice 10. Week 2 flips it.
         const rows = rankedRows([
@@ -82,6 +121,19 @@ describe('rankedRows', () => {
             user('b', 'Bob', 'Brown', [20, 20])
         ]);
         expect(rows.map(r => r.delta)).toEqual([0, 0]);
+    });
+
+    it('counts losing a share of the lead as a slip', () => {
+        // Week 1 both on 50 (co-leaders). Week 2 Alice pulls ahead, so Bob really
+        // does drop from 1st to 2nd — the old index-based delta called it "no
+        // change", because neither moved position in the sorted array.
+        const rows = rankedRows([
+            user('a', 'Alice', 'Adams', [50, 10]),
+            user('b', 'Bob', 'Brown', [50, 0])
+        ]);
+        expect(rows.map(r => r.id)).toEqual(['a', 'b']);
+        expect(rows[0].delta).toBe(0);    // held 1st
+        expect(rows[1].delta).toBe(-1);   // 1st -> 2nd
     });
 
     it('has no movement to report after a single week', () => {
@@ -214,17 +266,34 @@ describe('buildStandingsRowsHtml (classic)', () => {
         expect(html).toContain('&lt;script&gt;x&lt;/script&gt;');
     });
 
-    it('labels the leader, the gap, and a tie', () => {
-        // Gaps are measured to the leader, so "Tied" only shows for a manager
-        // level with first place.
-        const html = buildStandingsRowsHtml(rankedRows([
+    it('labels a lone leader, a shared lead, and the gap behind', () => {
+        const alone = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [50]),
+            user('b', 'Bob', 'Brown', [30])
+        ]), {});
+        expect(alone).toContain('<span class="gap leader">Leader</span>');
+        expect(alone).toContain('<span class="gap">-20 back</span>');
+
+        // Level on points: both are leading, and both say so.
+        const shared = buildStandingsRowsHtml(rankedRows([
             user('a', 'Alice', 'Adams', [50]),
             user('b', 'Bob', 'Brown', [50]),
             user('c', 'Cara', 'Cole', [30])
         ]), {});
-        expect(html).toContain('<span class="gap leader">Leader</span>');
-        expect(html).toContain('<span class="gap">-20 back</span>');
-        expect(html).toContain('<span class="gap">Tied</span>');
+        expect(shared.match(/<span class="gap leader">Co-leader<\/span>/g)).toHaveLength(2);
+        expect(shared).not.toContain('>Leader<');
+        expect(shared).toContain('<span class="gap">-20 back</span>');
+    });
+
+    it('prefixes a shared placement with T- in the rank cell', () => {
+        const html = buildStandingsRowsHtml(rankedRows([
+            user('a', 'Alice', 'Adams', [50]),
+            user('b', 'Bob', 'Brown', [30]),
+            user('c', 'Cara', 'Cole', [30])
+        ]), {});
+        expect(html).toContain('<span class="rank-num">1</span>');
+        expect(html.match(/<span class="rank-num">T-2<\/span>/g)).toHaveLength(2);
+        expect(html).not.toContain('>3<');   // the tie consumed 3rd
     });
 
     it('renders every preseason row as tied with no medals', () => {

--- a/tests/WeeklyRecap.spec.js
+++ b/tests/WeeklyRecap.spec.js
@@ -193,6 +193,83 @@ describe('buildWeeklyRecaps', () => {
     });
 });
 
+// The nightly scoring job seeds a zero-point weeklyScore entry for every manager
+// as soon as a week's games exist — through the preseason with undrafted, 0-team
+// rosters, and again mid-week before a game goes final. Those weeks haven't been
+// PLAYED, so they get no recap; the empty list is what keeps the popup and the My
+// Team tile hidden (public/weekly-recap.js, public/userHome.js hydrateRecap).
+describe('only weeks the league actually played are recapped', () => {
+    // A manager the way the dev DB looks in the 2026 preseason: a season entry,
+    // an empty roster, and one seeded zero-point week.
+    const preseason = (id) => ({
+        _id: id, firstName: 'Pre', lastName: 'Season', league: 'graham-league',
+        seasons: [{ season: 2026, teams: [], cumulativeScore: 0, weeklyScore: [{ week: 1, score: 0, scoreByTeam: [] }] }]
+    });
+    // weeks: [[week, score], …] with a one-team roster, so scores are easy to read.
+    const played = (id, weeks) => ({
+        _id: id, firstName: 'Pl', lastName: 'Ayed', league: 'graham-league',
+        seasons: [{
+            season: 2026, teams: [{ id: 1, school: 'Oregon', logos: ['o.png'] }],
+            weeklyScore: weeks.map(([week, score]) => ({ week, score, scoreByTeam: [{ team: 'Oregon', teamId: 1, score }] }))
+        }]
+    });
+
+    test('a season whose only week is a seeded zero yields no recaps', () => {
+        const a = preseason('a'), b = preseason('b');
+        expect(buildWeeklyRecaps({ user: a, leagueUsers: [a, b], season: 2026 }).recaps).toEqual([]);
+    });
+
+    test('week one appears as soon as one manager banks points', () => {
+        const a = preseason('a'), b = played('b', [[1, 12]]);
+        const { recaps } = buildWeeklyRecaps({ user: b, leagueUsers: [a, b], season: 2026 });
+        expect(recaps.map(r => r.week)).toEqual([1]);
+    });
+
+    test('a manager who banked 0 in a week the league DID play still gets that week', () => {
+        const quiet = preseason('q'), scorer = played('s', [[1, 12]]);
+        const { recaps } = buildWeeklyRecaps({ user: quiet, leagueUsers: [quiet, scorer], season: 2026 });
+        expect(recaps.map(r => r.week)).toEqual([1]);
+        expect(recaps[0].score).toBe(0);
+        expect(recaps[0].narrative).toBe('Quiet week — no points banked.');
+    });
+
+    test('mid-season: the in-progress seeded week is dropped, played weeks stay', () => {
+        // Weeks 1–2 scored; week 3's games exist so the job seeded zeros for all.
+        const a = played('a', [[1, 20], [2, 30], [3, 0]]);
+        const b = played('b', [[1, 10], [2, 15], [3, 0]]);
+        const { recaps } = buildWeeklyRecaps({ user: a, leagueUsers: [a, b], season: 2026 });
+        expect(recaps.map(r => r.week)).toEqual([1, 2]);
+    });
+
+    test('the latest recap (what the popup shows) is the last PLAYED week', () => {
+        const a = played('a', [[1, 20], [2, 30], [3, 0]]);
+        const b = played('b', [[1, 10], [2, 15], [3, 0]]);
+        const { recaps } = buildWeeklyRecaps({ user: a, leagueUsers: [a, b], season: 2026 });
+        const latest = recaps[recaps.length - 1];
+        expect(latest.label).toBe('Week 2');
+        expect(latest.score).toBe(30);
+    });
+
+    test('a seeded zero week does not become the previous week for rank movement', () => {
+        // Week 2 seeded to zero league-wide, week 3 real: week 3's movement must
+        // compare against week 1, the last week actually played.
+        const a = played('a', [[1, 10], [2, 0], [3, 40]]);
+        const b = played('b', [[1, 30], [2, 0], [3, 5]]);
+        const { recaps } = buildWeeklyRecaps({ user: a, leagueUsers: [a, b], season: 2026 });
+        expect(recaps.map(r => r.week)).toEqual([1, 3]);
+        expect(recaps[0].rank).toBe(2);           // 10 vs 30 through week 1
+        expect(recaps[1].rank).toBe(1);           // 50 vs 35 through week 3
+        expect(recaps[1].rankDelta).toBe(1);      // climbed from 2nd, not "held"
+    });
+
+    test('a seeded zero postseason entry is dropped too', () => {
+        const a = played('a', [[1, 20]]);
+        a.seasons[0].weeklyScore.push({ week: 1, season: 'postseason', score: 0, scoreByTeam: [] });
+        const { recaps } = buildWeeklyRecaps({ user: a, leagueUsers: [a], season: 2026 });
+        expect(recaps.map(r => r.label)).toEqual(['Week 1']);
+    });
+});
+
 describe('indexUpsets + layered narrative', () => {
     // Oregon (away) beats favored Georgia; home spread -7 means Georgia was a
     // 7-pt favorite, so Oregon won as a 7-pt underdog.

--- a/tests/helpers/standings-dom.js
+++ b/tests/helpers/standings-dom.js
@@ -257,6 +257,9 @@ async function loadStandingsPage(opts = {}) {
     // and chart gate on it, so the gate itself should be under test here too.
     // The navbar partial supplies it in the browser (views/partials/navbar.ejs).
     global.ccSeasonScoring = require('../../public/season-scoring.js');
+    // Likewise the real ranking helper — rankedRows places the standings table
+    // through it, so a stub would hide the tie behavior the rows are asserted on.
+    global.ccLeagueRank = require('../../public/league-rank.js');
     global.Chart = class {
         constructor(canvas, config) { charts.push({ canvas, config }); this.destroyed = false; }
         destroy() { this.destroyed = true; }

--- a/tests/helpers/standings-dom.js
+++ b/tests/helpers/standings-dom.js
@@ -253,6 +253,10 @@ async function loadStandingsPage(opts = {}) {
     global.$ = jquery;
     global.userState = userState;
     global.ccLogo = (logos) => (logos && logos[0]) || '';
+    // The REAL shared season-underway helper, not a stub — the page's highlights
+    // and chart gate on it, so the gate itself should be under test here too.
+    // The navbar partial supplies it in the browser (views/partials/navbar.ejs).
+    global.ccSeasonScoring = require('../../public/season-scoring.js');
     global.Chart = class {
         constructor(canvas, config) { charts.push({ canvas, config }); this.destroyed = false; }
         destroy() { this.destroyed = true; }

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -25,6 +25,9 @@
      points", not "a weekly entry exists" — the nightly job seeds zero-point weeks
      early. Gates the Standings highlights + chart and the Weekly Recap alike. -->
 <script src="/season-scoring.js"></script>
+<!-- Shared league placement (ccLeagueRank): competition ranking off the season
+     total, so tied managers share a rank instead of being ordered by the DB. -->
+<script src="/league-rank.js"></script>
 <!-- Weekly Recap: shared card rendering + the once-a-week popup, app-wide so the
      popup can greet the logged-in viewer on whatever page they land on. -->
 <link rel="stylesheet" type="text/css" href="/weekly-recap.css">

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -21,6 +21,10 @@
 <!-- Shared team-logo selector (ccLogo): picks the dark, highest-res variant from
      CFBD's many-logo array. Loaded before page scripts that render team logos. -->
 <script src="/logo.js"></script>
+<!-- Shared season-underway test (ccSeasonScoring): "some manager has banked
+     points", not "a weekly entry exists" — the nightly job seeds zero-point weeks
+     early. Gates the Standings highlights + chart and the Weekly Recap alike. -->
+<script src="/season-scoring.js"></script>
 <!-- Weekly Recap: shared card rendering + the once-a-week popup, app-wide so the
      popup can greet the logged-in viewer on whatever page they land on. -->
 <link rel="stylesheet" type="text/css" href="/weekly-recap.css">


### PR DESCRIPTION
Three features were showing placements and season-to-date content that hadn't been earned yet, for two closely related reasons. One shared rule now answers each question.

> **Rebased on main after #285.** `origin/main` merged in cleanly (no textual conflicts), but #285 introduced one semantic overlap worth knowing about — see [After #285](#after-285) at the bottom. CI green, 799 tests.

## The bugs

**Root cause A — the nightly scoring job seeds a zero-point `weeklyScore` entry** for every manager as soon as a week's games *exist*: through the preseason with undrafted, 0-team rosters, and again mid-week before any game is final. So `weeklyScore.length` does not mean "the season started."

**Root cause B — reading a rank off an array index.** `Array#sort` is stable, so managers level on points keep whatever order the DB returned. Before kickoff *every* manager is level on 0, which turns the index into pure document order.

What that produced:

1. **The Weekly Recap (#212) fired during the 2026 preseason.** Every graham-league manager already had a 2026 season with `teams: 0` and `weeklyScore.length: 1`, so the popup told everyone about a Week 1 nobody had played. Not just a preseason problem — the same seeding happens mid-week all season, so the popup would surface the *current, unfinished* week (0 pts) instead of the last week that actually finished.
2. **My Team's hero rank invented a placement.** With every total at `0`, the sort was a no-op and each manager was handed their row position as a rank — stable across reloads, so it looked entirely legitimate. Measured on the live dev league, it would have told Garrett he was **2nd of 6** with nobody having played. Its own comment named the failure mode it was meant to prevent (`preseason ties everyone at 0`).
3. **The standings rank column did the same** — in two different files. `routes/standings.js` built the H2H payload with `rank: i + 1`, and that is the path graham-league actually renders (its table comes from the server payload, not `rankedRows`); `rankedRows` did it for the classic points-only table. Milder than #2 — no crown in the preseason and "Tied" under each score — but the column still read 1..6 as if someone were ahead, and a genuine mid-season tie still split 2nd and 3rd by document order.

`seasonHasScoring()` had already been added to `public/standings.js` to fix root cause A for the highlights panel and the points chart. There were simply several copies of each question, and they had drifted.

## The fix

| File | Change |
| --- | --- |
| `public/season-scoring.js` | **New.** UMD helper (the `public/logo.js` pattern), loaded app-wide by the navbar partial: `entryHasScoring`, `seasonHasScoring`, `postseasonHasScoring`. One definition of "has this been played yet" for client, server, and the recap module. |
| `modules/weekly-recap.js` | A week counts only once someone in the league banked points. Unplayed weeks drop out, so an unstarted season returns no recaps. |
| `routes/standings.js` | `season=latest` drops its weaker "an entry exists" pre-check (and a query with it); the H2H payload is competition-ranked. |
| `public/standings.js` | Both scoring gates delegate to the shared helper; carries `tie` through to the H2H rows. |
| `public/league-rank.js` | **New.** UMD helper: `competitionRanks(items, scoreOf)` → parallel `{ rank, tie }` array, plus `leagueRank(users, userId)`. `1 +` managers strictly ahead, so ties share a placement and consume the ones behind them (1, 2, 2, 4). Order-independent, so no document order is left to leak. |
| `public/userHome.js` | `computeRank` gates on `seasonHasScoring` and ranks via `leagueRank`; the hero tile prefixes `T-`. |
| `public/standings-insights.js` | `rankedRows` ranks through `competitionRanks` — **including movement**, which previously came from a sort index and so reported "no change" when a manager lost a share of the lead. The rank cell renders `T-2`; a shared lead reads `Co-leader`. |

Judgment calls worth a look:

- **The recap gate is league-wide, not per-manager.** A manager who scored 0 in a week the league really played still gets a genuine "Quiet week — no points banked." Only weeks *nobody* played disappear.
- **The recap gate lives in the module, not the call sites.** The popup, the My Team tile, and any future recap email already hide on an empty `recaps` list, so all of them inherit it.
- **The rank gate moved from the call site into `computeRank`.** "Has anyone played" is league-wide, and that's where the league payload is in hand. Costs one extra `/users/league` fetch during the drafted-but-unplayed window; buys a single obvious gate.
- **Preseason needs no ranking special case any more.** Everyone on 0 simply ties for 1st, so the column reads `T-1` down the page rather than a fabricated order. `preseason` now only governs the crown and medals.
- **A shared lead keeps both gold rows** (and skips silver: 1, 1, 3). Reviewed and deliberately left as-is — an exact tie at the top is uncommon and the static styling reads correctly.
- **`gapHtml` lost a branch** that competition ranking makes unreachable: `gap === 0` means you *are* (co-)leading, so "tied but not leading" can't occur in that cell.

## Tests

**42 suites, 799 tests passing**, coverage thresholds met, CI green.

- `tests/WeeklyRecap.spec.js` — preseason shape, the mid-season in-progress week, the quiet-week-that-counts, seeded postseason entries, and that a seeded zero week never becomes "last week" for rank movement.
- `tests/SeasonScoring.spec.js` — **new**, all three gates.
- `tests/LeagueRank.spec.js` — **new**, `competitionRanks` + `leagueRank`: ties sharing a placement, skipped placements, the all-zero preseason field, and **order-independence** — the property the sort-index approach lacked.
- `tests/StandingsInsights.spec.js` — shared placements, `T-` markup, `Co-leader`, order-independence, and that losing a share of the lead now counts as a slip.
- Both jsdom harnesses load the **real** helpers rather than stubs, so the page tests exercise the actual gates and ranking.

Both UMD helpers are kept out of `collectCoverageFrom` for the same reason `public/logo.js` is — the browser half of a UMD wrapper is unreachable from a CommonJS `require` — with dedicated specs instead.

## Verification

Recap gate, against the dev DB (`YEAR=2026`):

```
=== graham-league 2026 — 6 managers ===
  Garrett Graham     teams: 0 weeklyScore: 1 non-zero weeks: 0 -> recaps: 0
  ...  (all 6 identical)
  managers who would see a recap: 0/6

=== graham-league 2025 — 6 managers ===
  Garrett Graham     teams:10 weeklyScore:17 non-zero weeks:16 -> recaps:17  latest="Postseason" (24 pts)
  ...
  managers who would see a recap: 6/6
```

2025 is a useful control: managers with only 15–16 non-zero weeks of 17 still get all 17 recaps, confirming the league-wide semantics on real data.

In the browser, on live 2026 data:

- `GET /standings/recap/graham-league/latest/<id>` → `{ season: 2026, recaps: [] }`; `2025` still returns 17.
- Forcing `maybeShowPopup({ force: true })` — past both the Aug–Jan window and the once-a-week key — renders **nothing**, and leaves `ccRecapPopupSeen` unset, so the popup still fires properly once Week 1 finishes. Positive control: the 2025 recap still renders its full 8-slide deck.
- My Team rank: all six 2026 totals are `0`, `seasonHasScoring: false`, `computeRank → null` — where the old sort-index approach computes `2`.
- Standings, 2026: the H2H route returns `rank: 1, tie: true` for all six managers, and the page renders six `T-1 / Tied` rows with no medals.

On the `fantasy-cfb-2025` server (real scores):

- Standings ranks `1..6` by adjusted total (Brock 264 → Acuff Me Up 178), medals and `Leader` intact.
- My Team ranks `1..6` correctly; a synthetic tie renders `1st`, `T-2nd`, `T-2nd`, `4th of 4 teams`.
- Tie states painted into the live standings table hold the rank cell at 57px and rows at 40px — the extra characters shift nothing.
- No console errors on either page.

## After #285

`origin/main` merged cleanly, and `h2hRows` came through untouched (#285's additions sit below it), so `tie` landed where intended. Two notes:

1. **#285 added a fourth copy of the rule.** `postseasonHasScoring` went into `public/standings.js` three lines below the `seasonHasScoring` this branch had just replaced with a shared call — its own comment says it's gated on a non-zero score "for the same reason seasonHasScoring is". Since ending that duplication is the point of this PR, it moved into `public/season-scoring.js` too and the call site delegates. The comment explaining *why the postseason reveal isn't the same moment as "the H2H schedule ran out"* stayed at the call site, where it belongs. No behavior change: verified on 2025 that the two-stage reveal still retitles to **"Postseason Rivalries"** and shows the schedule note.
2. **Pre-existing noise, not from either PR:** on the 2025 postseason the standings page logs ~37 console errors, because [`routes/games.js:35`](https://github.com/gwadegraham/fantasy-cfb/blob/main/routes/games.js#L35) returns **400** for the ordinary "this team had no game that week" case, and most drafted teams played no bowl. Cosmetic — the client treats non-OK as "no game" and the schedule renders all 108 rows — but worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
