### PR TITLE
Give H2H leagues a postseason instead of a dark page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "node",
       "runtimeArgs": ["server.js"],
       "port": 3000
+    },
+    {
+      "name": "fantasy-cfb-2025",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "PORT=3001 YEAR=2025 node server.js"],
+      "port": 3001
     }
   ]
 }

--- a/public/standings.css
+++ b/public/standings.css
@@ -113,6 +113,31 @@
         align-content: center;
     }
 
+    /* Sub-line under the Rivalry Games header, filled by standings.js when an
+       H2H league reaches the postseason.
+       The gap to whatever follows the heading is .header-title's own bottom
+       padding, and that varies by breakpoint (5px under 768px, 35px above it,
+       20px past 64em). So the pair is tightened from the heading side when the
+       note is showing — pulling the note up by a fixed amount instead overlapped
+       the title at the mobile padding. standings.js adds .has-section-note. */
+    .header.has-section-note .header-title {
+        padding-bottom: 0.4em;   /* em, so the gap tracks the title at each breakpoint */
+    }
+
+    .section-note {
+        max-width: 640px;
+        margin: 0 auto 1.2rem;
+        padding: 0 20px;
+        text-align: center;
+        color: var(--cc-muted);
+        font-size: 0.82rem;
+        line-height: 1.45;
+    }
+
+    .section-note[hidden] {
+        display: none;
+    }
+
     /* No Games CSS */
     #no-games-container {
         margin: 1em;

--- a/public/standings.js
+++ b/public/standings.js
@@ -36,6 +36,19 @@ function seasonHasScoring(users) {
         .some(w => (w.score || 0) !== 0));
 }
 
+// True once someone has banked real postseason points — i.e. the bowl/playoff
+// slate has something on it. Gated on a non-zero score for the same reason
+// seasonHasScoring is: the scoring job writes the postseason entry whenever it
+// runs for the postseason, so a bare entry can exist at 0.
+//
+// This is deliberately NOT the same moment as "the H2H schedule ran out".
+// Conference championship week and Army/Navy fall between the two, and they
+// carry rivalry games of their own — see revealRivalryGames.
+function postseasonHasScoring(users) {
+    return (users || []).some(u => ((u.seasons && u.seasons[0] && u.seasons[0].weeklyScore) || [])
+        .some(w => w.season === 'postseason' && (w.score || 0) !== 0));
+}
+
 function detectMobile() {
     if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/.test(navigator.userAgent)){
         // true for mobile device
@@ -132,7 +145,9 @@ async function getUsers() {
                 }
             }
             // Standings table: decide the layout before painting so an H2H
-            // league doesn't flash the classic table then swap (see below).
+            // league doesn't flash the classic table then swap (see below). It
+            // owns the schedule render too — an H2H league hides that section,
+            // and its ~60 game fetches are pure waste until we know the mode.
             renderStandingsSection(data, leagueCode, data[0]?.seasons?.[0]?.season);
             maybePromptProfileSetup(data);
             displayLastUpdated(data);
@@ -143,7 +158,6 @@ async function getUsers() {
             // displayHighlights just hid.
             if (seasonHasScoring(data)) loadAdvancedHighlights(leagueCode, data[0]?.seasons?.[0]?.season);
             loadProjections(leagueCode, data[0]?.seasons?.[0]?.season);
-            displaySchedule(data);
             seedUserIdFromEmail(userMetadata, usersData);
             // Chart is responsive now, so show it on mobile too — but only once
             // the season has real scoring. A zero-point week the nightly job seeds
@@ -184,9 +198,12 @@ async function renderStandingsSection(data, league, season) {
         } catch (e) { /* timeout or error → treat as classic */ }
     }
 
-    if (!enabled && !preview) { displayUsers(data); return; }
-    hideLegacyH2HSchedule();   // hide the unrelated lower schedule ASAP (before it paints)
+    if (!enabled && !preview) { displayUsers(data); displaySchedule(data); return; }
+    hideLegacyH2HSchedule();   // hide the Rivalry Games section ASAP (before it paints)
     showStandingsLoading();
+    // The schedule render is deferred to revealRivalryGames(): while matchups
+    // are live the section stays hidden, so building it would cost a game fetch
+    // per team per week for markup nobody sees.
     loadH2H(league, season, data);   // renders H2H, or falls back to classic
 }
 
@@ -437,6 +454,7 @@ async function loadH2HMatchups(league, season, sim) {
         const url = `/standings/h2h/${league}/${season}` + (sim ? `?h2hSim=${encodeURIComponent(sim)}` : '');
         const res = await fetch(url, { headers: { Accept: 'application/json' } });
         const d = await res.json();
+        if (d && d.scheduleComplete) revealRivalryGames();
         if (d && (d.schedule || []).length) renderH2HMatchups(d);
     } catch (e) { /* matchups are best-effort */ }
 }
@@ -472,20 +490,73 @@ function h2hRows(d) {
     }));
 }
 
-// When the H2H game mode is on, hide the separate lower "Head to Head" schedule
-// section (the CFB games where two managers' drafted teams happen to meet). It's
-// an unrelated, older sense of "head-to-head" and showing both is confusing.
-function hideLegacyH2HSchedule() {
+// The pieces of the lower Rivalry Games section — real CFB games where two
+// managers' drafted teams meet. The divider directly above it is included, so
+// hiding the section doesn't leave a stray rule between the highlights and the
+// chart.
+function rivalryGamesEls() {
     const pollHeader = document.querySelector('[poll-name]');
     const headerWrap = pollHeader && pollHeader.closest('.header');
     const els = [headerWrap, document.querySelector('.dropdownWeek'), document.querySelector('.game-content')];
-    // The divider directly above that section goes too, so we don't leave a
-    // stray rule between the highlights and the chart.
     if (headerWrap) {
         const prev = headerWrap.previousElementSibling;
         if (prev && prev.classList && prev.classList.contains('hr-subtle')) els.push(prev);
     }
-    els.forEach(el => { if (el) el.style.display = 'none'; });
+    return els.filter(Boolean);
+}
+
+// While an H2H league has live matchups, the Rivalry Games section is hidden:
+// both surfaces pair manager against manager, and two of those on one page is
+// confusing. The H2H panel wins the slot because its pairings are the ones that
+// carry a bonus. revealRivalryGames() undoes this once no matchup is left.
+function hideLegacyH2HSchedule() {
+    rivalryGamesEls().forEach(el => { el.style.display = 'none'; });
+}
+
+// Every H2H week is final, so there is no live matchup left to confuse this
+// section with — bring it back to carry the rest of the season. Called from
+// loadH2HMatchups off the payload's scheduleComplete flag; if that fetch fails
+// the section simply stays hidden.
+//
+// The H2H schedule runs out weeks before the bowls start: conference
+// championship week and Army/Navy sit in between, and each carries rivalry
+// games of its own. So the reveal has two stages — the section comes back the
+// moment matchups end, but it only retitles and jumps to the postseason once
+// the postseason has points on it. Jumping straight there would park the league
+// on an empty "no rivalry games" view for a fortnight.
+function revealRivalryGames() {
+    rivalryGamesEls().forEach(el => { el.style.display = ''; });
+
+    const title = document.querySelector('[poll-name]');
+    const note = document.querySelector('[schedule-note]');
+    if (note) {
+        // True in both stages: championship-week points count too, and no week
+        // past the H2H schedule carries a bonus.
+        note.textContent = 'Real games where your teams meet another manager’s. These points count toward your total — matchup bonuses ended with the regular season.';
+        note.hidden = false;
+        // Closes the heading's bottom padding so the note reads as its sub-line
+        // rather than floating above the week picker (see .has-section-note).
+        if (title) title.closest('.header').classList.add('has-section-note');
+    }
+
+    // Stage two. Until it fires, the bootstrap's latest-scored-week default is
+    // the right landing and the season-neutral "Rivalry Games" title still reads
+    // true, so neither is touched.
+    if (postseasonHasScoring(usersData)) {
+        if (title) title.textContent = 'Postseason Rivalries';
+        // latestWeek() deliberately skips the postseason bucket, so the
+        // bootstrap defaulted to a regular week. A week the user picked
+        // themselves is left alone — the same rule the bootstrap uses.
+        if (!window.localStorage.getItem('week')) {
+            window.localStorage.setItem('weekCode', 'week-17');
+            weekCode = 'week-17';
+            $('#dropdownMenuButtonWeek').text('Postseason');
+        }
+    }
+
+    // This is the only schedule render an H2H league does; renderStandingsSection
+    // skipped the bootstrap one while the section was still hidden.
+    displaySchedule(usersData);
 }
 
 function renderH2HMatchups(d) {
@@ -496,9 +567,18 @@ function renderH2HMatchups(d) {
     const weekOpts = (d.schedule || []).map(s => `<option value="${s.week}"${s.week === d.featuredWeek ? ' selected' : ''}>Week ${s.week}</option>`).join('');
 
     const preview = !d.enabled ? '<span class="h2h-preview-tag">preview</span>' : '';
-    el.innerHTML = `<h2 class="h2h-panel-title">${window.ccIcon ? window.ccIcon('swords', { size: 22 }) : ''}This Week's Matchups${preview}</h2>
-        <p class="h2h-panel-note">Each week you face one rival — win the matchup for a <b>+${d.winBonus}</b> bonus${d.tieBonus > 0 ? `, or <b>+${d.tieBonus}</b> each on a tie` : ''} (regular season only). Bonuses are folded into your <b>Total</b> in the standings above; see your full matchup log on My Team.</p>
-        <div class="h2h-week-bar"><span class="h2h-week-cap">Matchups</span><select h2h-week aria-label="Matchup week">${weekOpts}</select></div>
+    // Once the schedule is exhausted the panel would otherwise sit on the last
+    // regular week forever under a "This Week's" heading. It becomes a closing
+    // summary instead, and hands the postseason off to the Rivalry Games section
+    // that revealRivalryGames() just brought back below it.
+    const done = !!d.scheduleComplete;
+    const title = done ? 'Final Matchups' : "This Week's Matchups";
+    const note = done
+        ? `Regular season complete — every matchup bonus is locked in and already folded into your <b>Total</b> above. Postseason points still count toward the title; the games are below. Your full matchup log is on My Team.`
+        : `Each week you face one rival — win the matchup for a <b>+${d.winBonus}</b> bonus${d.tieBonus > 0 ? `, or <b>+${d.tieBonus}</b> each on a tie` : ''} (regular season only). Bonuses are folded into your <b>Total</b> in the standings above; see your full matchup log on My Team.`;
+    el.innerHTML = `<h2 class="h2h-panel-title">${window.ccIcon ? window.ccIcon('swords', { size: 22 }) : ''}${title}${preview}</h2>
+        <p class="h2h-panel-note">${note}</p>
+        <div class="h2h-week-bar"><span class="h2h-week-cap">${done ? 'Final week' : 'Matchups'}</span><select h2h-week aria-label="Matchup week">${weekOpts}</select></div>
         <div class="h2h-matches" h2h-matches></div>`;
     el.hidden = false;
 
@@ -1128,7 +1208,7 @@ const noGamesMessages = [
     <div class="no-matchups-message trash-talk">
         <div class="emoji wiggle">🧢</div>
         <h3>Trash Talk Saturday Canceled</h3>
-        <p>No head-to-heads this week. The group chat is unusually calm.</p>
+        <p>No rivalry games this week. The group chat is unusually calm.</p>
         <p class="suggestion">Use this time to cook up excuses for next week.</p>
     </div>
   `,
@@ -1136,14 +1216,14 @@ const noGamesMessages = [
     <div class="no-matchups-message no-smoke">
         <div class="emoji fade-pulse">🫥</div>
         <h3>Nobody Wanted the Smoke</h3>
-        <p>No matchups on the board. Everyone’s ducking this week.</p>
+        <p>No rivalry games on the board. Everyone’s ducking this week.</p>
         <p class="suggestion">Feel free to flex your record anyway.</p>
     </div>
   `,
   `
     <div class="no-matchups-message gods-away">
         <div class="emoji blink">👀</div>
-        <h3>The Matchup Gods Looked Away</h3>
+        <h3>The Rivalry Gods Looked Away</h3>
         <p>No battles this week. It’s just punts and vibes.</p>
         <p class="suggestion">Enjoy the peace. Chaos returns soon.</p>
     </div>

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -574,7 +574,14 @@ router.get('/h2h/:league/:season', async (req, res) => {
             featuredWeek = w.week; currentWeekOut = w.week;
         }
 
-        res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, tieBonus, weeks: schedWeeks, featuredWeek, currentWeek: currentWeekOut, managers, schedule });
+        // No H2H week is left to play. The client uses this to bring the lower
+        // Rivalry Games section back for the postseason — it stays hidden while
+        // matchups are live so the two senses of "head to head" never share the
+        // page. Derived AFTER the sim block, so ?h2hSim (which fakes a live
+        // week) still reads as mid-season.
+        const scheduleComplete = !!(schedWeeks.length && !currentWeekOut);
+
+        res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, tieBonus, weeks: schedWeeks, featuredWeek, currentWeek: currentWeekOut, scheduleComplete, managers, schedule });
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/tests/StandingsPage.spec.js
+++ b/tests/StandingsPage.spec.js
@@ -352,6 +352,156 @@ describe('head-to-head matchups panel', () => {
     });
 });
 
+// --- postseason handoff ------------------------------------------------------
+
+// Once every H2H week is final the page swaps roles: the matchup panel closes
+// out as a summary, and the Rivalry Games section it displaced all season comes
+// back to carry the rest of the schedule.
+describe('postseason handoff', () => {
+    const schedule = [{ week: 1, games: [{ id: 'g1' }] }, { week: 2, games: [{ id: 'g2' }] }];
+    const matchups = (over = {}) => Object.assign({
+        enabled: true, winBonus: 5, tieBonus: 2, featuredWeek: 2,
+        managers: H2H_PAYLOAD.managers, schedule
+    }, over);
+    // Bowls are on the board: someone has banked postseason points.
+    const post = (extra = {}) => [
+        scored('a', 'Alice', 'Adams', [10, 40, { season: 'postseason', week: 1, score: 24 }], extra),
+        scored('b', 'Bob', 'Brown', [40, 5, { season: 'postseason', week: 1, score: 12 }])
+    ];
+    // The gap between the last matchup and the first bowl — championship week
+    // and Army/Navy. Regular weeks scored, nothing postseason yet.
+    const gap = (extra = {}) => [
+        scored('a', 'Alice', 'Adams', [10, 40, 22], extra),
+        scored('b', 'Bob', 'Brown', [40, 5, 18])
+    ];
+    const opts = (over = {}) => Object.assign({
+        users: post(),
+        h2hEnabled: true, h2hStandings: H2H_PAYLOAD, h2hMatchups: matchups({ scheduleComplete: true })
+    }, over);
+
+    const header = (page) => page.q('[poll-name]').closest('.header');
+
+    it('keeps the section hidden while a matchup week is still live', async () => {
+        const page = await loadStandingsPage(opts({ h2hMatchups: matchups() }));
+        expect(header(page).style.display).toBe('none');
+        expect(page.q('.game-content').style.display).toBe('none');
+        expect(page.q('[schedule-note]').hidden).toBe(true);
+    });
+
+    // The section is hidden all season, so building it would spend a game fetch
+    // per rostered team per week on markup nobody can see.
+    it('skips the schedule render entirely while the section is hidden', async () => {
+        const page = await loadStandingsPage(opts({
+            h2hMatchups: matchups(),
+            users: post({ teams: [{ id: 1, school: 'Indiana' }] })
+        }));
+        expect(page.urls().some(u => u.includes('/games/seasonType/'))).toBe(false);
+    });
+
+    it('renders the schedule once when the section comes back', async () => {
+        const page = await loadStandingsPage(opts({
+            users: post({ teams: [{ id: 1, school: 'Indiana' }] })
+        }));
+        const gameCalls = page.urls().filter(u => u.includes('/games/seasonType/'));
+        expect(gameCalls.length).toBeGreaterThan(0);
+        expect(gameCalls.every(u => u.includes('/postseason/'))).toBe(true);
+    });
+
+    it('brings the section back once the schedule is complete', async () => {
+        const page = await loadStandingsPage(opts());
+        expect(header(page).style.display).toBe('');
+        expect(page.q('.dropdownWeek').style.display).toBe('');
+        expect(page.q('.game-content').style.display).toBe('');
+        expect(document.querySelectorAll('.hr-subtle')[1].style.display).toBe('');
+    });
+
+    it('retitles the section for the postseason and explains the scoring', async () => {
+        const page = await loadStandingsPage(opts());
+        expect(page.q('[poll-name]').textContent).toBe('Postseason Rivalries');
+        const note = page.q('[schedule-note]');
+        expect(note.hidden).toBe(false);
+        expect(note.textContent).toContain('matchup bonuses ended with the regular season');
+        // Tightens the heading's bottom padding so the note reads as its
+        // sub-line at every breakpoint.
+        expect(header(page).classList.contains('has-section-note')).toBe(true);
+    });
+
+    it('lands on the postseason instead of the last regular week', async () => {
+        const page = await loadStandingsPage(opts());
+        expect(window.localStorage.getItem('weekCode')).toBe('week-17');
+        expect(page.jquery.store['#dropdownMenuButtonWeek'].text).toBe('Postseason');
+    });
+
+    it('leaves a manually picked week alone', async () => {
+        const page = await loadStandingsPage(opts({
+            localStorage: { week: 'Week 2', weekCode: 'week-2' }
+        }));
+        expect(window.localStorage.getItem('weekCode')).toBe('week-2');
+        expect(header(page).style.display).toBe('');   // still revealed
+    });
+
+    // The H2H schedule runs out weeks before the bowls start. Championship week
+    // and Army/Navy carry rivalry games of their own, so the section is revealed
+    // on the regular slate rather than parked on an empty postseason view.
+    describe('before the first bowl', () => {
+        it('still reveals the section', async () => {
+            const page = await loadStandingsPage(opts({ users: gap() }));
+            expect(header(page).style.display).toBe('');
+            expect(page.q('.game-content').style.display).toBe('');
+            expect(page.q('[schedule-note]').hidden).toBe(false);
+        });
+
+        it('keeps the season-neutral title and the latest scored week', async () => {
+            const page = await loadStandingsPage(opts({ users: gap() }));
+            expect(page.q('[poll-name]').textContent).toBe('Rivalry Games');
+            expect(window.localStorage.getItem('weekCode')).toBe('week-3');
+        });
+
+        it('renders that week rather than an empty postseason', async () => {
+            const page = await loadStandingsPage(opts({
+                users: gap({ teams: [{ id: 1, school: 'Indiana' }] })
+            }));
+            const gameCalls = page.urls().filter(u => u.includes('/games/seasonType/'));
+            expect(gameCalls.length).toBeGreaterThan(0);
+            expect(gameCalls.every(u => u.includes('/regular/week/3/'))).toBe(true);
+        });
+
+        // A postseason entry exists before any bowl is played, seeded at 0 by
+        // the scoring job — that must not count as the postseason starting.
+        it('ignores a postseason bucket with no points in it', async () => {
+            const page = await loadStandingsPage(opts({
+                users: [scored('a', 'Alice', 'Adams', [10, 40, { season: 'postseason', week: 1, score: 0 }])]
+            }));
+            expect(page.q('[poll-name]').textContent).toBe('Rivalry Games');
+            expect(window.localStorage.getItem('weekCode')).toBe('week-2');
+        });
+    });
+
+    it('closes the matchup panel out as a summary', async () => {
+        const page = await loadStandingsPage(opts());
+        const html = page.h2hPanel().innerHTML;
+        expect(html).toContain('Final Matchups');
+        expect(html).not.toContain("This Week's Matchups");
+        expect(html).toContain('Regular season complete');
+        expect(html).not.toContain('win the matchup for a');
+    });
+
+    it('leaves the panel in its live form while matchups remain', async () => {
+        const page = await loadStandingsPage(opts({ h2hMatchups: matchups() }));
+        expect(page.h2hPanel().innerHTML).toContain("This Week's Matchups");
+        expect(page.h2hPanel().innerHTML).not.toContain('Final Matchups');
+    });
+
+    it('never touches the section for a league without H2H', async () => {
+        const page = await loadStandingsPage({
+            users: [scored('a', 'Alice', 'Adams', [10, 40])], h2hEnabled: false
+        });
+        expect(header(page).style.display).toBe('');
+        expect(page.q('[poll-name]').textContent).toBe('Rivalry Games');
+        expect(page.q('[schedule-note]').hidden).toBe(true);
+    });
+});
+
 // --- roster drawer + score animation ----------------------------------------
 
 describe('roster drawer', () => {

--- a/tests/helpers/standings-dom.js
+++ b/tests/helpers/standings-dom.js
@@ -37,7 +37,8 @@ const FIXTURE = `
 <h2 class="highlights-header">League Highlights</h2>
 <div class="highlights-container"></div>
 <hr class="hr-subtle">
-<div class="header"><div class="header-title" poll-name>Head to Head</div></div>
+<div class="header"><div class="header-title" poll-name>Rivalry Games</div></div>
+<p class="section-note" schedule-note hidden></p>
 <div class="dropdown dropdownWeek">
     <button id="dropdownMenuButtonWeek"></button>
     <div class="dropdown-menu dropdown-menu-week"><a class="dropdown-item" value="week-1">Week 1</a></div>

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -84,11 +84,17 @@
     <!-- Cards are rendered from data by standings.js (buildHighlights). -->
     <div class="highlights-container"></div>
     <hr class="hr-subtle">
+    <!-- Real CFB games where two managers' drafted teams meet. Named for what it
+         holds, so it never collides with the H2H panel's weekly "matchups" (the
+         scheduled fantasy pairing that carries a bonus). standings.js retitles
+         this and fills [schedule-note] when an H2H league reaches the
+         postseason. -->
     <div class="header">
         <div class="header-title" poll-name>
-            Head to Head
+            Rivalry Games
         </div>
     </div>
+    <p class="section-note" schedule-note hidden></p>
     <div class="dropdown dropdownWeek">
         <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButtonWeek" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Week 1


### PR DESCRIPTION
## The problem

An H2H league goes quiet the moment its matchups run out. The weekly matchup system is regular-season only by design, and `hideLegacyH2HSchedule()` hid the lower schedule section for the entire season — so from the last matchup through the natty, roughly six weeks, the Standings page had nothing to show while points were still being scored.

Non-H2H leagues (claunts) saw those games normally the whole time, which is backwards: the more engaged league saw less.

## Why it was hidden, and why renaming beats hiding

The section was hidden because both surfaces pair manager against manager and calling both "head to head" was confusing. That's a real collision, not a lazy label — every card in that section is already a manager-vs-manager game.

What separates them is who scheduled it:

| | H2H panel | Rivalry Games |
|---|---|---|
| Origin | Round-robin, assigned by us | The CFB schedule happened to pair you |
| Frequency | One per manager per week | Zero, one, or several |
| Compares | Both managers' full weekly totals | Two specific teams on the field |
| Stakes | +N bonus | Bragging rights |

So each is named for what it is instead of one being hidden:

- **"Matchups"** now means only the scheduled fantasy pairing that carries a bonus.
- The section becomes **"Rivalry Games"**. Three empty-state lines that had borrowed "matchup" move to rivalry language — the rest of that copy ("No Grudge Games", "Nobody Wanted the Smoke") already spoke rivalry.
- The H2H panel gets an ending. It used to sit on the last regular week forever under "This Week's Matchups"; it now closes out as **"Final Matchups"** with the bonuses stated as locked in.

## Two-stage reveal

The H2H schedule runs out weeks before the bowls start — conference championship week and Army/Navy fall in between and carry rivalry games of their own (5 of them in graham-league 2025).

1. **`scheduleComplete`** — new on the H2H payload, true once every derived H2H week is final — reveals the section on the regular slate.
2. Once someone banks real postseason points, it retitles to **"Postseason Rivalries"** and lands on week 17.

Jumping straight to stage two would have parked the league on an empty "no rivalry games" view for a fortnight.

## Also: stops building a hidden section

`renderStandingsSection` now owns the schedule render, so an H2H league no longer spends ~60 game fetches per page load on markup nobody can see — all season, not just in the postseason. Non-H2H leagues are unaffected; they already blocked on the same `/enabled` check before painting the table.

## Not in scope

Per the Aug 2026 feature-gap audit, this changes **only what's displayed**. H2H remains a weekly win-bonus layer and the title is still decided on total points. No bracket, no playoff matchups, no bonuses past the regular season.

## Test plan

758 tests pass; 14 new under `postseason handoff` in `tests/StandingsPage.spec.js`.

Verified against real graham-league 2025 data on a local server pinned to `YEAR=2025`:

- **Timing.** Replayed the season week by week through `computeH2HAwards`: `scheduleComplete` is false through week 13 (`currentWeek: 14`) and flips true at week 14, the last H2H week. Preseason can't false-positive either — graham-league 2026 returns `weeks: [], scheduleComplete: false`.
- **Render.** 17 rivalry cards in the postseason, 6 carrying both managers' badges (the CFP games, via the owner-aware `pointsFor` fix from #283). Only `postseason` game fetches, no wasted regular-week pass.
- **Layout.** The new `.section-note` measured at 375 / 900 / 1280px — no overlap at any breakpoint, gap tracks the title size (an earlier fixed `-1.6rem` pull overlapped at the mobile padding).

One gap worth naming: the stage-one window is covered by the jest harness (which loads the real `public/standings.js` and runs its bootstrap) but was not reproduced in a browser, since that would mean doctoring postseason scores out of the dev database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)