### PR TITLE
Answer "no game this week" with 200 + [] instead of 400

### DIFF
--- a/modules/retrieve-games.js
+++ b/modules/retrieve-games.js
@@ -109,19 +109,15 @@ module.exports = {
     
         var game = await gamePromise;
         var response = await game.json();
-    
-        var games = new Array();
-    
-    
+
+        // The route answers "no game this week" with 200 + [], so a non-200 here
+        // is a real failure (500 / network) rather than an empty slate.
         if (game.status == 200) {
-            for (const game of response) {
-                games.push(game);
-            }
-        } else {
-            console.log(response.message);
+            return response;
         }
-    
-        return games;
+
+        console.error(`Could not load games for ${team.school}: ${response.message}`);
+        return [];
     },
 
     // Exported for testing.

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -127,7 +127,11 @@ module.exports= {
                         teamScores.push(teamScoreObject);
                     }
                 } else {
-                    console.log(response.message);
+                    // The route answers "no game this week" with 200 + [], so a
+                    // non-200 here means the lookup itself failed and this
+                    // team's points are missing from the week — not that it was
+                    // idle. Loud on purpose.
+                    console.error(`Could not load games for ${team.school}: ${response.message}`);
                 }
             }
 

--- a/public/standings.js
+++ b/public/standings.js
@@ -709,18 +709,14 @@ async function getGame(season, week, team) {
     var game = await gamePromise;
     var response = await game.json();
 
-    var games = new Array();
-
-
+    // The route answers "no game this week" with 200 + [], so a non-200 here is
+    // a real failure (500 / network) rather than an empty slate — log it as one.
     if (game.status == 200) {
-        for (const game of response) {
-            games.push(game);
-        }
-    } else {
-        console.log(`${response.message} | ${team.school}`);
+        return response;
     }
 
-    return games;
+    console.error(`Could not load games for ${team.school}: ${response.message}`);
+    return [];
 }
 
 async function getRankings (week, seasonType, seasonYear) {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -1458,18 +1458,14 @@ async function getGame(season, week, team) {
     var game = await gamePromise;
     var response = await game.json();
 
-    var games = new Array();
-
-
+    // The route answers "no game this week" with 200 + [], so a non-200 here is
+    // a real failure (500 / network) rather than an empty slate — log it as one.
     if (game.status == 200) {
-        for (const game of response) {
-            games.push(game);
-        }
-    } else {
-        console.log(response.message);
+        return response;
     }
 
-    return games;
+    console.error(`Could not load games for ${team.school}: ${response.message}`);
+    return [];
 }
 
 async function getRankings (week, seasonType, seasonYear) {

--- a/routes/games.js
+++ b/routes/games.js
@@ -29,11 +29,11 @@ router.get('/seasonType/:seasonType/week/:weekNum/team/:team', async (req, res) 
     try {
         const game = await Game.find({$and: [ { $or: [{"homeId":teamId}, {"awayId":teamId}]}, {"season":process.env.YEAR}, {seasonType: seasonType}, {week: week}]});
 
-        if (JSON.stringify(game) != '[]') {
-            res.status(200).json(game);
-        } else{
-            return res.status(400).json({message: `${teamId} did not have a game in week ${week}`});
-        }
+        // "This team had no game that week" is an empty result, not a client
+        // error. It used to 400, which put one console error per rostered team
+        // on every Standings load in the postseason (most drafted teams play no
+        // bowl game) and buried real failures in the noise.
+        res.status(200).json(game);
 
     } catch (err) {
         res.status(500).json({message: err.message});

--- a/tests/RoutesGames.spec.js
+++ b/tests/RoutesGames.spec.js
@@ -70,15 +70,18 @@ describe('GET reads', () => {
         expect(res.body[0].id).toBe(402);
     });
 
-    test('week-scoped lookup finds a game, and 400s when there is none', async () => {
+    // A team with no game that week is an empty result, not a client error. It
+    // used to 400, which logged one console error per rostered team on every
+    // postseason Standings load (most drafted teams play no bowl game).
+    test('week-scoped lookup finds a game, and 200s with [] when there is none', async () => {
         await Game.create(gameDoc({ homeId: 7, awayId: 8 }));
         const hit = await request(app).get('/games/seasonType/regular/week/1/team/7');
         expect(hit.status).toBe(200);
         expect(hit.body[0].id).toBe(401);
 
         const miss = await request(app).get('/games/seasonType/regular/week/9/team/7');
-        expect(miss.status).toBe(400);
-        expect(miss.body.message).toMatch(/did not have a game/);
+        expect(miss.status).toBe(200);
+        expect(miss.body).toEqual([]);
     });
 });
 

--- a/tests/StandingsPage.spec.js
+++ b/tests/StandingsPage.spec.js
@@ -1135,6 +1135,15 @@ describe('schedule', () => {
         expect(page.scheduleBody().querySelectorAll('.game-table')).toHaveLength(0);
     });
 
+    // Regression: the games route used to 400 for "this team had no game that
+    // week", so a normal postseason load logged one console error per rostered
+    // team (most drafted teams play no bowl game) and buried real failures. An
+    // empty slate is a 200 + [] now, and the page must stay quiet about it.
+    it('logs nothing when a team simply has no game that week', async () => {
+        await loadStandingsPage({ users: league(), games: [] });
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
     it('hides the loader and reveals the table when done', async () => {
         const page = await loadStandingsPage({ users: league(), games: [] });
         expect(page.q('.football-loader').style.display).toBe('none');
@@ -1343,6 +1352,9 @@ describe('degrading when upstream calls fail', () => {
         });
         expect(page.q('.football-loader').style.display).toBe('none');
         expect(page.q('#no-games-container').innerHTML).toContain('no-matchups-message');
+        // A genuine failure still has to be loud — that's the whole point of not
+        // spending the console on empty weeks.
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Could not load games for Indiana'));
     });
 
     it('survives the team-logo endpoint erroring', async () => {


### PR DESCRIPTION
`GET /games/seasonType/:seasonType/week/:weekNum/team/:team` returned **400** when no row matched. A team having no game that week is an ordinary empty result, not a client error.

The Standings page fetches this endpoint once per drafted team for the selected week, so a postseason load logged one 400 per team that played no bowl game — ~37 console errors on a normal render. Cosmetic (every caller already treated a non-OK response as "no game", and the schedule still rendered every row), but it buried real errors in noise and made the console useless for debugging that page. #285 made it far more visible by revealing the Rivalry Games section during the postseason.

## Changes

**The route** — `routes/games.js` always 200s with the array now. That retires the roundabout `JSON.stringify(game) != '[]'` emptiness check too; with nothing left to branch on, there's nothing to tidy.

**All four callers** had the same shape: build a local array, fill it on 200, leave it empty on the 400. Each now returns the response directly and reserves its error log for what a non-200 can actually mean here — a 500 or a network failure:

- `public/standings.js` — the schedule render
- `public/userHome.js` — My Team glance tile + schedule drawer
- `modules/retrieve-games.js`
- `modules/scoring.js` — kept its loop (the body is the scoring work); only the `else` changed. This one now says something stronger: a non-200 there means a team's points are silently missing from the week, so it logs as an error rather than a `console.log`.

No caller looked at `res.ok`, so none silently flipped behavior. Nothing else references the endpoint — no views, no other job code, no stale references to the old message.

## Tests

`tests/RoutesGames.spec.js` asserts `200` + `[]` for the miss. The `StandingsPage` fetch harness already stubs a bare body (200) for this path, so it needed no change — but two assertions now pin the behavior in both directions: an empty slate logs nothing, and the existing 500 test asserts the error *is* logged.

759 passing across 40 suites; `--coverage` gate exits 0 (`public/standings.js` at 96.3/83.2/96.4/99.5 against its 95/80/95/98 ratchet).

## Verified locally

On the `fantasy-cfb-2025` config, postseason week:

- Server-side across every league on the dev tenant: 120 drafted teams, 120 × `200`, 32 of them empty slates that previously 400'd.
- Standings page: 60 game fetches, **0 non-200**, console clean, all 17 schedule rows still rendering with no "no games" fallback.
- `userHome`'s `getGame` exercised directly — array both ways (2 games for a bowl team, `[]` for a team with none), no log.

## Unrelated finding

My Team on that 2025 server 500s on `GET /users/null` and bails before the schedule, so its `getGame` never ran during the page load — hence exercising it directly. Not caused by this change (the session's Auth0 id doesn't resolve to a franchise on the 2025 dev tenant), but a `/users/:id` route that 500s on a null id may be worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)