### PR TITLE
Make the Campus Clash wordmark actually clash

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -161,10 +161,6 @@
         width: 100%;
     }
 
-    .brand-title {
-        font-size: 2rem;
-    }
-
     .header-title {
         font-size: 3.4rem;
         padding: 35px 35px 35px 0px;

--- a/public/draftRoom.css
+++ b/public/draftRoom.css
@@ -21,10 +21,6 @@
 }
 
 @media only screen and (min-width: 64em) {
-    .brand-title {
-        font-size: 2rem;
-    }
-
     body {
         margin: 0;
         padding: 0;

--- a/public/scoringRules.css
+++ b/public/scoringRules.css
@@ -63,10 +63,6 @@
 
 @media only screen and (min-width: 64em) {
 
-    .brand-title {
-        font-size: 2rem;
-    }
-
     .header-title {
         font-size: 3.4rem;
     }

--- a/public/standings.css
+++ b/public/standings.css
@@ -330,10 +330,6 @@
 
 @media only screen and (min-width: 64em) {
 
-    .brand-title {
-        font-size: 2rem;
-    }
-
     .header-title {
         font-size: 2.6rem;
         padding: 20px 20px 20px 0px;

--- a/public/styles.css
+++ b/public/styles.css
@@ -152,9 +152,62 @@ body {
     display: inline-block;
 }
 
+/* Brand wordmark. CAMPUS and Clash collide on purpose — that overlap is the
+   whole idea of the mark, so it's set in `em` and lands in the same place at
+   every size. It used to be `margin-top: -18%`, and percentage margins resolve
+   against the containing block's WIDTH, so the depth of the collision drifted
+   as the navbar resized (−16px to −36px at a fixed 32px font).
+
+   The script carries a keyline in the page's own background colour, which cuts
+   a clean channel through the block caps. Without it a deep overlap just reads
+   as two words smudging together; with it, the collision reads as intentional.
+   Every metric below is em-relative, so --brand-size is the only knob. */
 .brand-title {
-    font-size: 1.5rem;
-    margin: .5rem;
+    --brand-size: 2.1rem;
+    --brand-ground: var(--cc-bg);   /* keyline = a hole punched in the ground */
+    font-size: var(--brand-size);
+    line-height: 1;                 /* Pacifico's default line box is ~1.5x and inflates the navbar */
+    display: inline-grid;
+    justify-items: center;
+    margin: .3rem .5rem;
+}
+
+.brand-campus {
+    font-family: Graduate, serif;
+    font-size: .62em;
+    letter-spacing: .10em;
+    text-indent: .10em;    /* cancel the trailing letter-space so it centers true */
+}
+
+.brand-clash {
+    font-family: Pacifico, cursive;
+    font-size: 1.1em;      /* larger script crashing into smaller caps reads as impact */
+    /* THE clash. em, so it cannot drift with width. Note this resolves against
+       .brand-clash's OWN font-size (1.1em), so -.18em here eats about a third
+       of CAMPUS's height — deep enough to read as a deliberate hit, shallow
+       enough that every cap stays legible. Past -.27em CAMPUS starts to erode.
+       Retune this alongside font-size above: the two are coupled, so shrinking
+       the script shrinks the bite unless this rises to compensate. */
+    margin-top: -.18em;
+    margin-left: -.04em;   /* optical centering — Pacifico enters left-heavy */
+    color: var(--cc-accent);
+    position: relative;
+    z-index: 1;            /* script passes in front of the caps */
+    /* Keyline. text-shadow rather than -webkit-text-stroke: the stroke version
+       needs `paint-order: stroke fill`, and where that's ignored the stroke
+       paints over the fill and hollows the letters out. */
+    text-shadow:
+        .052em 0 var(--brand-ground), -.052em 0 var(--brand-ground),
+        0 .052em var(--brand-ground), 0 -.052em var(--brand-ground),
+        .037em .037em var(--brand-ground), -.037em .037em var(--brand-ground),
+        .037em -.037em var(--brand-ground), -.037em -.037em var(--brand-ground);
+}
+
+/* Desktop size lives here, once. Every page's own stylesheet used to carry its
+   own `.brand-title { font-size: 2rem }` at this breakpoint — six copies of the
+   same rule, and each one overrode styles.css because the page CSS loads after. */
+@media only screen and (min-width: 64em) {
+    .brand-title { --brand-size: 2.4rem; }
 }
 
 /* Current page indicator */
@@ -715,8 +768,12 @@ footer {
    on page load. Gated behind prefers-reduced-motion (no-preference only), so
    the logo just appears normally for readers who opt out. */
 @media (prefers-reduced-motion: no-preference) {
+    /* Only the RIGHT inset animates, so the wipe is purely horizontal. The other
+       three sides stay slack: with line-height:1 the script's ascenders and its
+       keyline both sit outside the content box, and an `inset(0 0 0 0)` end state
+       would shave them off for good (animation-fill-mode is `both`). */
     .brand-title > div {
-        clip-path: inset(0 100% 0 0);
+        clip-path: inset(-.4em 100% -.4em -.4em);
         animation: brand-draw .7s cubic-bezier(.4, 0, .2, 1) both;
     }
     .brand-title > div:nth-child(1) { animation-delay: .05s; }
@@ -724,7 +781,7 @@ footer {
 }
 
 @keyframes brand-draw {
-    to { clip-path: inset(0 0 0 0); }
+    to { clip-path: inset(-.4em -.4em -.4em -.4em); }
 }
 /* Dev-only role-spoof switcher in the navbar (rendered only in non-production
    for a real Admin). Amber signals "development tool". */

--- a/public/team.css
+++ b/public/team.css
@@ -256,10 +256,6 @@
 }
 
 @media only screen and (min-width: 64em) {
-    .brand-title {
-        font-size: 2rem;
-    }
-
     .games-container {
         display: flex;
         flex-direction: column;

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -266,10 +266,6 @@
         width: 100%;
     }
 
-    .brand-title {
-        font-size: 2rem;
-    }
-
     .header-title {
         font-size: 3.4rem;
         padding: 35px 35px 35px 0px;

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -51,9 +51,9 @@
 </script>
 <nav id="navbar" class="navbar" aria-label="Main">
     <a href="/standings" class="brand-link" aria-label="Campus Clash — home">
-        <div class="brand-title" style="display: flex; flex-flow: column;">
-            <div style="font-family: Graduate, serif;font-weight: 400;font-style: normal;margin: auto;">CAMPUS</div>
-            <div style="font-family: Pacifico, cursive;font-weight: 400;font-style: normal;margin: auto;margin-top: -18%;">Clash</div>
+        <div class="brand-title">
+            <div class="brand-campus">CAMPUS</div>
+            <div class="brand-clash">Clash</div>
         </div>
     </a>
     <button type="button" class="toggle-button" aria-label="Toggle navigation" aria-controls="navbar-links" aria-expanded="false">


### PR DESCRIPTION
The two words overlapping is the whole idea of the mark, but the overlap was a few ambiguous pixels — enough to read as a CSS accident rather than a decision. This commits to the collision and gives it an edge.

## The bug

The depth was set with `margin-top: -18%`, and percentage margins resolve against the containing block's *inline* size — so the overlap was a function of the wordmark's **width**, not its type size. Measured on the running app at a fixed 32px font:

| container width | font size | resolved overlap |
| --- | --- | --- |
| 90px | 32px | −16.19px |
| 133px *(as shipped)* | 32px | −23.94px |
| 200px | 32px | −36.00px |

Cosmetic if the overlap were incidental. Since it *is* the concept, it's the thing most worth nailing down. Everything is em-relative now, so the hit lands in the same place at every size.

## The keyline

`Clash` gets a ring in the page's own background colour, which cuts a clean channel through the block caps where the script crosses them. Without it a deeper overlap just blurs the two words together. It's a `text-shadow` ring rather than `-webkit-text-stroke`, which needs `paint-order: stroke fill` and hollows the letters out wherever that's ignored. The script is `--cc-accent`.

Tuned in-browser at full size: `1.1em` script, `-.18em` bite (≈⅓ of CAMPUS's height). Past `-.27em` the caps start to erode.

## Two things this exposed

**The draw-in wipe would have shaved the mark.** It ended on `clip-path: inset(0 0 0 0)` with fill-mode `both`. With `line-height: 1` the script's ascenders and its keyline sit outside the content box, so that end state would have clipped them permanently. Only the right inset animates now; the other three stay slack, keeping the wipe purely horizontal.

**Six copies of the same rule.** Every page's stylesheet carried its own `.brand-title { font-size: 2rem }` at the 64em breakpoint, and each overrode `styles.css` because page CSS loads after it. Consolidated into one rule, so `--brand-size` is the single knob. Those six diffs are pure deletions.

## Notes

- `font-size` and `margin-top` on `.brand-clash` are **coupled** — the margin resolves against the script's own size, so shrinking one shrinks the bite unless the other compensates. Called out in a comment.
- The keyline is tied to `--brand-ground: var(--cc-bg)` so it follows the ground rather than being hard-coded navy. Worth knowing for light surfaces: red on cream measures 2.97:1, just under the 3.0 floor, so use ink there instead.
- `aria-label="Campus Clash — home"` and the `prefers-reduced-motion` gate are both untouched.

## Verification

- 2379 tests / 127 suites passing.
- Rendering checked at 375px and 1280px on every page that mounts the navbar; no inline brand styles remain.
- Sticky navbar down from 87px to 78px on mobile, and it no longer wraps to two rows on desktop.

Design rationale and specimens: https://claude.ai/code/artifact/1490b890-615a-4902-ba4b-c46629587498

🤖 Generated with [Claude Code](https://claude.com/claude-code)