### PR TITLE
Give unknown routes a real page instead of "Cannot GET"

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -88,6 +88,12 @@ module.exports = {
             functions: 100,
             lines: 100
         },
+        "./modules/http-errors.js": {
+            statements: 100,
+            branches: 90,
+            functions: 100,
+            lines: 100
+        },
         "./modules/job-runs-util.js": {
             statements: 100,
             branches: 100,

--- a/modules/http-errors.js
+++ b/modules/http-errors.js
@@ -1,0 +1,90 @@
+// Terminal 404 / 500 handlers. Registered after every route in server.js, so
+// they only ever see requests that no route claimed.
+//
+// Without them an unmatched path fell through to Express's built-in
+// finalhandler, which answers with a bare unstyled "Cannot GET /whatever".
+// That hurt in two places: logged-out visitors following a stale link saw it
+// instead of a hand-off to /login (authRequired is false, so unmatched paths
+// never reach the auth router at all), and a mistyped fetch against one of the
+// JSON routers got HTML back — so client code calling res.json() threw a parse
+// error instead of surfacing the status.
+//
+// Both handlers content-negotiate: a JSON body for API/XHR callers, the branded
+// views/error.ejs page for browser navigations.
+
+// Every prefix that server.js mounts a JSON router on. A request falling
+// through under one of these was an API call, so it gets JSON even when the
+// caller sent no Accept header (fetch's default is "*/*").
+const API_PREFIXES = [
+    '/users', '/teams', '/games', '/rankings', '/scores', '/recruiting',
+    '/records', '/betting', '/draft', '/scoring-config', '/leagues',
+    '/job-runs', '/audit-log', '/standings', '/history',
+    '/calculate-team-score', '/dev'
+];
+
+function isApiPath(pathname) {
+    return API_PREFIXES.some(p => pathname === p || pathname.startsWith(p + '/'));
+}
+
+// Explicit signals win over the path heuristic: an XHR or a JSON-only Accept
+// always gets JSON, and anything that asked for HTML (i.e. someone typing in
+// the address bar, even under an API prefix) always gets the page.
+function prefersJson(req) {
+    const accept = (req.headers && req.headers.accept) || '';
+    if (req.xhr) return true;
+    if (accept.includes('application/json')) return true;
+    if (accept.includes('text/html')) return false;
+    return isApiPath(req.path || '');
+}
+
+function isAuthenticated(req) {
+    try {
+        return !!(req.oidc && req.oidc.isAuthenticated && req.oidc.isAuthenticated());
+    } catch (e) {
+        return false;   // never let the error page itself throw
+    }
+}
+
+// apiMessage, when given, replaces `message` in the JSON body — "that page" is
+// the wrong noun for a caller that asked for an endpoint.
+function respond(req, res, status, heading, message, apiMessage) {
+    res.status(status);
+    if (prefersJson(req)) return res.json({ status, message: apiMessage || message });
+    // res.render can throw in its own right (missing view, bad template). With a
+    // callback nothing is sent until we say so, so a template failure degrades to
+    // plain text instead of re-entering the error handler.
+    res.render('error', {
+        status,
+        heading,
+        message,
+        isAuthenticated: isAuthenticated(req)
+    }, (err, html) => {
+        if (err) {
+            console.error('Failed to render the error page:', err.message);
+            return res.type('txt').send(status + ' ' + heading);
+        }
+        res.type('html').send(html);
+    });
+}
+
+function notFound(req, res) {
+    respond(req, res, 404, 'Page not found',
+        "We couldn't find that page. It may have moved, or the link may be out of date.",
+        'No route matches ' + req.method + ' ' + req.path);
+}
+
+// Four args: that signature is how Express recognizes error middleware.
+function errorHandler(err, req, res, next) {
+    if (res.headersSent) return next(err);
+    const status = Number(err && (err.status || err.statusCode)) || 500;
+    if (status >= 500) console.error('Unhandled request error:', (err && err.stack) || err);
+    // Deliberately never echoes err.message — the message would leak internals
+    // (stack frames, driver errors, connection strings) to the browser.
+    const heading = status >= 500 ? 'Something went wrong' : 'That request went sideways';
+    const message = status >= 500
+        ? "This one's on us. Try again in a moment — if it keeps happening, let the commissioner know."
+        : "That request couldn't be completed. Head back and give it another shot.";
+    respond(req, res, status, heading, message);
+}
+
+module.exports = { notFound, errorHandler, isApiPath, prefersJson, API_PREFIXES };

--- a/server.js
+++ b/server.js
@@ -499,6 +499,12 @@ app.get('/calculate-team-score/:season/:teamId/:teamName', requireAdmin, async (
     }
 });
 
+// Terminal handlers — must stay last, after every route and router above, since
+// Express matches in registration order and these two claim everything left.
+const { notFound, errorHandler } = require('./modules/http-errors');
+app.use(notFound);
+app.use(errorHandler);
+
 // Wrap Express in an HTTP server so Socket.IO (live draft) can share the port.
 const server = http.createServer(app);
 const io = new Server(server);

--- a/tests/HttpErrors.spec.js
+++ b/tests/HttpErrors.spec.js
@@ -1,0 +1,170 @@
+// HTTP-level tests for modules/http-errors.js — the terminal 404 / 500 handlers.
+// Mounted on a bare Express app configured with the real EJS view directory, so
+// these exercise the actual content negotiation and the actual error.ejs render.
+
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+const { notFound, errorHandler, isApiPath, prefersJson } = require('../modules/http-errors');
+
+// Mirrors server.js: view engine + views dir, one real route, then the two
+// terminal handlers. `auth` fakes an Auth0 session when ?signedIn=1 is present.
+function buildApp(opts) {
+    const options = opts || {};
+    const app = express();
+    app.set('view engine', 'ejs');
+    app.set('views', options.views || path.join(__dirname, '..', 'views'));
+
+    app.use((req, res, next) => {
+        if (req.query.signedIn === '1') req.oidc = { isAuthenticated: () => true };
+        if (req.query.brokenAuth === '1') {
+            req.oidc = { isAuthenticated: () => { throw new Error('session decrypt failed'); } };
+        }
+        next();
+    });
+
+    app.get('/standings', (req, res) => res.send('ok'));
+    app.get('/boom', () => { throw new Error('DATABASE_URL=mongodb://secret@host failed'); });
+    app.get('/forbidden', () => {
+        const err = new Error('nope');
+        err.status = 403;
+        throw err;
+    });
+    app.get('/late', (req, res, next) => {
+        res.status(200).send('already sent');
+        next(new Error('too late'));
+    });
+
+    app.use(notFound);
+    app.use(errorHandler);
+    return app;
+}
+
+let consoleError;
+beforeEach(() => { consoleError = jest.spyOn(console, 'error').mockImplementation(() => {}); });
+afterEach(() => { consoleError.mockRestore(); });
+
+describe('prefersJson / isApiPath', () => {
+    test('recognizes mounted router prefixes, and only on a path boundary', () => {
+        expect(isApiPath('/users')).toBe(true);
+        expect(isApiPath('/users/123/roster')).toBe(true);
+        expect(isApiPath('/draft/2026')).toBe(true);
+        // /draft-room is a page, not the /draft router
+        expect(isApiPath('/draft-room')).toBe(false);
+        expect(isApiPath('/userHome')).toBe(false);
+        expect(isApiPath('/')).toBe(false);
+    });
+
+    test('explicit signals outrank the path heuristic', () => {
+        // fetch() with no Accept header on an API path
+        expect(prefersJson({ headers: {}, path: '/users/1' })).toBe(true);
+        expect(prefersJson({ headers: {}, path: '/typo' })).toBe(false);
+        // someone typing an API path into the address bar gets the page
+        expect(prefersJson({ headers: { accept: 'text/html' }, path: '/users/1' })).toBe(false);
+        expect(prefersJson({ headers: { accept: 'application/json' }, path: '/typo' })).toBe(true);
+        expect(prefersJson({ headers: {}, path: '/typo', xhr: true })).toBe(true);
+    });
+});
+
+describe('404 for unmatched paths', () => {
+    test('renders the branded page for a browser navigation', async () => {
+        const res = await request(buildApp()).get('/no-such-page').set('Accept', 'text/html');
+        expect(res.status).toBe(404);
+        expect(res.headers['content-type']).toMatch(/html/);
+        expect(res.text).toContain('Page not found');
+        expect(res.text).toContain('CAMPUS');           // wordmark rendered
+        expect(res.text).not.toContain('Cannot GET');   // not Express's default
+    });
+
+    test('references every asset absolutely, so it survives a nested path', async () => {
+        const res = await request(buildApp()).get('/foo/bar/baz').set('Accept', 'text/html');
+        expect(res.status).toBe(404);
+        expect(res.text).toContain('href="/styles.css"');
+        expect(res.text).toContain('href="/images/favicon.svg"');
+        // a relative asset here would resolve against /foo/bar/ and 404 too
+        expect(res.text).not.toMatch(/href="(styles\.css|images\/)/);
+    });
+
+    test('answers JSON under an API prefix even with no Accept header', async () => {
+        const res = await request(buildApp()).get('/users/nope');
+        expect(res.status).toBe(404);
+        expect(res.headers['content-type']).toMatch(/json/);
+        // names the path that missed, so a mistyped fetch is obvious in the console
+        expect(res.body).toEqual({ status: 404, message: 'No route matches GET /users/nope' });
+    });
+
+    test('does not put the page wording in an API response', async () => {
+        const res = await request(buildApp()).post('/leagues/typo');
+        expect(res.status).toBe(404);
+        expect(res.body.message).toBe('No route matches POST /leagues/typo');
+        expect(res.body.message).not.toMatch(/page/);
+    });
+
+    test('answers JSON for an XHR on a non-API path', async () => {
+        const res = await request(buildApp()).get('/typo').set('X-Requested-With', 'XMLHttpRequest');
+        expect(res.status).toBe(404);
+        expect(res.body.status).toBe(404);
+    });
+
+    test('offers Sign in when logged out and Standings when signed in', async () => {
+        const app = buildApp();
+        const out = await request(app).get('/nope').set('Accept', 'text/html');
+        expect(out.text).toContain('href="/login"');
+        expect(out.text).not.toContain('href="/standings"');
+
+        const inn = await request(app).get('/nope?signedIn=1').set('Accept', 'text/html');
+        expect(inn.text).toContain('href="/standings"');
+        expect(inn.text).not.toContain('href="/login"');
+    });
+
+    test('treats a session that throws as logged out instead of 500ing', async () => {
+        const res = await request(buildApp()).get('/nope?brokenAuth=1').set('Accept', 'text/html');
+        expect(res.status).toBe(404);
+        expect(res.text).toContain('href="/login"');
+    });
+
+    test('degrades to plain text when the view itself cannot render', async () => {
+        const app = buildApp({ views: path.join(__dirname, 'no-views-here') });
+        const res = await request(app).get('/nope').set('Accept', 'text/html');
+        expect(res.status).toBe(404);
+        expect(res.headers['content-type']).toMatch(/text\/plain/);
+        expect(res.text).toBe('404 Page not found');
+    });
+
+    test('leaves real routes alone', async () => {
+        const res = await request(buildApp()).get('/standings');
+        expect(res.status).toBe(200);
+        expect(res.text).toBe('ok');
+    });
+});
+
+describe('error handler', () => {
+    test('turns a thrown error into a 500 page without leaking the message', async () => {
+        const res = await request(buildApp()).get('/boom').set('Accept', 'text/html');
+        expect(res.status).toBe(500);
+        expect(res.text).toContain('Something went wrong');
+        expect(res.text).not.toContain('mongodb://');
+        expect(res.text).not.toContain('DATABASE_URL');
+        expect(consoleError).toHaveBeenCalled();          // but it is logged server-side
+    });
+
+    test('returns JSON for an API caller, also without the message', async () => {
+        const res = await request(buildApp()).get('/boom').set('Accept', 'application/json');
+        expect(res.status).toBe(500);
+        expect(res.body.status).toBe(500);
+        expect(JSON.stringify(res.body)).not.toContain('mongodb://');
+    });
+
+    test('honors an explicit err.status and stays quiet in the log for 4xx', async () => {
+        const res = await request(buildApp()).get('/forbidden').set('Accept', 'text/html');
+        expect(res.status).toBe(403);
+        expect(res.text).toContain('403');
+        expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    test('does not try to re-send once headers are out', async () => {
+        const res = await request(buildApp()).get('/late');
+        expect(res.status).toBe(200);
+        expect(res.text).toBe('already sent');
+    });
+});

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
+    <title><%= status %> — Campus Clash</title>
+    <!-- Every asset path here is absolute. This page can be served at any depth
+         (/foo/bar/baz), where the relative paths the other views use would
+         resolve against the wrong directory and 404 in their own right. -->
+    <link href="/styles.css" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        /* Standalone page — no navbar partial, since that reads user.role /
+           user.userId / userState and this page also renders for logged-out
+           visitors. body is already a centered flex column (styles.css). */
+        .error-card {
+            max-width: 32rem;
+            margin: 2rem 1.25rem;
+            padding: 2.5rem 2rem;
+            text-align: center;
+            background: var(--cc-surface);
+            border: 1px solid var(--cc-border);
+            border-radius: var(--cc-r-lg);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+        }
+        .error-brand { display: inline-block; text-decoration: none; color: inherit; }
+        /* --brand-size is the wordmark's only size knob (styles.css); every
+           metric of the mark is em-relative off it. --brand-ground is the colour
+           the keyline punches through CAMPUS, so it has to match what the mark
+           actually sits on — this card is --cc-surface, not the page's --cc-bg. */
+        .error-brand .brand-title {
+            --brand-size: 2.2rem;
+            --brand-ground: var(--cc-surface);
+            margin: 0 0 1.75rem;
+        }
+        .error-status {
+            font-family: Graduate, serif;
+            font-size: 3.5rem;
+            line-height: 1;
+            color: var(--cc-accent);
+            margin: 0;
+        }
+        .error-heading {
+            font-size: 1.35rem;
+            font-weight: 600;
+            margin: 0.75rem 0 0.5rem;
+        }
+        .error-message {
+            color: var(--cc-muted);
+            font-size: 0.95rem;
+            line-height: 1.5;
+            margin: 0 0 1.75rem;
+        }
+        .error-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            justify-content: center;
+        }
+        .error-btn {
+            display: inline-block;
+            padding: 0.6rem 1.35rem;
+            border-radius: var(--cc-r-pill);
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-decoration: none;
+            border: 1px solid var(--cc-accent);
+            background: var(--cc-accent);
+            color: var(--cc-text);
+        }
+        .error-btn:hover { filter: brightness(1.1); }
+        .error-btn:focus-visible { outline: 2px solid var(--cc-info); outline-offset: 2px; }
+    </style>
+</head>
+
+<body>
+    <main class="error-card">
+        <a href="/" class="error-brand" aria-label="Campus Clash — home">
+            <div class="brand-title">
+                <div class="brand-campus">CAMPUS</div>
+                <div class="brand-clash">Clash</div>
+            </div>
+        </a>
+        <p class="error-status"><%= status %></p>
+        <h1 class="error-heading"><%= heading %></h1>
+        <p class="error-message"><%= message %></p>
+        <div class="error-actions">
+            <% if (isAuthenticated) { %>
+                <%# Standings only. /userHome needs a ?user= param — bare, its
+                    client fetches /users/null and renders an empty page. %>
+                <a class="error-btn" href="/standings">Back to standings</a>
+            <% } else { %>
+                <a class="error-btn" href="/login">Sign in</a>
+            <% } %>
+        </div>
+    </main>
+</body>
+
+</html>


### PR DESCRIPTION
There was no catch-all route and no error middleware, so anything unmatched fell through to Express's built-in `finalhandler` — a bare unstyled `Cannot GET /whatever` that also advertises the stack. This adds a branded 404 page, a matching 500 handler, and content negotiation so API callers get JSON.

### Why it mattered, worst first

**A mistyped `fetch` got HTML back.** Every JSON router falls through to the same handler, so client code calling `res.json()` threw a parse error instead of surfacing the status. The visible failure was about the response body, not the request — the kind of thing you lose an hour to.

**Logged-out strangers saw it.** `authRequired` is `false`, so unmatched paths never reach the auth router at all; someone following a stale link got the Express default rather than a hand-off to `/login`. That undercut the OG work in fd28954, which exists so shared links look like something.

**League members have enough surface to typo** — `/index`, `/userHome`, `/team`, `/hall-of-fame`, `/rules` — with no graceful landing for an out-of-date bookmark.

### How it negotiates

An XHR or an `application/json` Accept always gets JSON. Anything asking for `text/html` always gets the page, so an API path typed into the address bar still reads. Otherwise the path decides: a fall-through under one of the mounted router prefixes returns JSON even with no Accept header, which is what `fetch` sends by default. The JSON body names the route that missed; the page never does.

Note that auth still wins over 404 on API paths — `curl /users/bogus` gets `401` from `requireAuthOrToken` before reaching this handler. That's the right precedence, just worth knowing when reading logs.

### Three deliberate calls

- **The 500 branch never echoes `err.message`.** A Mongoose or driver error can carry a connection string, and this handler is exactly where that would reach a browser. Full stack still goes to the server log, and a test asserts `mongodb://` cannot come out the front.
- **Every asset on the page is referenced absolutely.** The other views use relative paths, which is fine at `/standings` but resolves against the wrong directory at `/some/deep/stale/link` — the error page would otherwise 404 its own stylesheet.
- **The page is standalone rather than including the navbar partial,** which reads `user.role` / `user.userId` / `userState` — none of which exist for the logged-out visitor this page has to serve. It reuses the wordmark classes from 6b002a3, overriding `--brand-ground` to `--cc-surface`: the keyline is a hole punched in whatever the mark sits on, and here that's the card, not the page.

No "My Team" button beside *Back to standings* — `/userHome` without a `?user=` param fetches `/users/null` and renders empty, and the error page has no userId in scope. A link to a broken page is worse than one button.

### Verification

Beyond the 15 new tests, checked in the running app: a browser navigation and a 4-deep path both render with fonts and stylesheet loading; an authenticated in-page `fetch` to a mistyped API path returns 404 JSON that `res.json()` parses cleanly; logged out offers *Sign in*; mobile at 375px is fine. Computed `--brand-ground` confirmed as `#1A1F33`, matching the card rather than the page background.

46 suites / 836 tests pass, green on three consecutive full runs.

### Unrelated flake seen along the way

During those runs, two Mongo-backed suites each failed exactly once and passed on rerun — `H2HBonusPersistence` with a socket-level `Parse Error`, and `SeasonReadiness:382` with an empty `body.leagues`. A clean checkout of `origin/main` ran green 3/3, and the suite added here touches no database, so this looks like a pre-existing race on the shared in-memory Mongo. Not addressed here; worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
