### PR TITLE
Stop the scoring jobs from guessing "week 1"

### DIFF
--- a/modules/live-poll.js
+++ b/modules/live-poll.js
@@ -158,6 +158,13 @@ async function run() {
         const r = await runFullUpdate({ withBetting: false });
         // Keep the ceiling fresh for free from this poll's own CFBD response.
         if (typeof r.remainingCalls === 'number') lastKnownRemaining = r.remainingCalls;
+        // A live game whose calendar window has closed (or hasn't opened) —
+        // shouldn't happen, since the games-live gate ran first, but the pipeline
+        // has nothing to score and says so rather than guessing a week.
+        if (r.skipped) {
+            await finishRun(id, 'success', `Nothing to score — ${r.skipped}`);
+            return { skipped: r.skipped };
+        }
         await finishRun(id, 'success',
             `Live update ${r.seasonType} wk ${r.week} · ${r.gamesNew} new / ${r.gamesUpdated} updated`,
             { week: r.week, seasonType: r.seasonType });

--- a/modules/score-job.js
+++ b/modules/score-job.js
@@ -22,6 +22,15 @@ function makeJob({ jobName, label, withBetting }) {
         try {
             const r = await runFullUpdate({ withBetting: !!withBetting });
             const secs = Math.round((Date.now() - startMs) / 1000);
+
+            // Out of season the pipeline scores nothing and says why. That is a
+            // healthy outcome, not a failure — record it and skip the email, so
+            // the offseason is quiet instead of reporting a week it didn't score.
+            if (r.skipped) {
+                await finishRun(id, 'success', `Nothing to score — ${r.skipped} (${secs}s)`);
+                return r;
+            }
+
             const summary = `Updated ${r.seasonType} week ${r.week} · ${r.gamesNew} new / ${r.gamesUpdated} updated games · ${r.teams} teams (${secs}s)`;
             await finishRun(id, 'success', summary, { week: r.week, seasonType: r.seasonType });
             if (emailOnSuccess()) {

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -24,56 +24,93 @@ function postseasonWeeksToScore(massResult) {
     return weeks.length ? weeks : [1];
 }
 
+// Which week + phase the pipeline should score right now, from a CFBD calendar.
+//
+// CFBD's calendar is a list of CONTIGUOUS windows: each entry's lastGameStart is
+// the next entry's firstGameStart, and the final entry closes weeks after the
+// national championship. So "the current week" is simply the last window that
+// has opened. Returns:
+//
+//   { week, seasonType }  a window covers `now`
+//   { skip: reason }      before the first window, or after the last one closed
+//
+// and THROWS when the calendar is unusable. That last part is the point of this
+// function. It replaced a loop that initialized `weekNumber = 1` and could not
+// tell "it is week 1" apart from "no window matched" — so an empty calendar (a
+// CFBD hiccup, or an empty response served from cache) silently rescored week 1
+// mid-season while reporting success, and every offseason run did the same for
+// months. Guessing a week is worse than failing: a failed run records a JobRun
+// error and emails, a wrong week quietly leaves the real week unscored.
+//
+// `seasonType` comes from the matched entry rather than being inferred, so the
+// postseason is recognized however CFBD numbers its weeks.
+function resolveCurrentWeek(calendar, now) {
+    if (!Array.isArray(calendar) || !calendar.length) {
+        throw new Error('CFBD calendar unavailable or empty — refusing to guess the current week');
+    }
+
+    // Sorted by start rather than trusting array order, and entries without a
+    // parseable kickoff boundary are dropped — a single garbled row must not be
+    // able to shift which week gets scored.
+    const windows = calendar
+        .map(c => ({
+            week: c && c.week,
+            seasonType: (c && c.seasonType) === 'postseason' ? 'postseason' : 'regular',
+            start: Date.parse((c && c.firstGameStart) || ''),
+            end: Date.parse((c && c.lastGameStart) || '')
+        }))
+        .filter(w => w.week != null && !Number.isNaN(w.start))
+        .sort((a, b) => a.start - b.start);
+
+    if (!windows.length) {
+        throw new Error('CFBD calendar has no usable week windows — refusing to guess the current week');
+    }
+
+    const t = now.getTime();
+    const opened = windows.filter(w => w.start <= t);
+    if (!opened.length) {
+        return { skip: 'preseason — the first week has not started' };
+    }
+
+    // In a gap between windows this lands on the week that just ended, which is
+    // the one that still needs finalizing.
+    const current = opened[opened.length - 1];
+    const isFinalWindow = current === windows[windows.length - 1];
+    if (isFinalWindow && !Number.isNaN(current.end) && t > current.end) {
+        return { skip: 'season over — the last calendar week has closed' };
+    }
+
+    return { week: current.week, seasonType: current.seasonType };
+}
+
 // The shared "update everything for the current week" pipeline that the daily /
 // Saturday / Sunday jobs all run. Determines the current week from the CFBD
 // calendar, ensures rankings exist, pulls games, then updates scores, cumulative
 // scores, team scores and records. `withBetting` also refreshes betting lines —
 // only the daily job did that historically, so it stays opt-in.
-// Returns { week, seasonType } for logging.
+// Returns { week, seasonType } for logging, or { skipped } out of season.
 async function runFullUpdate({ withBetting = false } = {}) {
 
     // Cached per-season (modules/cfbd-calendar.js): the week windows are static
     // intra-day, so frequent polls reuse one fetch instead of spending a CFBD
     // call each time just to compute the current week.
     var calendar = await getCalendar(process.env.YEAR);
-    var weekNumber = 1;
-    var isPostseason = false;
+    var resolved = resolveCurrentWeek(calendar, new Date());
 
-    if (calendar) {
-        for (const calendarWeek of calendar) {
-            var startDate = new Date(calendarWeek.firstGameStart);
-            var endDate = new Date(calendarWeek.lastGameStart);
-            var currentDate = new Date();
-
-            if ((currentDate > startDate) && (currentDate < endDate)) {
-                weekNumber = calendarWeek.week;
-                if (calendarWeek.seasonType == "postseason") {
-                    isPostseason = true;
-                }
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week == 1)) {
-                weekNumber = 1;
-                break;
-            } else if ((currentDate < startDate) && (calendarWeek.week > 1)) {
-                weekNumber = (calendarWeek.week - 1);
-                break;
-            }
-        }
+    if (resolved.skip) {
+        console.log(`Nothing to score — ${resolved.skip}`);
+        return { skipped: resolved.skip, week: null, seasonType: null, teams: 0, gamesNew: 0, gamesUpdated: 0 };
     }
+
+    var weekNumber = resolved.week;
+    var isPostseason = resolved.seasonType === 'postseason';
 
     console.log("It is currently Week", weekNumber);
     console.log("Is it the postseason yet? ", isPostseason);
 
     const season = process.env.YEAR;
-    var seasonType = '';
-    var week = weekNumber;
-
-    if (!isPostseason) {
-        seasonType = "regular";
-    } else {
-        seasonType = "postseason";
-        week = 1;
-    }
+    var seasonType = resolved.seasonType;
+    var week = isPostseason ? 1 : weekNumber;
 
     var response = await internalFetch(`${process.env.URL}/rankings/${season}/${week}/${seasonType}`, {
         method: 'GET',
@@ -165,4 +202,4 @@ async function runFullUpdate({ withBetting = false } = {}) {
     return { week, seasonType, teams: teamCount, gamesNew, gamesUpdated, remainingCalls };
 }
 
-module.exports = { runFullUpdate, postseasonWeeksToScore };
+module.exports = { runFullUpdate, postseasonWeeksToScore, resolveCurrentWeek };

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -7,7 +7,16 @@ const { postseasonWeeksToScore } = require('../modules/score-update');
 // updateCumulativeScores. Reorder these and the bonus silently stops reaching the
 // season total of record — exactly the bug this replaced. Hence the assertion.
 
-jest.mock('../modules/cfbd-calendar', () => ({ getCalendar: jest.fn(async () => null) }));
+// The calendar mock hands back a regular-season window that is open right now, so
+// runFullUpdate resolves a week the ordinary way. This used to be `null`, which
+// the old current-week loop silently turned into "regular week 1" — the exact
+// fallback resolveCurrentWeek now refuses, so the ordering tests below have to
+// supply a real window.
+jest.mock('../modules/cfbd-calendar', () => ({
+    getCalendar: jest.fn(async () => [
+        { week: 7, seasonType: 'regular', firstGameStart: '2000-01-01', lastGameStart: '2100-01-01' }
+    ])
+}));
 jest.mock('../modules/internal-api', () => ({
     internalFetch: jest.fn(async () => ({ status: 200, json: async () => ({}) }))
 }));
@@ -35,6 +44,7 @@ describe('runFullUpdate scoring order', () => {
 
     beforeEach(() => {
         scoringModule._calls.length = 0;
+        retrieveGames.massRetrieveGames.mockClear();
         jest.spyOn(console, 'log').mockImplementation(() => {});
     });
     afterEach(() => { jest.restoreAllMocks(); });
@@ -55,6 +65,111 @@ describe('runFullUpdate scoring order', () => {
         const calls = scoringModule._calls;
         expect(calls.indexOf('applyH2HBonuses')).toBeGreaterThan(calls.indexOf('updateScores'));
         expect(calls.indexOf('applyH2HBonuses')).toBeLessThan(calls.indexOf('updateCumulativeScores'));
+    });
+
+    // The whole point of resolveCurrentWeek throwing/skipping instead of
+    // defaulting to week 1: out of season the pipeline must not score ANYTHING,
+    // and with an unusable calendar it must fail rather than pick a week.
+    it('scores nothing at all when the season is over', async () => {
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce([
+            { week: 1, seasonType: 'postseason', firstGameStart: '2000-01-01', lastGameStart: '2000-02-01' }
+        ]);
+        const r = await runFullUpdate({ withBetting: false });
+        expect(r.skipped).toMatch(/season over/);
+        expect(r.week).toBeNull();
+        expect(scoringModule._calls).toEqual([]);
+        expect(retrieveGames.massRetrieveGames).not.toHaveBeenCalled();
+    });
+
+    it('fails loudly on an empty calendar rather than rescoring week 1', async () => {
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce([]);
+        await expect(runFullUpdate({ withBetting: false })).rejects.toThrow(/calendar/i);
+        expect(scoringModule._calls).toEqual([]);
+    });
+});
+
+describe('resolveCurrentWeek', () => {
+    const { resolveCurrentWeek } = require('../modules/score-update');
+    const at = (iso) => new Date(iso);
+    const w = (week, seasonType, start, end) =>
+        ({ week, seasonType, firstGameStart: start, lastGameStart: end });
+
+    // The REAL 2026 CFBD calendar (GET /calendar?year=2026). Its windows are
+    // contiguous — each entry's lastGameStart is the next one's firstGameStart —
+    // which is why "the current week" is the last window that has opened.
+    const CAL_2026 = [
+        w(1, 'regular', '2026-08-29T07:00:00.000Z', '2026-09-08T06:59:00.000Z'),
+        w(2, 'regular', '2026-09-08T07:00:00.000Z', '2026-09-14T06:59:00.000Z'),
+        w(13, 'regular', '2026-11-23T08:00:00.000Z', '2026-11-30T07:59:00.000Z'),
+        w(14, 'regular', '2026-11-30T08:00:00.000Z', '2026-12-07T07:59:00.000Z'),
+        w(15, 'regular', '2026-12-07T08:00:00.000Z', '2026-12-12T07:59:00.000Z'),
+        w(1, 'postseason', '2026-12-12T08:00:00.000Z', '2027-01-28T07:59:00.000Z')
+    ];
+
+    it('reads the current regular week off the live 2026 calendar', () => {
+        expect(resolveCurrentWeek(CAL_2026, at('2026-11-28T20:00:00.000Z')))
+            .toEqual({ week: 13, seasonType: 'regular' });
+        expect(resolveCurrentWeek(CAL_2026, at('2026-12-05T22:00:00.000Z')))
+            .toEqual({ week: 14, seasonType: 'regular' });
+    });
+
+    it('recognizes the postseason from the entry, not from the week number', () => {
+        expect(resolveCurrentWeek(CAL_2026, at('2026-12-19T22:00:00.000Z')))
+            .toEqual({ week: 1, seasonType: 'postseason' });
+    });
+
+    // These two are the bug. The old loop hit its `calendarWeek.week == 1` branch
+    // (postseason is numbered week 1) and its `weekNumber = 1` initializer, so
+    // both of these resolved to "regular week 1" and rescored week 1 — every
+    // night, for months, while reporting success.
+    it('skips before the season opens instead of scoring week 1', () => {
+        expect(resolveCurrentWeek(CAL_2026, at('2026-08-10T18:00:00.000Z')).skip)
+            .toMatch(/preseason/);
+    });
+
+    it('skips once the final window closes instead of scoring week 1', () => {
+        expect(resolveCurrentWeek(CAL_2026, at('2027-01-28T12:00:00.000Z')).skip)
+            .toMatch(/season over/);
+        expect(resolveCurrentWeek(CAL_2026, at('2027-06-15T12:00:00.000Z')).skip)
+            .toMatch(/season over/);
+    });
+
+    it('still scores inside the final window (the title game is in there)', () => {
+        expect(resolveCurrentWeek(CAL_2026, at('2027-01-19T01:00:00.000Z')))
+            .toEqual({ week: 1, seasonType: 'postseason' });
+    });
+
+    it('lands on the week that just ended when a gap opens between windows', () => {
+        const gapped = [
+            w(3, 'regular', '2026-09-14T07:00:00.000Z', '2026-09-19T06:59:00.000Z'),
+            w(4, 'regular', '2026-09-21T07:00:00.000Z', '2026-09-28T06:59:00.000Z')
+        ];
+        expect(resolveCurrentWeek(gapped, at('2026-09-20T12:00:00.000Z')))
+            .toEqual({ week: 3, seasonType: 'regular' });
+    });
+
+    it('does not trust array order', () => {
+        const shuffled = [CAL_2026[5], CAL_2026[2], CAL_2026[0], CAL_2026[4], CAL_2026[3], CAL_2026[1]];
+        expect(resolveCurrentWeek(shuffled, at('2026-12-05T22:00:00.000Z')))
+            .toEqual({ week: 14, seasonType: 'regular' });
+    });
+
+    it('ignores rows with no parseable kickoff boundary', () => {
+        const messy = [
+            w(9, 'regular', 'not a date', 'not a date'),
+            w(10, 'regular', '2026-11-02T08:00:00.000Z', '2026-11-09T07:59:00.000Z')
+        ];
+        expect(resolveCurrentWeek(messy, at('2026-11-05T20:00:00.000Z')))
+            .toEqual({ week: 10, seasonType: 'regular' });
+    });
+
+    it('throws rather than guess when the calendar is unusable', () => {
+        expect(() => resolveCurrentWeek(null, at('2026-10-10T20:00:00.000Z'))).toThrow(/calendar/i);
+        expect(() => resolveCurrentWeek([], at('2026-10-10T20:00:00.000Z'))).toThrow(/calendar/i);
+        expect(() => resolveCurrentWeek({}, at('2026-10-10T20:00:00.000Z'))).toThrow(/calendar/i);
+        expect(() => resolveCurrentWeek(
+            [w(undefined, 'regular', 'garbage', 'garbage')], at('2026-10-10T20:00:00.000Z')
+        )).toThrow(/no usable week windows/i);
     });
 });
 


### PR DESCRIPTION
Audit finding #1 of 4. The scoring jobs could not tell "it is week 1" apart from "I could not work out the week", and scored week 1 either way.

## The bug

`runFullUpdate`s current-week loop initialized `weekNumber = 1` and walked the CFBD calendar looking for a window covering now. Two ways it landed on week 1 wrongly:

- **CFBD numbers the postseason entry week 1.** So once the last regular-season window closed, the loops `(currentDate < startDate) && (calendarWeek.week == 1)` branch matched the postseason entry and set `weekNumber = 1`, `isPostseason = false`.
- **Nothing matched.** After the final window closes, or when `getCalendar` returns `[]` (it serves an empty response rather than throwing when CFBD hiccups), the loop fell out and the initializer stood.

Either way the job pulled and rescored regular week 1, logged `It is currently Week 1`, and recorded a successful JobRun. Mid-season the `[]` case is the damaging one: the real week goes unscored while week 1 is rewritten, with no signal anywhere.

Run against the live 2026 calendar, before:

```
Aug 10 2026 (preseason)                 -> regular wk 1
Jan 28 2027 (after the window closes)   -> regular wk 1
Feb 15 2027 (offseason daily job)       -> regular wk 1
CFBD returns []  (mid-season)           -> regular wk 1
```

## The fix

`resolveCurrentWeek(calendar, now)` — pure and exported, so it is testable on its own:

- CFBDs windows are contiguous (each entrys `lastGameStart` is the next ones `firstGameStart`), so the current week is just **the last window that has opened**. In a gap it lands on the week that just ended, which is the one still needing finalizing.
- `seasonType` comes off the matched entry instead of being inferred from the week number.
- Before the first window, or after the final one closes: `{ skip: reason }`. `runFullUpdate` returns `{ skipped }` and scores nothing. `makeJob` records that as a successful run with the reason and sends no email, so the offseason goes quiet instead of re-pulling week 1 every night.
- Unusable calendar (not an array, empty, or no parseable rows): **throws**. A thrown run records a JobRun error and fires the failure email. Guessing a week is worse than failing loudly.

Rows are sorted by start rather than trusted in array order, and rows with an unparseable `firstGameStart` are dropped, so one garbled entry cannot move which week gets scored.

## Tests

New `resolveCurrentWeek` block in `tests/ScoreUpdate.spec.js` runs the **real 2026 CFBD calendar** (fetched from `GET /calendar?year=2026`) and pins: current regular week, postseason recognition, preseason skip, season-over skip, still-scoring inside the final window (the title game lives there), gaps, shuffled input, garbled rows, and the throw cases. Plus two `runFullUpdate` tests: season-over scores nothing at all, and an empty calendar rejects instead of touching week 1.

The two existing ordering tests mocked `getCalendar` to `null` and relied on the old silent week-1 fallback — they now supply a real open window, which is the behaviour change in miniature.

847 passing (was 836).

## Note for review

The offseason behaviour change is intentional: the daily job will now no-op from the end of the postseason until the next season opens, instead of re-pulling and rescoring week 1 nightly. It still records a JobRun, so the admin status strip keeps advancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)