### PR TITLE
Score the regular week the postseason window opens on top of

### DIFF
--- a/modules/admin-status.js
+++ b/modules/admin-status.js
@@ -53,4 +53,44 @@ function computeAdminStatus(users, games, season) {
     };
 }
 
-module.exports = { computeAdminStatus };
+// The highest regular-season week that still has unfinished business: a game
+// involving a drafted team that has kicked off but isn't marked complete. null
+// when every kicked-off regular-season game is final.
+//
+// This exists because CFBD's postseason calendar window OPENS BEFORE the last
+// regular-season game kicks off. In 2026 the week-15 window closes
+// 2026-12-12T07:59Z while Army–Navy — a week-15 regular-season game — kicks off
+// at 20:00Z the same day. From 2am CT that morning the pipeline resolves to the
+// postseason and pulls `seasonType=postseason`, which never contains that game,
+// so week 15 would keep the 0 it was seeded with. The postseason pipeline
+// consults this to catch the trailing week without a calendar heuristic.
+//
+// Two bounds keep it from costing a CFBD call forever:
+//   - drafted teams only. The Game collection also holds non-FBS rows from older
+//     ingests; one of those left un-completed would pin a week open for good.
+//   - `maxHours` since kickoff. A game still not final days later is stuck data,
+//     not live business.
+function pendingRegularWeek(users, games, season, nowMs, maxHours) {
+    const windowMs = (maxHours || 48) * 3600 * 1000;
+
+    const draftedIds = new Set();
+    (users || []).forEach(u => {
+        const seasons = (u && u.seasons) || [];
+        const s = seasons.find(x => String(x.season) === String(season));
+        ((s && s.teams) || []).forEach(t => { if (t && t.id != null) draftedIds.add(Number(t.id)); });
+    });
+    if (!draftedIds.size) return null;
+
+    let pending = null;
+    (games || []).forEach(g => {
+        if (!g || g.seasonType !== 'regular' || typeof g.week !== 'number') return;
+        if (g.completed === true) return;
+        const start = Date.parse(g.startDate);
+        if (Number.isNaN(start) || start > nowMs || (nowMs - start) > windowMs) return;
+        if (!draftedIds.has(Number(g.homeId)) && !draftedIds.has(Number(g.awayId))) return;
+        if (pending == null || g.week > pending) pending = g.week;
+    });
+    return pending;
+}
+
+module.exports = { computeAdminStatus, pendingRegularWeek };

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -24,6 +24,25 @@ function postseasonWeeksToScore(massResult) {
     return weeks.length ? weeks : [1];
 }
 
+// Asks the app whether a regular-season week still has drafted-team games that
+// kicked off and aren't final (see modules/admin-status.js pendingRegularWeek).
+// Goes through the API like every other step so it works in-process and from a
+// standalone job run alike. A failed check degrades to the old behaviour —
+// postseason only — and the next run tries again, so it never blocks scoring.
+async function fetchPendingRegularWeek(season) {
+    try {
+        const res = await internalFetch(`${process.env.URL}/scores/pending-regular/${season}`, {
+            method: 'GET',
+            headers: { 'Accept': 'application/json' }
+        });
+        const data = await res.json();
+        if (res.status == 200 && data && data.week != null) return Number(data.week);
+    } catch (err) {
+        console.log('Could not check for a trailing regular week:', err.message);
+    }
+    return null;
+}
+
 // Which week + phase the pipeline should score right now, from a CFBD calendar.
 //
 // CFBD's calendar is a list of CONTIGUOUS windows: each entry's lastGameStart is
@@ -153,10 +172,32 @@ async function runFullUpdate({ withBetting = false } = {}) {
     var remainingCalls;
 
     if (isPostseason) {
+        // CFBD's postseason window OPENS BEFORE the regular season's last game
+        // kicks off: in 2026 the week-15 window closes 2026-12-12T07:59Z while
+        // Army–Navy (a week-15 regular-season game) kicks off at 20:00Z that same
+        // day. The postseason pull below is `seasonType=postseason`, which never
+        // contains that game — so without this the trailing week keeps the 0 it
+        // was seeded with and the result is silently lost.
+        //
+        // Runs FIRST so the shared applyH2HBonuses / updateCumulativeScores /
+        // team-score passes below fold in both phases. Costs nothing once the
+        // trailing week's games are final: the endpoint answers null and this
+        // whole block is skipped.
+        var trailingWeek = await fetchPendingRegularWeek(season);
+        if (trailingWeek != null) {
+            console.log(`Regular week ${trailingWeek} still has games to finalize — pulling it alongside the postseason`);
+            var trailing = await retrieveGamesModule.massRetrieveGames(trailingWeek, "regular");
+            if (trailing) {
+                gamesNew += (trailing.newGames || []).length;
+                gamesUpdated += (trailing.existingGames || []).length;
+            }
+            await scoringModule.updateScores("regular", trailingWeek);
+        }
+
         // One CFBD call pulls the whole postseason slate (all CFP rounds).
         var games = await retrieveGamesModule.massRetrieveGames(null, "postseason");
-        gamesNew = games.newGames.length;
-        gamesUpdated = games.existingGames.length;
+        gamesNew += games.newGames.length;
+        gamesUpdated += games.existingGames.length;
         remainingCalls = games.remainingCalls;
         console.log("number of returned new games", gamesNew);
         console.log("number of returned existing games", gamesUpdated);

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -7,7 +7,7 @@ const ScoringConfig = require('../models/scoringConfig');
 const Team = require('../models/team');
 const Draft = require('../models/draft');
 const League = require('../models/league');
-const { computeAdminStatus } = require('../modules/admin-status');
+const { computeAdminStatus, pendingRegularWeek } = require('../modules/admin-status');
 const { computeSeasonReadiness } = require('../modules/season-readiness');
 const { engagementForSeason, LEAGUES } = require('../modules/scoring-defaults');
 const { canManageLeague } = require('../modules/league-access');
@@ -25,6 +25,40 @@ router.get('/status/:season', async (req, res) => {
             { id: 1, week: 1, seasonType: 1, completed: 1, homeId: 1, awayId: 1, homePoints: 1, awayPoints: 1, _id: 0 }
         );
         res.json(computeAdminStatus(users, games, season));
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Does a regular-season week still need finalizing? Returns { season, week }
+// with week = null when nothing is outstanding.
+//
+// The postseason branch of the scoring pipeline calls this because CFBD's
+// postseason calendar window opens before the last regular-season game kicks off
+// (see pendingRegularWeek for the 2026 Army–Navy case). Read-only, derived from
+// data already on file, no CFBD calls — and it answers null the moment the
+// trailing week's games are final, so the pipeline stops paying for the extra
+// pull on its own.
+//
+// How long a game counts as outstanding is env-tunable for ops; the default
+// covers the nightly + Sunday sweeps after a Saturday kickoff.
+const PENDING_REGULAR_MAX_HOURS = Number(process.env.PENDING_REGULAR_MAX_HOURS) || 48;
+
+router.get('/pending-regular/:season', async (req, res) => {
+    try {
+        const season = req.params.season;
+        const users = await User.find(
+            { 'seasons.season': season },
+            { 'seasons.season': 1, 'seasons.teams.id': 1 }
+        ).lean();
+        const games = await Game.find(
+            { season: Number(season), seasonType: 'regular', completed: { $ne: true } },
+            { week: 1, seasonType: 1, completed: 1, startDate: 1, homeId: 1, awayId: 1, _id: 0 }
+        ).lean();
+        res.json({
+            season: String(season),
+            week: pendingRegularWeek(users, games, season, Date.now(), PENDING_REGULAR_MAX_HOURS)
+        });
     } catch (err) {
         res.status(500).json({ message: err.message });
     }

--- a/tests/AdminStatus.spec.js
+++ b/tests/AdminStatus.spec.js
@@ -66,3 +66,71 @@ describe('computeAdminStatus', () => {
         });
     });
 });
+
+// --- pendingRegularWeek ------------------------------------------------------
+//
+// The postseason pipeline uses this to catch the trailing regular week, because
+// CFBD's postseason calendar window opens BEFORE the regular season's last game
+// kicks off (2026: week-15 window closes 2026-12-12T07:59Z, Army–Navy kicks off
+// 20:00Z the same day). It has to answer null as soon as that week is final, or
+// the extra CFBD pull it triggers never stops.
+describe('pendingRegularWeek', () => {
+    const { pendingRegularWeek } = require('../modules/admin-status');
+    const NOW = Date.parse('2026-12-13T05:00:00.000Z');   // the nightly job after Army–Navy
+    const hoursAgo = (h) => new Date(NOW - h * 3600 * 1000).toISOString();
+
+    // Team 1 and 2 are drafted; 99 is not.
+    const managers = [{ seasons: [{ season: 2026, teams: [{ id: 1 }, { id: 2 }] }] }];
+    const g = (week, opts = {}) => Object.assign({
+        week, seasonType: 'regular', completed: false,
+        startDate: hoursAgo(9), homeId: 1, awayId: 50
+    }, opts);
+
+    it('reports the trailing week when its game kicked off and is not final', () => {
+        expect(pendingRegularWeek(managers, [g(15)], 2026, NOW, 48)).toBe(15);
+    });
+
+    it('answers null once that game is complete', () => {
+        expect(pendingRegularWeek(managers, [g(15, { completed: true })], 2026, NOW, 48)).toBeNull();
+    });
+
+    it('takes the highest outstanding week', () => {
+        expect(pendingRegularWeek(managers, [g(13), g(15), g(14)], 2026, NOW, 48)).toBe(15);
+    });
+
+    it('ignores games that have not kicked off yet', () => {
+        expect(pendingRegularWeek(managers, [g(15, { startDate: hoursAgo(-3) })], 2026, NOW, 48)).toBeNull();
+    });
+
+    // Both bounds on the extra CFBD pull this triggers.
+    it('ignores a game stuck un-complete past the window', () => {
+        expect(pendingRegularWeek(managers, [g(15, { startDate: hoursAgo(72) })], 2026, NOW, 48)).toBeNull();
+    });
+
+    it('ignores games involving no drafted team', () => {
+        // The Game collection still holds non-FBS rows from older ingests; one of
+        // those left un-completed would otherwise pin a week open for good.
+        expect(pendingRegularWeek(managers, [g(15, { homeId: 98, awayId: 99 })], 2026, NOW, 48)).toBeNull();
+    });
+
+    it('ignores postseason games and rows with no usable week or kickoff', () => {
+        expect(pendingRegularWeek(managers, [g(15, { seasonType: 'postseason' })], 2026, NOW, 48)).toBeNull();
+        expect(pendingRegularWeek(managers, [g(null)], 2026, NOW, 48)).toBeNull();
+        expect(pendingRegularWeek(managers, [g(15, { startDate: 'nope' })], 2026, NOW, 48)).toBeNull();
+    });
+
+    it('matches the drafted team on either side of the game', () => {
+        expect(pendingRegularWeek(managers, [g(15, { homeId: 60, awayId: 2 })], 2026, NOW, 48)).toBe(15);
+    });
+
+    it('handles empty inputs and an undrafted season without throwing', () => {
+        expect(pendingRegularWeek([], [g(15)], 2026, NOW, 48)).toBeNull();
+        expect(pendingRegularWeek(managers, [], 2026, NOW, 48)).toBeNull();
+        expect(pendingRegularWeek(null, null, 2026, NOW, 48)).toBeNull();
+        expect(pendingRegularWeek([{ seasons: [{ season: 2025, teams: [{ id: 1 }] }] }], [g(15)], 2026, NOW, 48)).toBeNull();
+    });
+
+    it('defaults the window when none is given', () => {
+        expect(pendingRegularWeek(managers, [g(15)], 2026, NOW)).toBe(15);
+    });
+});

--- a/tests/RoutesPendingRegular.spec.js
+++ b/tests/RoutesPendingRegular.spec.js
@@ -1,0 +1,104 @@
+// GET /scores/pending-regular/:season — the signal the postseason pipeline uses
+// to catch a trailing regular-season week.
+//
+// CFBD's postseason calendar window opens BEFORE the regular season's last game
+// kicks off: in 2026 the week-15 window closes 2026-12-12T07:59Z while Army–Navy
+// (a week-15 regular-season game) kicks off at 20:00Z the same day. From then on
+// the pipeline resolves to the postseason and pulls `seasonType=postseason`,
+// which never contains that game — so week 15 would keep the 0 it was seeded
+// with. This endpoint is what tells the pipeline to pull week 15 anyway.
+//
+// Runs against an in-memory Mongo with the real models and the real route.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const scoresRouter = require('../routes/scores');
+
+const app = express();
+app.use(express.json());
+app.use('/scores', scoresRouter);
+
+useMongo();
+
+const SEASON = 2026;
+
+function team(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'American Athletic', color: '#000', logos: ['http://x/logo.png'],
+        location: {
+            venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000',
+            latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false
+        }
+    };
+}
+
+// Army is drafted; nobody has team 99.
+async function manager() {
+    return User.create({
+        firstName: 'Ann', lastName: 'Test', league: 'graham-league',
+        seasons: [{ season: SEASON, teams: [team(2, 'Army')], weeklyScore: [] }]
+    });
+}
+
+const hoursAgo = (h) => new Date(Date.now() - h * 3600 * 1000).toISOString();
+
+async function game(overrides) {
+    return Game.create(Object.assign({
+        id: 900001, season: SEASON, week: 15, seasonType: 'regular',
+        startDate: hoursAgo(9), startTimeTbd: false, completed: false,
+        neutralSite: true, conferenceGame: false,
+        homeId: 2, homeTeam: 'Army', awayId: 99, awayTeam: 'Navy'
+    }, overrides));
+}
+
+const ask = () => request(app).get(`/scores/pending-regular/${SEASON}`);
+
+describe('GET /scores/pending-regular/:season', () => {
+    test('names the week when a drafted team has kicked off and is not final', async () => {
+        await manager();
+        await game();
+        const res = await ask();
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ season: '2026', week: 15 });
+    });
+
+    test('answers null once the game is complete — so the extra pull stops', async () => {
+        await manager();
+        await game({ completed: true, homePoints: 24, awayPoints: 17 });
+        const res = await ask();
+        expect(res.body.week).toBeNull();
+    });
+
+    test('answers null with nothing on file at all', async () => {
+        const res = await ask();
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ season: '2026', week: null });
+    });
+
+    test('ignores a game no manager drafted', async () => {
+        await manager();
+        await game({ id: 900002, homeId: 98, homeTeam: 'Somebody', awayId: 99 });
+        const res = await ask();
+        expect(res.body.week).toBeNull();
+    });
+
+    test('ignores a game that has not kicked off', async () => {
+        await manager();
+        await game({ startDate: new Date(Date.now() + 3 * 3600 * 1000).toISOString() });
+        const res = await ask();
+        expect(res.body.week).toBeNull();
+    });
+
+    test('ignores another season entirely', async () => {
+        await manager();
+        await game({ id: 900003, season: 2025 });
+        const res = await ask();
+        expect(res.body.week).toBeNull();
+    });
+});

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -42,9 +42,15 @@ describe('runFullUpdate scoring order', () => {
     const scoringModule = require('../modules/scoring.js');
     const retrieveGames = require('../modules/retrieve-games.js');
 
+    const { internalFetch } = require('../modules/internal-api');
+
     beforeEach(() => {
         scoringModule._calls.length = 0;
+        scoringModule.updateScores.mockClear();
         retrieveGames.massRetrieveGames.mockClear();
+        // Default: no trailing regular week outstanding (the endpoint answers
+        // { week: null }, which this bare body stands in for).
+        internalFetch.mockImplementation(async () => ({ status: 200, json: async () => ({}) }));
         jest.spyOn(console, 'log').mockImplementation(() => {});
     });
     afterEach(() => { jest.restoreAllMocks(); });
@@ -65,6 +71,56 @@ describe('runFullUpdate scoring order', () => {
         const calls = scoringModule._calls;
         expect(calls.indexOf('applyH2HBonuses')).toBeGreaterThan(calls.indexOf('updateScores'));
         expect(calls.indexOf('applyH2HBonuses')).toBeLessThan(calls.indexOf('updateCumulativeScores'));
+    });
+
+    // CFBD's postseason window opens BEFORE the regular season's last game kicks
+    // off (2026: week-15 window closes 2026-12-12T07:59Z, Army–Navy kicks off
+    // 20:00Z that day), and the postseason pull is `seasonType=postseason` — which
+    // never contains that game. Without the trailing pass, week 15 keeps its 0.
+    const POSTSEASON_CALENDAR = [
+        { week: 1, seasonType: 'postseason', firstGameStart: '2000-01-01', lastGameStart: '2100-01-01' }
+    ];
+
+    it('finalizes a trailing regular week alongside the postseason', async () => {
+        internalFetch.mockImplementation(async (url) => /pending-regular/.test(url)
+            ? { status: 200, json: async () => ({ season: '2026', week: 15 }) }
+            : { status: 200, json: async () => ({}) });
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce(POSTSEASON_CALENDAR);
+
+        await runFullUpdate({ withBetting: false });
+
+        // Regular week 15 pulled and scored FIRST, so the shared H2H / cumulative
+        // / team-score passes below fold in both phases.
+        expect(retrieveGames.massRetrieveGames.mock.calls).toEqual([[15, 'regular'], [null, 'postseason']]);
+        expect(scoringModule.updateScores.mock.calls).toEqual([['regular', 15], ['postseason', 1]]);
+        const calls = scoringModule._calls;
+        expect(calls.lastIndexOf('updateScores')).toBeLessThan(calls.indexOf('applyH2HBonuses'));
+    });
+
+    it('leaves the postseason run alone when no regular week is outstanding', async () => {
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce(POSTSEASON_CALENDAR);
+        await runFullUpdate({ withBetting: false });
+        expect(retrieveGames.massRetrieveGames.mock.calls).toEqual([[null, 'postseason']]);
+        expect(scoringModule.updateScores.mock.calls).toEqual([['postseason', 1]]);
+    });
+
+    it('falls back to postseason-only when the trailing-week check fails', async () => {
+        internalFetch.mockImplementation(async (url) => {
+            if (/pending-regular/.test(url)) throw new Error('boom');
+            return { status: 200, json: async () => ({}) };
+        });
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce(POSTSEASON_CALENDAR);
+        await runFullUpdate({ withBetting: false });
+        expect(scoringModule.updateScores.mock.calls).toEqual([['postseason', 1]]);
+    });
+
+    it('never runs the trailing pass during the regular season', async () => {
+        internalFetch.mockImplementation(async (url) => /pending-regular/.test(url)
+            ? { status: 200, json: async () => ({ season: '2026', week: 15 }) }
+            : { status: 200, json: async () => ({}) });
+        await runFullUpdate({ withBetting: false });
+        expect(retrieveGames.massRetrieveGames.mock.calls).toEqual([[7, 'regular']]);
+        expect(scoringModule.updateScores.mock.calls).toEqual([['regular', 7]]);
     });
 
     // The whole point of resolveCurrentWeek throwing/skipping instead of


### PR DESCRIPTION
Audit finding #2 of 4. **Stacked on #296** — both touch `runFullUpdate`, so this targets that branch rather than `main`. Merge #296 first and GitHub will retarget this to `main`.

## The bug

CFBD's postseason calendar window opens **before** the regular season's last game kicks off. From the live 2026 calendar:

```
regular    wk 15  2026-12-07T08:00Z .. 2026-12-12T07:59Z
postseason wk  1  2026-12-12T08:00Z .. 2027-01-28T07:59Z
```

And from the 2026 schedule already in the DB, the only week-15 FBS game — Army–Navy — kicks off `2026-12-12T20:00Z`, twelve hours after the week-15 window closed:

```
Sat Dec 12 2026, Army-Navy kickoff  -> postseason wk 1
Sun Dec 13 2026, daily job          -> postseason wk 1
```

From 2am CT that morning the pipeline pulls `seasonType=postseason`, which never contains a regular-season game, and only calls `updateScores("postseason", …)`. So Army–Navy's final score is never ingested, and week 15 keeps the 0 that the Dec 7–11 runs seeded it with. If either team is drafted, that win is silently lost.

(H2H is unaffected — `h2hWeekRange` correctly drops a one-game week — so this is a straight loss of the week's points, not a corrupted matchup.)

## The fix

Rather than a calendar heuristic, ask the data. New read-only `GET /scores/pending-regular/:season` answers "which regular-season week still has a drafted-team game that kicked off and isn't final", or null. The postseason branch consults it and, when a week comes back, pulls + scores that regular week **before** the postseason pass — so the shared `applyH2HBonuses` / `updateCumulativeScores` / team-score passes fold in both phases.

Self-limiting: the moment the trailing week's games are final the endpoint answers null and the extra pull stops. That matters against the 1,000-call CFBD budget, since with live polling on, an unbounded extra pull would be one wasted call every 10 minutes for the whole bowl season. Two bounds:

- **Drafted teams only.** The Game collection still holds non-FBS rows from older ingests (750 already in 2026); one of those left un-completed would pin a week open for good.
- **48h since kickoff** (`PENDING_REGULAR_MAX_HOURS`). Long enough to cover the nightly + Sunday sweeps after a Saturday kickoff; short enough that genuinely stuck data stops costing calls.

A failed check degrades to the old behaviour (postseason only) and the next run retries, so it can never block scoring.

## Tests

- `pendingRegularWeek` unit tests in `tests/AdminStatus.spec.js` — the trailing week, clearing once complete, highest-of-several, not-yet-kicked-off, past the window, undrafted, postseason rows, garbled rows, either side of the game, empty inputs.
- New `tests/RoutesPendingRegular.spec.js` — the real route against in-memory Mongo with an Army–Navy fixture.
- Four `runFullUpdate` tests — the trailing pass fires in the right order, is skipped when nothing is outstanding, degrades on a failed check, and never runs during the regular season.

867 passing (was 847 on #296).

## Note for review

One run of the suite hit a pre-existing flake in the untouched `AuditLog.spec.js` (`Parse Error: Expected HTTP/`) — a supertest/worker contention artifact, plausibly nudged by this PR adding a 47th suite. Four subsequent full runs were clean. Flagging it rather than hiding it; happy to look at suite isolation separately if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)