### PR TITLE
Stop two overlapping updates from double-counting a week

### DIFF
--- a/models/game.js
+++ b/models/game.js
@@ -124,6 +124,14 @@ const gameSchema = new mongoose.Schema({
     },
 });
 
+// CFBD's game id is the identity of a game everywhere in the app, and the ingest
+// routes upsert on it. UNIQUE because a duplicate is not a cosmetic problem: the
+// per-team week lookup (`GET /games/seasonType/:st/week/:w/team/:id`) returns
+// every match, and modules/scoring.js adds a team's points once per returned
+// game — so a second doc with the same id DOUBLES that team's score for the week.
+// The index is the backstop; routes/games.js upserting is the fix.
+gameSchema.index({ id: 1 }, { unique: true });
+
 // Indexes for the standings / H2H / highlights lookups, which all filter by
 // season + seasonType (+ week), and by home/away team id via $or. Without these
 // every season lookup scans the whole Game collection. Non-unique, additive.

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -102,13 +102,39 @@ function resolveCurrentWeek(calendar, now) {
     return { week: current.week, seasonType: current.seasonType };
 }
 
+// Only one full update at a time in this process.
+//
+// The scheduler and the live poller share the one web dyno, and their rules
+// collide by construction: saturday-scores fires at 15:00/18:00/22:00 on the
+// minute, and the live poller fires on every :00 mark. So three times every
+// Saturday two full updates ran concurrently — two CFBD pulls of the same slate
+// (double spend against the monthly budget) and two passes reading, mutating and
+// writing back the same weeklyScore arrays.
+//
+// In-process only. A standalone `node update-daily-scores-job.js` on another host
+// isn't covered; the unique index on Game.id is what makes the ingest itself safe
+// regardless of who is running it.
+let inFlight = null;
+
+function runFullUpdate(opts) {
+    if (inFlight) {
+        console.log('A full update is already running — skipping this one');
+        return Promise.resolve({
+            skipped: 'a full update was already running', week: null, seasonType: null,
+            teams: 0, gamesNew: 0, gamesUpdated: 0
+        });
+    }
+    inFlight = doFullUpdate(opts || {}).finally(() => { inFlight = null; });
+    return inFlight;
+}
+
 // The shared "update everything for the current week" pipeline that the daily /
 // Saturday / Sunday jobs all run. Determines the current week from the CFBD
 // calendar, ensures rankings exist, pulls games, then updates scores, cumulative
 // scores, team scores and records. `withBetting` also refreshes betting lines —
 // only the daily job did that historically, so it stays opt-in.
 // Returns { week, seasonType } for logging, or { skipped } out of season.
-async function runFullUpdate({ withBetting = false } = {}) {
+async function doFullUpdate({ withBetting = false } = {}) {
 
     // Cached per-season (modules/cfbd-calendar.js): the week windows are static
     // intra-day, so frequent polls reuse one fetch instead of spending a CFBD
@@ -243,4 +269,9 @@ async function runFullUpdate({ withBetting = false } = {}) {
     return { week, seasonType, teams: teamCount, gamesNew, gamesUpdated, remainingCalls };
 }
 
-module.exports = { runFullUpdate, postseasonWeeksToScore, resolveCurrentWeek };
+module.exports = {
+    runFullUpdate, postseasonWeeksToScore, resolveCurrentWeek,
+    // Exported so a test can prove the overlap guard releases; nothing in the app
+    // should need to clear it.
+    _clearInFlight: () => { inFlight = null; }
+};

--- a/routes/games.js
+++ b/routes/games.js
@@ -152,6 +152,18 @@ router.post('/week/mass-create', async (req, res) => {
     const remHeader = response.headers.get('x-calllimit-remaining');
     const remainingCalls = remHeader != null ? Number(remHeader) : undefined;
 
+    // UPSERT, one game at a time, rather than find-then-insertMany.
+    //
+    // Two runs of this route can overlap by construction: the Saturday job fires
+    // at 15:00/18:00/22:00 on the minute and the live poller fires on every :00
+    // mark, so they collide three times a Saturday. Under find-then-insert both
+    // runs could decide the same game was new and insert it twice — and a second
+    // doc with the same CFBD id makes the per-team week lookup return the game
+    // twice, which modules/scoring.js scores twice, DOUBLING that team's points
+    // for the week. The unique index on Game.id backs this up.
+    //
+    // Per-game try/catch also means one unsaveable game no longer takes the whole
+    // slate down with it, which the batch insertMany did.
     for (const game of gameData) {
         var alreadyExists = await Game.find({ id: game.id });
 
@@ -185,43 +197,46 @@ router.post('/week/mass-create', async (req, res) => {
         var centralTime = date.toLocaleString("en-US", {timeZone: "America/Chicago"});
         game.lastUpdated = centralTime;
 
-        if (alreadyExists.length == 0) {
-            const newGame = new Game(game);
-            allNewGames.push(newGame);
-        } else {
-            var filter = {id: game.id};
-            delete game.id;
-            try {
-                var updatedGame = await Game.findOneAndUpdate(filter, game, {new: true});
-                allExistingGames.push(updatedGame);
-            } catch (err) {
-                console.log("Error updating game with id:", game.id);
-                console.log("Update error:", err.message);
-            } 
+        // findOneAndUpdate does not run validators, and the `required` validator
+        // doesn't fire for a merely-absent path on upsert — so validate the
+        // candidate up front. insertMany used to do this for new games; doing it
+        // for updates too means a malformed CFBD row is skipped rather than
+        // written over a good doc.
+        var invalid = new Game(game).validateSync();
+        if (invalid) {
+            console.log("Skipping invalid game with id:", game.id, "|", invalid.message);
+            continue;
+        }
+
+        // `id` stays in the $set (same value the filter matches on), so an insert
+        // seeds it and the error log below can still name the game.
+        try {
+            var savedGame = await Game.findOneAndUpdate(
+                { id: game.id },
+                { $set: game },
+                { new: true, upsert: true, setDefaultsOnInsert: true }
+            );
+            if (alreadyExists.length == 0) {
+                allNewGames.push(savedGame);
+            } else {
+                allExistingGames.push(savedGame);
+            }
+        } catch (err) {
+            console.log("Error saving game with id:", game.id);
+            console.log("Save error:", err.message);
         }
     }
 
+    console.log("all new games length", allNewGames.length);
     console.log("Total number of existing games: ", allExistingGames.length);
 
-    try {
-        try {
-            console.log("all new games length", allNewGames.length);
-            const newGames = await Game.insertMany(allNewGames);
+    var returnedGames = {
+        newGames: allNewGames,
+        existingGames: allExistingGames,
+        remainingCalls: remainingCalls
+    };
 
-            var returnedGames = {
-                newGames: newGames,
-                existingGames: allExistingGames,
-                remainingCalls: remainingCalls
-            };
-
-            return res.status(201).json(returnedGames);
-        } catch (err) {
-            console.log("Error saving games: ", err.message)
-            res.status(400).json({message: err.message});
-        }
-    } catch (err) {
-        res.status(400).json({message: err.message});
-    }
+    return res.status(201).json(returnedGames);
 });
 
 // Bulk-ingest a full FBS schedule in one CFBD call. Preseason prerequisite for

--- a/tests/ModelSchemas.spec.js
+++ b/tests/ModelSchemas.spec.js
@@ -134,6 +134,21 @@ describe('Game schema', () => {
         expect(typeof g.season).toBe('number');
         expect(g.season).toBe(2025);
     });
+
+    // A duplicate id is not cosmetic: the per-team week lookup returns every
+    // match and modules/scoring.js adds a team's points once per returned game,
+    // so a second doc with the same id doubles that team's score for the week.
+    test('CFBD game id is unique — a duplicate cannot be written', async () => {
+        const doc = () => ({
+            id: 401, season: 2025, week: 1, seasonType: 'regular',
+            startDate: '2025-08-30', startTimeTbd: false, neutralSite: false, conferenceGame: false,
+            homeId: 1, homeTeam: 'Oregon', awayId: 2, awayTeam: 'Duke'
+        });
+        await Game.init();          // ensure the index is built before asserting on it
+        await Game.create(doc());
+        await expect(Game.create(doc())).rejects.toThrow(/duplicate key/i);
+        expect(await Game.countDocuments({ id: 401 })).toBe(1);
+    });
 });
 
 describe('harness sanity', () => {

--- a/tests/RoutesGames.spec.js
+++ b/tests/RoutesGames.spec.js
@@ -145,6 +145,49 @@ describe('POST /games/week/mass-create', () => {
         expect(res.status).toBe(400);
         expect(res.body.message).toMatch(/rate limited/);
     });
+
+    test('updates an existing game in place and reports it as existing', async () => {
+        await Game.create(gameDoc({ id: 501, homePoints: 0, awayPoints: 0, completed: false }));
+        global.fetch = jest.fn(() => fetchOk([cfbdGame({ homePoints: 30, awayPoints: 10, completed: true })]));
+        const res = await request(app).post('/games/week/mass-create').send({ week: 1, seasonType: 'regular' });
+        expect(res.status).toBe(201);
+        expect(res.body.existingGames).toHaveLength(1);
+        expect(res.body.newGames).toHaveLength(0);
+        expect(await Game.countDocuments()).toBe(1);
+        const saved = await Game.findOne({ id: 501 }).lean();
+        expect(saved).toMatchObject({ homePoints: 30, completed: true });
+    });
+
+    // The race this route has to survive. The Saturday job fires at 15:00/18:00/
+    // 22:00 on the minute and the live poller fires on every :00 mark, so two runs
+    // land together three times a Saturday. Under the old find-then-insertMany
+    // both could decide the same game was new and insert it twice — and a second
+    // doc with the same CFBD id makes the per-team week lookup return the game
+    // twice, which scoring adds twice, doubling that team's points for the week.
+    test('two concurrent ingests of the same slate leave exactly one doc per game', async () => {
+        global.fetch = jest.fn(() => fetchOk([cfbdGame(), cfbdGame({ id: 502, homeTeam: 'Iowa' })]));
+        const send = () => request(app).post('/games/week/mass-create').send({ week: 1, seasonType: 'regular' });
+
+        const [a, b] = await Promise.all([send(), send()]);
+
+        expect(a.status).toBe(201);
+        expect(b.status).toBe(201);
+        expect(await Game.countDocuments()).toBe(2);
+        expect(await Game.countDocuments({ id: 501 })).toBe(1);
+        expect(await Game.countDocuments({ id: 502 })).toBe(1);
+    });
+
+    test('one unsaveable game does not take the rest of the slate down', async () => {
+        // homeTeam is required, so this row can't save — the other one still must.
+        global.fetch = jest.fn(() => fetchOk([
+            cfbdGame({ id: 503, homeTeam: undefined }),
+            cfbdGame({ id: 504, homeTeam: 'Iowa' })
+        ]));
+        const res = await request(app).post('/games/week/mass-create').send({ week: 1, seasonType: 'regular' });
+        expect(res.status).toBe(201);
+        expect(await Game.countDocuments({ id: 504 })).toBe(1);
+        expect(await Game.countDocuments({ id: 503 })).toBe(0);
+    });
 });
 
 describe('POST /games/:season/schedule', () => {

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -144,6 +144,51 @@ describe('runFullUpdate scoring order', () => {
     });
 });
 
+// saturday-scores fires at 15:00/18:00/22:00 on the minute and the live poller
+// fires on every :00 mark, so two full updates overlapped three times every
+// Saturday — two CFBD pulls of the same slate, and two passes mutating the same
+// weeklyScore arrays.
+describe('runFullUpdate overlap guard', () => {
+    const scoreUpdate = require('../modules/score-update');
+    const scoringModule = require('../modules/scoring.js');
+    const retrieveGames = require('../modules/retrieve-games.js');
+
+    beforeEach(() => {
+        scoringModule._calls.length = 0;
+        scoringModule.updateScores.mockClear();
+        retrieveGames.massRetrieveGames.mockClear();
+        scoreUpdate._clearInFlight();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+    afterEach(() => { jest.restoreAllMocks(); });
+
+    it('runs the first update and skips the one that lands on top of it', async () => {
+        const [first, second] = await Promise.all([
+            scoreUpdate.runFullUpdate({ withBetting: false }),
+            scoreUpdate.runFullUpdate({ withBetting: false })
+        ]);
+        expect(first.skipped).toBeUndefined();
+        expect(second.skipped).toMatch(/already running/);
+        // One pull, one scoring pass — not two of each.
+        expect(retrieveGames.massRetrieveGames).toHaveBeenCalledTimes(1);
+        expect(scoringModule.updateScores).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the guard so the next scheduled run proceeds', async () => {
+        await scoreUpdate.runFullUpdate({ withBetting: false });
+        const next = await scoreUpdate.runFullUpdate({ withBetting: false });
+        expect(next.skipped).toBeUndefined();
+        expect(scoringModule.updateScores).toHaveBeenCalledTimes(2);
+    });
+
+    it('releases the guard even when the run throws', async () => {
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce([]);
+        await expect(scoreUpdate.runFullUpdate({ withBetting: false })).rejects.toThrow(/calendar/i);
+        const next = await scoreUpdate.runFullUpdate({ withBetting: false });
+        expect(next.skipped).toBeUndefined();
+    });
+});
+
 describe('resolveCurrentWeek', () => {
     const { resolveCurrentWeek } = require('../modules/score-update');
     const at = (iso) => new Date(iso);


### PR DESCRIPTION
Audit finding #3 of 4 — the one that can actually put wrong numbers in the standings. **Stacked on #297** (which is stacked on #296); merge in order and GitHub retargets each.

## The bug

Two schedules collide by construction:

| job | rule |
|---|---|
| `saturday-scores` | `dayOfWeek 6, hour [15,18,22], minute 0` |
| `live-scores` | `minute [0,10,20,30,40,50]`, any hour, any day |

With `LIVE_POLL_ENABLED=true` both fire at Sat 15:00, 18:00 and 22:00 — and the live poller's own gates all pass at those moments (Saturday, on-cadence, a game in progress). So `runFullUpdate` ran twice concurrently, three times every Saturday.

The damage lands in the ingest. `POST /games/week/mass-create` did:

```js
var alreadyExists = await Game.find({ id: game.id });
...
if (alreadyExists.length == 0) allNewGames.push(new Game(game));
...
const newGames = await Game.insertMany(allNewGames);
```

Find-then-insert, and **`Game.id` had no unique index** — so both runs could decide the same game was new and insert it. A second doc with the same CFBD id then makes `GET /games/seasonType/:st/week/:w/team/:id` return the game twice, and `modules/scoring.js` adds a team's points once per returned game:

```js
for (const game of response) {
    teamScore = await calculateScoreV1(...);   // or V2
    score += teamScore;
}
```

**That doubles the team's points for the week.** And the admin console cannot see it — `unscoredResults` only counts results that are *missing* from `scoreByTeam`, and both duplicate ids look scored.

No duplicates exist in the DB today, so this hasn't fired yet. The exposure is the first pull of a slate, when games are actually created rather than updated. During the regular season the preseason schedule ingest means most pulls are updates — but the **postseason schedule is not pre-ingested** (2026 has zero postseason games on file), so the first postseason pull creates all ~45 games at once.

## The fix

1. **`mass-create` upserts on `id`** instead of find-then-insertMany, so a concurrent run merges rather than duplicates.
2. **Unique index on `Game.id`** as the backstop, so nothing else can create one either.
3. **`runFullUpdate` refuses to start while another is in flight**, returning `{ skipped: "a full update was already running" }`. That also halves the CFBD spend at those three Saturday marks. In-process only — a standalone `node update-daily-scores-job.js` on another host isn't covered, which is exactly why the index and the upsert carry the safety rather than the guard.

### One thing the tests caught

`findOneAndUpdate` runs **no validators**, and Mongoose's `required` validator doesn't fire for a merely-absent path on upsert. So the naive upsert happily wrote a Game doc that `insertMany` would have rejected — a real regression I would have shipped. There is now an explicit `validateSync()` before the write, which also means a malformed CFBD row is skipped instead of being written over a good doc. Per-game try/catch replaces the batch insert, so one bad row no longer takes the whole slate down.

## Tests

New in `tests/RoutesGames.spec.js`:

- **two concurrent ingests of the same slate leave exactly one doc per game** — the regression test. Verified it bites: with the route reverted and only the index in place, one request comes back **400** (the duplicate-key error from `insertMany`), which is the same race showing up as a failed ingest instead of doubled points.
- an existing game is updated in place and reported as existing
- one unsaveable game does not take the rest of the slate down

`tests/ModelSchemas.spec.js`: a duplicate `id` is rejected. `tests/ScoreUpdate.spec.js`: the guard skips the second concurrent run, releases afterwards, and releases even when the run throws.

874 passing (was 867 on #297).

## Before merging

Check prod has no duplicate `Game.id` rows, or the unique index build will fail on deploy (Mongoose logs the failure rather than crashing, but the index silently won't exist):

```js
db.games.aggregate([{ $group: { _id: "$id", n: { $sum: 1 } } }, { $match: { n: { $gt: 1 } } }])
```

Zero groups in the dev tenant. If prod returns any, they need collapsing first — and any week involving one of those games was scored twice and needs a rescore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)