### PR TITLE
Stop a failed scoring write from taking the dyno down

### DIFF
--- a/modules/internal-api.js
+++ b/modules/internal-api.js
@@ -12,4 +12,23 @@ function internalFetch(url, options = {}) {
     });
 }
 
-module.exports = { internalFetch };
+// A failed internal call's message, read WITHOUT ever rejecting.
+//
+// The app's own API answers JSON, but what sits in front of it may not: Heroku
+// serves an HTML error page for H12 (30s request timeout) and 503, which is
+// exactly what a long Saturday scoring run provokes. response.json() rejects on
+// that, and the scoring write helpers used to leave the rejection unhandled — no
+// await, no catch. With no process-level unhandledRejection handler anywhere,
+// Node exits: mid-pass, some managers written and others not, and the web dyno
+// goes down with it because that is where the scheduler runs.
+async function failureMessage(response) {
+    try {
+        const data = await response.json();
+        if (data && data.message) return `${data.message} (HTTP ${response.status})`;
+    } catch (err) {
+        return `HTTP ${response.status} — non-JSON response body`;
+    }
+    return `HTTP ${response.status}`;
+}
+
+module.exports = { internalFetch, failureMessage };

--- a/modules/records.js
+++ b/modules/records.js
@@ -1,23 +1,33 @@
-const { internalFetch } = require('./internal-api');
+const { internalFetch, failureMessage } = require('./internal-api');
 module.exports = {
+    // Records are a non-critical tail step of the scoring pipeline, so a failure
+    // is logged and swallowed rather than failing the run — the same contract
+    // modules/betting.js already had.
+    //
+    // It used to end in an un-awaited `response.json().then(...)` with no .catch,
+    // so a non-JSON body (Heroku's H12 / 503 page, which a long run provokes)
+    // became an unhandled rejection — and with no process-level handler, that
+    // exits Node partway through the pipeline. See internal-api failureMessage().
     updateAllTeamRecords: async function() {
-        const response = await internalFetch(`${process.env.URL}/records/new/${process.env.YEAR}`, {
-            method: 'POST',
-            headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            },
-            body: `{
-            "season": "${process.env.YEAR}"
-            }`,
-        });
+        try {
+            const response = await internalFetch(`${process.env.URL}/records/new/${process.env.YEAR}`, {
+                method: 'POST',
+                headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+                },
+                body: `{
+                "season": "${process.env.YEAR}"
+                }`,
+            });
 
-        response.json().then(data => {
             if (response.status == 201) {
                 console.log("✅ New team records retrieved");
             } else {
-                console.log("❌ Team Records could not be retrieved" + " | " + response.status);
+                console.log("❌ Team Records could not be retrieved | " + await failureMessage(response));
             }
-        });
+        } catch (err) {
+            console.log("❌ Team records update failed: " + (err && err.message ? err.message : err));
+        }
     }
 };

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -1,4 +1,4 @@
-const { internalFetch } = require('./internal-api');
+const { internalFetch, failureMessage } = require('./internal-api');
 const { resolveConfig, MODELS, engagementForSeason, ruleEnabled } = require('./scoring-defaults');
 const { CONDITIONS, buildContext } = require('./scoring-detectors');
 const { resolveCaptain, captainWeeklyBonus } = require('./captain');
@@ -38,7 +38,11 @@ module.exports= {
             // array with no initial value" and aborting the whole loop.
             var weeklyScore = user.seasons[0].weeklyScore || [];
             var totalScore = weeklyScore.map(score).reduce(sum, 0);
-            updateUserCumulativeScore(user._id, totalScore);
+            // Awaited: un-awaited, this whole step resolved before a single
+            // cumulativeScore had actually been written, so the job moved on to
+            // team scores (and reported success) with the writes still in flight —
+            // and a rejected one had nowhere to go but the process.
+            await updateUserCumulativeScore(user._id, totalScore);
         }
     },
 
@@ -256,9 +260,15 @@ module.exports= {
 
         var response = await module.exports.updateTeamScoresWithYear(season, teamId, scoreUpdateObject);
 
-        if (response.status == 200) {
+        // Guarded: updateTeamScoresWithYear used to resolve to `undefined` on a
+        // failed PATCH, so this line threw a TypeError, which rejected up through
+        // the /calculate-team-score handler — an async Express 4 handler, which
+        // does not catch that. Unhandled rejection, process gone, in the middle of
+        // a 138-team loop.
+        if (response && response.status == 200) {
             return response;
         }
+        return { status: (response && response.status) || 500, updatedTeam: null };
     },
 
     // Scoring for the Claunts league (claunts model). `cfg` may be a flat point-
@@ -291,15 +301,8 @@ module.exports= {
             },
             body: JSON.stringify(requestBody),
         });
-    
-        return response.json().then(data => {
-            if (response.status == 200) {
-                var updatedTeam = {status: response.status, updatedTeam: data};
-                return updatedTeam;
-            } else {
-                console.log(data.message);
-            }
-        });
+
+        return readTeamWrite(response, teamId);
     },
     
     updateTeamScoresWithYear: async function (season, teamId, scoreUpdate) {
@@ -318,20 +321,36 @@ module.exports= {
             },
             body: JSON.stringify(requestBody),
         });
-    
-        return response.json().then(data => {
-            if (response.status == 200) {
-                var updatedTeam = {status: response.status, updatedTeam: data};
-                return updatedTeam;
-            } else {
-                console.log(data.message);
-            }
-        });
+
+        return readTeamWrite(response, teamId);
     }
 };
 
+// Shared tail of both team-score writes. ALWAYS resolves to a { status } object —
+// it used to resolve to `undefined` on a failed PATCH, which is what turned a
+// failed write into a TypeError and then an unhandled rejection. A junk body
+// can't reject here either.
+async function readTeamWrite(response, teamId) {
+    if (response.status == 200) {
+        let data = null;
+        try { data = await response.json(); } catch (err) { /* body isn't the point on success */ }
+        return { status: response.status, updatedTeam: data };
+    }
+    console.error(`❌ Failed to write scores for team ${teamId}: ${await failureMessage(response)}`);
+    return { status: response.status, updatedTeam: null };
+}
+
+// Both user write helpers below used to end in an un-awaited
+// `response.json().then(...)` with no .catch. A non-JSON body — Heroku's H12 /
+// 503 page during a long run — made that an unhandled rejection, which with no
+// process-level handler exits Node mid-pass. See failureMessage().
+//
+// They now await the read, can't reject on a junk body, and log a FAILED write at
+// error level instead of quietly at log level. Returning a boolean so a caller
+// can tell a landed write from a lost one.
+
 async function updateUser(userId, scoreUpdate) {
-    
+
     var requestBody = `{
         "weeklyScore": ${JSON.stringify(scoreUpdate)},
         "isUpdated": true
@@ -345,14 +364,13 @@ async function updateUser(userId, scoreUpdate) {
             },
             body: requestBody,
         });
-    
-        response.json().then(data => {
-            if (response.status == 200) {
-                console.log(`✅ Successfully updated User ${userId} with new weeklyScore`);
-            } else {
-                console.log(data.message);
-            }
-        });
+
+    if (response.status == 200) {
+        console.log(`✅ Successfully updated User ${userId} with new weeklyScore`);
+        return true;
+    }
+    console.error(`❌ Failed to write weeklyScore for user ${userId}: ${await failureMessage(response)}`);
+    return false;
 }
 
 async function updateUserCumulativeScore(userId, cumulativeScore) {
@@ -367,14 +385,13 @@ async function updateUserCumulativeScore(userId, cumulativeScore) {
             "isUpdated": true
             }`,
         });
-    
-        response.json().then(data => {
-            if (response.status == 200) {
-                console.log(`Update User ${userId} with new cumulativeScore:`, cumulativeScore);
-            } else {
-                console.log(data.message);
-            }
-        });
+
+    if (response.status == 200) {
+        console.log(`Update User ${userId} with new cumulativeScore:`, cumulativeScore);
+        return true;
+    }
+    console.error(`❌ Failed to write cumulativeScore for user ${userId}: ${await failureMessage(response)}`);
+    return false;
 }
 
 

--- a/server.js
+++ b/server.js
@@ -531,13 +531,22 @@ app.use('/standings', requireAuthOrToken, standingsRouter);
 const historyRouter = require('./routes/history');
 app.use('/history', requireAuthOrToken, historyRouter);
 
+// try/catch because Express 4 does NOT catch a rejection from an async handler:
+// anything thrown in here becomes an unhandled rejection, and with no
+// process-level handler that exits the dyno. The team-score loop calls this ~138
+// times per scoring run, so one bad team used to be able to take the app down.
 app.get('/calculate-team-score/:season/:teamId/:teamName', requireAdmin, async (req, res) => {
-    var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);
+    try {
+        var response = await scoringModule.calculateTeamScores(req.params.season, req.params.teamId, req.params.teamName);
 
-    if (response.status == 200) {
-        res.status(200).json(response.updatedTeam);
-    } else {
-        res.status(400).json("Bad Request");
+        if (response && response.status == 200) {
+            res.status(200).json(response.updatedTeam);
+        } else {
+            res.status(400).json("Bad Request");
+        }
+    } catch (err) {
+        console.error(`❌ calculate-team-score failed for team ${req.params.teamId}:`, err);
+        res.status(500).json({ message: err.message });
     }
 });
 

--- a/tests/ScoringWrites.spec.js
+++ b/tests/ScoringWrites.spec.js
@@ -1,0 +1,175 @@
+// The scoring pipeline's write paths, and specifically their failure handling.
+//
+// Every one of these helpers used to end in an un-awaited
+// `response.json().then(...)` with no .catch. The app's own API answers JSON, but
+// what sits in front of it may not: Heroku serves an HTML page for H12 (30s
+// request timeout) and 503 — exactly what a long Saturday run provokes. json()
+// rejects on that, the rejection had no handler, and with no
+// process.on('unhandledRejection') anywhere in the app, Node exits. Mid-pass:
+// some managers written, others not, and the web dyno gone with it, since that is
+// where the scheduler runs.
+//
+// So the contract these lock in is narrow and specific: a failing or junk
+// response must never produce an unhandled rejection, and must never be mistaken
+// for a successful write.
+
+const scoringModule = require('../modules/scoring.js');
+const recordsModule = require('../modules/records.js');
+const { failureMessage } = require('../modules/internal-api');
+
+// A response whose body is NOT JSON — the Heroku error-page case.
+function htmlErrorPage(status) {
+    return {
+        status,
+        json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON at position 0')),
+        text: () => Promise.resolve('<html><body>Application error</body></html>')
+    };
+}
+function jsonResponse(status, body) {
+    return { status, json: () => Promise.resolve(body) };
+}
+
+describe('failureMessage', () => {
+    it('prefers the API message when the body is JSON', async () => {
+        expect(await failureMessage(jsonResponse(400, { message: 'Cannot find user' })))
+            .toBe('Cannot find user (HTTP 400)');
+    });
+
+    it('falls back to the status when the body has no message', async () => {
+        expect(await failureMessage(jsonResponse(500, {}))).toBe('HTTP 500');
+    });
+
+    it('never rejects on a non-JSON body', async () => {
+        await expect(failureMessage(htmlErrorPage(503))).resolves.toMatch(/non-JSON/);
+    });
+});
+
+describe('scoring write failures never become unhandled rejections', () => {
+    const OLD_ENV = process.env;
+    const realFetch = global.fetch;
+    let unhandled;
+
+    beforeEach(() => {
+        process.env = { ...OLD_ENV, URL: 'http://test.local', YEAR: '2025' };
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        // Fail the test if anything in here leaks a rejection, which is the whole
+        // point — an unhandled rejection exits the real process.
+        unhandled = [];
+        process.on('unhandledRejection', (err) => unhandled.push(err));
+    });
+
+    afterEach(async () => {
+        // Let any leaked rejection surface before asserting none did.
+        await new Promise(resolve => setImmediate(resolve));
+        process.removeAllListeners('unhandledRejection');
+        expect(unhandled).toEqual([]);
+        process.env = OLD_ENV;
+        global.fetch = realFetch;
+        jest.restoreAllMocks();
+    });
+
+    // ---- weeklyScore write (updateScores -> PATCH /users/:id) ----------------
+
+    it('reports a failed weeklyScore write instead of crashing on the body', async () => {
+        const users = [{ _id: 'u1', league: 'claunts-league', seasons: [{ season: '2025', teams: [], weeklyScore: [] }] }];
+        global.fetch = jest.fn((url) => {
+            if (url.includes('/users/season/')) return Promise.resolve(jsonResponse(200, users));
+            if (url.includes('/scoring-config/')) return Promise.resolve(jsonResponse(200, { model: 'claunts', values: {} }));
+            return Promise.resolve(htmlErrorPage(503));   // the PATCH
+        });
+
+        await expect(scoringModule.updateScores('regular', 1)).resolves.toBeUndefined();
+        expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Failed to write weeklyScore for user u1.*non-JSON/));
+    });
+
+    // ---- cumulativeScore write (updateCumulativeScores -> PATCH /users/:id) --
+
+    it('reports a failed cumulativeScore write instead of crashing on the body', async () => {
+        const users = [{ _id: 'u2', seasons: [{ season: '2025', weeklyScore: [{ score: 7 }] }] }];
+        global.fetch = jest.fn((url) => url.includes('/users/season/')
+            ? Promise.resolve(jsonResponse(200, users))
+            : Promise.resolve(htmlErrorPage(503)));
+
+        await expect(scoringModule.updateCumulativeScores()).resolves.toBeUndefined();
+        expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Failed to write cumulativeScore for user u2/));
+    });
+
+    // Un-awaited, this step resolved before a single write had landed — so the job
+    // moved on to team scores, and reported success, with writes still in flight.
+    it('does not resolve until every cumulativeScore write has landed', async () => {
+        const users = [
+            { _id: 'a', seasons: [{ season: '2025', weeklyScore: [{ score: 1 }] }] },
+            { _id: 'b', seasons: [{ season: '2025', weeklyScore: [{ score: 2 }] }] }
+        ];
+        const written = [];
+        global.fetch = jest.fn((url, opts) => {
+            if (url.includes('/users/season/')) return Promise.resolve(jsonResponse(200, users));
+            return new Promise(resolve => setImmediate(() => {
+                written.push(JSON.parse(opts.body).cumulativeScore);
+                resolve(jsonResponse(200, {}));
+            }));
+        });
+
+        await scoringModule.updateCumulativeScores();
+        expect(written).toEqual([1, 2]);   // not [] — the writes are already done
+    });
+
+    // ---- team-score write (PATCH /teams/:id[/:season]) ----------------------
+
+    it('always resolves to a status object on a failed team-score write', async () => {
+        global.fetch = jest.fn(() => Promise.resolve(htmlErrorPage(503)));
+
+        // Previously resolved to `undefined`, which made the caller below throw.
+        await expect(scoringModule.updateTeamScores(333, { weeklyScore: [] }))
+            .resolves.toMatchObject({ status: 503, updatedTeam: null });
+        await expect(scoringModule.updateTeamScoresWithYear(2025, 333, { weeklyScore: [] }))
+            .resolves.toMatchObject({ status: 503, updatedTeam: null });
+        expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Failed to write scores for team 333/));
+    });
+
+    // The crash path this guards: calculateTeamScores read `.status` off that
+    // undefined, throwing a TypeError that rejected up through an async Express 4
+    // handler — which does not catch it. The team loop calls that route ~138 times
+    // per run, so one bad team could take the app down.
+    it('calculateTeamScores reports a failed write rather than throwing', async () => {
+        global.fetch = jest.fn((url) => {
+            if (url.includes('/games/season/')) return Promise.resolve(jsonResponse(200, []));
+            return Promise.resolve(htmlErrorPage(503));
+        });
+
+        const result = await scoringModule.calculateTeamScores(2025, 333, 'Oregon');
+        expect(result).toMatchObject({ status: 503, updatedTeam: null });
+    });
+
+    // ---- records tail step -------------------------------------------------
+
+    it('swallows a records failure the way the betting step already did', async () => {
+        global.fetch = jest.fn(() => Promise.resolve(htmlErrorPage(503)));
+        await expect(recordsModule.updateAllTeamRecords()).resolves.toBeUndefined();
+        expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Team Records could not be retrieved.*non-JSON/));
+    });
+
+    it('swallows a records network error too', async () => {
+        global.fetch = jest.fn(() => Promise.reject(new Error('ECONNRESET')));
+        await expect(recordsModule.updateAllTeamRecords()).resolves.toBeUndefined();
+        expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Team records update failed.*ECONNRESET/));
+    });
+
+    // ---- and the happy paths still work ------------------------------------
+
+    it('still reports a successful write', async () => {
+        global.fetch = jest.fn(() => Promise.resolve(jsonResponse(200, { id: 333 })));
+        await expect(scoringModule.updateTeamScoresWithYear(2025, 333, { weeklyScore: [] }))
+            .resolves.toMatchObject({ status: 200, updatedTeam: { id: 333 } });
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a 200 whose body is not JSON', async () => {
+        global.fetch = jest.fn(() => Promise.resolve({
+            status: 200, json: () => Promise.reject(new SyntaxError('nope'))
+        }));
+        await expect(scoringModule.updateTeamScoresWithYear(2025, 333, { weeklyScore: [] }))
+            .resolves.toMatchObject({ status: 200, updatedTeam: null });
+    });
+});


### PR DESCRIPTION
Audit finding #4 of 4. Independent of #296/#297/#298 — touches different files, targets `main` directly.

## The bug

Three scoring write helpers ended like this:

```js
const response = await internalFetch(...);

response.json().then(data => {          // not awaited, no .catch
    if (response.status == 200) { ... } else { console.log(data.message); }
});
```

The app's own API answers JSON, but what sits in front of it may not — Heroku serves an HTML page for H12 (30s request timeout) and 503, and a long Saturday run is exactly what provokes those. `json()` rejects on an HTML body, nothing handles the rejection, and there is **no `process.on("unhandledRejection")` anywhere in the app**. So Node exits: mid-pass, some managers written and others not, and the web app goes down with it, because the scheduler runs in that same dyno.

Sites: `modules/scoring.js` `updateUser` / `updateUserCumulativeScore`, and `modules/records.js` `updateAllTeamRecords`.

## Three more in the same family, found while fixing it

- **`updateCumulativeScores` never awaited `updateUserCumulativeScore`.** The whole step resolved before a single `cumulativeScore` had been written — so the pipeline moved on to team scores, and the job reported success, with the writes still in flight. A rejected one had nowhere to go but the process.
- **`updateTeamScores` / `updateTeamScoresWithYear` resolved to `undefined` on a failed PATCH** (the `.then` had no return in the else branch). `calculateTeamScores` then read `.status` off `undefined` → TypeError.
- **That TypeError rejected up through `GET /calculate-team-score`, an async Express 4 handler with no try/catch.** Express 4 does not catch async rejections, so it became another unhandled rejection. `updateAllTeamScores` calls that route ~138 times per run, so one team with a failing write could kill the app.

## The fix

- `failureMessage(response)` in `modules/internal-api.js` — reads a failed response's message and **cannot reject**, falling back to the status (and saying so) when the body is not JSON.
- Both user writes await the read, log failures via `console.error` rather than `console.log`, and return a boolean so a lost write is distinguishable from a landed one.
- `updateCumulativeScores` awaits each write.
- A shared `readTeamWrite` tail always resolves to a `{ status, updatedTeam }` object, never `undefined`, and tolerates a non-JSON body even on a 200.
- `calculateTeamScores` guards the result; the `/calculate-team-score` handler gets a try/catch.
- `records.js` swallows failures and logs them — the same contract `modules/betting.js` already had for the other non-critical tail step.

## Tests

New `tests/ScoringWrites.spec.js`. It registers a `process.on("unhandledRejection")` listener and **asserts nothing leaked** in `afterEach`, which is the actual property at stake rather than a proxy for it. Cases: failed weeklyScore write, failed cumulativeScore write, writes-have-landed-before-resolve, team-score write returning a status object, `calculateTeamScores` not throwing, records swallowing both a junk body and a network error, plus the happy paths and a 200 with a non-JSON body.

**Eight of the twelve fail against the old code** — verified by reverting `modules/scoring.js` and `modules/records.js` and re-running.

848 passing (was 836 on `main`).

## Deliberately not in scope

`updateScores` still writes each manager in turn and, with this change, keeps going after a failed write rather than aborting — it just now says so loudly. Making the pass *fail* the run when any write is lost (count failures, throw at the end, so the JobRun goes red and the failure email fires) is the natural follow-up, but it changes job-level control flow and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)