### PR TITLE
Pin the H2H manager list once a week has settled

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -35,6 +35,16 @@ const scoringConfigSchema = new mongoose.Schema({
     // affects another, and a rescore of a season without an entry adds no
     // captain/H2H bonus. Stored as Mixed so seasons can be added freely.
     engagementBySeason: { type: mongoose.Schema.Types.Mixed, default: {} },
+    // The FROZEN H2H manager list per season, e.g.
+    // { "2026": { ids: ["65a…", "65b…"], pinnedAt: Date } }.
+    //
+    // H2H pairings come from a positional round robin, so this list's contents
+    // and order decide who plays whom in every week. Derived fresh each pass, a
+    // membership change mid-season restructured the round robin and re-decided
+    // every already-settled week — moving banked bonuses between managers. The
+    // list is pinned the first time a week settles and read verbatim after that.
+    // See modules/h2h.js h2hRoster.
+    h2hScheduleBySeason: { type: mongoose.Schema.Types.Mixed, default: {} },
     updatedAt: { type: Date, default: Date.now }
 });
 

--- a/modules/h2h.js
+++ b/modules/h2h.js
@@ -184,6 +184,36 @@ function h2hManagerIds(users, season) {
         .sort();
 }
 
+// The FROZEN manager list stored for a league+season, or null if none yet.
+// Reads a ScoringConfig doc (or lean object); kept here so the scoring-time pass
+// and the standings read model can't disagree about where the pin lives.
+function pinnedH2HIds(cfgDoc, season) {
+    const bySeason = cfgDoc && cfgDoc.h2hScheduleBySeason;
+    const entry = bySeason && (bySeason[String(season)] || bySeason[Number(season)]);
+    const ids = entry && entry.ids;
+    return (Array.isArray(ids) && ids.length) ? ids.map(String) : null;
+}
+
+// The EFFECTIVE manager list for a season's H2H — pinned if one has been stored,
+// otherwise derived from who currently has a scored week.
+//
+// The pairing schedule is POSITIONAL (circle-method round robin), so this list's
+// contents and order decide who plays whom in every week. Deriving it fresh on
+// every pass was a latent history-rewriter: add or remove a manager mid-season
+// and the round robin restructures (6 managers = 5 rounds, 7 = 7 rounds with a
+// bye, and round 0's pairings differ entirely), so every already-settled week is
+// re-decided under new pairings — and applyAwards, which rebuilds each week's
+// bonus from base, duly moves the banked points to whoever now "won".
+//
+// So the caller pins the list the first time a week settles. Before that nothing
+// is banked to protect, so the derived list is used and preseason roster churn
+// costs nothing. After it, membership changes cannot touch decided weeks — a
+// manager who joins later simply has no H2H schedule for that season.
+function h2hRoster(users, season, pinned) {
+    if (Array.isArray(pinned) && pinned.length) return pinned.map(String);
+    return h2hManagerIds(users, season);
+}
+
 const round1 = (v) => Math.round(v * 10) / 10;
 
 // The single source of truth for "who won which H2H week, and what is it worth".
@@ -202,9 +232,9 @@ const round1 = (v) => Math.round(v * 10) / 10;
 //   weekFinal   { [week]: bool }
 //   finalWeeks  settled weeks, ascending
 //   currentWeek the first week with games that hasn't settled (or null)
-function computeH2HAwards({ users, games, season, winBonus, tieBonus, maxWeek }) {
+function computeH2HAwards({ users, games, season, winBonus, tieBonus, maxWeek, pinnedIds }) {
     const bound = maxWeek || H2H_MAX_WEEK;
-    const ids = h2hManagerIds(users, season);
+    const ids = h2hRoster(users, season, pinnedIds);
 
     const awards = {};
     ids.forEach(id => { awards[id] = {}; });
@@ -366,5 +396,5 @@ module.exports = {
     buildRoundRobin, scheduleForWeeks, resolveWeek, seasonH2H,
     gameStatus, isWeekFinal, matchupWinProb,
     H2H_MAX_WEEK, h2hWeekRange, seasonEntry, baseWeekScore, persistedBonus,
-    h2hManagerIds, computeH2HAwards, applyAwards
+    h2hManagerIds, h2hRoster, pinnedH2HIds, computeH2HAwards, applyAwards
 };

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -11,7 +11,7 @@ const { computeAdminStatus, pendingRegularWeek } = require('../modules/admin-sta
 const { computeSeasonReadiness } = require('../modules/season-readiness');
 const { engagementForSeason, LEAGUES } = require('../modules/scoring-defaults');
 const { canManageLeague } = require('../modules/league-access');
-const { H2H_MAX_WEEK, seasonEntry, computeH2HAwards, applyAwards } = require('../modules/h2h');
+const { H2H_MAX_WEEK, seasonEntry, computeH2HAwards, applyAwards, pinnedH2HIds } = require('../modules/h2h');
 
 // Read-only status summary for the admin console: how far scoring/games have
 // progressed and whether any completed results are still unscored. Derived from
@@ -183,10 +183,14 @@ async function applyH2HBonuses(season) {
 
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
         const eng = engagementForSeason(cfgDoc && cfgDoc.engagementBySeason, seasonStr);
+        // The frozen manager list for this season, if one has been stored. Passed
+        // through so a membership change can never re-pair an already-settled
+        // week (see modules/h2h.js h2hRoster).
+        const pinnedIds = pinnedH2HIds(cfgDoc, seasonStr);
 
         // Only load games when there's a chance of awarding. With H2H off the
         // award map stays empty, which still strips any previously-stored bonus.
-        let awards = {};
+        let awards = {}, computed = null;
         if (eng.h2hEnabled) {
             const drafted = new Set();
             users.forEach(u => {
@@ -199,10 +203,11 @@ async function applyH2HBonuses(season) {
                   $or: [{ homeId: { $in: idList } }, { awayId: { $in: idList } }] },
                 { id: 1, week: 1, seasonType: 1, completed: 1, homeId: 1, awayId: 1, _id: 0 }
             ).lean() : [];
-            awards = computeH2HAwards({
-                users, games, season: seasonStr,
+            computed = computeH2HAwards({
+                users, games, season: seasonStr, pinnedIds,
                 winBonus: eng.h2hWinBonus, tieBonus: eng.h2hTieBonus
-            }).awards;
+            });
+            awards = computed.awards;
         }
 
         let updated = 0, awarded = 0;
@@ -218,7 +223,22 @@ async function applyH2HBonuses(season) {
             updated++;
             awarded += next.weeklyScore.reduce((sum, e) => sum + (e.h2hBonus || 0), 0);
         }
-        summary.push({ league, enabled: !!eng.h2hEnabled, managersUpdated: updated, bonusAwarded: awarded });
+        // Freeze the manager list the moment the first week settles. Everything
+        // before that is unbanked, so the list stays live and preseason roster
+        // churn costs nothing; from here on, no membership change can re-decide a
+        // week that has already paid out.
+        let pinned = false;
+        if (eng.h2hEnabled && !pinnedIds && computed && computed.finalWeeks.length && computed.ids.length) {
+            await ScoringConfig.updateOne(
+                { league },
+                { $set: { ['h2hScheduleBySeason.' + seasonStr]: { ids: computed.ids, pinnedAt: new Date() } } },
+                { upsert: true }
+            );
+            pinned = true;
+            console.log(`H2H roster pinned · ${league} ${seasonStr}: ${computed.ids.length} manager(s)`);
+        }
+
+        summary.push({ league, enabled: !!eng.h2hEnabled, managersUpdated: updated, bonusAwarded: awarded, rosterPinned: pinned });
         console.log(`H2H bonus · ${league}: ${eng.h2hEnabled ? 'on' : 'off'}, ${updated} manager(s) updated`);
     }
 

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -18,7 +18,7 @@ const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
 // the same everywhere.
 const { competitionRanks } = require('../public/league-rank.js');
 const { gameStatus, matchupWinProb, H2H_MAX_WEEK, baseWeekScore, persistedBonus,
-        h2hManagerIds, computeH2HAwards } = require('../modules/h2h');
+        h2hRoster, pinnedH2HIds, computeH2HAwards } = require('../modules/h2h');
 const { pickLogo } = require('../public/logo.js');
 
 // The scoring jobs that actually refresh standings data (see modules/score-job.js
@@ -305,8 +305,12 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const isRegular = w => w.season !== 'postseason' && w.week <= 16;
         const round = v => Math.round(v * 10) / 10;
         // Deterministic manager ordering — the pairing schedule is positional, so
-        // this must match what the scoring-time pass used (modules/h2h.js).
-        const ids = h2hManagerIds(users, season);
+        // this must match what the scoring-time pass used (modules/h2h.js). Once
+        // a week has settled that pass PINS the list, and reading the same pin
+        // here is what keeps the rendered matchups identical to the banked ones
+        // after any membership change.
+        const pinnedIds = pinnedH2HIds(cfgDoc, season);
+        const ids = h2hRoster(users, season, pinnedIds);
         const idSet = new Set(ids);
         const meta = {}, totals = {}, teamDetail = {}, caps = {}, banked = {};
         const draftedSet = new Set();
@@ -426,7 +430,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // from the SAME function the scoring job uses to bank the bonus, so the
         // table and cumulativeScore can never tell different stories.
         const { awards, weekFinal, finalWeeks, currentWeek, schedule: scheduleAll } = computeH2HAwards({
-            users, games, season, winBonus, tieBonus, maxWeek: H2H_MAX_WEEK
+            users, games, season, winBonus, tieBonus, maxWeek: H2H_MAX_WEEK, pinnedIds
         });
 
         // Records + win bonus count FINAL weeks only (an in-progress week has no
@@ -440,7 +444,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             });
             rec[id] = a;
         });
-        const managers = ids.map(id => ({
+        const managers = ids.filter(id => meta[id]).map(id => ({
             ...meta[id],
             wins: rec[id].wins, losses: rec[id].losses, ties: rec[id].ties,
             record: `${rec[id].wins}-${rec[id].losses}-${rec[id].ties}`,

--- a/tests/H2H.spec.js
+++ b/tests/H2H.spec.js
@@ -425,3 +425,87 @@ describe('seasonH2H', () => {
         ids.forEach(id => expect(h[id].bonus).toBe(h[id].wins * 3));
     });
 });
+
+// --- pinned roster -----------------------------------------------------------
+//
+// The pairing schedule is positional, so the manager list's contents and order
+// decide who plays whom in EVERY week. Derived fresh each pass, a membership
+// change mid-season restructured the round robin and re-decided already-settled
+// weeks — and applyAwards, rebuilding each week's bonus from base, duly moved the
+// banked points to whoever now "won".
+describe('h2hRoster / pinnedH2HIds', () => {
+    const { h2hRoster, pinnedH2HIds, buildRoundRobin, scheduleForWeeks } = require('../modules/h2h');
+
+    const user = (id) => ({ _id: id, seasons: [{ season: 2026, weeklyScore: [{ week: 1, score: 5 }] }] });
+    const SIX = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const users = SIX.map(user);
+
+    it('derives from scored managers when nothing is pinned', () => {
+        expect(h2hRoster(users, 2026, null)).toEqual(SIX);
+        expect(h2hRoster(users, 2026, undefined)).toEqual(SIX);
+        expect(h2hRoster(users, 2026, [])).toEqual(SIX);
+    });
+
+    it('uses the pinned list verbatim, ignoring who is currently scored', () => {
+        const pinned = ['f', 'e', 'd', 'c', 'b', 'a'];
+        expect(h2hRoster(users, 2026, pinned)).toEqual(pinned);
+        // A seventh manager who joined after the pin gets no schedule.
+        expect(h2hRoster(users.concat([user('g')]), 2026, pinned)).toEqual(pinned);
+    });
+
+    it('coerces pinned ids to strings (they round-trip through Mongo)', () => {
+        expect(h2hRoster(users, 2026, [1, 2])).toEqual(['1', '2']);
+    });
+
+    // The damage the pin prevents, demonstrated directly: one extra manager and
+    // week 1's pairings are completely different.
+    it('a seventh manager reshuffles every prior week without a pin', () => {
+        const before = scheduleForWeeks(SIX, [1, 2, 3]);
+        const after = scheduleForWeeks(SIX.concat(['g']), [1, 2, 3]);
+        expect(buildRoundRobin(SIX)).toHaveLength(5);
+        expect(buildRoundRobin(SIX.concat(['g']))).toHaveLength(7);
+        expect(after[1]).not.toEqual(before[1]);
+    });
+
+    it('reads the pin off a config doc, tolerating a missing or empty one', () => {
+        const doc = { h2hScheduleBySeason: { '2026': { ids: ['a', 'b'] } } };
+        expect(pinnedH2HIds(doc, 2026)).toEqual(['a', 'b']);
+        expect(pinnedH2HIds(doc, '2026')).toEqual(['a', 'b']);
+        expect(pinnedH2HIds(doc, 2025)).toBeNull();
+        expect(pinnedH2HIds({ h2hScheduleBySeason: { '2026': { ids: [] } } }, 2026)).toBeNull();
+        expect(pinnedH2HIds({}, 2026)).toBeNull();
+        expect(pinnedH2HIds(null, 2026)).toBeNull();
+    });
+});
+
+describe('computeH2HAwards honors a pinned roster', () => {
+    const { computeH2HAwards } = require('../modules/h2h');
+
+    const mgr = (id, totals) => ({
+        _id: id,
+        seasons: [{ season: 2026, teams: [{ id: 1 }], weeklyScore: Object.keys(totals).map(w => ({ week: Number(w), score: totals[w] })) }]
+    });
+    const game = (week) => ({ week, seasonType: 'regular', completed: true, homeId: 1, awayId: 2 });
+    const games = [game(1), game(2)];
+
+    it('pairs by the pinned list, not by who is scored now', () => {
+        const users = [mgr('a', { 1: 10, 2: 10 }), mgr('b', { 1: 5, 2: 5 })];
+        const derived = computeH2HAwards({ users, games, season: 2026, winBonus: 3 });
+        // Adding 'c' to the pin makes it a 3-manager round robin (one bye a week),
+        // so the pairings differ from the 2-manager derived one.
+        const pinnedRun = computeH2HAwards({ users, games, season: 2026, winBonus: 3, pinnedIds: ['a', 'b', 'c'] });
+        expect(derived.ids).toEqual(['a', 'b']);
+        expect(pinnedRun.ids).toEqual(['a', 'b', 'c']);
+    });
+
+    it('a manager who left the season keeps their slot rather than reshuffling', () => {
+        const both = [mgr('a', { 1: 10 }), mgr('b', { 1: 5 })];
+        const pinnedIds = ['a', 'b'];
+        const withBoth = computeH2HAwards({ users: both, games: [game(1)], season: 2026, winBonus: 3, pinnedIds });
+        const withoutB = computeH2HAwards({ users: [mgr('a', { 1: 10 })], games: [game(1)], season: 2026, winBonus: 3, pinnedIds });
+        // a still beats b in week 1 either way — the result does not flip.
+        expect(withBoth.awards.a[1].result).toBe('W');
+        expect(withoutB.awards.a[1].result).toBe('W');
+        expect(withoutB.ids).toEqual(['a', 'b']);
+    });
+});

--- a/tests/H2HBonusPersistence.spec.js
+++ b/tests/H2HBonusPersistence.spec.js
@@ -19,6 +19,7 @@ const Game = require('../models/game');
 const ScoringConfig = require('../models/scoringConfig');
 const scoresRouter = require('../routes/scores');
 const standingsRouter = require('../routes/standings');
+const { pinnedH2HIds } = require('../modules/h2h');
 
 const app = express();
 app.use(express.json());
@@ -233,5 +234,93 @@ describe('GET /standings/h2h agrees with what was persisted', () => {
         const after = await request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}?standingsOnly=1`);
         expect(totalsOf(after.body)).toEqual({ Ann: 23, Bob: 14 });
         expect(after.body.managers.find(m => m.name.startsWith('Ann'))).toMatchObject({ record: '1-0-0', h2hBonus: 3 });
+    });
+});
+
+// The pairing schedule is positional, so the manager list decides who plays whom
+// in every week. Deriving it fresh on each pass meant a mid-season membership
+// change restructured the round robin and re-decided already-settled weeks —
+// applyAwards, which rebuilds each week's bonus from base, then moved the banked
+// points to whoever now "won". Pinning the list on the first settled week is what
+// makes a decided week stay decided.
+describe('the H2H roster is pinned once a week settles', () => {
+    async function settledWeekOne() {
+        await enableH2H();
+        const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        const b = await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, true), game(102, 1, 2, 98, true)]);
+        return { a, b };
+    }
+
+    test('pins the manager list and reports it', async () => {
+        const { a, b } = await settledWeekOne();
+        const res = await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        expect(res.body.leagues[0].rosterPinned).toBe(true);
+        const cfg = await ScoringConfig.findOne({ league: LEAGUE }).lean();
+        const pin = cfg.h2hScheduleBySeason[String(SEASON)];
+        expect(pin.ids.map(String).sort()).toEqual([String(a._id), String(b._id)].sort());
+        expect(pin.pinnedAt).toBeInstanceOf(Date);
+    });
+
+    test('does not pin before any week has settled', async () => {
+        await enableH2H();
+        await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+        await Game.create([game(101, 1, 1, 99, false)]);   // still in progress
+
+        const res = await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(res.body.leagues[0].rosterPinned).toBe(false);
+        // Mongoose `minimize` strips an empty object on save, so the field is
+        // absent rather than {} — pinnedH2HIds tolerates both.
+        const cfg = await ScoringConfig.findOne({ league: LEAGUE }).lean();
+        expect(pinnedH2HIds(cfg, SEASON)).toBeNull();
+    });
+
+    test('pins once — a second pass does not re-pin', async () => {
+        await settledWeekOne();
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        const first = (await ScoringConfig.findOne({ league: LEAGUE }).lean())
+            .h2hScheduleBySeason[String(SEASON)].pinnedAt;
+
+        const res = await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(res.body.leagues[0].rosterPinned).toBe(false);
+        const after = (await ScoringConfig.findOne({ league: LEAGUE }).lean())
+            .h2hScheduleBySeason[String(SEASON)].pinnedAt;
+        expect(after).toEqual(first);
+    });
+
+    // The regression. A third manager joins after week 1 has paid out; week 1's
+    // result and banked bonus must not move.
+    test('a manager joining mid-season cannot re-decide a settled week', async () => {
+        const { a, b } = await settledWeekOne();
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+        expect(await sumCumulative(a._id)).toBe(23);
+        expect(await sumCumulative(b._id)).toBe(14);
+
+        // Cal joins and gets scored for week 1 too.
+        await manager('Cal', [team(4, 'Iowa')], [[1, 30]]);
+        await Game.create(game(104, 1, 4, 97, true));
+
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        const wk = (u) => u.seasons[0].weeklyScore[0];
+        expect(wk(await User.findById(a._id).lean())).toMatchObject({ score: 23, h2hBonus: 3, h2hResult: 'W' });
+        expect(wk(await User.findById(b._id).lean()).h2hBonus).toBeUndefined();
+        expect(await sumCumulative(a._id)).toBe(23);
+        expect(await sumCumulative(b._id)).toBe(14);
+    });
+
+    test('the late joiner gets no H2H for the pinned season', async () => {
+        await settledWeekOne();
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        const c = await manager('Cal', [team(4, 'Iowa')], [[1, 30]]);
+        await Game.create(game(104, 1, 4, 97, true));
+        await request(app).post('/scores/h2h-bonus').send({ season: SEASON });
+
+        const cal = await User.findById(c._id).lean();
+        expect(cal.seasons[0].weeklyScore[0].h2hBonus).toBeUndefined();
+        expect(cal.seasons[0].weeklyScore[0].h2hResult).toBeUndefined();
     });
 });


### PR DESCRIPTION
Audit finding #5 of the pre-season scoring audit. Live exposure: graham-league has H2H on for 2026 (+3 win / +1 tie).

## The bug

H2H pairings come from a positional circle-method round robin, so the manager list's **contents and order** decide who plays whom in every week. That list was derived fresh on every pass:

```js
const ids = h2hManagerIds(users, season);   // whoever currently has a scored week
const schedule = scheduleForWeeks(ids, weeks);
```

Six managers is a 5-round robin; seven is 7 rounds with a bye, and round 0's pairings differ entirely. So adding or removing a manager mid-season re-paired every **already-settled** week — and `applyAwards`, which deliberately rebuilds each week's bonus from its base to stay idempotent, then moved the banked points to whoever now "won". A manager could lose a win they had already been paid for, weeks later, with nothing anywhere flagging it.

The existing sort-by-id made the list stable against *document order*, which is what the comment there claims. It was never stable against *membership*.

## The fix

Freeze the list the first time a week settles, stored per season on the league's `ScoringConfig`:

```js
h2hScheduleBySeason: { "2026": { ids: [...], pinnedAt: Date } }
```

- **Before the first settled week**, nothing is banked to protect, so the list stays derived — preseason roster churn costs nothing.
- **After it**, the pinned list is used verbatim. A manager who joins later has no H2H schedule for that season; one who leaves keeps their slot rather than reshuffling everyone else.

The standings read model reads the **same pin**, which is what keeps the rendered matchups identical to the banked ones — that shared-computation property is the whole point of `computeH2HAwards` being used by both. A pinned manager who later leaves the season stays in the pairings but drops out of the rendered table; without that filter the row build would have thrown on their missing `meta[id].cumulative`.

## Tests

Unit (`tests/H2H.spec.js`): derive-vs-pin precedence, verbatim use, string coercion for ids round-tripping through Mongo, the config-doc reader against missing/empty/numeric-key shapes, and a direct demonstration that a seventh manager changes week 1's pairings.

End-to-end (`tests/H2HBonusPersistence.spec.js`, real routes + in-memory Mongo): pins on the first settled week and reports it, does **not** pin while a week is still in progress, does not re-pin on a later pass, the late joiner gets no H2H — and the regression itself: **a manager joining mid-season cannot re-decide a settled week**. Verified it bites: reverting `computeH2HAwards` to the derived list fails that test with Ann's banked +3 moving off her.

898 passing (was 886).

## Note for review

`enableH2H` in the persistence spec exposed a Mongoose wrinkle worth knowing: `minimize` (on by default) strips an empty object on save, so a config with no pin has `h2hScheduleBySeason` **absent**, not `{}`. `pinnedH2HIds` tolerates both and has a test for it.

Nothing backfills existing seasons — 2025 has no pin, so it keeps deriving exactly as before unless someone rescores it, at which point it pins on the first settled week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)