### PR TITLE
Fail the run when a league's scoring config won't load

### DIFF
--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -400,28 +400,50 @@ async function updateUserCumulativeScore(userId, cumulativeScore) {
 // API, so it works in the web process and in job processes alike. Falls back
 // to that league's defaults on any error.
 async function getScoringConfig(league) {
+    var res, data;
     try {
-        var res = await internalFetch(`${process.env.URL}/scoring-config/${league}`, {
+        res = await internalFetch(`${process.env.URL}/scoring-config/${league}`, {
             method: 'GET', headers: { 'Accept': 'application/json' }
         });
-        var data = await res.json();
-        // Forward the FULL config — model, values, combineMode, disabled AND
-        // enabled — so the scoring jobs honor every structural change a
-        // commissioner makes (combine mode, disabled postseason events, opted-in
-        // finer win categories), not just point values. Dropping any of these
-        // here would make computed scores silently ignore structural config while
-        // the rules page still showed it.
-        if (data && data.values) return resolveConfig(league, {
-            model: data.model,
-            values: data.values,
-            combineMode: data.combineMode,
-            disabled: data.disabled,
-            enabled: data.enabled,
-            engagement: data.engagement,
-            engagementBySeason: data.engagementBySeason
-        });
-    } catch (e) { /* fall through to defaults */ }
-    return resolveConfig(league, null);
+        data = await res.json();
+    } catch (err) {
+        throw new Error(`Could not load scoring config for ${league}: ${err.message}`);
+    }
+
+    // A config that didn't load is NOT a config of defaults.
+    //
+    // This used to swallow every failure and return resolveConfig(league, null).
+    // That looks harmless — the route already resolves defaults for a league with
+    // no saved doc — but the fallback carries an EMPTY engagementBySeason, so the
+    // captain bonus silently became 0 for the whole run, and any commissioner
+    // point values, combine mode or rule toggles were ignored while the rules page
+    // kept showing them. Silently, at log level nothing. And updateScores caches
+    // per league per run, so one bad fetch poisoned every manager in it.
+    //
+    // Scoring on a guess is worse than not scoring: the pass is idempotent and
+    // retried within the hour, whereas a wrong week is banked until someone
+    // notices. So this throws, the job records a JobRun error, and the failure
+    // email fires.
+    if (res.status != 200 || !data || !data.values) {
+        throw new Error(`Could not load scoring config for ${league}: HTTP ${res.status}`
+            + ((data && data.message) ? ` — ${data.message}` : ''));
+    }
+
+    // Forward the FULL config — model, values, combineMode, disabled AND
+    // enabled — so the scoring jobs honor every structural change a
+    // commissioner makes (combine mode, disabled postseason events, opted-in
+    // finer win categories), not just point values. Dropping any of these
+    // here would make computed scores silently ignore structural config while
+    // the rules page still showed it.
+    return resolveConfig(league, {
+        model: data.model,
+        values: data.values,
+        combineMode: data.combineMode,
+        disabled: data.disabled,
+        enabled: data.enabled,
+        engagement: data.engagement,
+        engagementBySeason: data.engagementBySeason
+    });
 }
 
 // Builds the rankings-fetch URL for a game and returns the parsed rankings.

--- a/tests/ScoringAggregation.spec.js
+++ b/tests/ScoringAggregation.spec.js
@@ -85,6 +85,13 @@ describe('scoring aggregation', () => {
                 if (url.includes('/users/season/')) {
                     return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
                 }
+                if (url.includes('/scoring-config/')) {
+                    // getScoringConfig now THROWS on a config it can't load, so
+                    // every updateScores test has to answer this. It used to fall
+                    // back to defaults silently, which is precisely the bug —
+                    // these mocks were relying on it without saying so.
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve({ model: 'graham', values: {} }) });
+                }
                 if (url.includes('/games/seasonType/')) {
                     return Promise.resolve({ status: 200, json: () => Promise.resolve([game]) });
                 }
@@ -175,7 +182,10 @@ describe('scoring aggregation', () => {
                     return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
                 }
                 if (url.includes('/scoring-config/')) {
-                    return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+                    // A resolved config, which is what the real route always
+                    // returns. A bare {} used to be silently swallowed into
+                    // defaults; it now throws, so the stub has to be honest.
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve({ model: 'graham', values: {} }) });
                 }
                 if (url.includes('/games/seasonType/postseason/week/1/')) {
                     return Promise.resolve({ status: 200, json: () => Promise.resolve([g1]) });
@@ -213,7 +223,10 @@ describe('scoring aggregation', () => {
                     return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
                 }
                 if (url.includes('/scoring-config/')) {
-                    return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+                    // A resolved config, which is what the real route always
+                    // returns. A bare {} used to be silently swallowed into
+                    // defaults; it now throws, so the stub has to be honest.
+                    return Promise.resolve({ status: 200, json: () => Promise.resolve({ model: 'graham', values: {} }) });
                 }
                 if (url.includes('/games/seasonType/regular/week/1/')) {
                     return Promise.resolve({ status: 200, json: () => Promise.resolve([regGame]) });
@@ -233,5 +246,76 @@ describe('scoring aggregation', () => {
             expect(reg.score).toBe(3);           // regular week added alongside it
             expect(ws).toHaveLength(2);
         });
+    });
+});
+
+// A config that didn't load is NOT a config of defaults.
+//
+// getScoringConfig used to swallow every failure and return the model defaults.
+// That reads as harmless — the route resolves defaults for a league with no saved
+// doc — but the fallback carries an EMPTY engagementBySeason, so the Captain
+// bonus silently became 0 for the whole run, and any commissioner point values,
+// combine mode or rule toggles were ignored while the rules page kept showing
+// them. At log level: nothing. And updateScores caches the config per league per
+// run, so one bad fetch poisoned every manager in that league.
+describe('a scoring config that will not load fails the run', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+        process.env = { ...OLD_ENV, URL: 'http://test.local', YEAR: '2026' };
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+    afterEach(() => { process.env = OLD_ENV; jest.restoreAllMocks(); });
+
+    const user = {
+        _id: 'u1', league: 'graham-league',
+        seasons: [{ season: '2026', teams: [{ id: 333, school: 'Alabama' }], weeklyScore: [] }]
+    };
+    const mockConfigResponse = (response) => {
+        global.fetch = jest.fn((url) => {
+            if (url.includes('/users/season/')) return Promise.resolve({ status: 200, json: () => Promise.resolve([user]) });
+            if (url.includes('/scoring-config/')) return response();
+            return Promise.resolve({ status: 200, json: () => Promise.resolve({}) });
+        });
+    };
+
+    it('throws when the config endpoint errors', async () => {
+        mockConfigResponse(() => Promise.resolve({ status: 500, json: () => Promise.resolve({ message: 'boom' }) }));
+        await expect(scoringModule.updateScores('regular', 1))
+            .rejects.toThrow(/Could not load scoring config for graham-league.*500.*boom/);
+    });
+
+    it('throws when the body is not a resolved config', async () => {
+        // A 200 with no `values` — the shape the real route never returns. This
+        // path did not even reach the old catch; it just fell out into defaults.
+        mockConfigResponse(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) }));
+        await expect(scoringModule.updateScores('regular', 1))
+            .rejects.toThrow(/Could not load scoring config for graham-league/);
+    });
+
+    it('throws when the body is not JSON at all', async () => {
+        mockConfigResponse(() => Promise.resolve({ status: 200, json: () => Promise.reject(new SyntaxError('Unexpected token <')) }));
+        await expect(scoringModule.updateScores('regular', 1))
+            .rejects.toThrow(/Could not load scoring config for graham-league.*Unexpected token/);
+    });
+
+    it('throws when the request itself fails', async () => {
+        mockConfigResponse(() => Promise.reject(new Error('ECONNRESET')));
+        await expect(scoringModule.updateScores('regular', 1))
+            .rejects.toThrow(/Could not load scoring config for graham-league.*ECONNRESET/);
+    });
+
+    // The consequence that made this worth failing over: a silent default config
+    // has no engagement, so Captain scores nothing.
+    it('a real config keeps the per-season engagement the fallback would have dropped', async () => {
+        mockConfigResponse(() => Promise.resolve({
+            status: 200,
+            json: () => Promise.resolve({
+                model: 'graham', values: {},
+                engagementBySeason: { '2026': { captainEnabled: true, captainMultiplier: 2 } }
+            })
+        }));
+        const cfg = await scoringModule.getScoringConfig('graham-league');
+        expect(cfg.engagementBySeason['2026'].captainEnabled).toBe(true);
     });
 });

--- a/tests/ScoringWrites.spec.js
+++ b/tests/ScoringWrites.spec.js
@@ -135,7 +135,8 @@ describe('scoring write failures never become unhandled rejections', () => {
     it('calculateTeamScores reports a failed write rather than throwing', async () => {
         global.fetch = jest.fn((url) => {
             if (url.includes('/games/season/')) return Promise.resolve(jsonResponse(200, []));
-            return Promise.resolve(htmlErrorPage(503));
+            if (url.includes('/scoring-config/')) return Promise.resolve(jsonResponse(200, { model: 'claunts', values: {} }));
+            return Promise.resolve(htmlErrorPage(503));   // the team PATCH
         });
 
         const result = await scoringModule.calculateTeamScores(2025, 333, 'Oregon');


### PR DESCRIPTION
Audit finding #6. Live exposure: Captain is on for graham-league in 2026.

## The bug

```js
} catch (e) { /* fall through to defaults */ }
return resolveConfig(league, null);
```

That reads as harmless — the route resolves defaults for a league with no saved doc, so defaults look like a reasonable answer. They are not the same thing. `resolveConfig(league, null)` carries an **empty `engagementBySeason`**, so a single failed fetch:

- silently zeroed the **Captain bonus** for the entire run, and
- ignored every commissioner point value, combine mode and rule toggle, while `/rules` kept showing them.

At log level: nothing. And `updateScores` caches the resolved config per league per run, so one bad fetch poisoned every manager in that league for that week.

A 200 with an unexpected body was worse — `if (data && data.values)` simply fell out of the function into the same defaults without even entering the `catch`.

## The fix

Both paths throw now, with the league and the reason. The scoring pass is idempotent and retried within the hour, so a failed run costs nothing but a red JobRun and an email; a wrong score sits banked until somebody notices. Same reasoning as refusing to guess the week in #296.

Covered: a non-200, a 200 that isn't a resolved config, a non-JSON body, and a rejected request.

## Tests

Four existing tests were **relying on the fallback** — their fetch mocks either never answered `/scoring-config/` or answered it with a bare `{}`, and the silent default rescued them. They now stub a resolved config, which is what the real route always returns. That the suite was leaning on this is part of why it went unnoticed.

New block in `tests/ScoringAggregation.spec.js` pins all four failure modes, plus one that names the actual consequence: a real config keeps the per-season `engagementBySeason` the fallback would have dropped.

891 passing (was 886).

## Note for review

`getScoringConfig` is also used by `GET /scoring-config/:league/explain` (the member-facing per-game breakdown). That route already has a try/catch, so a config it can't load now returns 500 with the reason instead of rendering a breakdown computed from the wrong rules. That seems right — a wrong explanation is worse than an error — but it is a user-visible behaviour change, so worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)