### PR TITLE
Stop asking CFBD for a poll nothing reads

### DIFF
--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -159,48 +159,48 @@ async function doFullUpdate({ withBetting = false } = {}) {
 
     // Make sure the rankings doc the ENGINE will actually read exists.
     //
-    // Postseason games resolve their rankings from the week-1 REGULAR poll
-    // (modules/scoring.js getRankingsForGame), and no postseason rule reads a
-    // rank anyway — every one of them keys off notes / home-away. So checking
-    // for a `postseason` rankings doc was checking for something nothing reads.
+    // Regular season only. Postseason games are scored against the LATEST
+    // regular-season poll (modules/scoring.js getRankingsForGame) — a doc written
+    // months earlier, during the season — so a postseason run has nothing to
+    // create. And no postseason rule reads a rank anyway; they all key off notes
+    // or home/away.
     //
-    // Worse, CFBD publishes no postseason poll until after the title game
-    // (`/rankings?year=2026&week=1&seasonType=postseason` returns []), so
-    // retrieveRankings threw on data[0].polls and 400'd — burning a CFBD call
-    // EVERY run for the whole bowl season. With live polling at postseason
-    // cadence that is a call every 10 minutes against a 1,000/month budget, for
-    // a document that would never be read.
-    const rankingsWeek = isPostseason ? 1 : weekNumber;
-    const rankingsSeasonType = 'regular';
-
-    var rankingsRes = await internalFetch(`${process.env.URL}/rankings/${season}/${rankingsWeek}/${rankingsSeasonType}`, {
-        method: 'GET',
-        headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-        }
-    });
-    // Drain the body — an unread response body holds its socket open, and this
-    // runs on every poll.
-    await rankingsRes.json().catch(() => null);
-
-    if (rankingsRes.status == 200) {
-        console.log(`Rankings already in system for Season: ${season}, Season Type: ${rankingsSeasonType}, Week: ${rankingsWeek}`);
-    } else {
-        const created = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
-            method: 'POST',
+    // This used to ask for a `postseason` rankings doc. CFBD publishes none until
+    // after the title game (`/rankings?year=2026&week=1&seasonType=postseason`
+    // returns []), so retrieveRankings threw on data[0].polls and 400'd — every
+    // run, all bowl season. With live polling at postseason cadence that is a CFBD
+    // call every 10 minutes against a 1,000/month budget, for a document nothing
+    // would ever read.
+    if (!isPostseason) {
+        var rankingsRes = await internalFetch(`${process.env.URL}/rankings/${season}/${weekNumber}/regular`, {
+            method: 'GET',
             headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ season: String(season), seasonType: rankingsSeasonType, week: String(rankingsWeek) }),
+            }
         });
+        // Drain the body — an unread response body holds its socket open, and
+        // this runs on every poll.
+        await rankingsRes.json().catch(() => null);
 
-        const data = await created.json().catch(() => null);
-        if (created.status == 201) {
-            console.log("New Rankings", data);
+        if (rankingsRes.status == 200) {
+            console.log(`Rankings already in system for Season: ${season}, Season Type: regular, Week: ${weekNumber}`);
         } else {
-            console.log(created.status + " Rankings could not be retrieved");
+            const created = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
+                method: 'POST',
+                headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ season: String(season), seasonType: 'regular', week: String(weekNumber) }),
+            });
+
+            const data = await created.json().catch(() => null);
+            if (created.status == 201) {
+                console.log("New Rankings", data);
+            } else {
+                console.log(created.status + " Rankings could not be retrieved");
+            }
         }
     }
 

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -157,39 +157,51 @@ async function doFullUpdate({ withBetting = false } = {}) {
     var seasonType = resolved.seasonType;
     var week = isPostseason ? 1 : weekNumber;
 
-    var response = await internalFetch(`${process.env.URL}/rankings/${season}/${week}/${seasonType}`, {
+    // Make sure the rankings doc the ENGINE will actually read exists.
+    //
+    // Postseason games resolve their rankings from the week-1 REGULAR poll
+    // (modules/scoring.js getRankingsForGame), and no postseason rule reads a
+    // rank anyway — every one of them keys off notes / home-away. So checking
+    // for a `postseason` rankings doc was checking for something nothing reads.
+    //
+    // Worse, CFBD publishes no postseason poll until after the title game
+    // (`/rankings?year=2026&week=1&seasonType=postseason` returns []), so
+    // retrieveRankings threw on data[0].polls and 400'd — burning a CFBD call
+    // EVERY run for the whole bowl season. With live polling at postseason
+    // cadence that is a call every 10 minutes against a 1,000/month budget, for
+    // a document that would never be read.
+    const rankingsWeek = isPostseason ? 1 : weekNumber;
+    const rankingsSeasonType = 'regular';
+
+    var rankingsRes = await internalFetch(`${process.env.URL}/rankings/${season}/${rankingsWeek}/${rankingsSeasonType}`, {
         method: 'GET',
         headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json'
         }
     });
+    // Drain the body — an unread response body holds its socket open, and this
+    // runs on every poll.
+    await rankingsRes.json().catch(() => null);
 
-    var rankings = await response;
-
-    if (rankings.status == 200) {
-        console.log(`Rankings already in system for Season: ${season}, Season Type: ${seasonType}, Week: ${week}`);
+    if (rankingsRes.status == 200) {
+        console.log(`Rankings already in system for Season: ${season}, Season Type: ${rankingsSeasonType}, Week: ${rankingsWeek}`);
     } else {
-        const response = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
+        const created = await internalFetch(`${process.env.URL}/rankings/retrieveRankings`, {
             method: 'POST',
             headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
             },
-            body: `{
-            "season": "${season}",
-            "seasonType": "${seasonType}",
-            "week": "${week}"
-            }`,
+            body: JSON.stringify({ season: String(season), seasonType: rankingsSeasonType, week: String(rankingsWeek) }),
         });
 
-        await response.json().then(data => {
-            if (response.status == 201) {
-                console.log("New Rankings", data);
-            } else {
-                console.log(response.status + " Rankings could not be retrieved");
-            }
-        });
+        const data = await created.json().catch(() => null);
+        if (created.status == 201) {
+            console.log("New Rankings", data);
+        } else {
+            console.log(created.status + " Rankings could not be retrieved");
+        }
     }
 
     var teamCount = 0;

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -446,23 +446,35 @@ async function getScoringConfig(league) {
     });
 }
 
-// Builds the rankings-fetch URL for a game and returns the parsed rankings.
-// Fetches the ranking doc for a game's week from the internal /rankings
-// endpoint (a Mongo read). The same (season, week, seasonType) doc is needed by
-// every game in a week and by both league models, so callers that score many
-// games in one run (updateScores / calculateTeamScores) pass a `cache` Map to
-// reuse it instead of re-reading it per game. Without a cache it always fetches
-// — so direct callers stay stateless and correct even if rankings change.
+// The rankings a game should be scored against, from the internal /rankings
+// endpoint (a Mongo read).
+//
+// Regular season: that week's poll — the ranking a team held at kickoff.
+//
+// Postseason: the LATEST regular-season poll, i.e. the last one published before
+// the bowls. That is where CFBD puts the selection-day Playoff Committee
+// Rankings, and findPoll already prefers those over AP, so a bowl game is scored
+// against the actual bracket seeding. This used to read `{season}/1/regular` —
+// week 1 of the regular season, which is the AUGUST PRESEASON POLL, published
+// before a game had been played. Inert so far, because no postseason rule reads a
+// rank and every rank-reading rule is gated to isRegular; but it is the wrong
+// poll, and the first rank-sensitive postseason rule anyone adds would have
+// silently scored off it.
+//
+// The same (season, week, seasonType) doc is needed by every game in a week and
+// by both league models, so callers that score many games in one run
+// (updateScores / calculateTeamScores) pass a `cache` Map to reuse it instead of
+// re-reading it per game. Without a cache it always fetches — so direct callers
+// stay stateless and correct even if rankings change.
 async function getRankingsForGame(game, week, season, cache) {
-    var key = (game.seasonType == "postseason")
-        ? `${season}|1|regular`
-        : `${season}|${week}|${game.seasonType}`;
+    var isPost = game.seasonType == "postseason";
+    var lookupWeek = isPost ? 'latest' : week;
+    var lookupType = isPost ? 'regular' : game.seasonType;
+
+    var key = `${season}|${lookupWeek}|${lookupType}`;
     if (cache && cache.has(key)) return cache.get(key);
 
-    var url = (game.seasonType == "postseason")
-        ? `${process.env.URL}/rankings/${season}/1/regular`
-        : `${process.env.URL}/rankings/${season}/${week}/${game.seasonType}`;
-    var response = await internalFetch(url, {
+    var response = await internalFetch(`${process.env.URL}/rankings/${season}/${lookupWeek}/${lookupType}`, {
         method: 'GET',
         headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
     });

--- a/routes/rankings.js
+++ b/routes/rankings.js
@@ -83,14 +83,26 @@ router.post('/retrieveRankings', async (req, res) => {
         const data = await rankingsApi.getRankings(req.body.season, opts);
         console.log('Rankings API called successfully.');
 
-        const ranking = new Ranking({
-            season: req.body.season,
-            seasonType: req.body.seasonType,
-            week: req.body.week,
-            polls: data[0].polls
-        });
+        // CFBD answers [] for a poll it hasn't published yet (e.g. any postseason
+        // week before the title game). Reading data[0].polls off that threw a
+        // TypeError that surfaced as an opaque 400, so callers retried it — and
+        // each retry spends a CFBD call. Say what actually happened instead.
+        if (!Array.isArray(data) || !data.length || !data[0].polls) {
+            return res.status(404).json({
+                message: `CFBD has no rankings for season ${req.body.season} ${req.body.seasonType} week ${req.body.week}`
+            });
+        }
 
-        const newRanking = await ranking.save();
+        // Upsert on (season, seasonType, week). A plain insert meant two runs
+        // racing on the same missing week — the Saturday job and the live poller
+        // collide on the :00 mark — could each create a doc for it, and
+        // getRankingsForGame's findOne would then pick whichever came back first.
+        const filter = { season: req.body.season, seasonType: req.body.seasonType, week: req.body.week };
+        const newRanking = await Ranking.findOneAndUpdate(
+            filter,
+            { $set: Object.assign({}, filter, { polls: data[0].polls }) },
+            { new: true, upsert: true, setDefaultsOnInsert: true }
+        );
         console.log("New Ranking Record", newRanking);
 
         res.status(201).json(newRanking);

--- a/routes/rankings.js
+++ b/routes/rankings.js
@@ -38,9 +38,21 @@ router.get('/:week/:seasonType', async (req, res) => {
 });
 
 // Getting One By Year & Week & Season Type
+// `week` accepts the literal "latest", meaning the highest week on file for that
+// season + seasonType. Postseason scoring needs the poll as it stood going INTO
+// the bowls, which is the final regular-season doc — that is where CFBD publishes
+// the selection-day Playoff Committee Rankings (findPoll already prefers those
+// over AP). Handled here rather than as its own route so it can't be shadowed by
+// this one's `:week` param.
 router.get('/:season/:week/:seasonType', async (req, res) => {
     try {
-        const ranking = await Ranking.findOne({season: req.params.season, week: req.params.week, seasonType: req.params.seasonType});
+        const query = { season: req.params.season, seasonType: req.params.seasonType };
+        const latest = req.params.week === 'latest';
+        if (!latest) query.week = req.params.week;
+
+        const ranking = latest
+            ? await Ranking.findOne(query).sort({ week: -1 })
+            : await Ranking.findOne(query);
 
         if (JSON.stringify(ranking) == "null") {
             res.status(400).json({message: `No rankings found for season ${req.params.season} & week ${req.params.week} & seasonType ${req.params.seasonType}`});

--- a/tests/RoutesRankings.spec.js
+++ b/tests/RoutesRankings.spec.js
@@ -1,0 +1,96 @@
+// POST /rankings/retrieveRankings — the lazy per-week poll ingest the scoring
+// pipeline calls when a rankings doc is missing.
+//
+// Two things went wrong here, and both cost CFBD calls against a 1,000/month
+// budget. CFBD answers `[]` for a poll it hasn't published yet, and reading
+// `data[0].polls` off that threw a TypeError which surfaced as an opaque 400 —
+// so the caller kept retrying it, one CFBD call at a time, for as long as the
+// poll stayed unpublished. And the handler always INSERTED, so two runs racing on
+// the same missing week (the Saturday job and the live poller collide on the :00
+// mark) could each create a doc for it.
+//
+// The CFBD client is mocked; the route, model and Mongo are real.
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const Ranking = require('../models/ranking');
+
+// cfb.js hangs getRankings off the INSTANCE, not the prototype, and the route
+// constructs its own client at import — so the module is the only seam.
+const mockGetRankings = jest.fn();
+jest.mock('cfb.js', () => ({
+    ApiClient: { instance: { authentications: { ApiKeyAuth: {} } } },
+    RankingsApi: function RankingsApi() { this.getRankings = (...args) => mockGetRankings(...args); }
+}));
+const getRankings = mockGetRankings;
+
+const rankingsRouter = require('../routes/rankings');
+const app = express();
+app.use(express.json());
+app.use('/rankings', rankingsRouter);
+
+useMongo();
+
+const POLLS = [{ poll: 'AP Top 25', ranks: [{ school: 'Oregon', rank: 1 }] }];
+const body = { season: '2026', seasonType: 'regular', week: '3' };
+const send = () => request(app).post('/rankings/retrieveRankings').send(body);
+
+beforeEach(() => { jest.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { getRankings.mockReset(); jest.restoreAllMocks(); });
+
+describe('POST /rankings/retrieveRankings', () => {
+    test('stores a newly published poll', async () => {
+        getRankings.mockResolvedValue([{ polls: POLLS }]);
+        const res = await send();
+        expect(res.status).toBe(201);
+        expect(res.body.polls[0].poll).toBe('AP Top 25');
+        expect(await Ranking.countDocuments()).toBe(1);
+    });
+
+    test('re-running updates in place instead of creating a second doc', async () => {
+        getRankings.mockResolvedValue([{ polls: POLLS }]);
+        await send();
+        getRankings.mockResolvedValue([{ polls: [{ poll: 'AP Top 25', ranks: [{ school: 'Ohio State', rank: 1 }] }] }]);
+        await send();
+
+        expect(await Ranking.countDocuments()).toBe(1);
+        const saved = await Ranking.findOne({ season: 2026, seasonType: 'regular', week: 3 }).lean();
+        expect(saved.polls[0].ranks[0].school).toBe('Ohio State');
+    });
+
+    // The race: the Saturday job and the live poller both fire on the :00 mark,
+    // and a missing week sends both of them here at once.
+    test('two concurrent calls leave exactly one doc', async () => {
+        getRankings.mockResolvedValue([{ polls: POLLS }]);
+        const [a, b] = await Promise.all([send(), send()]);
+        expect(a.status).toBe(201);
+        expect(b.status).toBe(201);
+        expect(await Ranking.countDocuments()).toBe(1);
+    });
+
+    // CFBD publishes no postseason poll until after the title game, so this is
+    // what the pipeline used to hit on every single run all bowl season.
+    test('says so when CFBD has not published the poll, instead of a bare 400', async () => {
+        getRankings.mockResolvedValue([]);
+        const res = await request(app).post('/rankings/retrieveRankings')
+            .send({ season: '2026', seasonType: 'postseason', week: '1' });
+        expect(res.status).toBe(404);
+        expect(res.body.message).toMatch(/no rankings for season 2026 postseason week 1/i);
+        expect(await Ranking.countDocuments()).toBe(0);
+    });
+
+    test('handles a row with no polls the same way', async () => {
+        getRankings.mockResolvedValue([{}]);
+        const res = await send();
+        expect(res.status).toBe(404);
+        expect(await Ranking.countDocuments()).toBe(0);
+    });
+
+    test('surfaces a CFBD failure as a 400', async () => {
+        getRankings.mockRejectedValue(new Error('rate limited'));
+        const res = await send();
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/rate limited/);
+    });
+});

--- a/tests/RoutesRankings.spec.js
+++ b/tests/RoutesRankings.spec.js
@@ -94,3 +94,45 @@ describe('POST /rankings/retrieveRankings', () => {
         expect(res.body.message).toMatch(/rate limited/);
     });
 });
+
+// Postseason scoring needs the poll as it stood going INTO the bowls — the final
+// regular-season doc, which is where CFBD publishes the selection-day Playoff
+// Committee Rankings. Before this the engine asked for week 1 of the regular
+// season: the AUGUST PRESEASON poll, published before a game had been played.
+describe('GET /rankings/:season/latest/:seasonType', () => {
+    const poll = (school) => [{ poll: 'Playoff Committee Rankings', ranks: [{ school, rank: 1 }] }];
+
+    beforeEach(async () => {
+        await Ranking.create([
+            { season: 2025, seasonType: 'regular', week: 1, polls: [{ poll: 'AP Top 25', ranks: [{ school: 'Preseason No1', rank: 1 }] }] },
+            { season: 2025, seasonType: 'regular', week: 15, polls: poll('Ohio State') },
+            { season: 2025, seasonType: 'regular', week: 16, polls: poll('Indiana') },
+            { season: 2025, seasonType: 'postseason', week: 1, polls: [{ poll: 'AP Top 25', ranks: [{ school: 'Final AP No1', rank: 1 }] }] },
+            { season: 2024, seasonType: 'regular', week: 16, polls: poll('Oregon') }
+        ]);
+    });
+
+    test('returns the highest week on file, not the first', async () => {
+        const res = await request(app).get('/rankings/2025/latest/regular');
+        expect(res.status).toBe(200);
+        expect(res.body.week).toBe(16);
+        expect(res.body.polls[0].ranks[0].school).toBe('Indiana');   // selection-day CFP, not the August AP
+    });
+
+    test('is scoped to the season and seasonType asked for', async () => {
+        expect((await request(app).get('/rankings/2024/latest/regular')).body.week).toBe(16);
+        expect((await request(app).get('/rankings/2024/latest/regular')).body.polls[0].ranks[0].school).toBe('Oregon');
+        expect((await request(app).get('/rankings/2025/latest/postseason')).body.week).toBe(1);
+    });
+
+    test('an explicit week still wins over the latest', async () => {
+        const res = await request(app).get('/rankings/2025/1/regular');
+        expect(res.body.week).toBe(1);
+        expect(res.body.polls[0].ranks[0].school).toBe('Preseason No1');
+    });
+
+    test('400s when the season has nothing on file', async () => {
+        const res = await request(app).get('/rankings/2099/latest/regular');
+        expect(res.status).toBe(400);
+    });
+});

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -1,3 +1,8 @@
+// Real-looking values so the asserted URLs read as URLs rather than
+// "undefined/rankings/undefined/...".
+process.env.URL = 'http://test.local';
+process.env.YEAR = '2026';
+
 const { postseasonWeeksToScore } = require('../modules/score-update');
 
 // --- pipeline ordering -------------------------------------------------------
@@ -48,6 +53,7 @@ describe('runFullUpdate scoring order', () => {
         scoringModule._calls.length = 0;
         scoringModule.updateScores.mockClear();
         retrieveGames.massRetrieveGames.mockClear();
+        internalFetch.mockClear();
         // Default: no trailing regular week outstanding (the endpoint answers
         // { week: null }, which this bare body stands in for).
         internalFetch.mockImplementation(async () => ({ status: 200, json: async () => ({}) }));
@@ -71,6 +77,47 @@ describe('runFullUpdate scoring order', () => {
         const calls = scoringModule._calls;
         expect(calls.indexOf('applyH2HBonuses')).toBeGreaterThan(calls.indexOf('updateScores'));
         expect(calls.indexOf('applyH2HBonuses')).toBeLessThan(calls.indexOf('updateCumulativeScores'));
+    });
+
+    // Postseason games resolve rankings from the week-1 REGULAR poll, and no
+    // postseason rule reads a rank at all — so asking for a `postseason` rankings
+    // doc was asking for something nothing reads. CFBD publishes no postseason
+    // poll until after the title game, so retrieveRankings 400'd on every run for
+    // the whole bowl season, spending a CFBD call each time.
+    it('ensures the week-1 regular poll on a postseason run, never a postseason one', async () => {
+        require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce([
+            { week: 1, seasonType: 'postseason', firstGameStart: '2000-01-01', lastGameStart: '2100-01-01' }
+        ]);
+        await runFullUpdate({ withBetting: false });
+
+        const rankingUrls = internalFetch.mock.calls
+            .map(c => c[0]).filter(u => /\/rankings\//.test(u));
+        expect(rankingUrls).toEqual([`${process.env.URL}/rankings/${process.env.YEAR}/1/regular`]);
+        expect(rankingUrls.join(' ')).not.toMatch(/postseason/);
+    });
+
+    it('ensures the current week\'s regular poll during the regular season', async () => {
+        await runFullUpdate({ withBetting: false });
+        const rankingUrls = internalFetch.mock.calls
+            .map(c => c[0]).filter(u => /\/rankings\//.test(u));
+        expect(rankingUrls).toEqual([`${process.env.URL}/rankings/${process.env.YEAR}/7/regular`]);
+    });
+
+    it('does not try to create a poll that already exists', async () => {
+        await runFullUpdate({ withBetting: false });
+        const posts = internalFetch.mock.calls.filter(c => /retrieveRankings/.test(c[0]));
+        expect(posts).toHaveLength(0);   // the GET answered 200
+    });
+
+    it('creates the poll for the week the engine reads when it is missing', async () => {
+        internalFetch.mockImplementation(async (url) => /\/rankings\/\d+\/\d+\//.test(url)
+            ? { status: 400, json: async () => ({ message: 'not found' }) }
+            : { status: 201, json: async () => ({}) });
+        await runFullUpdate({ withBetting: false });
+
+        const post = internalFetch.mock.calls.find(c => /retrieveRankings/.test(c[0]));
+        expect(post).toBeDefined();
+        expect(JSON.parse(post[1].body)).toEqual({ season: process.env.YEAR, seasonType: 'regular', week: '7' });
     });
 
     // CFBD's postseason window opens BEFORE the regular season's last game kicks

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -79,21 +79,20 @@ describe('runFullUpdate scoring order', () => {
         expect(calls.indexOf('applyH2HBonuses')).toBeLessThan(calls.indexOf('updateCumulativeScores'));
     });
 
-    // Postseason games resolve rankings from the week-1 REGULAR poll, and no
-    // postseason rule reads a rank at all — so asking for a `postseason` rankings
-    // doc was asking for something nothing reads. CFBD publishes no postseason
-    // poll until after the title game, so retrieveRankings 400'd on every run for
-    // the whole bowl season, spending a CFBD call each time.
-    it('ensures the week-1 regular poll on a postseason run, never a postseason one', async () => {
+    // Postseason games are scored against the LATEST regular-season poll — a doc
+    // written months earlier — and no postseason rule reads a rank anyway. So a
+    // postseason run has no poll to ensure. It used to ask CFBD for a
+    // `postseason` poll, which CFBD does not publish until after the title game,
+    // burning a call on a 400 every run for the whole bowl season.
+    it('creates no poll at all on a postseason run', async () => {
         require('../modules/cfbd-calendar').getCalendar.mockResolvedValueOnce([
             { week: 1, seasonType: 'postseason', firstGameStart: '2000-01-01', lastGameStart: '2100-01-01' }
         ]);
         await runFullUpdate({ withBetting: false });
 
         const rankingUrls = internalFetch.mock.calls
-            .map(c => c[0]).filter(u => /\/rankings\//.test(u));
-        expect(rankingUrls).toEqual([`${process.env.URL}/rankings/${process.env.YEAR}/1/regular`]);
-        expect(rankingUrls.join(' ')).not.toMatch(/postseason/);
+            .map(c => c[0]).filter(u => /\/rankings/.test(u));
+        expect(rankingUrls).toEqual([]);
     });
 
     it('ensures the current week\'s regular poll during the regular season', async () => {

--- a/tests/ScoringRankings.spec.js
+++ b/tests/ScoringRankings.spec.js
@@ -1,0 +1,93 @@
+// Which rankings doc a game gets scored against (modules/scoring.js
+// getRankingsForGame).
+//
+// Regular season: that week's poll — the ranking a team held at kickoff.
+//
+// Postseason: the LATEST regular-season poll, i.e. the last one published before
+// the bowls, which is where CFBD puts the selection-day Playoff Committee
+// Rankings. This used to read `{season}/1/regular` — week 1 of the REGULAR
+// season, which is the August preseason poll, published before a game had been
+// played. Nothing has scored wrong because of it (no postseason rule reads a
+// rank, and every rank-reading rule is gated to isRegular), but it is the wrong
+// poll and the first rank-sensitive postseason rule would have inherited it.
+
+const scoringModule = require('../modules/scoring.js');
+
+describe('getRankingsForGame', () => {
+    const OLD_ENV = process.env;
+    const realFetch = global.fetch;
+    let urls;
+
+    beforeEach(() => {
+        process.env = { ...OLD_ENV, URL: 'http://test.local', YEAR: '2026' };
+        urls = [];
+        global.fetch = jest.fn((url) => {
+            urls.push(url);
+            return Promise.resolve({ status: 200, json: () => Promise.resolve({ polls: [] }) });
+        });
+    });
+    afterEach(() => { process.env = OLD_ENV; global.fetch = realFetch; jest.restoreAllMocks(); });
+
+    const game = (seasonType, week) => ({ seasonType, week });
+
+    it("reads the week's own poll during the regular season", async () => {
+        await scoringModule.getRankingsForGame(game('regular', 7), 7, 2026);
+        expect(urls).toEqual(['http://test.local/rankings/2026/7/regular']);
+    });
+
+    // The fix. Not /2026/1/regular (August), and not /2026/1/postseason (which
+    // CFBD does not publish until after the title game).
+    it('reads the LATEST regular poll for a postseason game', async () => {
+        await scoringModule.getRankingsForGame(game('postseason', 1), 1, 2026);
+        expect(urls).toEqual(['http://test.local/rankings/2026/latest/regular']);
+    });
+
+    it('ignores the passed week for a postseason game', async () => {
+        await scoringModule.getRankingsForGame(game('postseason', 1), 14, 2026);
+        expect(urls).toEqual(['http://test.local/rankings/2026/latest/regular']);
+    });
+
+    // A conference championship is seasonType 'regular', so it keeps reading its
+    // own week — the poll those teams were ranked in at kickoff.
+    it('treats a conference championship as the regular-season game it is', async () => {
+        await scoringModule.getRankingsForGame(game('regular', 14), 14, 2026);
+        expect(urls).toEqual(['http://test.local/rankings/2026/14/regular']);
+    });
+
+    describe('caching', () => {
+        it('reuses one fetch across every postseason game in a run', async () => {
+            const cache = new Map();
+            await scoringModule.getRankingsForGame(game('postseason', 1), 1, 2026, cache);
+            await scoringModule.getRankingsForGame(game('postseason', 1), 1, 2026, cache);
+            await scoringModule.getRankingsForGame(game('postseason', 2), 2, 2026, cache);
+            expect(urls).toHaveLength(1);
+        });
+
+        it('keeps regular weeks on separate cache keys', async () => {
+            const cache = new Map();
+            await scoringModule.getRankingsForGame(game('regular', 7), 7, 2026, cache);
+            await scoringModule.getRankingsForGame(game('regular', 8), 8, 2026, cache);
+            await scoringModule.getRankingsForGame(game('regular', 7), 7, 2026, cache);
+            expect(urls).toEqual([
+                'http://test.local/rankings/2026/7/regular',
+                'http://test.local/rankings/2026/8/regular'
+            ]);
+        });
+
+        it('does not let a postseason game share a regular week 1 entry', async () => {
+            const cache = new Map();
+            await scoringModule.getRankingsForGame(game('regular', 1), 1, 2026, cache);
+            await scoringModule.getRankingsForGame(game('postseason', 1), 1, 2026, cache);
+            expect(urls).toEqual([
+                'http://test.local/rankings/2026/1/regular',
+                'http://test.local/rankings/2026/latest/regular'
+            ]);
+        });
+
+        it('fetches every time without a cache, so direct callers stay correct', async () => {
+            await scoringModule.getRankingsForGame(game('regular', 7), 7, 2026);
+            await scoringModule.getRankingsForGame(game('regular', 7), 7, 2026);
+            expect(urls).toHaveLength(2);
+        });
+    });
+});


### PR DESCRIPTION
Audit finding #7, plus the postseason-rankings mapping it turned up in review. A CFBD-budget bug with a scoring consequence: once the ceiling is hit the live poller stops, and scores stop updating.

Now up to date with `main` (#300 + #301 merged in).

## 1. The pipeline asked CFBD for a poll nothing reads

Every postseason run checked for a `postseason` rankings doc and, not finding one, tried to create it. Both halves were wrong.

**Nothing reads that doc.** Postseason games resolve rankings from a *regular*-season poll, and no postseason rule reads a rank at all — `bowlWin`, `cfpQuarterfinal`, `nationalChampionship` and the rest all key off `notes` or home/away. The rank-reading rules are gated on `ctx.isRegular`.

**And CFBD has no postseason poll to give until after the title game.** Verified against the live API:

```
/rankings?year=2026&week=1&seasonType=postseason  ->  200  []
```

`retrieveRankings` read `data[0].polls` off that, threw a TypeError, and returned an opaque 400 — so the pipeline retried it **every run, all bowl season**. At postseason live-poll cadence that is a CFBD call every 10 minutes against a 1,000/month budget, for a document that would never be read. Hitting the ceiling stops the poller, so this ends in stale scores during the CFP.

A postseason run now creates no poll at all — the one it reads was written months earlier during the season.

## 2. Postseason games were scored against the AUGUST preseason poll

Folded in after review raised it. `getRankingsForGame` mapped every postseason game to `{season}/1/regular` — which is week 1 of the *regular* season, i.e. the preseason poll, published before a game had been played. Three different polls, three different answers:

| doc | 2025 content |
|---|---|
| `regular/1` — **what it read** | Coaches + AP preseason. No CFP poll at all. |
| `regular/16` — last regular week | **Playoff Committee Rankings: 1 Indiana, 2 Ohio State, 3 Georgia** — the selection-day bracket |
| `postseason/1` | Final AP poll, published *after* the title game |

Nothing has scored wrong because of it — an opponent ranked #1 and an unranked one score identically across all twelve postseason cases in both models, since every rank-reading rule is gated to `isRegular`. But it is the wrong poll sitting in the open, and the first rank-sensitive postseason rule anyone adds (a bonus for beating a top-10 team in a bowl; deriving `isTop4Seed` from the actual CFP seed instead of the current `homeId == teamId` heuristic) would silently inherit it.

Postseason games now read the **latest** regular-season poll. `findPoll` already prefers `Playoff Committee Rankings` over `AP Top 25`, so a bowl game gets scored against the real bracket seeding for free. The `/rankings` lookup accepts the literal week `latest`, handled inside the existing `:week` route so it cannot be shadowed by it.

## 3. `retrieveRankings` always INSERTED

Two runs racing on the same missing week — the Saturday job and the live poller collide on the `:00` mark — could each create a doc, and `getRankingsForGame`s `findOne` would then pick whichever came back first. It upserts on `(season, seasonType, week)` now, and an unpublished poll answers **404** naming the season/type/week instead of a bare 400 that reads like a transient failure and invites a retry.

Also drains the ensure-GETs response body, which ran unread on every poll.

## Tests

- New `tests/ScoringRankings.spec.js` — the mapping itself: regular reads its own week, postseason reads `latest/regular` (and ignores the week passed in), a conference championship stays a regular-season game, plus the cache keys, including that a postseason game can no longer share a regular week-1 cache entry. **Verified it bites**: reverting the mapping to week 1 fails 3 of its 8.
- `tests/RoutesRankings.spec.js` — `latest` returns the highest week not the first, is scoped by season + seasonType, an explicit week still wins, and 400s on an empty season. Plus the upsert: re-running updates in place, two concurrent calls leave one doc, an unpublished poll 404s, a CFBD failure still 400s.
- `tests/ScoreUpdate.spec.js` — a postseason run creates **no** poll; a regular run ensures the current weeks.

925 passing across 50 suites.

## Note for review

`cfb.js` hangs `getRankings` off the **instance**, not the prototype, and the route constructs its own client at import — so `jest.spyOn` has nothing to grab and the module factory is the only seam. Called out in the spec, since it will bite the next person stubbing a CFBD call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)