### PR TITLE
Stop flagging six working accounts as needing an invite

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -888,13 +888,15 @@ async function loadManagerLogins() {
             var email = p.email
                 ? '<span class="login-email">' + escHtml(p.email) + '</span>'
                 : '<span class="login-email is-missing">No email on file</span>';
-            // Meaningful now that modules/auth-sub-backfill.js records a sub the
-            // first time an existing member loads a page: "Needs invite" means we
-            // have genuinely never seen a login for this team, rather than just
-            // "no invite was used", which was true of everybody.
+            // Three states, and the middle one is the reason this isn't a
+            // boolean. `linked` means we've seen their login. Someone who has
+            // been drafted a team obviously has one too — we just haven't
+            // watched them sign in yet — and calling that "Needs invite" told
+            // the commissioner six working accounts were broken. Only a
+            // franchise that has never played gets the amber flag.
             var badge = p.linked
                 ? '<span class="login-badge is-linked">Claimed</span>'
-                : '<span class="login-badge is-pending">Needs invite</span>';
+                : (p.hasPlayed ? '' : '<span class="login-badge is-pending">Needs invite</span>');
             var action = p.linked
                 ? '<button type="button" class="login-btn-ghost" onclick="resetInviteLink(\'' + id + '\', \'' + name + '\')">Reset</button>'
                 : '<button type="button" class="login-btn" onclick="copyInviteLink(\'' + id + '\', \'' + name + '\')">Copy invite</button>';

--- a/routes/users.js
+++ b/routes/users.js
@@ -221,15 +221,21 @@ router.get('/league/:leagueCodeReq/roster', async (req, res) => {
         const year = Number(process.env.YEAR);
         const users = await User.find({ league: leagueCode },
             { firstName: 1, lastName: 1, color: 1, email: 1, authSub: 1,
-              'seasons.season': 1, 'seasons.weeklyScore.scoreByTeam': 1 }).lean();
+              'seasons.season': 1, 'seasons.teams.id': 1, 'seasons.weeklyScore.scoreByTeam': 1 }).lean();
         const players = users.map(u => {
             const s = (u.seasons || []).find(x => Number(x.season) === year);
             const scored = !!(s && (s.weeklyScore || []).some(w => (w.scoreByTeam || []).length > 0));
-            // `linked` drives the Manager Logins panel: who has claimed an invite
-            // and who still needs one. The sub itself never leaves the server.
+            // Has this person ever actually played? Manager Logins needs to tell a
+            // long-standing member from one who was never set up, and `authSub`
+            // alone can't: it's only learned when someone loads a page, so every
+            // member who hasn't signed in since the feature shipped looks brand
+            // new. Anyone who has ever been drafted a team plainly has a working
+            // login — you can't draft without one — so that's the honest signal
+            // while `authSub` catches up.
+            const hasPlayed = (u.seasons || []).some(x => (x.teams || []).length > 0);
             return {
                 _id: u._id, firstName: u.firstName, lastName: u.lastName, color: u.color,
-                inSeason: !!s, scored, linked: !!u.authSub, email: u.email || null
+                inSeason: !!s, scored, linked: !!u.authSub, hasPlayed, email: u.email || null
             };
         }).sort((a, b) => (a.firstName + ' ' + a.lastName).localeCompare(b.firstName + ' ' + b.lastName));
         // Once the season is underway, only an admin can change the roster —

--- a/tests/RoutesInvite.spec.js
+++ b/tests/RoutesInvite.spec.js
@@ -474,6 +474,34 @@ describe('GET /users/league/:league/roster', () => {
         expect(JSON.stringify(res.body)).not.toContain('auth0|1');
     });
 
+    // The panel needs three states, not two: `authSub` is only learned when
+    // someone loads a page, so a member who hasn't signed in since the feature
+    // shipped looks identical to one who was never set up. Having been drafted a
+    // team is proof of a working login and is what keeps the amber "Needs
+    // invite" flag off six people who don't need it.
+    test('separates a long-standing member from one who has never played', async () => {
+        // The roster subdocument demands a full team; same shape as
+        // RosterCorrection.spec.js builds.
+        const TEAM = {
+            id: 1, school: 'Iowa', mascot: 'Hawkeyes', abbreviation: 'IOW',
+            conference: 'Big Ten', color: '#000', logos: ['iowa.png'],
+            location: { venue_id: 1, name: 'V', city: 'C', state: 'ST', zip: '1',
+                latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+        };
+        await User.create(player({ firstName: 'Longstanding',
+            seasons: [{ season: SEASON - 1, teams: [TEAM] }, { season: SEASON }] }));
+        await User.create(player({ firstName: 'Brandnew' }));
+        await User.create(player({ firstName: 'Claimed', authSub: 'auth0|1',
+            seasons: [{ season: SEASON, teams: [TEAM] }] }));
+
+        const res = await request(managerApp).get(`/users/league/${LEAGUE}/roster`);
+        const by = (n) => res.body.players.find(p => p.firstName === n);
+
+        expect(by('Longstanding')).toMatchObject({ linked: false, hasPlayed: true });
+        expect(by('Brandnew')).toMatchObject({ linked: false, hasPlayed: false });
+        expect(by('Claimed')).toMatchObject({ linked: true, hasPlayed: true });
+    });
+
     // An Admin is never `locked`, but still needs to know the season has started
     // before adding someone onto an empty roster — so the two are separate flags.
     test('reports seasonUnderway separately from locked', async () => {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -476,7 +476,6 @@
                 </div>
                 <div class="sub-container" manager-logins-container style="display: none">
                     <p class="function-description">Copy an invite link and send it however you normally talk to the league &mdash; they can claim it with Google, Apple, or an email and password, and it connects whichever they choose to their team.</p>
-                    <p class="function-description">Members who were set up before invites existed still show <b>Needs invite</b> until the next time they open the app, which is when it learns their login.</p>
                     <div manager-logins-list class="season-roster-list"></div>
                 </div>
             </div>


### PR DESCRIPTION
Manager Logins in production shows an amber **Needs invite** on every member. They've all been signing in for seasons — the panel was calling six working accounts broken.

## Cause

The badge read `User.authSub`, which `modules/auth-sub-backfill.js` only learns when someone loads a page while signed in. Anyone who hadn't happened to visit since the feature shipped looked identical to someone who was never set up. In the offseason that could stay wrong for months.

The paragraph underneath ("Members who were set up before invites existed still show Needs invite until…") was the tell — copy apologising for a signal that was just wrong. It's deleted.

## Fix

The answer was already in the roster: **you can't be drafted a team without a working login.** So having played is proof of exactly what `authSub` was trying to establish.

Three states instead of two:

| | Meaning |
|---|---|
| **Claimed** (green) | We've seen their login |
| *(no badge)* | Has played, so plainly has one — `authSub` just hasn't caught up |
| **Needs invite** (amber) | Never played, no login we know of |

Everyone keeps their **Copy invite** button for the lost-access case.

## Verification

**1087 tests pass**, including one asserting all three states.

Behaviour was checked against the **dev** database, where every established member has 10–30 drafted teams and only never-set-up test records have none. One row flagged, and it was the test record.

⚠️ **Not verified against prod.** The fix assumes established prod members have at least one drafted team — near-certain after three seasons, but inference rather than a check. Worth confirming before merge:

```bash
heroku run node -e "require('dotenv').config();const m=require('mongoose'),U=require('./models/user');m.connect(process.env.DATABASE_URL).then(async()=>{const us=await U.find({},{firstName:1,lastName:1,authSub:1,'seasons.teams.id':1}).lean();us.forEach(u=>console.log(u.firstName,u.lastName,'|linked:',!!u.authSub,'|teams:',(u.seasons||[]).reduce((n,s)=>n+((s.teams||[]).length),0)));await m.disconnect()})"
```

Any real member showing zero teams would still get the amber flag.

## What this doesn't change

`authSub` still fills in only as people visit; rows flip to **Claimed** on their own. This just stops the panel asserting they're broken while it waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)