### PR TITLE
Stop Notre Dame collecting the Group-of-5 upset bonus

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -17,6 +17,14 @@ const scoringConfigSchema = new mongoose.Schema({
     // A condition here is ON; absence keeps a default-off rule OFF — so adding a
     // new default-off rule never changes an existing league's scoring.
     enabled: { type: [String], default: [] },
+    // Which conferences the non-P5 upset bonus treats as "power". Absent = the
+    // engine default (ACC / Big 12 / Big Ten / SEC), so a league that never sets
+    // it scores exactly as before. Graham's league adds 'FBS Independents':
+    // Notre Dame sits there, so under the bare four it drew the +2 underdog
+    // bonus on all ~10 of its power-conference wins a year — a top-5 program
+    // collecting a rule written for Group-of-5 upsets. Only the Graham model has
+    // an upset rule at all, so this is inert for Claunts.
+    powerConferences: { type: [String], default: undefined },
     // Optional weekly-engagement layer (GitHub #230), per-league opt-in.
     // DEPRECATED / legacy: a single league-wide engagement blob. Superseded by
     // engagementBySeason (below) so a league can run the game modes in one

--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -188,8 +188,23 @@ function resolveConfig(league, overrides) {
         // the resolved shape for back-compat with any old reader.
         engagement: normalizeEngagement((overrides && overrides.engagement) || {}),
         // Raw per-season map, passed through untouched for engagementForSeason().
-        engagementBySeason: (overrides && overrides.engagementBySeason) || {}
+        engagementBySeason: (overrides && overrides.engagementBySeason) || {},
+        // Which conferences the non-P5 upset bonus treats as "power". undefined
+        // = use the engine default (the bare four), so a league that never sets
+        // it scores exactly as before. See normalizePowerConferences.
+        powerConferences: normalizePowerConferences(overrides && overrides.powerConferences)
     };
+}
+
+// A league's power-conference override, or undefined when it hasn't set a usable
+// one. Deliberately strict: a malformed value falls back to the engine default
+// rather than silently scoring against a half-built list. Kept here (rather than
+// importing the default from scoring-detectors) so this module stays dependency-
+// free — the detector applies the fallback.
+function normalizePowerConferences(list) {
+    if (!Array.isArray(list)) return undefined;
+    const clean = list.filter(c => typeof c === 'string' && c.trim()).map(c => c.trim());
+    return clean.length ? clean : undefined;
 }
 
 // Engagement (game modes) defaults: everything off, with the standard bonus /
@@ -219,6 +234,6 @@ function engagementForSeason(bySeason, season) {
 
 module.exports = {
     CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, STRUCTURES, MODELS, LEAGUES,
-    modelForLeague, fieldsForModel, resolveConfig, ruleEnabled,
+    modelForLeague, fieldsForModel, resolveConfig, ruleEnabled, normalizePowerConferences,
     ENGAGEMENT_DEFAULTS, normalizeEngagement, engagementForSeason
 };

--- a/modules/scoring-detectors.js
+++ b/modules/scoring-detectors.js
@@ -45,8 +45,18 @@ function rankValue(team, rankings) {
     return entry.rank <= 10 ? 2 : 1;
 }
 
-function isPowerFiveUpset(teamConf, oppConf) {
-    var powerFive = ["ACC", "Big 12", "Big Ten", "SEC"];
+// The conferences the upset bonus treats as "power" — a win over one of these
+// by a team outside them is the upset. Kept as a DEFAULT rather than a constant
+// because which programs count as power is a league judgment, not a fact of the
+// engine: Notre Dame sits in `FBS Independents`, so under the bare four it
+// collected the underdog bonus on every P4 win despite being a top-5 program.
+// A league overrides the list via its scoring config (`powerConferences`); the
+// default below must stay exactly these four so the frozen-oracle parity test
+// (tests/ScoringParity.spec.js) keeps proving the unchanged engine.
+var POWER_CONFERENCES = ["ACC", "Big 12", "Big Ten", "SEC"];
+
+function isPowerFiveUpset(teamConf, oppConf, powerConferences) {
+    var powerFive = powerConferences || POWER_CONFERENCES;
     return (!powerFive.includes(teamConf)) && (powerFive.includes(oppConf));
 }
 
@@ -131,7 +141,10 @@ function isTop4Seed(game, teamId, bracket) {
 // whole season's bracket — the round lookup happens before the context is built.
 // Omitted or null everywhere a caller has no bracket, and the detectors fall
 // back to notes.
-function buildContext(team, game, rankings, bracket) {
+//
+// `powerConferences` is the league's power list for the upset bonus; omitted
+// everywhere a caller has no config and the default four apply.
+function buildContext(team, game, rankings, bracket, powerConferences) {
     var isHome = game.homeId == team;
     var isAway = game.awayId == team;
     var won = isHome ? (game.homePoints > game.awayPoints)
@@ -148,7 +161,7 @@ function buildContext(team, game, rankings, bracket) {
         opponent: opponent,
         rankVal: rankValue(opponent, rankings),
         isConference: isConference(game),
-        isPowerFiveUpset: isPowerFiveUpset(teamConf, oppConf)
+        isPowerFiveUpset: isPowerFiveUpset(teamConf, oppConf, powerConferences)
     };
 }
 
@@ -195,7 +208,7 @@ module.exports = {
     CONDITIONS,
     buildContext,
     // exported for reuse/tests:
-    isConference, findPoll, rankValue, isPowerFiveUpset,
+    isConference, findPoll, rankValue, isPowerFiveUpset, POWER_CONFERENCES,
     isConferenceChampion, isBowlGame, isFirstRound,
     isQuarterFinalist, isSemiFinalist, isFinalist, isTop4Seed,
     bracketRound

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -528,7 +528,13 @@ async function getBracketForGame(game, season, cache) {
 // all postseason events enabled.
 function normalizeCfg(model, cfg) {
     if (cfg && typeof cfg === 'object' && cfg.values && typeof cfg.values === 'object') {
-        return { combineMode: cfg.combineMode, values: cfg.values, disabled: cfg.disabled || [], enabled: cfg.enabled || [] };
+        // Whitelist: every field the engine reads must be listed here or it is
+        // silently dropped between a resolved config and evaluate().
+        return {
+            combineMode: cfg.combineMode, values: cfg.values,
+            disabled: cfg.disabled || [], enabled: cfg.enabled || [],
+            powerConferences: cfg.powerConferences
+        };
     }
     return { combineMode: undefined, values: cfg || {}, disabled: [], enabled: [] };
 }
@@ -554,7 +560,7 @@ function evaluate(model, team, game, rankings, cfg, bracket) {
     var enabled = cfg.enabled || [];
     var combineMode = (cfg.combineMode === 'sum' || cfg.combineMode === 'first')
         ? cfg.combineMode : structure.combineMode;
-    var ctx = buildContext(team, game, rankings, bracket);
+    var ctx = buildContext(team, game, rankings, bracket, cfg.powerConferences);
 
     // 1. Postseason events, in order. Each ON matching rule adds its points; a
     //    non-additive match stops evaluation. This first-match-stop reproduces
@@ -651,7 +657,7 @@ function explainGame(model, team, game, rankings, cfg, bracket) {
     var enabled = cfg.enabled || [];
     var combineMode = (cfg.combineMode === 'sum' || cfg.combineMode === 'first')
         ? cfg.combineMode : structure.combineMode;
-    var ctx = buildContext(team, game, rankings, bracket);
+    var ctx = buildContext(team, game, rankings, bracket, cfg.powerConferences);
     var matched = [];
     var add = function (r, group) {
         matched.push({ key: r.pointsKey, label: r.label, points: pointsOf(values, r.pointsKey), group: group });

--- a/public/admin.css
+++ b/public/admin.css
@@ -811,6 +811,15 @@
 }
 .scoring-note::before { content: "\21B3"; position: absolute; left: 0; color: var(--cc-muted-2); }
 
+/* A rule PARAMETER rather than a rule: indented under the rule it modifies, and
+   with no points stepper of its own. Uses the same left-hook as .scoring-note so
+   the two read as one attached block. */
+.draft-config-form .scoring-subfield {
+    margin-left: 14px;
+    margin-bottom: 4px;
+}
+.scoring-subfield .scoring-param { flex: 0 0 auto; }
+
 .scoring-field .num-stepper { flex: none; }
 
 /* Custom number stepper: native spinners hidden, themed -/+ buttons flanking a

--- a/public/admin.js
+++ b/public/admin.js
@@ -2238,7 +2238,24 @@ function renderScoringFields() {
                 <input type="number" step="1" min="0" data-key="${f.key}" value="${vals[f.key]}">
                 <button type="button" class="step-up" tabindex="-1" aria-label="Increase points">+</button>
             </div>
-        </div>${note}`;
+        </div>${note}${f.condition === 'nonP5UpsetBonus' ? independentsRow() : ''}`;
+    }
+
+    // Who counts as "power" for the upset bonus above. Independents are the only
+    // real question — Notre Dame sits there, so with the bare four it drew the
+    // underdog bonus on every power-conference win it had. Exposed as a single
+    // checkbox rather than an editable conference list: the list is stored in
+    // full, but a free-text field here would let a typo silently change scoring.
+    function independentsRow() {
+        var on = (scoringConfigData.powerConferences || []).indexOf('FBS Independents') !== -1;
+        // NB: deliberately NOT class="scoring-toggle" — that class is harvested
+        // into the disabled/enabled RULE lists by data-condition, and this is a
+        // rule parameter, not a rule.
+        return `<div class="draft-field scoring-field scoring-subfield">
+            <label><input type="checkbox" class="scoring-param" id="power-independents" ${on ? 'checked' : ''}>
+                Count independents as a power conference</label>
+        </div>
+        <div class="scoring-note">Stops Notre Dame and UConn earning the upset bonus, and makes beating them count as one.</div>`;
     }
 
     var regular = fields.filter(function (f) { return f.group === 'regular'; });
@@ -2311,12 +2328,21 @@ async function saveScoringConfig() {
         }
     });
 
+    // Power list for the upset bonus: the base four always, plus independents
+    // when the box is ticked. Sent as null when off so the server clears the
+    // stored list back to the engine default. The base comes from the server so
+    // conference names are never spelled here.
+    var indep = document.getElementById('power-independents');
+    var base = scoringConfigData.powerConferencesBase || [];
+    var powerConferences = (indep && indep.checked) ? base.concat('FBS Independents') : null;
+
     var res = await fetch('/scoring-config', {
         method: 'POST',
         headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
         body: JSON.stringify({
             league: leagueCode, model: getShape(),
-            values: values, disabled: disabled, enabled: enabled
+            values: values, disabled: disabled, enabled: enabled,
+            powerConferences: powerConferences
         })
     });
     var data = await res.json();

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -29,20 +29,43 @@ function withFields(cfg) {
     });
 }
 
+// The stored fields that make up a config, as resolveConfig() overrides.
+//
+// ONE list, shared by the read and the write response. It used to be written out
+// twice, and the copies drifted: the save response omitted engagement, so saving
+// point values came back claiming H2H and captain were off while the database
+// still had them on — and the admin caches that response. Every field the engine
+// reads must be here: modules/scoring.js getScoringConfig loads the live config
+// through this route, so a field left out is a field the scorer never sees,
+// however faithfully it is stored.
+function overridesFrom(doc) {
+    if (!doc) return null;
+    return {
+        model: doc.model, values: doc.values, combineMode: doc.combineMode,
+        disabled: doc.disabled, enabled: doc.enabled,
+        engagement: doc.engagement, engagementBySeason: doc.engagementBySeason || {},
+        powerConferences: doc.powerConferences
+    };
+}
+
+// The full response body for a league's config: resolved values + field metadata,
+// with `engagement` narrowed to one season and the raw per-season map alongside.
+function configResponse(league, doc, season, overrides) {
+    const bySeason = (doc && doc.engagementBySeason) || {};
+    const cfg = withFields(resolveConfig(league, overrides === undefined ? overridesFrom(doc) : overrides));
+    cfg.engagement = engagementForSeason(bySeason, season);
+    cfg.engagementBySeason = bySeason;
+    cfg.season = String(season);
+    return cfg;
+}
+
 // Resolved config (defaults-merged) for a league — always returns usable
 // values, combine mode, disabled events, and field metadata, even if the
 // commissioner hasn't saved a config yet.
 router.get('/:league', async (req, res) => {
     try {
         const doc = await ScoringConfig.findOne({ league: req.params.league });
-        const bySeason = (doc && doc.engagementBySeason) || {};
-        let overrides = doc
-            // Every field the engine reads has to be listed here: modules/scoring.js
-            // getScoringConfig loads the live scoring config through THIS route, so
-            // a field left out is a field the scorer never sees, however faithfully
-            // it is stored.
-            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, engagement: doc.engagement, engagementBySeason: bySeason, powerConferences: doc.powerConferences }
-            : null;
+        let overrides = overridesFrom(doc);
         // `?model=` lets the admin preview a different rule shape (Fixed =
         // claunts, Stacking = graham): force that model and drop the saved
         // combineMode so the shape's own default combine behavior applies,
@@ -55,10 +78,7 @@ router.get('/:league', async (req, res) => {
         // YEAR) so callers get the right game-mode state without knowing the
         // per-season storage. `engagementBySeason` is the full map for the admin.
         const season = req.query.season || process.env.YEAR;
-        const cfg = withFields(resolveConfig(req.params.league, overrides));
-        cfg.engagement = engagementForSeason(bySeason, season);
-        cfg.engagementBySeason = bySeason;
-        cfg.season = String(season);
+        const cfg = configResponse(req.params.league, doc, season, overrides);
         // Whether this caller may still edit scoring. Admins always can (they can
         // trigger a rescore). League Managers are locked out once the season has a
         // scored game — they must ask an admin. Only computed for a signed-in
@@ -152,9 +172,13 @@ router.post('/', async (req, res) => {
             summary: `Scoring rules updated (${resolved.model === 'graham' ? 'stacking' : 'fixed'} win values)`,
             meta: { model: resolved.model, combineMode: resolved.combineMode, disabled: resolved.disabled, enabled: resolved.enabled, powerConferences: resolved.powerConferences || null }
         });
-        res.json(withFields(resolveConfig(league, {
-            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, powerConferences: doc.powerConferences
-        })));
+        // Same builder the GET uses, so a save can never report a different
+        // config than a reload would. `isAdmin` decides which "Saved" message the
+        // admin shows (only an admin can run the rescore it tells them to run),
+        // and was absent here — so every save read as a non-admin save.
+        const saved = configResponse(league, doc, process.env.YEAR);
+        saved.isAdmin = effectiveRoles(req).includes('Admin');
+        res.json(saved);
     } catch (err) {
         res.status(400).json({ message: err.message });
     }

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -4,6 +4,7 @@ const ScoringConfig = require('../models/scoringConfig');
 const Game = require('../models/game');
 const { resolveConfig, fieldsForModel, engagementForSeason } = require('../modules/scoring-defaults');
 const { explainRegularWin, explainGame, getScoringConfig, getRankingsForGame, getBracketForGame } = require('../modules/scoring');
+const { POWER_CONFERENCES } = require('../modules/scoring-detectors');
 const { canManageLeague } = require('../modules/league-access');
 const { effectiveRoles } = require('../modules/dev-role');
 const { hasScoredGames } = require('../modules/season-status');
@@ -14,9 +15,17 @@ const audit = require('../modules/audit-log');
 // the resolved `disabled` set via each field's `enabled` flag; `example` is
 // computed from the live point values so it tracks edits.
 function withFields(cfg) {
+    const fields = fieldsForModel(cfg.model, cfg.disabled, cfg.enabled);
     return Object.assign({}, cfg, {
-        fields: fieldsForModel(cfg.model, cfg.disabled, cfg.enabled),
-        example: explainRegularWin(cfg.model, cfg.values, cfg.disabled, cfg.enabled)
+        fields,
+        example: explainRegularWin(cfg.model, cfg.values, cfg.disabled, cfg.enabled),
+        // The upset bonus's power list is a PARAMETER of one rule, not a rule, so
+        // it isn't in `fields`. The admin renders it beside that rule when the
+        // model has one — the base list ships with the response so the client
+        // never has to spell conference names itself (a typo there would silently
+        // change scoring).
+        powerConferencesBase: POWER_CONFERENCES,
+        hasUpsetRule: fields.some(f => f.condition === 'nonP5UpsetBonus')
     });
 }
 
@@ -103,7 +112,7 @@ router.get('/:league/explain', async (req, res) => {
 // nonsensical shape/mode combo can't be saved.
 router.post('/', async (req, res) => {
     try {
-        const { league, model, values, disabled, enabled } = req.body;
+        const { league, model, values, disabled, enabled, powerConferences } = req.body;
         if (!league) {
             return res.status(400).json({ message: 'league is required' });
         }
@@ -116,18 +125,24 @@ router.post('/', async (req, res) => {
         if (!effectiveRoles(req).includes('Admin') && await hasScoredGames(league, process.env.YEAR)) {
             return res.status(423).json({ message: 'Scoring is locked once the season is underway. Ask an admin to change it — the change needs a re-score.' });
         }
-        const resolved = resolveConfig(league, { model, values, disabled, enabled });
+        const resolved = resolveConfig(league, { model, values, disabled, enabled, powerConferences });
+        // An absent/malformed power list normalizes to undefined, which means
+        // "use the engine default". Mongoose strips an undefined from a $set, so
+        // clearing it back to the default needs an explicit $unset — otherwise
+        // turning the setting OFF would silently leave the old list in place.
+        const update = { $set: {
+            league,
+            model: resolved.model,
+            values: resolved.values,
+            combineMode: resolved.combineMode,
+            disabled: resolved.disabled,
+            enabled: resolved.enabled,
+            updatedAt: new Date()
+        } };
+        if (resolved.powerConferences) update.$set.powerConferences = resolved.powerConferences;
+        else update.$unset = { powerConferences: 1 };
         const doc = await ScoringConfig.findOneAndUpdate(
-            { league },
-            { $set: {
-                league,
-                model: resolved.model,
-                values: resolved.values,
-                combineMode: resolved.combineMode,
-                disabled: resolved.disabled,
-                enabled: resolved.enabled,
-                updatedAt: new Date()
-            } },
+            { league }, update,
             { new: true, upsert: true, setDefaultsOnInsert: true }
         );
         // Scoring changes how every past game counts, so the trail records the
@@ -135,10 +150,10 @@ router.post('/', async (req, res) => {
         await audit.record(req, {
             action: 'scoring.config', league, season: String(process.env.YEAR),
             summary: `Scoring rules updated (${resolved.model === 'graham' ? 'stacking' : 'fixed'} win values)`,
-            meta: { model: resolved.model, combineMode: resolved.combineMode, disabled: resolved.disabled, enabled: resolved.enabled }
+            meta: { model: resolved.model, combineMode: resolved.combineMode, disabled: resolved.disabled, enabled: resolved.enabled, powerConferences: resolved.powerConferences || null }
         });
         res.json(withFields(resolveConfig(league, {
-            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled
+            model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, powerConferences: doc.powerConferences
         })));
     } catch (err) {
         res.status(400).json({ message: err.message });

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -28,7 +28,11 @@ router.get('/:league', async (req, res) => {
         const doc = await ScoringConfig.findOne({ league: req.params.league });
         const bySeason = (doc && doc.engagementBySeason) || {};
         let overrides = doc
-            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, engagement: doc.engagement, engagementBySeason: bySeason }
+            // Every field the engine reads has to be listed here: modules/scoring.js
+            // getScoringConfig loads the live scoring config through THIS route, so
+            // a field left out is a field the scorer never sees, however faithfully
+            // it is stored.
+            ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, engagement: doc.engagement, engagementBySeason: bySeason, powerConferences: doc.powerConferences }
             : null;
         // `?model=` lets the admin preview a different rule shape (Fixed =
         // claunts, Stacking = graham): force that model and drop the saved

--- a/tests/AdminScoringPowerConferences.spec.js
+++ b/tests/AdminScoringPowerConferences.spec.js
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Browser-side tests for the upset-bonus power-conference control in
+ * public/admin.js.
+ *
+ * The control is a rule PARAMETER sitting inside the rule list, which is exactly
+ * where it can go wrong: saveScoringConfig() harvests every `.scoring-toggle` in
+ * that container into the disabled/enabled RULE lists, keyed by data-condition.
+ * A parameter checkbox wearing that class would push a null condition into
+ * `disabled` and switch a real scoring rule off. That regression is silent in
+ * the UI and invisible to the route tests, so it is asserted directly below.
+ *
+ * public/admin.js is a classic script, so `require` would keep its functions in
+ * a module scope where nothing can reach them. It's evaluated into the global
+ * scope instead, which is how the browser actually runs it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FIELDS = [
+    { key: 'baseWin', condition: 'baseWin', label: 'Any win (base points)', group: 'regular', toggleable: false, defaultOff: false, enabled: true, additive: false },
+    { key: 'confBonus', condition: 'confBonus', label: 'Conference win', group: 'regular', toggleable: false, defaultOff: false, enabled: true, additive: true },
+    { key: 'nonP5UpsetBonus', condition: 'nonP5UpsetBonus', label: 'Non P5 team beats a P5 team', group: 'regular', toggleable: false, defaultOff: false, enabled: true, additive: true },
+    { key: 'bowlWin', condition: 'bowlWin', label: 'Non-playoff bowl win', group: 'postseason', toggleable: true, defaultOff: false, enabled: true, additive: false }
+];
+const BASE = ['ACC', 'Big 12', 'Big Ten', 'SEC'];
+const POWER_PLUS = BASE.concat('FBS Independents');
+
+function loadAdmin() {
+    const jq = () => new Proxy(function () {}, { get: () => jq, apply: () => jq });
+    global.$ = global.jQuery = Object.assign(jq, { fn: {}, ajax: () => {}, each: () => {} });
+    global.Toastify = () => ({ showToast: () => {}, options: {} });
+    global.ccIcon = () => '';
+    global.ccLogo = () => '';
+    global.io = () => ({ on: () => {}, emit: () => {} });
+    document.body.innerHTML =
+        '<div scoring-config-fields></div>' +
+        '<p scoring-config-note style="display:none"></p>' +   // saveScoringConfig writes its status here
+        '<form id="scoring-config-form"></form>';
+    const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'admin.js'), 'utf8');
+    (0, eval)(src);                                   // indirect eval → global scope
+    // Toasts are built from a Toastify() call the stub above doesn't reach.
+    global.successToast = global.failToast = { options: {}, showToast: () => {} };
+    global.getDraftLeagueCode = () => 'graham-league';
+    global.getShape = () => 'graham';
+    global.applyScoringConfig = () => {};
+    global.renderShapeExample = () => {};
+}
+
+function setConfig(powerConferences) {
+    global.scoringConfigData = {
+        model: 'graham', combineMode: 'sum',
+        values: { baseWin: 1, confBonus: 1, nonP5UpsetBonus: 2, bowlWin: 6 },
+        fields: FIELDS, powerConferencesBase: BASE, powerConferences
+    };
+    global.renderScoringFields();
+}
+
+const box = () => document.getElementById('power-independents');
+
+beforeEach(() => { jest.resetModules(); loadAdmin(); });
+
+describe('power-conference control rendering', () => {
+    it('renders under the upset-bonus rule, not as a rule of its own', () => {
+        setConfig(undefined);
+        expect(box()).not.toBeNull();
+        // It follows the rule it modifies rather than floating elsewhere.
+        const rows = [...document.querySelectorAll('[scoring-config-fields] .scoring-field')];
+        const upset = rows.findIndex(r => r.getAttribute('data-condition') === 'nonP5UpsetBonus');
+        const param = rows.findIndex(r => r.contains(box()));
+        expect(upset).toBeGreaterThanOrEqual(0);
+        expect(param).toBe(upset + 1);
+        // A parameter has no points stepper.
+        expect(rows[param].querySelector('.num-stepper')).toBeNull();
+    });
+
+    it('reflects whether independents are already counted', () => {
+        setConfig(undefined);
+        expect(box().checked).toBe(false);
+        setConfig(POWER_PLUS);
+        expect(box().checked).toBe(true);
+        setConfig(BASE);
+        expect(box().checked).toBe(false);
+    });
+
+    it('is NOT harvested as a scoring rule toggle', () => {
+        setConfig(POWER_PLUS);
+        expect(box().classList.contains('scoring-toggle')).toBe(false);
+        const conditions = [...document.querySelectorAll('[scoring-config-fields] .scoring-toggle')]
+            .map(cb => cb.getAttribute('data-condition'));
+        expect(conditions).not.toContain(null);
+        expect(conditions).toEqual(['bowlWin']);
+    });
+
+    it('is hidden for a model with no upset rule', () => {
+        global.scoringConfigData = {
+            model: 'claunts', values: { baseWin: 1 },
+            fields: [{ key: 'baseWin', condition: 'baseWin', label: 'Win', group: 'regular', enabled: true }],
+            powerConferencesBase: BASE
+        };
+        global.renderScoringFields();
+        expect(box()).toBeNull();
+    });
+});
+
+describe('what the save sends', () => {
+    async function save() {
+        let body = null;
+        global.fetch = jest.fn((url, opts) => {
+            body = JSON.parse(opts.body);
+            return Promise.resolve({ status: 200, json: () => Promise.resolve(global.scoringConfigData) });
+        });
+        await global.saveScoringConfig();
+        return body;
+    }
+
+    it('sends the base list plus independents when ticked', async () => {
+        setConfig(undefined);
+        box().checked = true;
+        expect((await save()).powerConferences).toEqual(POWER_PLUS);
+    });
+
+    it('sends null when un-ticked, so the server clears it', async () => {
+        setConfig(POWER_PLUS);
+        box().checked = false;
+        expect((await save()).powerConferences).toBeNull();
+    });
+
+    it('never spells conference names itself — it builds on the server list', async () => {
+        setConfig(undefined);
+        global.scoringConfigData.powerConferencesBase = ['Only Conference'];
+        box().checked = true;
+        expect((await save()).powerConferences).toEqual(['Only Conference', 'FBS Independents']);
+    });
+
+    it('leaves the real rule toggles alone', async () => {
+        setConfig(POWER_PLUS);
+        box().checked = true;
+        const body = await save();
+        expect(body.disabled).toEqual([]);
+        expect(body.enabled).toEqual([]);
+        expect(body.values).toMatchObject({ baseWin: 1, nonP5UpsetBonus: 2 });
+    });
+});

--- a/tests/RoutesScoringConfig.spec.js
+++ b/tests/RoutesScoringConfig.spec.js
@@ -1,0 +1,67 @@
+// HTTP-level tests for the powerConferences override in routes/scoringConfig.js.
+//
+// Why at the route level: modules/scoring.js getScoringConfig loads the LIVE
+// scoring config through GET /scoring-config/:league, so the route's overrides
+// object is a whitelist — a field that isn't listed there never reaches the
+// scorer no matter how faithfully it is stored. That gap is invisible to the
+// unit tests (which mock the HTTP layer) and to the model tests (which never
+// call the route), so it gets its own round-trip test here.
+//
+// The router is mounted on a bare Express app backed by in-memory Mongo.
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const ScoringConfig = require('../models/scoringConfig');
+const scoringConfigRouter = require('../routes/scoringConfig');
+
+const LEAGUE = 'graham-league';
+const POWER_PLUS = ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'];
+
+const app = express();
+app.use(express.json());
+app.use('/scoring-config', scoringConfigRouter);
+
+useMongo();
+
+function seed(extra) {
+    return ScoringConfig.create(Object.assign({
+        league: LEAGUE, model: 'graham', values: {}, disabled: [], enabled: []
+    }, extra || {}));
+}
+
+describe('GET /scoring-config/:league — powerConferences round trip', () => {
+    it('surfaces a stored power list so the engine actually sees it', async () => {
+        await seed({ powerConferences: POWER_PLUS });
+        const res = await request(app).get(`/scoring-config/${LEAGUE}`);
+        expect(res.status).toBe(200);
+        expect(res.body.powerConferences).toEqual(POWER_PLUS);
+    });
+
+    it('omits it when unset, so an unconfigured league keeps the engine default', async () => {
+        await seed();
+        const res = await request(app).get(`/scoring-config/${LEAGUE}`);
+        expect(res.status).toBe(200);
+        expect(res.body.powerConferences).toBeUndefined();
+    });
+
+    it('a league with no saved doc at all resolves without one (Claunts today)', async () => {
+        const res = await request(app).get('/scoring-config/claunts-league');
+        expect(res.status).toBe(200);
+        expect(res.body.model).toBe('claunts');
+        expect(res.body.powerConferences).toBeUndefined();
+    });
+
+    it('survives a commissioner saving point values from the admin form', async () => {
+        await seed({ powerConferences: POWER_PLUS });
+        // The save route $sets only the fields the form owns; the power list is
+        // not one of them and must not be collateral damage.
+        await ScoringConfig.findOneAndUpdate(
+            { league: LEAGUE },
+            { $set: { values: { baseWin: 2 }, disabled: [], enabled: [] } }
+        );
+        const res = await request(app).get(`/scoring-config/${LEAGUE}`);
+        expect(res.body.values.baseWin).toBe(2);
+        expect(res.body.powerConferences).toEqual(POWER_PLUS);
+    });
+});

--- a/tests/RoutesScoringConfig.spec.js
+++ b/tests/RoutesScoringConfig.spec.js
@@ -121,6 +121,30 @@ describe('POST /scoring-config — saving the power list', () => {
         expect((await ScoringConfig.findOne({ league: LEAGUE })).powerConferences).toBeUndefined();
     });
 
+    // The save response is what admin.js caches into scoringConfigData, so it
+    // reporting something the database doesn't say is a live trap for whatever
+    // reads that object next. It used to omit engagement entirely: saving point
+    // values came back claiming H2H and captain were off while the doc had them
+    // on. Both responses are built by one function now; these lock that together.
+    it('echoes the stored engagement instead of defaults', async () => {
+        const bySeason = { 2026: { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 1, captainEnabled: true, captainMultiplier: 2 } };
+        await ScoringConfig.findOneAndUpdate({ league: LEAGUE }, { $set: { engagementBySeason: bySeason } }, { upsert: true });
+        const res = await save({});
+        expect(res.body.engagement).toMatchObject({ h2hEnabled: true, captainEnabled: true, h2hTieBonus: 1 });
+        expect(res.body.engagementBySeason).toEqual(bySeason);
+        // ...and the stored map is untouched by a scoring-values save.
+        expect((await ScoringConfig.findOne({ league: LEAGUE })).engagementBySeason).toEqual(bySeason);
+    });
+
+    it('returns the same config a reload would', async () => {
+        await ScoringConfig.findOneAndUpdate({ league: LEAGUE },
+            { $set: { engagementBySeason: { 2026: { h2hEnabled: true, captainEnabled: true } } } }, { upsert: true });
+        const saved = await save({ powerConferences: POWER_PLUS });
+        const reloaded = await request(app).get(`/scoring-config/${LEAGUE}?season=2026`);
+        ['values', 'engagement', 'engagementBySeason', 'powerConferences', 'combineMode', 'disabled', 'enabled', 'season']
+            .forEach(k => expect(saved.body[k]).toEqual(reloaded.body[k]));
+    });
+
     it('records the list in the audit trail alongside the other scoring changes', async () => {
         await save({ powerConferences: POWER_PLUS });
         const AuditLog = require('../models/auditLog');

--- a/tests/RoutesScoringConfig.spec.js
+++ b/tests/RoutesScoringConfig.spec.js
@@ -17,12 +17,24 @@ const scoringConfigRouter = require('../routes/scoringConfig');
 
 const LEAGUE = 'graham-league';
 const POWER_PLUS = ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'];
+// Saving is commissioner-gated; authorize via the internal-token path in
+// modules/league-access.js (the auth tiers themselves live in Permissions.spec.js).
+const TOKEN = 'scoring-config-spec-token';
 
 const app = express();
 app.use(express.json());
 app.use('/scoring-config', scoringConfigRouter);
 
 useMongo();
+
+// YEAR is read by the save route's season lock (hasScoredGames) and the audit
+// entry; without it the lookup casts NaN and the save 400s.
+let prevToken, prevYear;
+beforeAll(() => {
+    prevToken = process.env.INTERNAL_API_TOKEN; process.env.INTERNAL_API_TOKEN = TOKEN;
+    prevYear = process.env.YEAR; process.env.YEAR = '2026';
+});
+afterAll(() => { process.env.INTERNAL_API_TOKEN = prevToken; process.env.YEAR = prevYear; });
 
 function seed(extra) {
     return ScoringConfig.create(Object.assign({
@@ -52,6 +64,16 @@ describe('GET /scoring-config/:league — powerConferences round trip', () => {
         expect(res.body.powerConferences).toBeUndefined();
     });
 
+    it('ships the base list and an upset-rule flag so the admin can render the control', async () => {
+        await seed();
+        const graham = await request(app).get(`/scoring-config/${LEAGUE}`);
+        expect(graham.body.powerConferencesBase).toEqual(['ACC', 'Big 12', 'Big Ten', 'SEC']);
+        expect(graham.body.hasUpsetRule).toBe(true);
+        // Claunts has no upset rule, so the admin hides the control entirely.
+        const claunts = await request(app).get('/scoring-config/claunts-league');
+        expect(claunts.body.hasUpsetRule).toBe(false);
+    });
+
     it('survives a commissioner saving point values from the admin form', async () => {
         await seed({ powerConferences: POWER_PLUS });
         // The save route $sets only the fields the form owns; the power list is
@@ -63,5 +85,46 @@ describe('GET /scoring-config/:league — powerConferences round trip', () => {
         const res = await request(app).get(`/scoring-config/${LEAGUE}`);
         expect(res.body.values.baseWin).toBe(2);
         expect(res.body.powerConferences).toEqual(POWER_PLUS);
+    });
+});
+
+describe('POST /scoring-config — saving the power list', () => {
+    const save = (body) => request(app).post('/scoring-config')
+        .set('X-Internal-Token', TOKEN)
+        .send(Object.assign({ league: LEAGUE, model: 'graham', values: {}, disabled: [], enabled: [] }, body));
+
+    it('persists a list sent by the admin form', async () => {
+        const res = await save({ powerConferences: POWER_PLUS });
+        expect(res.status).toBe(200);
+        expect(res.body.powerConferences).toEqual(POWER_PLUS);
+        expect((await ScoringConfig.findOne({ league: LEAGUE })).powerConferences).toEqual(POWER_PLUS);
+    });
+
+    // The failure this guards: Mongoose strips an undefined from a $set, so
+    // without the explicit $unset, un-ticking the box would appear to save while
+    // leaving the old list — and the league would keep scoring the old way.
+    it('clears back to the engine default when the box is un-ticked', async () => {
+        await save({ powerConferences: POWER_PLUS });
+        const res = await save({ powerConferences: null });
+        expect(res.status).toBe(200);
+        expect(res.body.powerConferences).toBeUndefined();
+        const doc = await ScoringConfig.findOne({ league: LEAGUE });
+        expect(doc.powerConferences).toBeUndefined();
+        expect(await request(app).get(`/scoring-config/${LEAGUE}`)
+            .then(r => r.body.powerConferences)).toBeUndefined();
+    });
+
+    it('refuses a malformed list rather than scoring against half of one', async () => {
+        const res = await save({ powerConferences: ['', 42] });
+        expect(res.status).toBe(200);
+        expect(res.body.powerConferences).toBeUndefined();
+        expect((await ScoringConfig.findOne({ league: LEAGUE })).powerConferences).toBeUndefined();
+    });
+
+    it('records the list in the audit trail alongside the other scoring changes', async () => {
+        await save({ powerConferences: POWER_PLUS });
+        const AuditLog = require('../models/auditLog');
+        const entry = await AuditLog.findOne({ action: 'scoring.config' }).sort({ _id: -1 });
+        expect(entry.meta.powerConferences).toEqual(POWER_PLUS);
     });
 });

--- a/tests/ScoringDetectors.spec.js
+++ b/tests/ScoringDetectors.spec.js
@@ -6,7 +6,7 @@
 
 const {
     CONDITIONS, buildContext,
-    isConference, findPoll, rankValue, isPowerFiveUpset,
+    isConference, findPoll, rankValue, isPowerFiveUpset, POWER_CONFERENCES,
     isConferenceChampion, isBowlGame, isFirstRound,
     isQuarterFinalist, isSemiFinalist, isFinalist, isTop4Seed,
     bracketRound
@@ -81,6 +81,26 @@ describe('low-level game predicates', () => {
             ['ACC', 'Big 12', 'Big Ten', 'SEC'].forEach(conf => {
                 expect(isPowerFiveUpset('Conference USA', conf)).toBe(true);
             });
+        });
+
+        // The default list is load-bearing: tests/ScoringParity.spec.js proves the
+        // engine matches the frozen pre-Phase-2 oracle, and that oracle hardcodes
+        // these four. Widening the DEFAULT (rather than a league's config) would
+        // silently void the parity guarantee.
+        test('the default power list is exactly the four P4 conferences', () => {
+            expect(POWER_CONFERENCES).toEqual(['ACC', 'Big 12', 'Big Ten', 'SEC']);
+        });
+
+        test('a caller-supplied power list overrides the default', () => {
+            const withIndependents = ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'];
+            // Notre Dame's case: an independent beating a P4 team stops being an upset...
+            expect(isPowerFiveUpset('FBS Independents', 'ACC', withIndependents)).toBe(false);
+            expect(isPowerFiveUpset('FBS Independents', 'ACC')).toBe(true);   // ...but only for that league
+            // ...while a genuine Group-of-5 upset is untouched...
+            expect(isPowerFiveUpset('Mid-American', 'Big Ten', withIndependents)).toBe(true);
+            // ...and beating an independent now counts, which it didn't before.
+            expect(isPowerFiveUpset('Mid-American', 'FBS Independents', withIndependents)).toBe(true);
+            expect(isPowerFiveUpset('Mid-American', 'FBS Independents')).toBe(false);
         });
     });
 
@@ -190,6 +210,20 @@ describe('CONDITIONS vocabulary', () => {
         const upset = ctxFor(1, game({ homeConference: 'Sun Belt', awayConference: 'SEC' }));
         expect(CONDITIONS.nonP5UpsetBonus(upset)).toBe(true);
         expect(CONDITIONS.nonP5UpsetBonus(ctxFor(1, game()))).toBe(false); // Big Ten host, no upset
+    });
+
+    // Graham's league counts independents as power, so Notre Dame stops drawing
+    // the underdog bonus on its ~10 power-conference games a year. The list
+    // reaches the detector through buildContext's last argument.
+    test('nonP5UpsetBonus honours a league power list that includes independents', () => {
+        const POWER_PLUS = ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'];
+        const ndBeatsAcc = game({ homeConference: 'FBS Independents', awayConference: 'ACC' });
+        expect(CONDITIONS.nonP5UpsetBonus(buildContext(1, ndBeatsAcc, null, null))).toBe(true);
+        expect(CONDITIONS.nonP5UpsetBonus(buildContext(1, ndBeatsAcc, null, null, POWER_PLUS))).toBe(false);
+
+        // A real Group-of-5 upset still pays under the widened list.
+        const macBeatsBigTen = game({ homeConference: 'Mid-American', awayConference: 'Big Ten' });
+        expect(CONDITIONS.nonP5UpsetBonus(buildContext(1, macBeatsBigTen, null, null, POWER_PLUS))).toBe(true);
     });
 
     test('confChampionship fires only on a won conference-title game', () => {

--- a/tests/ScoringStructure.spec.js
+++ b/tests/ScoringStructure.spec.js
@@ -110,6 +110,54 @@ describe('disabled postseason events', () => {
     });
 });
 
+// A league can widen which conferences count as "power" for the non-P5 upset
+// bonus. Motivating case: Notre Dame sits in FBS Independents, so under the bare
+// four it drew the +2 underdog bonus on every power-conference win — ~19 points a
+// season for a top-5 program the rule was never meant to reward.
+describe('powerConferences override (non-P5 upset bonus)', () => {
+    const POWER_PLUS = ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'];
+    const ndOverAcc = () => homeWin({ homeConf: 'FBS Independents', awayConf: 'ACC' });
+    const macOverBigTen = () => homeWin({ homeConf: 'Mid-American', awayConf: 'Big Ten' });
+
+    it('defaults to the bare four, so an unconfigured league scores as before', async () => {
+        mockRankings([]);
+        const cfg = resolveConfig('graham-league', null);
+        expect(cfg.powerConferences).toBeUndefined();
+        // base 1 + nonP5 upset 2
+        expect(await scoring.calculateScoreV2(1, ndOverAcc(), 5, 2025, cfg)).toBe(3);
+    });
+
+    it('drops the bonus for an independent once the league counts them as power', async () => {
+        mockRankings([]);
+        const cfg = resolveConfig('graham-league', { powerConferences: POWER_PLUS });
+        expect(await scoring.calculateScoreV2(1, ndOverAcc(), 5, 2025, cfg)).toBe(1);   // base only
+    });
+
+    it('leaves a genuine Group-of-5 upset paying, and starts paying wins over independents', async () => {
+        mockRankings([]);
+        const cfg = resolveConfig('graham-league', { powerConferences: POWER_PLUS });
+        expect(await scoring.calculateScoreV2(1, macOverBigTen(), 5, 2025, cfg)).toBe(3);
+        const macOverNd = homeWin({ homeConf: 'Mid-American', awayConf: 'FBS Independents' });
+        expect(await scoring.calculateScoreV2(1, macOverNd, 5, 2025, cfg)).toBe(3);
+    });
+
+    it('is inert for Claunts, whose model has no upset rule at all', async () => {
+        mockRankings([]);
+        const plain = resolveConfig('claunts-league', null);
+        const widened = resolveConfig('claunts-league', { powerConferences: POWER_PLUS });
+        // Non-conference win vs an unranked opponent = 1 either way.
+        expect(await scoring.calculateScoreV1(1, ndOverAcc(), 5, 2025, plain)).toBe(1);
+        expect(await scoring.calculateScoreV1(1, ndOverAcc(), 5, 2025, widened)).toBe(1);
+    });
+
+    it('falls back to the default when the stored value is malformed', () => {
+        [null, 'SEC', [], [''], [42], undefined].forEach(bad => {
+            expect(resolveConfig('graham-league', { powerConferences: bad }).powerConferences).toBeUndefined();
+        });
+        expect(resolveConfig('graham-league', { powerConferences: [' SEC '] }).powerConferences).toEqual(['SEC']);
+    });
+});
+
 describe('fieldsForModel', () => {
     it('marks postseason fields toggleable and reflects disabled state', () => {
         const fields = fieldsForModel('claunts', ['bowlWin']);


### PR DESCRIPTION
## The problem

The Graham model's +2 `nonP5UpsetBonus` asks whether the winner's conference is outside `["ACC","Big 12","Big Ten","SEC"]`. Notre Dame's is `FBS Independents`, so a top-5 SP+ program drew the underdog bonus on **every** power-conference win.

Not theoretical — this is real 2025 scoring:

| Wk | Opponent | Conf | Scored |
|---|---|---|---|
| 4 | Purdue | Big Ten | 3 (1 base + 2 upset) |
| 5 | @ Arkansas | SEC | 3 |
| 7 | NC State | ACC | 3 |
| 8 | USC | Big Ten | 4 (+1 ranked) |
| 12 | @ Pittsburgh | ACC | 4 (+1 ranked) |

**28 points on a 10-2 season**, with zero conference bonuses, where a comparable SEC team gets about 19. The 2026 schedule has 10 power-conference opponents — roughly 19 bonus points.

## The fix

The power set becomes a **per-league config value** rather than a constant.

The default stays exactly the four conferences, which matters: `ScoringParity.spec.js` proves the engine matches the frozen pre-Phase-2 oracle in `legacyScoring.reference.js` (marked do-not-edit), and its matrix includes `FBS Independents`. Hardcoding a different list would have broken that test with no legitimate fix. Leaving the default alone also makes **Claunts untouched by construction** rather than by argument — its model has no upset rule and no config document at all.

The Graham league adds `FBS Independents` to its own list, which also means beating Notre Dame now counts as an upset, as it always should have.

## Commissioner control

A checkbox under the upset-bonus rule on the admin scoring page — *"Count independents as a power conference"*. Deliberately a checkbox rather than an editable conference list: the array is stored in full, but a free-text field there lets one typo silently change how the league scores. The base list ships in the API response so the client never spells conference names, and the control is hidden for models without the rule.

## Three failure modes worth knowing about

- **`normalizeCfg` whitelists what reaches `evaluate()`.** The first version had a working detector and unchanged scoring, because the new field was dropped in between.
- **`GET /scoring-config/:league` is how `modules/scoring.js` loads the live config.** A field missing from that route's overrides never reaches the scorer, however faithfully it's stored.
- **Clearing needs an explicit `$unset`.** Mongoose strips `undefined` from a `$set`, so without it, un-ticking the box would report "Saved" and change nothing.

The last commit also fixes a pre-existing bug found along the way: the save and read responses each built from their own copy of the stored-field list and had drifted, so saving point values returned engagement defaults while the database had H2H and captain on. Both now share one builder. That also restores `isAdmin` on the save response, which was never set — every save showed the non-admin message.

## Impact

Notre Dame moves from **43.8 (board #1) to 24.8 (#11)**. Miami (OH) and James Madison gain, since beating Notre Dame now pays. UConn loses a bonus it legitimately earned (~4 points across all of 2025; projects 123rd).

Rescoring 2025 changes **no manager's finishing position** — Brock still wins, 224 to Cole's 209.

## Testing

1,114 tests across 56 suites, including the frozen-oracle parity test. New: 11 route tests (persist, clear-to-default, malformed input, audit trail, engagement echo, save-equals-reload) and 8 browser tests for the admin control.

`scoring-detectors.js` coverage 100/98.6/100/100 against its 95/90/100/95 ratchet.

## After merge

Production needs the setting ticked on the Graham league's scoring page — the code ships the control, not the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)