### PR TITLE
Route every config consumer through one field list

### DIFF
--- a/modules/scoring-defaults.js
+++ b/modules/scoring-defaults.js
@@ -211,6 +211,30 @@ function normalizePowerConferences(list) {
 // multiplier values used when a mode is turned on.
 const ENGAGEMENT_DEFAULTS = { h2hEnabled: false, h2hWinBonus: 3, h2hTieBonus: 0, captainEnabled: false, captainMultiplier: 2 };
 
+// THE canonical list of stored config fields, as resolveConfig() overrides.
+//
+// Every consumer that turns a saved ScoringConfig (a Mongo doc, or the JSON the
+// /scoring-config route returns) into a resolved config MUST go through here.
+// This list was previously spelled out at six call sites — the scoring job, the
+// config route's read and write, draft grades, and two standings projections —
+// and they drifted: adding `powerConferences` to the schema and the route left
+// five of them silently dropping it, so the league's own scoring never saw the
+// setting the admin page had happily saved. A field added here reaches every
+// consumer at once; a field added anywhere else reaches one.
+function overridesFromDoc(doc) {
+    if (!doc) return null;
+    return {
+        model: doc.model,
+        values: doc.values,
+        combineMode: doc.combineMode,
+        disabled: doc.disabled,
+        enabled: doc.enabled,
+        engagement: doc.engagement,
+        engagementBySeason: doc.engagementBySeason || {},
+        powerConferences: doc.powerConferences
+    };
+}
+
 // Coerce a stored/partial engagement object into a complete, well-typed one.
 function normalizeEngagement(e) {
     e = e || {};
@@ -234,6 +258,6 @@ function engagementForSeason(bySeason, season) {
 
 module.exports = {
     CLAUNTS_DEFAULTS, GRAHAM_DEFAULTS, STRUCTURES, MODELS, LEAGUES,
-    modelForLeague, fieldsForModel, resolveConfig, ruleEnabled, normalizePowerConferences,
+    modelForLeague, fieldsForModel, resolveConfig, ruleEnabled, normalizePowerConferences, overridesFromDoc,
     ENGAGEMENT_DEFAULTS, normalizeEngagement, engagementForSeason
 };

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -1,5 +1,5 @@
 const { internalFetch, failureMessage } = require('./internal-api');
-const { resolveConfig, MODELS, engagementForSeason, ruleEnabled } = require('./scoring-defaults');
+const { resolveConfig, MODELS, engagementForSeason, ruleEnabled, overridesFromDoc } = require('./scoring-defaults');
 const { CONDITIONS, buildContext } = require('./scoring-detectors');
 const { factsForGame } = require('./cfp-bracket');
 const { resolveCaptain, captainWeeklyBonus } = require('./captain');
@@ -438,15 +438,7 @@ async function getScoringConfig(league) {
     // finer win categories), not just point values. Dropping any of these
     // here would make computed scores silently ignore structural config while
     // the rules page still showed it.
-    return resolveConfig(league, {
-        model: data.model,
-        values: data.values,
-        combineMode: data.combineMode,
-        disabled: data.disabled,
-        enabled: data.enabled,
-        engagement: data.engagement,
-        engagementBySeason: data.engagementBySeason
-    });
+    return resolveConfig(league, overridesFromDoc(data));
 }
 
 // The rankings a game should be scored against, from the internal /rankings

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -7,7 +7,7 @@ const Team = require('../models/team');
 const Game = require('../models/game');
 const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
-const { resolveConfig } = require('../modules/scoring-defaults');
+const { resolveConfig, overridesFromDoc } = require('../modules/scoring-defaults');
 const { computeGrades } = require('../modules/draft-grades');
 const { canManageLeague } = require('../modules/league-access');
 const { sanitizeCallUrl } = require('../modules/draft-call-link');
@@ -43,10 +43,7 @@ router.get('/grades/:league/:season', async (req, res) => {
               awayId: 1, awayTeam: 1, awayConference: 1 }).lean();
 
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
-        const config = resolveConfig(league, cfgDoc ? {
-            model: cfgDoc.model, values: cfgDoc.values,
-            combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled, enabled: cfgDoc.enabled
-        } : null);
+        const config = resolveConfig(league, overridesFromDoc(cfgDoc));
 
         const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
         const apPoll = apDoc && Array.isArray(apDoc.polls)

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const ScoringConfig = require('../models/scoringConfig');
 const Game = require('../models/game');
-const { resolveConfig, fieldsForModel, engagementForSeason } = require('../modules/scoring-defaults');
+const { resolveConfig, fieldsForModel, engagementForSeason, overridesFromDoc } = require('../modules/scoring-defaults');
 const { explainRegularWin, explainGame, getScoringConfig, getRankingsForGame, getBracketForGame } = require('../modules/scoring');
 const { POWER_CONFERENCES } = require('../modules/scoring-detectors');
 const { canManageLeague } = require('../modules/league-access');
@@ -38,15 +38,7 @@ function withFields(cfg) {
 // reads must be here: modules/scoring.js getScoringConfig loads the live config
 // through this route, so a field left out is a field the scorer never sees,
 // however faithfully it is stored.
-function overridesFrom(doc) {
-    if (!doc) return null;
-    return {
-        model: doc.model, values: doc.values, combineMode: doc.combineMode,
-        disabled: doc.disabled, enabled: doc.enabled,
-        engagement: doc.engagement, engagementBySeason: doc.engagementBySeason || {},
-        powerConferences: doc.powerConferences
-    };
-}
+const overridesFrom = overridesFromDoc;
 
 // The full response body for a league's config: resolved values + field metadata,
 // with `engagement` narrowed to one season and the raw per-season map alongside.

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -9,7 +9,7 @@ const Draft = require('../models/draft');
 const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
 const JobRun = require('../models/jobRun');
-const { resolveConfig, engagementForSeason } = require('../modules/scoring-defaults');
+const { resolveConfig, engagementForSeason, overridesFromDoc } = require('../modules/scoring-defaults');
 const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../modules/draft-projection');
 const { buildProjections, simulateTitleOdds } = require('../modules/standings-projection');
 const { buildAdvancedHighlights } = require('../modules/standings-highlights');
@@ -166,9 +166,7 @@ router.get('/projections/:league/:season', async (req, res) => {
         });
 
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
-        const cfg = resolveConfig(league, cfgDoc ? {
-            model: cfgDoc.model, values: cfgDoc.values, combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled, enabled: cfgDoc.enabled
-        } : null);
+        const cfg = resolveConfig(league, overridesFromDoc(cfgDoc));
         const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
         const apPoll = apDoc && Array.isArray(apDoc.polls) ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
 
@@ -398,9 +396,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
                     if (draftedSet.has(tid)) (gamesByTeam[tid] = gamesByTeam[tid] || []).push(g);
                 });
             });
-            const cfg = resolveConfig(league, cfgDoc ? {
-                model: cfgDoc.model, values: cfgDoc.values, combineMode: cfgDoc.combineMode, disabled: cfgDoc.disabled
-            } : null);
+            const cfg = resolveConfig(league, overridesFromDoc(cfgDoc));
             const apDoc = await Ranking.findOne({ season: seasonNum, seasonType: 'regular' }).sort({ week: 1 }).lean();
             const apPoll = apDoc && Array.isArray(apDoc.polls) ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
             const rankings = buildRankingProxy(seasonNum, teamsById, apPoll);

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ const { leagueCodeFor, canManageLeague } = require('./modules/league-access');
 const ScoringConfig = require('./models/scoringConfig');
 const User = require('./models/user');
 const League = require('./models/league');
-const { resolveConfig, fieldsForModel, LEAGUES, engagementForSeason } = require('./modules/scoring-defaults');
+const { resolveConfig, fieldsForModel, LEAGUES, engagementForSeason, overridesFromDoc } = require('./modules/scoring-defaults');
 const draftToken = require('./modules/draft-token');
 const registerDraftSockets = require('./modules/draft-socket');
 const { cloudinaryConfig } = require('./modules/profile-update');
@@ -476,9 +476,7 @@ app.get('/rules', async (req, res) => {
         let cfg;
         try {
             const doc = await ScoringConfig.findOne({ league: leagueCode });
-            cfg = resolveConfig(leagueCode, doc
-                ? { model: doc.model, values: doc.values, combineMode: doc.combineMode, disabled: doc.disabled, enabled: doc.enabled, engagement: doc.engagement, engagementBySeason: doc.engagementBySeason }
-                : null);
+            cfg = resolveConfig(leagueCode, overridesFromDoc(doc));
         } catch (err) {
             cfg = resolveConfig(leagueCode, null);
         }

--- a/tests/ScoringStructure.spec.js
+++ b/tests/ScoringStructure.spec.js
@@ -158,6 +158,49 @@ describe('powerConferences override (non-P5 upset bonus)', () => {
     });
 });
 
+// The gap that let a merged, tested, admin-editable setting do nothing: every
+// earlier test either handed evaluate() a config directly or checked what the
+// route returned. Nothing covered the path the scoring JOB takes — load the
+// config over HTTP, re-resolve it, then score — and that re-resolve was
+// dropping the field. These walk the real path.
+describe('config survives the load-then-score path', () => {
+    const POWER_PLUS = ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'];
+
+    function mockConfigRoute(body) {
+        global.fetch = jest.fn((url) => {
+            if (String(url).includes('/scoring-config/')) {
+                return Promise.resolve({ status: 200, ok: true, json: () => Promise.resolve(body) });
+            }
+            return Promise.resolve({ status: 200, ok: true, json: () => Promise.resolve({ polls: [{ poll: 'AP Top 25', ranks: [] }] }) });
+        });
+    }
+
+    it('carries every stored field through getScoringConfig', async () => {
+        mockConfigRoute({
+            model: 'graham', values: { baseWin: 1 }, combineMode: 'sum',
+            disabled: ['bowlWin'], enabled: [], powerConferences: POWER_PLUS,
+            engagementBySeason: { 2026: { captainEnabled: true, captainMultiplier: 2 } }
+        });
+        const cfg = await scoring.getScoringConfig('graham-league');
+        expect(cfg.powerConferences).toEqual(POWER_PLUS);
+        expect(cfg.disabled).toEqual(['bowlWin']);
+        expect(cfg.engagementBySeason).toEqual({ 2026: { captainEnabled: true, captainMultiplier: 2 } });
+    });
+
+    it('scores Notre Dame with the loaded list, not the engine default', async () => {
+        const ndOverAcc = homeWin({ homeConf: 'FBS Independents', awayConf: 'ACC' });
+        const base = { model: 'graham', values: {}, combineMode: 'sum', disabled: [], enabled: [] };
+
+        mockConfigRoute(Object.assign({}, base, { powerConferences: POWER_PLUS }));
+        const closed = await scoring.getScoringConfig('graham-league');
+        expect(await scoring.calculateScoreV2(1, ndOverAcc, 5, 2025, closed)).toBe(1);
+
+        mockConfigRoute(base);                                   // league never set one
+        const open = await scoring.getScoringConfig('graham-league');
+        expect(await scoring.calculateScoreV2(1, ndOverAcc, 5, 2025, open)).toBe(3);
+    });
+});
+
 describe('fieldsForModel', () => {
     it('marks postseason fields toggleable and reflects disabled state', () => {
         const fields = fieldsForModel('claunts', ['bowlWin']);


### PR DESCRIPTION
## The bug

`powerConferences` shipped in #305, is editable from the admin page, has tests — and **did nothing.**

Six places turn a saved `ScoringConfig` into `resolveConfig` overrides by spelling the field list out by hand. Five never learned about the new field:

| Site | Effect |
|---|---|
| `modules/scoring.js` `getScoringConfig` | **Live scoring ran the bare four.** This is the one the scoring jobs use. |
| `routes/draft.js` | Draft grades showed Notre Dame with the loophole open |
| `routes/standings.js` ×2 | Title odds + per-team projections likewise (one also dropped `enabled`, so opted-in Claunts win categories were ignored) |
| `server.js` | `/rules` page |

The admin page reported the setting saved, the route returned it, the database stored it, and the scorer never saw it.

## The fix

One `overridesFromDoc()` in `scoring-defaults.js`; every consumer calls it. A field added to the schema now reaches all of them at once instead of one.

## Why the tests missed it

Every existing test either handed `evaluate()` a config directly or asserted what the route returned. Nothing walked the path the job actually takes — load the config over HTTP, re-resolve, score. Two tests now do exactly that, and the second one fails against the old code.

## Testing

1,116 tests across 56 suites, parity test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)