### PR TITLE
Add a live draft board for draft night

### DIFF
--- a/modules/draft-board.js
+++ b/modules/draft-board.js
@@ -48,6 +48,49 @@ function available(projections, draft) {
         .sort((a, b) => b.total - a.total);
 }
 
+// --- captain -----------------------------------------------------------------
+//
+// The weekly Captain multiplies ONE rostered team's score, regular season only.
+// Captain the same team every week and you bank its entire REGULAR projection
+// again — so a roster's captain value is just its best regular projection, and a
+// new team is worth extra only if it RAISES that.
+//
+// The consequence that matters at the table: the multiplier never touches
+// postseason points. Two teams level on total value are not level if one earns
+// its points in the playoff — Ohio State (34.4 total, 21.9 regular) and Texas
+// (34.3 total, 24.0 regular) are a tenth apart on the board and two points apart
+// once the captain is priced in.
+//
+// Simplification, stated on the page: optimal play captains the best EXPECTED
+// team each week, which occasionally isn't the anchor (a bye, a soft matchup for
+// a lesser team). True captain value is therefore a little higher than this, so
+// the figure is a floor, like the scarcity estimate.
+
+// Best regular projection already on the roster. 0 for an empty roster, which is
+// what makes a first-round pick's whole regular projection count.
+function captainAnchor(roster) {
+    return (roster || []).reduce(function (best, r) {
+        return (r && typeof r.regular === 'number' && r.regular > best) ? r.regular : best;
+    }, 0);
+}
+
+// What a candidate adds in captain points: the amount it lifts the anchor,
+// scaled by the multiplier (a 2x captain banks the difference once).
+function captainGain(team, anchorRegular, multiplier) {
+    if (!team || typeof team.regular !== 'number') return 0;
+    var lift = team.regular - (anchorRegular || 0);
+    if (lift <= 0) return 0;
+    return Math.round(lift * ((multiplier || 2) - 1) * 10) / 10;
+}
+
+// Value of a team TO THIS ROSTER: board value plus whatever captain upgrade it
+// brings. With the captain off, or once the anchor can't be beaten, this is just
+// the board value.
+function effectiveValue(team, captain) {
+    if (!captain || !captain.enabled) return team.total;
+    return Math.round((team.total + captainGain(team, captain.anchorRegular, captain.multiplier)) * 10) / 10;
+}
+
 // The advice itself.
 //
 // `gap` other managers pick before this manager's turn comes round again, so as
@@ -65,23 +108,59 @@ function available(projections, draft) {
 //   atRisk      — teams likely gone before the manager picks again
 //   safeToWait  — teams likely still there, so no need to spend this pick on one
 function advise(availableTeams, schedule, opts = {}) {
-    const list = availableTeams || [];
-    const take = list[0] || null;
+    const list = availableTeams || [];          // market order: by board value
+    const captain = opts.captain || null;
+    // Two orders, deliberately. The MARKET prices on board value — that's what
+    // decides who is gone when the turn comes round. What I should BUY is priced
+    // on value to my roster, which includes a captain upgrade the market has no
+    // reason to care about. Ranking both the same way would quietly assume the
+    // other five managers are drafting for my roster.
+    const best = (pool) => pool.reduce((b, t) =>
+        (b == null || effectiveValue(t, captain) > effectiveValue(b, captain)) ? t : b, null);
+
+    const take = best(list);
+    const captainInfo = captain && captain.enabled ? {
+        enabled: true,
+        anchorRegular: captain.anchorRegular || 0,
+        anchorSchool: captain.anchorSchool || null,
+        // The upgrade this specific pick buys.
+        gain: take ? captainGain(take, captain.anchorRegular, captain.multiplier) : 0,
+        // True when nothing left on the board could beat the anchor — the captain
+        // slot is decided and per-week value can be ignored for the rest of the
+        // draft, which is worth saying rather than leaving to be worked out.
+        settled: !list.some(t => captainGain(t, captain.anchorRegular, captain.multiplier) > 0)
+    } : { enabled: false, gain: 0, settled: false };
+
     if (!take || schedule.gap == null) {
-        return { take, cost: null, atRisk: [], safeToWait: [], survivorRank: null };
+        return { take, cost: null, atRisk: [], safeToWait: [], survivorRank: null, captain: captainInfo,
+                 effective: take ? effectiveValue(take, captain) : null };
     }
     const limit = opts.listSize || 6;
-    // With `gap` picks in between, list[gap] is the best team expected to still
-    // be here. If the board is shorter than the gap, nothing is guaranteed.
-    const survivorRank = Math.min(schedule.gap, list.length - 1);
-    const survivor = list[survivorRank] || null;
-    const cost = survivor ? Math.round((take.total - survivor.total) * 10) / 10 : null;
+    // With `gap` picks in between, the market takes the top `gap` teams, so what
+    // survives is everything from there down — and what I'd actually take then is
+    // the best of THOSE by my own valuation.
+    //
+    // When the wait is longer than the board, NOTHING survives. This used to be
+    // clamped to the last team, which quietly contradicted itself: it priced the
+    // cost of waiting against a team it simultaneously listed as unavailable. An
+    // exhausted board is its own answer — waiting costs you the pick, not a
+    // couple of points — so it is reported rather than approximated.
+    const exhausted = schedule.gap >= list.length;
+    const survivors = exhausted ? [] : list.slice(schedule.gap);
+    const survivor = best(survivors);
+    const cost = survivor
+        ? Math.round((effectiveValue(take, captain) - effectiveValue(survivor, captain)) * 10) / 10
+        : null;
     return {
         take,
         cost,
-        survivorRank,
+        exhausted,
+        survivorRank: exhausted ? null : schedule.gap,
+        survivor,
+        effective: effectiveValue(take, captain),
+        captain: captainInfo,
         atRisk: list.slice(0, schedule.gap).slice(0, limit),
-        safeToWait: list.slice(schedule.gap, schedule.gap + limit)
+        safeToWait: survivors.slice(0, limit)
     };
 }
 
@@ -97,10 +176,12 @@ function rosterFor(draft, userId, projections) {
             return {
                 overall: p.overall, round: p.round,
                 id: p.team && p.team.id, school: (p.team && p.team.school) || '?',
-                total: proj ? proj.total : null
+                total: proj ? proj.total : null,
+                // Needed to work out the captain anchor — see captainAnchor().
+                regular: proj ? proj.regular : null
             };
         })
         .sort((a, b) => a.overall - b.overall);
 }
 
-module.exports = { picksFor, pickSchedule, available, advise, rosterFor };
+module.exports = { picksFor, pickSchedule, available, advise, rosterFor, captainAnchor, captainGain, effectiveValue };

--- a/modules/draft-board.js
+++ b/modules/draft-board.js
@@ -1,0 +1,106 @@
+// Live draft advice: given the projected value of every team and the picks made
+// so far, what should this manager do with their next pick?
+//
+// Pure and I/O-free — the route supplies the projections and the draft doc, the
+// client re-runs nothing. All the interesting logic is the scarcity question,
+// not the ranking one.
+//
+// WHY SCARCITY AND NOT "BEST AVAILABLE": in this league every roster spot is
+// interchangeable — there are no positions, so a roster's value is just the sum
+// of its teams. That makes "who is best?" trivial (the top of the board) and
+// pushes the real decision onto "who will still be here next time?". A manager
+// picking 2nd in a 6-team snake waits 9 picks between round 1 and round 2, then
+// 3 picks between rounds 2 and 3. What they give up by waiting is entirely a
+// function of that gap, so that's what this models.
+
+const engine = require('./draft-engine');
+
+// Overall pick numbers belonging to one manager, in order.
+function picksFor(draft, userId) {
+    if (!draft || !userId) return [];
+    return engine.pickOrder(draft)
+        .filter(p => String(p.userId) === String(userId))
+        .map(p => ({ overall: p.overall, round: p.round }));
+}
+
+// This manager's upcoming picks: the one they're waiting on and the one after.
+// `gap` is how many OTHER managers pick in between — the number of teams that
+// can come off the board while they wait. null `next` means they're done.
+function pickSchedule(draft, userId) {
+    const current = (draft && draft.currentOverall) || 1;
+    const mine = picksFor(draft, userId).filter(p => p.overall >= current);
+    const next = mine[0] || null;
+    const after = mine[1] || null;
+    return {
+        next, after,
+        onTheClock: !!next && next.overall === current,
+        // Picks by others between this manager's next two turns.
+        gap: (next && after) ? (after.overall - next.overall - 1) : null
+    };
+}
+
+// Teams not yet drafted, best first. `projections` is [{ id, school, ... , total }].
+function available(projections, draft) {
+    const taken = new Set(((draft && draft.picks) || [])
+        .map(p => p.team && p.team.id).filter(id => id != null).map(String));
+    return (projections || [])
+        .filter(t => !taken.has(String(t.id)))
+        .sort((a, b) => b.total - a.total);
+}
+
+// The advice itself.
+//
+// `gap` other managers pick before this manager's turn comes round again, so as
+// a first approximation the top `gap` teams on the board will be gone. That is
+// deliberately pessimistic — it assumes every other manager takes the best team
+// left, which they demonstrably do not (this league drafts on brand: in 2025
+// Indiana went 31st and scored a league-high 58). Treating it as a floor rather
+// than a forecast is the honest reading, and it still answers the only question
+// that matters at the table: of the teams I want, which survive the wait?
+//
+// Returns:
+//   take        — the best team available now
+//   cost        — points given up by passing on `take` and picking at the next
+//                 turn instead (its value minus the best expected to survive)
+//   atRisk      — teams likely gone before the manager picks again
+//   safeToWait  — teams likely still there, so no need to spend this pick on one
+function advise(availableTeams, schedule, opts = {}) {
+    const list = availableTeams || [];
+    const take = list[0] || null;
+    if (!take || schedule.gap == null) {
+        return { take, cost: null, atRisk: [], safeToWait: [], survivorRank: null };
+    }
+    const limit = opts.listSize || 6;
+    // With `gap` picks in between, list[gap] is the best team expected to still
+    // be here. If the board is shorter than the gap, nothing is guaranteed.
+    const survivorRank = Math.min(schedule.gap, list.length - 1);
+    const survivor = list[survivorRank] || null;
+    const cost = survivor ? Math.round((take.total - survivor.total) * 10) / 10 : null;
+    return {
+        take,
+        cost,
+        survivorRank,
+        atRisk: list.slice(0, schedule.gap).slice(0, limit),
+        safeToWait: list.slice(schedule.gap, schedule.gap + limit)
+    };
+}
+
+// What a manager has already taken, best first — so the page can show the
+// roster building up next to the board.
+function rosterFor(draft, userId, projections) {
+    const byId = {};
+    (projections || []).forEach(t => { byId[String(t.id)] = t; });
+    return ((draft && draft.picks) || [])
+        .filter(p => String(p.userId) === String(userId))
+        .map(p => {
+            const proj = p.team && p.team.id != null ? byId[String(p.team.id)] : null;
+            return {
+                overall: p.overall, round: p.round,
+                id: p.team && p.team.id, school: (p.team && p.team.school) || '?',
+                total: proj ? proj.total : null
+            };
+        })
+        .sort((a, b) => a.overall - b.overall);
+}
+
+module.exports = { picksFor, pickSchedule, available, advise, rosterFor };

--- a/public/draftBoard.css
+++ b/public/draftBoard.css
@@ -3,15 +3,34 @@
    this is read at speed with a pick clock running, so the advice is large and
    everything else is a reference table. */
 
+/* Page containers.
+   body is `display:flex; flex-direction:column; align-items:center` (styles.css),
+   so every top-level section here is a FLEX ITEM. Flex items shrink to fit, so a
+   plain `max-width + margin:auto + padding` never produced a gutter — sections
+   narrower than the viewport were centred by the flex `align-items`, and any
+   section whose content filled the viewport ran flush to both edges with no
+   padding at all. `width:100%` makes them fill the cross axis first, and then the
+   max-width and padding behave as intended. */
+.db-shell,
+.db-strip,
+.db-cols {
+    width: 100%;
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
 .db-strip {
     display: flex;
     align-items: center;
     gap: 14px;
-    max-width: 1280px;
-    margin: 0 auto 18px;
-    padding: 0 20px;
+    margin-bottom: 18px;
     flex-wrap: wrap;
 }
+
+.db-shell { margin-bottom: 22px; }
 
 .db-live {
     display: inline-flex;
@@ -54,8 +73,6 @@
 /* ---- the advice block: the one thing worth reading at a glance ---- */
 
 .db-advice {
-    max-width: 1280px;
-    margin: 0 auto 22px;
     padding: 20px 22px;
     background: var(--cc-surface);
     border: 1px solid var(--cc-border);
@@ -149,9 +166,7 @@
 /* ---- columns ---- */
 
 .db-cols {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 0 20px 60px;
+    padding-bottom: 60px;
     display: grid;
     grid-template-columns: minmax(0, 1fr) 300px;
     gap: 18px;

--- a/public/draftBoard.css
+++ b/public/draftBoard.css
@@ -129,6 +129,13 @@
 .db-why p { margin: 0 0 6px; }
 .db-why strong { color: var(--cc-text); }
 .db-caveat { font-size: 0.8rem; color: var(--cc-muted-2); }
+.db-captain {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--cc-border-2);
+    color: var(--cc-muted-bright);
+}
+.db-captain strong { color: var(--cc-amber); }
 
 .db-listrow { margin-top: 14px; }
 .db-listrow-label {

--- a/public/draftBoard.css
+++ b/public/draftBoard.css
@@ -79,7 +79,12 @@
     margin-top: 10px;
 }
 
-.db-pick { flex: 0 0 auto; }
+.db-pick { flex: 0 0 auto; display: flex; align-items: center; gap: 16px; }
+.db-pick-logo {
+    width: 68px; height: 68px; object-fit: contain;
+    filter: drop-shadow(0 2px 6px rgba(0,0,0,.5));
+}
+.db-pick-text { min-width: 0; }
 .db-pick-label {
     font-size: 0.74rem;
     letter-spacing: 0.12em;
@@ -119,7 +124,7 @@
 .db-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .db-chip {
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
     gap: 7px;
     padding: 4px 10px;
     border-radius: var(--cc-r-pill);
@@ -259,3 +264,50 @@
 .db-r-total .db-r-team, .db-r-total .db-r-val { color: var(--cc-text); }
 .db-log .db-mine .db-l-team { color: var(--cc-accent); font-weight: 600; }
 .db-empty { color: var(--cc-muted-2); font-style: italic; }
+
+
+/* ---- logos ---- */
+
+.db-logo {
+    width: 20px; height: 20px; object-fit: contain;
+    flex: 0 0 auto; vertical-align: middle;
+}
+.db-team, .db-r-team, .db-l-team {
+    display: flex; align-items: center; gap: 8px;
+}
+.db-chip-logo { width: 16px; height: 16px; object-fit: contain; flex: 0 0 auto; }
+
+/* Board rows sit tighter than a logo's natural line box; pin the height so a
+   team with no logo doesn't render a shorter row than its neighbours. */
+.db-table td { height: 34px; }
+
+/* ---- value bar ----
+   A proportional bar behind the projection, scaled to the best team STILL on the
+   board. It exists so the tier cliffs are visible at a glance: the gap between
+   round-1 teams and the flat 16-19 block is the whole strategic point of this
+   league, and a column of numbers hides it. */
+
+.db-proj { position: relative; }
+.db-bar {
+    position: absolute;
+    right: 12px;
+    bottom: 4px;
+    height: 3px;
+    border-radius: var(--cc-r-pill);
+    background: linear-gradient(90deg,
+        color-mix(in srgb, var(--cc-interactive) 25%, transparent),
+        var(--cc-interactive));
+    opacity: 0.55;
+    pointer-events: none;
+}
+.db-best .db-bar {
+    background: linear-gradient(90deg,
+        color-mix(in srgb, var(--cc-accent) 30%, transparent),
+        var(--cc-accent));
+    opacity: 0.9;
+}
+.db-proj-val { position: relative; }
+
+@media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; animation: none !important; }
+}

--- a/public/draftBoard.css
+++ b/public/draftBoard.css
@@ -1,0 +1,261 @@
+/* Live draft board — commissioner-only draft-night assistant.
+   Built entirely on the --cc-* design tokens in styles.css. Dense on purpose:
+   this is read at speed with a pick clock running, so the advice is large and
+   everything else is a reference table. */
+
+.db-strip {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    max-width: 1280px;
+    margin: 0 auto 18px;
+    padding: 0 20px;
+    flex-wrap: wrap;
+}
+
+.db-live {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--cc-muted);
+}
+.db-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: var(--cc-r-pill);
+    background: var(--cc-muted-2);
+}
+.db-live-on .db-dot { background: var(--cc-success); }
+.db-live-off .db-dot { background: var(--cc-danger-text); }
+
+.db-meta {
+    font-size: 0.78rem;
+    color: var(--cc-muted-2);
+}
+
+.db-refresh {
+    margin-left: auto;
+    font: inherit;
+    font-size: 0.78rem;
+    padding: 5px 12px;
+    border-radius: var(--cc-r-sm);
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border-2);
+    color: var(--cc-muted-bright);
+    cursor: pointer;
+}
+.db-refresh:hover { background: var(--cc-surface-3); color: var(--cc-text); }
+.db-refresh:focus-visible,
+.db-search:focus-visible { outline: 2px solid var(--cc-info); outline-offset: 2px; }
+
+/* ---- the advice block: the one thing worth reading at a glance ---- */
+
+.db-advice {
+    max-width: 1280px;
+    margin: 0 auto 22px;
+    padding: 20px 22px;
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border);
+    border-left: 4px solid var(--cc-accent);
+    border-radius: var(--cc-r-lg);
+}
+
+.db-eyebrow {
+    font-size: 0.74rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--cc-accent);
+    font-weight: 700;
+}
+
+.db-advice-main {
+    display: flex;
+    gap: 28px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    margin-top: 10px;
+}
+
+.db-pick { flex: 0 0 auto; }
+.db-pick-label {
+    font-size: 0.74rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--cc-muted-2);
+}
+.db-pick-team {
+    font-family: 'Graduate', serif;
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    line-height: 1.1;
+    color: var(--cc-text);
+}
+.db-pick-proj {
+    font-size: 0.85rem;
+    color: var(--cc-muted-bright);
+    font-variant-numeric: tabular-nums;
+}
+
+.db-why {
+    flex: 1 1 320px;
+    min-width: 0;
+    font-size: 0.92rem;
+    color: var(--cc-muted-bright);
+}
+.db-why p { margin: 0 0 6px; }
+.db-why strong { color: var(--cc-text); }
+.db-caveat { font-size: 0.8rem; color: var(--cc-muted-2); }
+
+.db-listrow { margin-top: 14px; }
+.db-listrow-label {
+    font-size: 0.74rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--cc-muted-2);
+    margin-bottom: 6px;
+}
+.db-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.db-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 7px;
+    padding: 4px 10px;
+    border-radius: var(--cc-r-pill);
+    background: var(--cc-surface-2);
+    border: 1px solid var(--cc-border);
+    font-size: 0.85rem;
+}
+.db-chip-val {
+    font-size: 0.76rem;
+    color: var(--cc-muted-2);
+    font-variant-numeric: tabular-nums;
+}
+.db-risk .db-chip { border-color: var(--cc-danger); }
+.db-safe .db-chip { border-color: var(--cc-border-2); }
+
+.db-done, .db-error {
+    font-size: 1rem;
+    color: var(--cc-muted-bright);
+}
+.db-error { color: var(--cc-danger-text); }
+
+/* ---- columns ---- */
+
+.db-cols {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 0 20px 60px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 300px;
+    gap: 18px;
+    align-items: start;
+}
+@media (max-width: 900px) {
+    .db-cols { grid-template-columns: 1fr; }
+}
+
+.db-panel {
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-lg);
+    overflow: hidden;
+}
+.db-side { display: grid; gap: 18px; }
+
+.db-panel-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--cc-border);
+}
+.db-panel-head h2 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--cc-text);
+}
+.db-search {
+    margin-left: auto;
+    font: inherit;
+    font-size: 0.82rem;
+    padding: 5px 10px;
+    border-radius: var(--cc-r-sm);
+    background: var(--cc-surface-2);
+    border: 1px solid var(--cc-border-2);
+    color: var(--cc-text);
+    min-width: 150px;
+}
+.db-count {
+    font-size: 0.76rem;
+    color: var(--cc-muted-2);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+/* ---- board table ---- */
+
+.db-tablewrap { overflow-x: auto; max-height: 70vh; overflow-y: auto; }
+.db-table { border-collapse: collapse; width: 100%; min-width: 520px; }
+.db-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--cc-surface-2);
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 0.72rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--cc-muted-2);
+    border-bottom: 1px solid var(--cc-border);
+    white-space: nowrap;
+}
+.db-table td {
+    padding: 7px 12px;
+    border-bottom: 1px solid var(--cc-border);
+    font-size: 0.88rem;
+    color: var(--cc-muted-bright);
+}
+.db-table tbody tr:hover td { background: var(--cc-surface-2); }
+.db-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.db-rank { color: var(--cc-muted-2); font-size: 0.78rem; width: 42px; }
+.db-team { color: var(--cc-text); font-weight: 600; }
+.db-conf { font-size: 0.8rem; color: var(--cc-muted); white-space: nowrap; }
+.db-proj { color: var(--cc-text); font-weight: 600; }
+
+.db-table tbody tr.db-best td {
+    background: color-mix(in srgb, var(--cc-accent) 12%, transparent);
+}
+.db-table tbody tr.db-best .db-team { color: var(--cc-text); }
+
+/* ---- roster + log ---- */
+
+.db-roster, .db-log { list-style: none; margin: 0; padding: 6px 0; }
+.db-roster li, .db-log li {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 6px 16px;
+    font-size: 0.86rem;
+    color: var(--cc-muted-bright);
+}
+.db-r-round, .db-l-num {
+    flex: 0 0 34px;
+    font-size: 0.74rem;
+    color: var(--cc-muted-2);
+    font-variant-numeric: tabular-nums;
+}
+.db-r-team, .db-l-team { flex: 1; min-width: 0; color: var(--cc-text); }
+.db-r-val { font-variant-numeric: tabular-nums; color: var(--cc-muted-bright); }
+.db-r-total {
+    border-top: 1px solid var(--cc-border);
+    margin-top: 4px;
+    padding-top: 10px;
+    font-weight: 600;
+}
+.db-r-total .db-r-team, .db-r-total .db-r-val { color: var(--cc-text); }
+.db-log .db-mine .db-l-team { color: var(--cc-accent); font-weight: 600; }
+.db-empty { color: var(--cc-muted-2); font-style: italic; }

--- a/public/draftBoard.js
+++ b/public/draftBoard.js
@@ -1,0 +1,235 @@
+// Live draft board — a commissioner-only draft-night assistant.
+//
+// Joins the same socket room the draft room uses and re-pulls the board on every
+// pick. Deliberately re-fetches rather than re-deriving the advice in the
+// browser: the scarcity math lives in modules/draft-board.js and a second copy
+// here would be a second thing to keep correct. A draft is 60 picks over a
+// couple of hours, and the server caches the expensive projection half, so the
+// re-fetch is cheap and the numbers can never disagree with the server's.
+
+(function () {
+    var LEAGUE = window.LEAGUE_CODE;
+    var SEASON = window.APP_YEAR;
+    var ME = (window.userState && (window.userState._id || window.userState.id)) || '';
+
+    var data = null;          // last board payload
+    var filter = '';
+    var socket = null;
+
+    var $ = function (sel) { return document.querySelector(sel); };
+    function el(tag, cls, txt) {
+        var n = document.createElement(tag);
+        if (cls) n.className = cls;
+        if (txt != null) n.textContent = txt;
+        return n;
+    }
+    function fmt(n) { return n == null ? '—' : Number(n).toFixed(1); }
+
+    // ---- data ---------------------------------------------------------------
+
+    async function load(refresh) {
+        var url = '/draft/board/' + encodeURIComponent(LEAGUE) + '/' + encodeURIComponent(SEASON)
+            + '?userId=' + encodeURIComponent(ME) + (refresh ? '&refresh=1' : '');
+        var res = await fetch(url, { headers: { Accept: 'application/json' } });
+        if (!res.ok) {
+            var msg = await res.json().catch(function () { return {}; });
+            renderError(msg.message || ('Could not load the board (' + res.status + ')'));
+            return;
+        }
+        data = await res.json();
+        render();
+    }
+
+    // ---- render -------------------------------------------------------------
+
+    function renderError(text) {
+        $('[db-advice]').innerHTML = '';
+        $('[db-advice]').appendChild(el('div', 'db-error', text));
+    }
+
+    function renderAdvice() {
+        var wrap = $('[db-advice]');
+        wrap.innerHTML = '';
+        var a = data.advice, s = data.schedule;
+
+        if (!s.next) {
+            wrap.appendChild(el('div', 'db-done', 'Your draft is complete — all ten picks are in.'));
+            return;
+        }
+        if (!a.take) {
+            wrap.appendChild(el('div', 'db-done', 'No teams left on the board.'));
+            return;
+        }
+
+        var head = el('div', 'db-advice-head');
+        head.appendChild(el('span', 'db-eyebrow',
+            s.onTheClock ? 'You are on the clock' : ('Your next pick — #' + s.next.overall + ', round ' + s.next.round)));
+        wrap.appendChild(head);
+
+        var main = el('div', 'db-advice-main');
+        var pick = el('div', 'db-pick');
+        pick.appendChild(el('div', 'db-pick-label', 'Take'));
+        pick.appendChild(el('div', 'db-pick-team', a.take.school));
+        pick.appendChild(el('div', 'db-pick-proj', fmt(a.take.total) + ' projected'));
+        main.appendChild(pick);
+
+        // The scarcity read: what waiting actually costs.
+        // `cost` and `after` arrive on different halves of the payload, so the
+        // no-more-turns branch checks both rather than trusting them to agree.
+        var why = el('div', 'db-why');
+        if (a.cost == null || !s.after) {
+            why.appendChild(el('p', null, 'This is your last pick, so there is nothing to weigh against it — just take the best team left.'));
+        } else {
+            var gapTxt = s.gap + (s.gap === 1 ? ' pick' : ' picks') + ' before your next turn (#' + s.after.overall + ')';
+            var p = el('p', null, '');
+            p.appendChild(document.createTextNode(gapTxt + '. If you passed and waited, the best you should expect is '));
+            p.appendChild(el('strong', null, (data.advice.safeToWait[0] || {}).school || 'nothing better'));
+            p.appendChild(document.createTextNode(' — costing you about '));
+            p.appendChild(el('strong', null, fmt(a.cost) + ' points'));
+            p.appendChild(document.createTextNode('.'));
+            why.appendChild(p);
+            why.appendChild(el('p', 'db-caveat',
+                'Assumes every other manager takes the best team left, which this league does not — treat it as a floor, not a forecast.'));
+        }
+        main.appendChild(why);
+        wrap.appendChild(main);
+
+        if (a.atRisk.length) {
+            wrap.appendChild(listRow('Likely gone by your next turn', a.atRisk, 'db-risk'));
+        }
+        if (a.safeToWait.length) {
+            wrap.appendChild(listRow('Should still be there — no need to reach', a.safeToWait, 'db-safe'));
+        }
+    }
+
+    function listRow(label, teams, cls) {
+        var row = el('div', 'db-listrow ' + cls);
+        row.appendChild(el('div', 'db-listrow-label', label));
+        var ul = el('div', 'db-chips');
+        teams.forEach(function (t) {
+            var c = el('span', 'db-chip');
+            c.appendChild(el('span', 'db-chip-name', t.school));
+            c.appendChild(el('span', 'db-chip-val', fmt(t.total)));
+            ul.appendChild(c);
+        });
+        row.appendChild(ul);
+        return row;
+    }
+
+    function renderBoard() {
+        var tbody = $('[db-board]');
+        tbody.innerHTML = '';
+        var taken = {};
+        (data.draft.picks || []).forEach(function (p) { if (p.teamId != null) taken[String(p.teamId)] = true; });
+        var q = filter.trim().toLowerCase();
+        var rows = data.projections.filter(function (t) {
+            if (taken[String(t.id)]) return false;
+            if (!q) return true;
+            return t.school.toLowerCase().indexOf(q) !== -1
+                || (t.conference || '').toLowerCase().indexOf(q) !== -1;
+        });
+        var best = data.advice.take;
+        rows.slice(0, 120).forEach(function (t, i) {
+            var tr = el('tr');
+            if (best && t.id === best.id) tr.className = 'db-best';
+            tr.appendChild(el('td', 'db-num db-rank', String(i + 1)));
+            tr.appendChild(el('td', 'db-team', t.school));
+            tr.appendChild(el('td', 'db-conf', t.conference || '—'));
+            tr.appendChild(el('td', 'db-num db-proj', fmt(t.total)));
+            tr.appendChild(el('td', 'db-num', fmt(t.regular)));
+            tr.appendChild(el('td', 'db-num', fmt(t.post)));
+            tr.appendChild(el('td', 'db-num', t.perWeek == null ? '—' : t.perWeek.toFixed(2)));
+            tbody.appendChild(tr);
+        });
+        $('[db-count]').textContent = rows.length + ' available';
+    }
+
+    function renderRoster() {
+        var ol = $('[db-roster]');
+        ol.innerHTML = '';
+        if (!data.roster.length) {
+            ol.appendChild(el('li', 'db-empty', 'No picks yet.'));
+            return;
+        }
+        var total = 0;
+        data.roster.forEach(function (r) {
+            total += r.total || 0;
+            var li = el('li');
+            li.appendChild(el('span', 'db-r-round', 'R' + r.round));
+            li.appendChild(el('span', 'db-r-team', r.school));
+            li.appendChild(el('span', 'db-r-val', fmt(r.total)));
+            ol.appendChild(li);
+        });
+        var sum = el('li', 'db-r-total');
+        sum.appendChild(el('span', 'db-r-round', ''));
+        sum.appendChild(el('span', 'db-r-team', 'Projected total'));
+        sum.appendChild(el('span', 'db-r-val', fmt(total)));
+        ol.appendChild(sum);
+    }
+
+    function renderLog() {
+        var ol = $('[db-log]');
+        ol.innerHTML = '';
+        var picks = (data.draft.picks || []).slice().sort(function (a, b) { return b.overall - a.overall; });
+        if (!picks.length) {
+            ol.appendChild(el('li', 'db-empty', 'Draft has not started.'));
+            return;
+        }
+        picks.slice(0, 40).forEach(function (p) {
+            var li = el('li');
+            if (String(p.userId) === String(ME)) li.className = 'db-mine';
+            li.appendChild(el('span', 'db-l-num', '#' + p.overall));
+            li.appendChild(el('span', 'db-l-team', p.school));
+            ol.appendChild(li);
+        });
+    }
+
+    function render() {
+        if (!data) return;
+        $('[db-source]').textContent = 'Ranked bonuses: ' + data.rankedSource;
+        renderAdvice();
+        renderBoard();
+        renderRoster();
+        renderLog();
+    }
+
+    // ---- live ---------------------------------------------------------------
+
+    function setLive(state, text) {
+        var strip = $('[db-live]');
+        strip.className = 'db-live db-live-' + state;
+        $('[db-live-text]').textContent = text;
+    }
+
+    async function connect() {
+        try {
+            var res = await fetch('/draft-token', { headers: { Accept: 'application/json' } });
+            var token = (await res.json()).token;
+            socket = io({ auth: { token } });
+            socket.on('connect', function () {
+                setLive('on', 'live');
+                socket.emit('join-draft', { league: LEAGUE, season: SEASON });
+            });
+            socket.on('disconnect', function () { setLive('off', 'disconnected'); });
+            socket.io.on('reconnect', function () { setLive('on', 'live'); load(); });
+            // Any change to the draft re-pulls the board; the server owns the math.
+            socket.on('pick-made', function () { load(); });
+            socket.on('draft-state', function () { load(); });
+            socket.on('draft-complete', function () { load(); });
+        } catch (e) {
+            setLive('off', 'offline — refresh to update');
+        }
+    }
+
+    // ---- wire up ------------------------------------------------------------
+
+    document.addEventListener('DOMContentLoaded', function () {
+        $('[db-search]').addEventListener('input', function (e) {
+            filter = e.target.value;
+            if (data) renderBoard();
+        });
+        $('[db-refresh]').addEventListener('click', function () { load(true); });
+        load();
+        connect();
+    });
+})();

--- a/public/draftBoard.js
+++ b/public/draftBoard.js
@@ -103,7 +103,11 @@
         var pickText = el('div', 'db-pick-text');
         pickText.appendChild(el('div', 'db-pick-label', 'Take'));
         pickText.appendChild(el('div', 'db-pick-team', a.take.school));
-        pickText.appendChild(el('div', 'db-pick-proj', fmt(a.take.total) + ' projected'));
+        var cap = a.captain || {};
+        pickText.appendChild(el('div', 'db-pick-proj',
+            cap.gain > 0
+                ? fmt(a.take.total) + ' projected  +  ' + fmt(cap.gain) + ' captain  =  ' + fmt(a.effective)
+                : fmt(a.take.total) + ' projected'));
         pick.appendChild(pickText);
         main.appendChild(pick);
 
@@ -125,6 +129,7 @@
             why.appendChild(el('p', 'db-caveat',
                 'Assumes every other manager takes the best team left, which this league does not — treat it as a floor, not a forecast.'));
         }
+        if (cap.enabled) why.appendChild(captainLine(cap, a));
         main.appendChild(why);
         wrap.appendChild(main);
 
@@ -134,6 +139,31 @@
         if (a.safeToWait.length) {
             wrap.appendChild(listRow('Should still be there — no need to reach', a.safeToWait, 'db-safe'));
         }
+    }
+
+    // What the captain is worth for THIS pick. Which of the three states shows is
+    // the useful part: an empty roster means this pick also picks your season
+    // captain; a settled anchor means per-week value can be ignored for the rest
+    // of the draft; in between, the upgrade gets priced.
+    function captainLine(cap) {
+        var p = el('p', 'db-captain');
+        if (cap.gain > 0) {
+            p.appendChild(document.createTextNode(
+                cap.anchorSchool ? 'Captain upgrade: ' : 'This also picks your season captain: '));
+            p.appendChild(el('strong', null, '+' + fmt(cap.gain) + ' points'));
+            p.appendChild(document.createTextNode(cap.anchorSchool
+                ? ' over ' + cap.anchorSchool + ', which you would captain otherwise.'
+                : ' on top of its board value \u2014 the captain doubles regular-season points every week.'));
+        } else if (cap.settled) {
+            p.appendChild(document.createTextNode('Captain settled \u2014 '));
+            p.appendChild(el('strong', null, cap.anchorSchool || 'your anchor'));
+            p.appendChild(document.createTextNode(' beats everything left on the board, so ignore Cap/wk for the rest of the draft.'));
+        } else {
+            p.appendChild(document.createTextNode('No captain upgrade here \u2014 '));
+            p.appendChild(el('strong', null, cap.anchorSchool || 'your anchor'));
+            p.appendChild(document.createTextNode(' still scores more per week.'));
+        }
+        return p;
     }
 
     function listRow(label, teams, cls) {
@@ -164,6 +194,8 @@
             return t.school.toLowerCase().indexOf(q) !== -1
                 || (t.conference || '').toLowerCase().indexOf(q) !== -1;
         });
+        // With the captain priced in the recommended team is not necessarily the
+        // top row — the board stays in market order and the highlight moves.
         var best = data.advice.take;
         // Bars are scaled to the best team STILL on the board, so the tier cliffs
         // stay legible as the top gets picked away.

--- a/public/draftBoard.js
+++ b/public/draftBoard.js
@@ -29,6 +29,32 @@
     }
     function fmt(n) { return n == null ? '—' : Number(n).toFixed(1); }
 
+    // Logos ride along on the projections; every other surface (chips, roster,
+    // pick log) looks them up by team id rather than carrying its own copy.
+    var logoById = {};
+    function indexLogos() {
+        logoById = {};
+        (data.projections || []).forEach(function (t) { if (t.logo) logoById[String(t.id)] = t.logo; });
+    }
+    // An <img> for a team, or nothing at all — a missing or broken logo must
+    // never leave a ghost box in a table row.
+    function logo(id, cls) {
+        var src = logoById[String(id)];
+        if (!src) return null;
+        var img = el('img', cls || 'db-logo');
+        img.src = src;
+        img.alt = '';
+        img.loading = 'lazy';
+        img.addEventListener('error', function () { img.remove(); });
+        return img;
+    }
+    function withLogo(cell, id, text) {
+        var img = logo(id);
+        if (img) cell.appendChild(img);
+        cell.appendChild(el('span', null, text));
+        return cell;
+    }
+
     // ---- data ---------------------------------------------------------------
 
     async function load(refresh) {
@@ -72,9 +98,13 @@
 
         var main = el('div', 'db-advice-main');
         var pick = el('div', 'db-pick');
-        pick.appendChild(el('div', 'db-pick-label', 'Take'));
-        pick.appendChild(el('div', 'db-pick-team', a.take.school));
-        pick.appendChild(el('div', 'db-pick-proj', fmt(a.take.total) + ' projected'));
+        var hero = logo(a.take.id, 'db-pick-logo');
+        if (hero) pick.appendChild(hero);
+        var pickText = el('div', 'db-pick-text');
+        pickText.appendChild(el('div', 'db-pick-label', 'Take'));
+        pickText.appendChild(el('div', 'db-pick-team', a.take.school));
+        pickText.appendChild(el('div', 'db-pick-proj', fmt(a.take.total) + ' projected'));
+        pick.appendChild(pickText);
         main.appendChild(pick);
 
         // The scarcity read: what waiting actually costs.
@@ -112,6 +142,8 @@
         var ul = el('div', 'db-chips');
         teams.forEach(function (t) {
             var c = el('span', 'db-chip');
+            var ci = logo(t.id, 'db-chip-logo');
+            if (ci) c.appendChild(ci);
             c.appendChild(el('span', 'db-chip-name', t.school));
             c.appendChild(el('span', 'db-chip-val', fmt(t.total)));
             ul.appendChild(c);
@@ -133,13 +165,21 @@
                 || (t.conference || '').toLowerCase().indexOf(q) !== -1;
         });
         var best = data.advice.take;
+        // Bars are scaled to the best team STILL on the board, so the tier cliffs
+        // stay legible as the top gets picked away.
+        var top = rows.length ? rows[0].total : 1;
         rows.slice(0, 120).forEach(function (t, i) {
             var tr = el('tr');
             if (best && t.id === best.id) tr.className = 'db-best';
             tr.appendChild(el('td', 'db-num db-rank', String(i + 1)));
-            tr.appendChild(el('td', 'db-team', t.school));
+            tr.appendChild(withLogo(el('td', 'db-team'), t.id, t.school));
             tr.appendChild(el('td', 'db-conf', t.conference || '—'));
-            tr.appendChild(el('td', 'db-num db-proj', fmt(t.total)));
+            var projCell = el('td', 'db-num db-proj');
+            var bar = el('span', 'db-bar');
+            bar.style.width = Math.max(2, Math.round((t.total / (top || 1)) * 100)) + '%';
+            projCell.appendChild(bar);
+            projCell.appendChild(el('span', 'db-proj-val', fmt(t.total)));
+            tr.appendChild(projCell);
             tr.appendChild(el('td', 'db-num', fmt(t.regular)));
             tr.appendChild(el('td', 'db-num', fmt(t.post)));
             tr.appendChild(el('td', 'db-num', t.perWeek == null ? '—' : t.perWeek.toFixed(2)));
@@ -160,7 +200,7 @@
             total += r.total || 0;
             var li = el('li');
             li.appendChild(el('span', 'db-r-round', 'R' + r.round));
-            li.appendChild(el('span', 'db-r-team', r.school));
+            li.appendChild(withLogo(el('span', 'db-r-team'), r.id, r.school));
             li.appendChild(el('span', 'db-r-val', fmt(r.total)));
             ol.appendChild(li);
         });
@@ -183,13 +223,14 @@
             var li = el('li');
             if (String(p.userId) === String(ME)) li.className = 'db-mine';
             li.appendChild(el('span', 'db-l-num', '#' + p.overall));
-            li.appendChild(el('span', 'db-l-team', p.school));
+            li.appendChild(withLogo(el('span', 'db-l-team'), p.teamId, p.school));
             ol.appendChild(li);
         });
     }
 
     function render() {
         if (!data) return;
+        indexLogos();
         $('[db-source]').textContent = 'Ranked bonuses: ' + data.rankedSource;
         renderAdvice();
         renderBoard();

--- a/public/draftBoard.js
+++ b/public/draftBoard.js
@@ -10,7 +10,11 @@
 (function () {
     var LEAGUE = window.LEAGUE_CODE;
     var SEASON = window.APP_YEAR;
-    var ME = (window.userState && (window.userState._id || window.userState.id)) || '';
+    // The app's user id lives in the Auth0 profile's nested metadata, NOT as an
+    // `_id` on userState — userState is the OIDC user, whose only identity keys
+    // are sub/email. Same accessor draftRoom.js uses (setUserContext).
+    var META = (window.userState && window.userState.user_metadata) || {};
+    var ME = (META.metadata && META.metadata.userId) || '';
 
     var data = null;          // last board payload
     var filter = '';

--- a/public/logo.js
+++ b/public/logo.js
@@ -22,6 +22,16 @@
         return isFinite(n) ? n : 0;
     }
 
+    // CFBD/ESPN hand these back as http:// URLs, with no https anywhere in the
+    // stored data. The app is served over https in production, where a browser
+    // blocks an http image as mixed content — so every logo silently vanishes.
+    // ESPN serves the identical path over https, so upgrade it here, in the one
+    // selector every surface already goes through. Protocol-relative and https
+    // URLs pass through untouched.
+    function secure(url) {
+        return String(url == null ? '' : url).replace(/^http:\/\//i, 'https://');
+    }
+
     // Best logo for a surface: the wanted variant (dark by default, for the dark
     // UI; opts.dark === false picks light, e.g. for emails / light pages) at the
     // highest resolution. Falls back to the full list when a team has only one
@@ -38,8 +48,8 @@
         // identify a genuinely better (dark, higher-res) logo.
         var best = pool.map(function (u, i) { return { u: u, i: i, s: logoSize(u) }; })
             .sort(function (a, b) { return (b.s - a.s) || (b.i - a.i); })[0];
-        return best.u;
+        return secure(best.u);
     }
 
-    return { pickLogo: pickLogo, logoSize: logoSize };
+    return { pickLogo: pickLogo, logoSize: logoSize, secure: secure };
 }));

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -13,6 +13,7 @@ const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../m
 const { computeGrades } = require('../modules/draft-grades');
 const { canManageLeague } = require('../modules/league-access');
 const { sanitizeCallUrl } = require('../modules/draft-call-link');
+const { pickLogo } = require('../public/logo.js');
 
 // Post-draft grades for a league + season — immediate preseason feedback. Each
 // roster is projected to EXPECTED FANTASY POINTS under that league's own scoring
@@ -149,6 +150,8 @@ function projectPool(teamsById, games, config, apPoll, season) {
         const s = (t.seasons || []).find(x => Number(x.season) === season) || {};
         return {
             id: t.id, school: t.school, conference: s.conference || null,
+            // Dark-variant logo at the best resolution — the page is dark-themed.
+            logo: pickLogo(t.logos) || null,
             total: Math.round(p.total * 10) / 10,
             regular: Math.round(p.regular * 10) / 10,
             post: Math.round((p.cfp + p.confChamp + p.bowl) * 10) / 10,

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -8,6 +8,8 @@ const Game = require('../models/game');
 const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
 const { resolveConfig, overridesFromDoc } = require('../modules/scoring-defaults');
+const draftBoard = require('../modules/draft-board');
+const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../modules/draft-projection');
 const { computeGrades } = require('../modules/draft-grades');
 const { canManageLeague } = require('../modules/league-access');
 const { sanitizeCallUrl } = require('../modules/draft-call-link');
@@ -55,6 +57,127 @@ router.get('/grades/:league/:season', async (req, res) => {
         res.status(500).json({ message: err.message });
     }
 });
+
+// Live draft board: every team's projected points for THIS league's scoring,
+// plus who's still on the board and what this manager's next pick is worth.
+//
+// Commissioner-gated (canManageLeague) — it's a draft-night advantage, not a
+// member feature, so it is not exposed to the league at large.
+//
+// The projections are the expensive half and never change during a draft (they
+// depend on the schedule and ratings, not on who has been picked), so they are
+// computed once per league+season and cached. The cheap half — available teams,
+// pick schedule, advice — is recomputed per request against the live draft, and
+// the client also recomputes it locally on each socket pick so the page reacts
+// without a round trip.
+const boardCache = new Map();     // `${league}:${season}` -> { projections, rankedSource }
+
+router.get('/board/:league/:season', async (req, res) => {
+    try {
+        const league = req.params.league;
+        const season = Number(req.params.season);
+        if (!canManageLeague(req, league)) {
+            return res.status(403).json({ message: 'Forbidden: not your league' });
+        }
+        const draft = await Draft.findOne({ league, season }).lean();
+        if (!draft) return res.status(404).json({ message: 'No draft configured' });
+
+        const key = `${league}:${season}`;
+        if (req.query.refresh === '1') boardCache.delete(key);
+        let cached = boardCache.get(key);
+        if (!cached) {
+            const teams = await Team.find({}, { id: 1, school: 1, alternateNames: 1, logos: 1, seasons: 1 }).lean();
+            const teamsById = {};
+            teams.forEach(t => { if (t.id != null) teamsById[String(t.id)] = t; });
+
+            const games = await Game.find({ season, seasonType: 'regular' },
+                { id: 1, season: 1, seasonType: 1, week: 1, neutralSite: 1, conferenceGame: 1,
+                  notes: 1, homeId: 1, homeTeam: 1, homeConference: 1,
+                  awayId: 1, awayTeam: 1, awayConference: 1 }).lean();
+
+            const cfgDoc = await ScoringConfig.findOne({ league }).lean();
+            const config = resolveConfig(league, overridesFromDoc(cfgDoc));
+
+            const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
+            const apPoll = apDoc && Array.isArray(apDoc.polls)
+                ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
+
+            cached = {
+                projections: projectPool(teamsById, games, config, apPoll, season),
+                rankedSource: apPollName(apDoc)
+            };
+            boardCache.set(key, cached);
+        }
+        const projections = cached.projections;
+
+        const userId = String(req.query.userId || (req.effUser && req.effUser._id) || '');
+        const schedule = draftBoard.pickSchedule(draft, userId);
+        const avail = draftBoard.available(projections, draft);
+        res.json({
+            league, season,
+            // Whether the ranked-win bonuses in these projections came from a real
+            // poll or an SP+ stand-in — the numbers move if a preseason AP poll
+            // lands mid-draft-prep, and the page says so rather than pretending.
+            rankedSource: cached.rankedSource,
+            projections, draft: publicDraft(draft), schedule,
+            advice: draftBoard.advise(avail, schedule),
+            roster: draftBoard.rosterFor(draft, userId, projections)
+        });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// Project every FBS team in the pool through this league's real scoring engine.
+function projectPool(teamsById, games, config, apPoll, season) {
+    const rankings = buildRankingProxy(season, teamsById, apPoll);
+    const poolCtx = buildPoolContext(teamsById, season);
+    const byTeam = {};
+    games.forEach(g => {
+        const h = String(g.homeId), a = String(g.awayId);
+        if (teamsById[h]) (byTeam[h] = byTeam[h] || []).push(g);
+        if (teamsById[a]) (byTeam[a] = byTeam[a] || []).push(g);
+    });
+    return Object.keys(teamsById).map(id => {
+        const t = teamsById[id];
+        const g = byTeam[id] || [];
+        if (!g.length) return null;
+        const p = projectTeamPoints(t, g, poolCtx, rankings, config, season);
+        const s = (t.seasons || []).find(x => Number(x.season) === season) || {};
+        return {
+            id: t.id, school: t.school, conference: s.conference || null,
+            total: Math.round(p.total * 10) / 10,
+            regular: Math.round(p.regular * 10) / 10,
+            post: Math.round((p.cfp + p.confChamp + p.bowl) * 10) / 10,
+            // Captain value: this league doubles one team a week, so the points
+            // a team is expected to bank in a single week is its own metric.
+            perWeek: g.length ? Math.round((p.regular / g.length) * 100) / 100 : 0,
+            wins: Math.round(p.projWins * 10) / 10,
+            expectedWins: s.expectedWins != null ? s.expectedWins : null,
+            sp: s.spRating != null ? s.spRating : null
+        };
+    }).filter(Boolean).sort((a, b) => b.total - a.total);
+}
+
+function apPollName(doc) {
+    const polls = (doc && doc.polls) || [];
+    if (polls.some(p => p.poll === 'AP Top 25')) return 'AP Top 25';
+    if (polls.length) return `SP+ stand-in (stored poll is "${polls.map(p => p.poll).join('", "')}")`;
+    return 'SP+ stand-in (no poll stored)';
+}
+
+// Only the draft fields the board needs — picks, order, and where we are.
+function publicDraft(d) {
+    return {
+        status: d.status, snake: d.snake, totalRounds: d.totalRounds,
+        currentOverall: d.currentOverall,
+        draftOrder: (d.draftOrder || []).map(String),
+        picks: (d.picks || []).map(p => ({
+            overall: p.overall, round: p.round, userId: String(p.userId),
+            teamId: p.team && p.team.id, school: (p.team && p.team.school) || '?'
+        }))
+    };
+}
 
 // Get the draft for a league + season (returns null if none configured yet).
 router.get('/:league/:season', async (req, res) => {

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -7,7 +7,7 @@ const Team = require('../models/team');
 const Game = require('../models/game');
 const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
-const { resolveConfig, overridesFromDoc } = require('../modules/scoring-defaults');
+const { resolveConfig, overridesFromDoc, engagementForSeason } = require('../modules/scoring-defaults');
 const draftBoard = require('../modules/draft-board');
 const { buildRankingProxy, buildPoolContext, projectTeamPoints } = require('../modules/draft-projection');
 const { computeGrades } = require('../modules/draft-grades');
@@ -117,15 +117,32 @@ router.get('/board/:league/:season', async (req, res) => {
         const userId = String(req.query.userId || (meta.metadata && meta.metadata.userId) || '');
         const schedule = draftBoard.pickSchedule(draft, userId);
         const avail = draftBoard.available(projections, draft);
+        const roster = draftBoard.rosterFor(draft, userId, projections);
+
+        // Captain settings are PER SEASON, so a league running the mode in 2026
+        // and not in 2027 prices picks differently in each. Off => the advice is
+        // pure board value, which is what Claunts gets.
+        const cfgDocForSeason = await ScoringConfig.findOne({ league }).lean();
+        const eng = engagementForSeason(cfgDocForSeason && cfgDocForSeason.engagementBySeason, season);
+        const anchorRegular = draftBoard.captainAnchor(roster);
+        const anchor = roster.reduce((b, r) =>
+            (r.regular != null && (!b || r.regular > b.regular)) ? r : b, null);
+        const captain = {
+            enabled: !!eng.captainEnabled,
+            multiplier: eng.captainMultiplier,
+            anchorRegular,
+            anchorSchool: anchor ? anchor.school : null
+        };
+
         res.json({
             league, season,
             // Whether the ranked-win bonuses in these projections came from a real
             // poll or an SP+ stand-in — the numbers move if a preseason AP poll
             // lands mid-draft-prep, and the page says so rather than pretending.
             rankedSource: cached.rankedSource,
-            projections, draft: publicDraft(draft), schedule,
-            advice: draftBoard.advise(avail, schedule),
-            roster: draftBoard.rosterFor(draft, userId, projections)
+            projections, draft: publicDraft(draft), schedule, captain,
+            advice: draftBoard.advise(avail, schedule, { captain }),
+            roster
         });
     } catch (err) {
         res.status(500).json({ message: err.message });

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -110,7 +110,10 @@ router.get('/board/:league/:season', async (req, res) => {
         }
         const projections = cached.projections;
 
-        const userId = String(req.query.userId || (req.effUser && req.effUser._id) || '');
+        // req.effUser is the OIDC profile, so the app user id is in its nested
+        // metadata (see buildUserContext in server.js) — never a top-level _id.
+        const meta = (req.effUser && req.effUser.user_metadata) || {};
+        const userId = String(req.query.userId || (meta.metadata && meta.metadata.userId) || '');
         const schedule = draftBoard.pickSchedule(draft, userId);
         const avail = draftBoard.available(projections, draft);
         res.json({

--- a/server.js
+++ b/server.js
@@ -503,6 +503,19 @@ app.get('/draft-room', (req, res) => {
     }
 });
 
+// Live draft board — commissioner-only draft-night assistant. Deliberately not
+// linked from the navbar: it is a private tool, not a member feature.
+app.get('/draft-board', (req, res) => {
+    if (!req.oidc.isAuthenticated()) return res.redirect('/login');
+    const roles = devRole.effectiveRoles(req);
+    if (!roles.includes('Admin') && !roles.includes('League Manager')) return res.redirect('/');
+    const user = buildUserContext(req.effUser);
+    res.render('draftBoard', {
+        user, userState: safeJson(req.effUser),
+        year: process.env.YEAR, leagueCode: leagueCodeFor(req.effUser)
+    });
+});
+
 app.get('/admin', (req, res) => {
     if (req.oidc.isAuthenticated()) {
         const user = buildUserContext(req.effUser);

--- a/tests/DraftBoard.spec.js
+++ b/tests/DraftBoard.spec.js
@@ -1,0 +1,141 @@
+// Pure logic for the live draft board (modules/draft-board.js).
+//
+// The scarcity math is the whole point of the page, so it gets the attention:
+// a 6-team snake gives the 2nd seat a 9-pick wait after round 1 and a 3-pick
+// wait after round 2, and the advice has to change shape accordingly.
+
+const board = require('../modules/draft-board');
+
+const ORDER = ['u1', 'u2', 'u3', 'u4', 'u5', 'u6'];
+const ME = 'u2';
+
+function draft(overrides = {}) {
+    return Object.assign({
+        league: 'graham-league', season: 2026,
+        draftOrder: ORDER, snake: true, totalRounds: 10,
+        currentOverall: 1, picks: []
+    }, overrides);
+}
+
+// 20 teams, descending value: T1 = 40, T2 = 39, ...
+const POOL = Array.from({ length: 20 }, (_, i) => ({ id: i + 1, school: `T${i + 1}`, total: 40 - i }));
+
+function pickedThrough(overall) {
+    // Every pick up to `overall` takes the best team left, in snake order.
+    const picks = [];
+    const engine = require('../modules/draft-engine');
+    const order = engine.pickOrder(draft());
+    for (let o = 1; o <= overall; o++) {
+        const slot = order[o - 1];
+        picks.push({ overall: o, round: slot.round, userId: slot.userId, team: POOL[o - 1] });
+    }
+    return picks;
+}
+
+describe('pick schedule', () => {
+    it('knows the 2nd seat picks 2, 11, 14, 23 …', () => {
+        expect(board.picksFor(draft(), ME).map(p => p.overall))
+            .toEqual([2, 11, 14, 23, 26, 35, 38, 47, 50, 59]);
+    });
+
+    it('reports the wait between this turn and the next', () => {
+        const s = board.pickSchedule(draft(), ME);
+        expect(s.next.overall).toBe(2);
+        expect(s.after.overall).toBe(11);
+        expect(s.gap).toBe(8);          // picks 3-10 belong to other managers
+    });
+
+    it('the round 2 -> 3 turn is a much shorter wait', () => {
+        const s = board.pickSchedule(draft({ currentOverall: 11 }), ME);
+        expect(s.next.overall).toBe(11);
+        expect(s.after.overall).toBe(14);
+        expect(s.gap).toBe(2);          // the snake turn: only 2 picks in between
+        expect(s.onTheClock).toBe(true);
+    });
+
+    it('has no gap left on the final pick', () => {
+        const s = board.pickSchedule(draft({ currentOverall: 59 }), ME);
+        expect(s.next.overall).toBe(59);
+        expect(s.after).toBeNull();
+        expect(s.gap).toBeNull();
+    });
+
+    it('is empty once the manager is done picking', () => {
+        expect(board.pickSchedule(draft({ currentOverall: 60 }), ME).next).toBeNull();
+    });
+});
+
+describe('available board', () => {
+    it('drops drafted teams and keeps the rest best-first', () => {
+        const avail = board.available(POOL, draft({ picks: pickedThrough(3) }));
+        expect(avail).toHaveLength(17);
+        expect(avail[0].school).toBe('T4');
+        expect(avail.map(t => t.total)).toEqual([...avail.map(t => t.total)].sort((a, b) => b - a));
+    });
+
+    it('is unaffected by a pick whose team lacks an id', () => {
+        const d = draft({ picks: [{ overall: 1, round: 1, userId: 'u1', team: {} }] });
+        expect(board.available(POOL, d)).toHaveLength(20);
+    });
+});
+
+describe('advice', () => {
+    it('prices what a long wait costs', () => {
+        const d = draft({ currentOverall: 2, picks: pickedThrough(1) });
+        const a = board.advise(board.available(POOL, d), board.pickSchedule(d, ME));
+        expect(a.take.school).toBe('T2');            // best left
+        // 8 picks in between, so T10 is the best expected to survive: 39 - 31 = 8
+        expect(a.survivorRank).toBe(8);
+        expect(a.cost).toBe(8);
+        expect(a.atRisk.map(t => t.school)).toEqual(['T2', 'T3', 'T4', 'T5', 'T6', 'T7']);
+        expect(a.safeToWait[0].school).toBe('T10');
+    });
+
+    it('prices a short wait as costing much less', () => {
+        const d = draft({ currentOverall: 11, picks: pickedThrough(10) });
+        const a = board.advise(board.available(POOL, d), board.pickSchedule(d, ME));
+        expect(a.take.school).toBe('T11');
+        expect(a.survivorRank).toBe(2);
+        expect(a.cost).toBe(2);                      // 30 - 28
+        expect(a.atRisk.map(t => t.school)).toEqual(['T11', 'T12']);
+    });
+
+    it('gives no scarcity read on the final pick', () => {
+        // Only 10 taken so the board isn't empty — it's the absent NEXT turn,
+        // not an exhausted pool, that has to switch the scarcity read off.
+        const d = draft({ currentOverall: 59, picks: pickedThrough(10) });
+        const a = board.advise(board.available(POOL, d), board.pickSchedule(d, ME));
+        expect(a.take).not.toBeNull();
+        expect(a.cost).toBeNull();
+        expect(a.atRisk).toEqual([]);
+    });
+
+    it('does not run off the end of a board shorter than the wait', () => {
+        const thin = POOL.slice(0, 3);
+        const d = draft({ currentOverall: 2, picks: [] });
+        const a = board.advise(board.available(thin, d), board.pickSchedule(d, ME));
+        expect(a.survivorRank).toBe(2);              // clamped to the last team
+        expect(a.safeToWait).toEqual([]);
+        expect(a.cost).toBe(2);
+    });
+
+    it('handles an empty board', () => {
+        const a = board.advise([], board.pickSchedule(draft(), ME));
+        expect(a.take).toBeNull();
+        expect(a.cost).toBeNull();
+    });
+});
+
+describe('roster', () => {
+    it('lists this manager only, in pick order, with projections attached', () => {
+        const d = draft({ currentOverall: 15, picks: pickedThrough(14) });
+        const mine = board.rosterFor(d, ME, POOL);
+        expect(mine.map(p => p.overall)).toEqual([2, 11, 14]);
+        expect(mine[0]).toMatchObject({ school: 'T2', total: 39, round: 1 });
+    });
+
+    it('survives a team that is not in the projection pool', () => {
+        const d = draft({ picks: [{ overall: 2, round: 1, userId: ME, team: { id: 999, school: 'Ghost' } }] });
+        expect(board.rosterFor(d, ME, POOL)).toEqual([{ overall: 2, round: 1, id: 999, school: 'Ghost', total: null }]);
+    });
+});

--- a/tests/DraftBoard.spec.js
+++ b/tests/DraftBoard.spec.js
@@ -110,13 +110,18 @@ describe('advice', () => {
         expect(a.atRisk).toEqual([]);
     });
 
-    it('does not run off the end of a board shorter than the wait', () => {
+    // An 8-pick wait against a 3-team board means nothing survives. Clamping the
+    // survivor to the last team (as this used to) priced the wait at 2 points
+    // while simultaneously listing nothing as safe — two answers to one question.
+    it('reports an exhausted board instead of pricing a survivor that will not exist', () => {
         const thin = POOL.slice(0, 3);
         const d = draft({ currentOverall: 2, picks: [] });
         const a = board.advise(board.available(thin, d), board.pickSchedule(d, ME));
-        expect(a.survivorRank).toBe(2);              // clamped to the last team
+        expect(a.exhausted).toBe(true);
+        expect(a.survivorRank).toBeNull();
         expect(a.safeToWait).toEqual([]);
-        expect(a.cost).toBe(2);
+        expect(a.cost).toBeNull();                   // waiting costs the pick, not 2 points
+        expect(a.take.school).toBe('T1');            // still says what to take
     });
 
     it('handles an empty board', () => {
@@ -136,6 +141,83 @@ describe('roster', () => {
 
     it('survives a team that is not in the projection pool', () => {
         const d = draft({ picks: [{ overall: 2, round: 1, userId: ME, team: { id: 999, school: 'Ghost' } }] });
-        expect(board.rosterFor(d, ME, POOL)).toEqual([{ overall: 2, round: 1, id: 999, school: 'Ghost', total: null }]);
+        expect(board.rosterFor(d, ME, POOL))
+            .toEqual([{ overall: 2, round: 1, id: 999, school: 'Ghost', total: null, regular: null }]);
+    });
+});
+
+// The weekly Captain doubles ONE rostered team's score, regular season only. So
+// a roster's captain value is its best REGULAR projection, and a candidate is
+// worth extra only if it raises that. The consequence worth testing: the
+// multiplier never touches postseason points, so two teams level on total value
+// are not level once the captain is priced in.
+describe('captain-aware advice', () => {
+    // Same total, very different split. OSU earns in the playoff, TEX in the
+    // regular season — only TEX's half gets doubled.
+    const OSU = { id: 90, school: 'Buckeyes', total: 34.4, regular: 21.9 };
+    const TEX = { id: 91, school: 'Horns',    total: 34.3, regular: 24.0 };
+    const MID = { id: 92, school: 'Middling', total: 25.0, regular: 18.0 };
+    const POOL2 = [OSU, TEX, MID];
+    const on = (anchorRegular, anchorSchool) =>
+        ({ enabled: true, multiplier: 2, anchorRegular, anchorSchool });
+
+    it('prices a first pick as also choosing the season captain', () => {
+        const d = draft({ currentOverall: 2 });
+        const a = board.advise(POOL2, board.pickSchedule(d, ME), { captain: on(0, null) });
+        // Board order puts OSU first; effective value flips it to TEX.
+        expect(POOL2[0].school).toBe('Buckeyes');
+        expect(a.take.school).toBe('Horns');
+        expect(a.captain.gain).toBe(24);
+        expect(a.effective).toBe(58.3);
+    });
+
+    it('leaves the ranking alone when the captain is off', () => {
+        const d = draft({ currentOverall: 2 });
+        const a = board.advise(POOL2, board.pickSchedule(d, ME), { captain: { enabled: false } });
+        expect(a.take.school).toBe('Buckeyes');       // straight board value
+        expect(a.captain.enabled).toBe(false);
+    });
+
+    it('adds nothing once a better anchor is already rostered', () => {
+        const d = draft({ currentOverall: 11 });
+        const a = board.advise(POOL2, board.pickSchedule(d, ME), { captain: on(24.0, 'Horns') });
+        expect(a.captain.gain).toBe(0);
+        expect(a.take.school).toBe('Buckeyes');       // back to pure board value
+        expect(a.effective).toBe(34.4);
+    });
+
+    it('reports the captain slot settled when nothing left can beat the anchor', () => {
+        const d = draft({ currentOverall: 11 });
+        const a = board.advise(POOL2, board.pickSchedule(d, ME), { captain: on(24.0, 'Horns') });
+        expect(a.captain.settled).toBe(true);
+        expect(a.captain.anchorSchool).toBe('Horns');
+    });
+
+    it('is not settled while an upgrade is still on the board', () => {
+        const d = draft({ currentOverall: 11 });
+        const a = board.advise(POOL2, board.pickSchedule(d, ME), { captain: on(20.0, 'Middling') });
+        expect(a.captain.settled).toBe(false);
+        expect(a.captain.gain).toBe(4);               // 24.0 - 20.0, at 2x
+    });
+
+    it('honours a multiplier other than 2', () => {
+        expect(board.captainGain({ regular: 24 }, 20, 3)).toBe(8);   // (24-20) x 2
+        expect(board.captainGain({ regular: 24 }, 20, 2)).toBe(4);
+        expect(board.captainGain({ regular: 18 }, 20, 2)).toBe(0);   // never negative
+    });
+
+    it('reads the anchor off the roster, ignoring teams with no projection', () => {
+        expect(board.captainAnchor([{ regular: 18 }, { regular: 24 }, { regular: null }])).toBe(24);
+        expect(board.captainAnchor([])).toBe(0);
+    });
+
+    it('prices the cost of waiting on effective value, not board value', () => {
+        // Gap of 8 with a 3-team board clamps the survivor to the last team.
+        const d = draft({ currentOverall: 2 });
+        const a = board.advise(POOL2, board.pickSchedule(d, ME), { captain: on(0, null) });
+        // 8-pick wait, 3-team board: nothing survives, so there is no cost to
+        // quote — the point is that waiting forfeits the pick entirely.
+        expect(a.exhausted).toBe(true);
+        expect(a.cost).toBeNull();
     });
 });

--- a/tests/DraftBoardPage.spec.js
+++ b/tests/DraftBoardPage.spec.js
@@ -26,7 +26,15 @@ const FIXTURE = `
 <ol db-roster></ol>
 <ol db-log></ol>`;
 
-const ME = 'me-id';
+// The real shape of window.userState: the OIDC profile. The app's user id is in
+// nested metadata — there is no _id here, which is exactly what the page got
+// wrong first time (it read userState._id, got undefined, and told the
+// commissioner their draft was complete before it had started).
+const ME = '64f539d45cf0433f3b6a6a1e';
+const USER_STATE = {
+    sub: 'auth0|65c83b61e1ecca451f9f657b', email: 'g@example.com', name: 'Garrett',
+    user_metadata: { roles: ['Admin'], metadata: { league: 'gg', userId: ME } }
+};
 function payload(over) {
     return Object.assign({
         league: 'graham-league', season: 2026,
@@ -53,7 +61,7 @@ function loadPage(body) {
     document.body.innerHTML = FIXTURE;
     window.LEAGUE_CODE = 'graham-league';
     window.APP_YEAR = '2026';
-    window.userState = { _id: ME };
+    window.userState = USER_STATE;
     global.io = () => ({ on: () => {}, emit: () => {}, io: { on: () => {} } });
     global.fetch = jest.fn((url) => {
         if (String(url).indexOf('/draft-token') !== -1) {
@@ -104,6 +112,31 @@ describe('the recommendation', () => {
     it('reports a finished draft rather than rendering an empty pick', async () => {
         await loadPage(payload({ schedule: { next: null, after: null, onTheClock: false, gap: null } }));
         expect(txt('[db-advice]')).toContain('draft is complete');
+    });
+});
+
+describe('identity', () => {
+    it('sends the app user id from nested metadata, not a top-level _id', async () => {
+        await loadPage(payload());
+        const urls = global.fetch.mock.calls.map(c => String(c[0]));
+        const boardCall = urls.find(u => u.indexOf('/draft/board/') !== -1);
+        expect(boardCall).toContain('userId=' + ME);
+    });
+
+    it('sends an empty id rather than "undefined" when metadata is missing', async () => {
+        document.body.innerHTML = FIXTURE;
+        window.LEAGUE_CODE = 'graham-league'; window.APP_YEAR = '2026';
+        window.userState = { sub: 'auth0|x', email: 'g@example.com' };   // no metadata at all
+        global.io = () => ({ on: () => {}, emit: () => {}, io: { on: () => {} } });
+        global.fetch = jest.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(payload()) }));
+        jest.isolateModules(() => {
+            (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'draftBoard.js'), 'utf8'));
+        });
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+        await new Promise(r => setTimeout(r, 0));
+        const boardCall = global.fetch.mock.calls.map(c => String(c[0])).find(u => u.indexOf('/draft/board/') !== -1);
+        expect(boardCall).toContain('userId=');
+        expect(boardCall).not.toContain('undefined');
     });
 });
 
@@ -174,7 +207,7 @@ describe('roster, log and provenance', () => {
 
     it('surfaces a failed load instead of rendering a blank page', async () => {
         document.body.innerHTML = FIXTURE;
-        window.LEAGUE_CODE = 'graham-league'; window.APP_YEAR = '2026'; window.userState = { _id: ME };
+        window.LEAGUE_CODE = 'graham-league'; window.APP_YEAR = '2026'; window.userState = USER_STATE;
         global.io = () => ({ on: () => {}, emit: () => {}, io: { on: () => {} } });
         global.fetch = jest.fn(() => Promise.resolve({
             ok: false, status: 403, json: () => Promise.resolve({ message: 'Forbidden: not your league' })

--- a/tests/DraftBoardPage.spec.js
+++ b/tests/DraftBoardPage.spec.js
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Browser-side tests for public/draftBoard.js — the live draft board page.
+ *
+ * The page's whole job is to turn one payload into a fast read at the table, so
+ * these assert what it actually renders: the recommendation, the scarcity
+ * sentence, and that drafted teams leave the board. The DOM fixture mirrors the
+ * hooks in views/draftBoard.ejs; if that view loses one, these fail loudly
+ * rather than the page quietly rendering nothing on draft night.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FIXTURE = `
+<div class="db-strip">
+    <span class="db-live" db-live><span class="db-dot"></span><span db-live-text>connecting…</span></span>
+    <span class="db-meta" db-source></span>
+    <button type="button" db-refresh>Recompute</button>
+</div>
+<section db-advice></section>
+<input db-search type="search">
+<span db-count></span>
+<table><tbody db-board></tbody></table>
+<ol db-roster></ol>
+<ol db-log></ol>`;
+
+const ME = 'me-id';
+function payload(over) {
+    return Object.assign({
+        league: 'graham-league', season: 2026,
+        rankedSource: 'SP+ stand-in (stored poll is "Coaches Poll")',
+        projections: [
+            { id: 1, school: 'Ohio State', conference: 'Big Ten', total: 34.4, regular: 21.9, post: 12.5, perWeek: 1.83 },
+            { id: 2, school: 'Texas', conference: 'SEC', total: 34.3, regular: 24.0, post: 10.3, perWeek: 2.0 },
+            { id: 3, school: 'Oregon', conference: 'Big Ten', total: 32.8, regular: 21.5, post: 11.3, perWeek: 1.79 },
+            { id: 4, school: 'LSU', conference: 'SEC', total: 25.6, regular: 18.8, post: 6.8, perWeek: 1.57 },
+            { id: 5, school: 'Notre Dame', conference: 'FBS Independents', total: 24.8, regular: 14.0, post: 10.7, perWeek: 1.17 }
+        ],
+        draft: { status: 'active', currentOverall: 2, snake: true, totalRounds: 10, draftOrder: [], picks: [] },
+        schedule: { next: { overall: 2, round: 1 }, after: { overall: 11, round: 2 }, onTheClock: false, gap: 8 },
+        advice: {
+            take: { id: 1, school: 'Ohio State', total: 34.4 }, cost: 8.8, survivorRank: 3,
+            atRisk: [{ id: 1, school: 'Ohio State', total: 34.4 }, { id: 2, school: 'Texas', total: 34.3 }],
+            safeToWait: [{ id: 4, school: 'LSU', total: 25.6 }, { id: 5, school: 'Notre Dame', total: 24.8 }]
+        },
+        roster: []
+    }, over || {});
+}
+
+function loadPage(body) {
+    document.body.innerHTML = FIXTURE;
+    window.LEAGUE_CODE = 'graham-league';
+    window.APP_YEAR = '2026';
+    window.userState = { _id: ME };
+    global.io = () => ({ on: () => {}, emit: () => {}, io: { on: () => {} } });
+    global.fetch = jest.fn((url) => {
+        if (String(url).indexOf('/draft-token') !== -1) {
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ token: 't' }) });
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+    });
+    jest.isolateModules(() => {
+        const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'draftBoard.js'), 'utf8');
+        (0, eval)(src);
+    });
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    return new Promise(r => setTimeout(r, 0));   // let the initial load() settle
+}
+
+const txt = (sel) => (document.querySelector(sel) || {}).textContent || '';
+
+describe('the recommendation', () => {
+    it('names the team to take and prices the wait', async () => {
+        await loadPage(payload());
+        const advice = txt('[db-advice]');
+        expect(advice).toContain('Ohio State');
+        expect(advice).toContain('34.4 projected');
+        expect(advice).toContain('8 picks before your next turn (#11)');
+        expect(advice).toContain('8.8 points');
+        expect(advice).toContain('LSU');                     // best expected to survive
+    });
+
+    it('is honest that the scarcity read is a floor, not a forecast', async () => {
+        await loadPage(payload());
+        expect(txt('[db-advice]')).toContain('treat it as a floor, not a forecast');
+    });
+
+    it('says so plainly when the manager is on the clock', async () => {
+        await loadPage(payload({ schedule: { next: { overall: 2, round: 1 }, after: null, onTheClock: true, gap: null } }));
+        expect(txt('[db-advice]')).toContain('You are on the clock');
+    });
+
+    // `cost` and `after` sit on different halves of the payload. The server keeps
+    // them consistent, but the page must not crash if they ever disagree — this
+    // is the combination that used to throw and blank the whole panel.
+    it('does not blow up on a last pick that still carries a cost', async () => {
+        await loadPage(payload({ schedule: { next: { overall: 59, round: 10 }, after: null, onTheClock: true, gap: null } }));
+        expect(txt('[db-advice]')).toContain('Ohio State');
+        expect(txt('[db-advice]')).toContain('nothing to weigh against it');
+    });
+
+    it('reports a finished draft rather than rendering an empty pick', async () => {
+        await loadPage(payload({ schedule: { next: null, after: null, onTheClock: false, gap: null } }));
+        expect(txt('[db-advice]')).toContain('draft is complete');
+    });
+});
+
+describe('the board', () => {
+    it('lists available teams best-first and flags the recommendation', async () => {
+        await loadPage(payload());
+        const rows = [...document.querySelectorAll('[db-board] tr')];
+        expect(rows).toHaveLength(5);
+        expect(rows[0].querySelector('.db-team').textContent).toBe('Ohio State');
+        expect(rows[0].classList.contains('db-best')).toBe(true);
+        expect(txt('[db-count]')).toBe('5 available');
+    });
+
+    it('drops teams that have been drafted', async () => {
+        await loadPage(payload({
+            draft: { status: 'active', currentOverall: 3, snake: true, totalRounds: 10, draftOrder: [],
+                picks: [{ overall: 1, round: 1, userId: 'other', teamId: 1, school: 'Ohio State' }] }
+        }));
+        const names = [...document.querySelectorAll('[db-board] .db-team')].map(e => e.textContent);
+        expect(names).not.toContain('Ohio State');
+        expect(names[0]).toBe('Texas');
+        expect(txt('[db-count]')).toBe('4 available');
+    });
+
+    it('filters on team and conference', async () => {
+        await loadPage(payload());
+        const search = document.querySelector('[db-search]');
+        search.value = 'sec';
+        search.dispatchEvent(new Event('input'));
+        expect([...document.querySelectorAll('[db-board] .db-team')].map(e => e.textContent))
+            .toEqual(['Texas', 'LSU']);
+    });
+});
+
+describe('roster, log and provenance', () => {
+    it('totals the roster it has built so far', async () => {
+        await loadPage(payload({
+            roster: [
+                { overall: 2, round: 1, id: 1, school: 'Ohio State', total: 34.4 },
+                { overall: 11, round: 2, id: 4, school: 'LSU', total: 25.6 }
+            ]
+        }));
+        const r = txt('[db-roster]');
+        expect(r).toContain('Ohio State');
+        expect(r).toContain('Projected total');
+        expect(r).toContain('60.0');
+    });
+
+    it('marks your own picks in the log', async () => {
+        await loadPage(payload({
+            draft: { status: 'active', currentOverall: 3, snake: true, totalRounds: 10, draftOrder: [],
+                picks: [
+                    { overall: 1, round: 1, userId: 'other', teamId: 3, school: 'Oregon' },
+                    { overall: 2, round: 1, userId: ME, teamId: 1, school: 'Ohio State' }
+                ] }
+        }));
+        const mine = document.querySelectorAll('[db-log] .db-mine');
+        expect(mine).toHaveLength(1);
+        expect(mine[0].textContent).toContain('Ohio State');
+        // Newest first.
+        expect(document.querySelector('[db-log] li').textContent).toContain('#2');
+    });
+
+    it('says out loud when the ranked bonuses came from a stand-in poll', async () => {
+        await loadPage(payload());
+        expect(txt('[db-source]')).toContain('SP+ stand-in');
+    });
+
+    it('surfaces a failed load instead of rendering a blank page', async () => {
+        document.body.innerHTML = FIXTURE;
+        window.LEAGUE_CODE = 'graham-league'; window.APP_YEAR = '2026'; window.userState = { _id: ME };
+        global.io = () => ({ on: () => {}, emit: () => {}, io: { on: () => {} } });
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: false, status: 403, json: () => Promise.resolve({ message: 'Forbidden: not your league' })
+        }));
+        jest.isolateModules(() => {
+            (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'draftBoard.js'), 'utf8'));
+        });
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+        await new Promise(r => setTimeout(r, 0));
+        expect(txt('[db-advice]')).toContain('Forbidden');
+    });
+});

--- a/tests/DraftBoardPage.spec.js
+++ b/tests/DraftBoardPage.spec.js
@@ -40,11 +40,11 @@ function payload(over) {
         league: 'graham-league', season: 2026,
         rankedSource: 'SP+ stand-in (stored poll is "Coaches Poll")',
         projections: [
-            { id: 1, school: 'Ohio State', conference: 'Big Ten', total: 34.4, regular: 21.9, post: 12.5, perWeek: 1.83 },
-            { id: 2, school: 'Texas', conference: 'SEC', total: 34.3, regular: 24.0, post: 10.3, perWeek: 2.0 },
+            { id: 1, school: 'Ohio State', conference: 'Big Ten', total: 34.4, regular: 21.9, post: 12.5, perWeek: 1.83, logo: 'https://x/osu-dark.png' },
+            { id: 2, school: 'Texas', conference: 'SEC', total: 34.3, regular: 24.0, post: 10.3, perWeek: 2.0, logo: 'https://x/tex-dark.png' },
             { id: 3, school: 'Oregon', conference: 'Big Ten', total: 32.8, regular: 21.5, post: 11.3, perWeek: 1.79 },
-            { id: 4, school: 'LSU', conference: 'SEC', total: 25.6, regular: 18.8, post: 6.8, perWeek: 1.57 },
-            { id: 5, school: 'Notre Dame', conference: 'FBS Independents', total: 24.8, regular: 14.0, post: 10.7, perWeek: 1.17 }
+            { id: 4, school: 'LSU', conference: 'SEC', total: 25.6, regular: 18.8, post: 6.8, perWeek: 1.57, logo: 'https://x/lsu-dark.png' },
+            { id: 5, school: 'Notre Dame', conference: 'FBS Independents', total: 24.8, regular: 14.0, post: 10.7, perWeek: 1.17, logo: null }
         ],
         draft: { status: 'active', currentOverall: 2, snake: true, totalRounds: 10, draftOrder: [], picks: [] },
         schedule: { next: { overall: 2, round: 1 }, after: { overall: 11, round: 2 }, onTheClock: false, gap: 8 },
@@ -168,6 +168,68 @@ describe('the board', () => {
         search.dispatchEvent(new Event('input'));
         expect([...document.querySelectorAll('[db-board] .db-team')].map(e => e.textContent))
             .toEqual(['Texas', 'LSU']);
+    });
+});
+
+describe('logos', () => {
+    it('shows the recommended team\'s logo big, and its name still reads plainly', async () => {
+        await loadPage(payload());
+        const hero = document.querySelector('.db-pick-logo');
+        expect(hero.src).toBe('https://x/osu-dark.png');
+        expect(hero.alt).toBe('');                                   // decorative; the name is right there
+        expect(document.querySelector('.db-pick-team').textContent).toBe('Ohio State');
+    });
+
+    it('puts a logo in every board row that has one', async () => {
+        await loadPage(payload());
+        const first = document.querySelector('[db-board] .db-team');
+        expect(first.querySelector('img').src).toBe('https://x/osu-dark.png');
+        expect(first.textContent).toBe('Ohio State');                // text unaffected by the img
+    });
+
+    it('renders no img at all for a team without a logo', async () => {
+        await loadPage(payload());
+        const nd = [...document.querySelectorAll('[db-board] .db-team')].find(e => e.textContent === 'Notre Dame');
+        expect(nd).toBeTruthy();
+        expect(nd.querySelector('img')).toBeNull();                  // no ghost box
+    });
+
+    it('drops a logo that fails to load rather than leaving a broken image', async () => {
+        await loadPage(payload());
+        const img = document.querySelector('[db-board] .db-team img');
+        const row = img.parentElement;
+        img.dispatchEvent(new Event('error'));
+        expect(row.querySelector('img')).toBeNull();
+        expect(row.textContent).toBe('Ohio State');
+    });
+
+    it('carries logos into the chips and the pick log', async () => {
+        await loadPage(payload({
+            draft: { status: 'active', currentOverall: 3, snake: true, totalRounds: 10, draftOrder: [],
+                picks: [{ overall: 1, round: 1, userId: 'other', teamId: 2, school: 'Texas' }] }
+        }));
+        expect(document.querySelector('.db-chip-logo')).not.toBeNull();
+        expect(document.querySelector('[db-log] .db-l-team img').src).toBe('https://x/tex-dark.png');
+    });
+});
+
+describe('the value bar', () => {
+    it('scales every bar against the best team still on the board', async () => {
+        await loadPage(payload());
+        const bars = [...document.querySelectorAll('[db-board] .db-bar')];
+        expect(bars).toHaveLength(5);
+        expect(bars[0].style.width).toBe('100%');                    // Ohio State, the top
+        expect(parseInt(bars[4].style.width, 10)).toBe(Math.round(24.8 / 34.4 * 100));
+    });
+
+    it('rescales once the top team is drafted', async () => {
+        await loadPage(payload({
+            draft: { status: 'active', currentOverall: 3, snake: true, totalRounds: 10, draftOrder: [],
+                picks: [{ overall: 1, round: 1, userId: 'other', teamId: 1, school: 'Ohio State' }] }
+        }));
+        const bars = [...document.querySelectorAll('[db-board] .db-bar')];
+        expect(bars[0].style.width).toBe('100%');                    // now Texas
+        expect(parseInt(bars[3].style.width, 10)).toBe(Math.round(24.8 / 34.3 * 100));
     });
 });
 

--- a/tests/DraftBoardPage.spec.js
+++ b/tests/DraftBoardPage.spec.js
@@ -50,6 +50,7 @@ function payload(over) {
         schedule: { next: { overall: 2, round: 1 }, after: { overall: 11, round: 2 }, onTheClock: false, gap: 8 },
         advice: {
             take: { id: 1, school: 'Ohio State', total: 34.4 }, cost: 8.8, survivorRank: 3,
+            effective: 34.4, captain: { enabled: false, gain: 0, settled: false },
             atRisk: [{ id: 1, school: 'Ohio State', total: 34.4 }, { id: 2, school: 'Texas', total: 34.3 }],
             safeToWait: [{ id: 4, school: 'LSU', total: 25.6 }, { id: 5, school: 'Notre Dame', total: 24.8 }]
         },
@@ -210,6 +211,61 @@ describe('logos', () => {
         }));
         expect(document.querySelector('.db-chip-logo')).not.toBeNull();
         expect(document.querySelector('[db-log] .db-l-team img').src).toBe('https://x/tex-dark.png');
+    });
+});
+
+// The captain doubles ONE team's weekly score, regular season only, so it prices
+// regular-season points and ignores postseason entirely. Which of the three
+// states shows is the useful part — especially "settled", which tells you to
+// stop reading the Cap/wk column for the rest of the draft.
+describe('the captain line', () => {
+    const withCaptain = (cap, extra) => payload(Object.assign({
+        advice: Object.assign({
+            take: { id: 2, school: 'Texas', total: 34.3 }, cost: 13.9, survivorRank: 8,
+            effective: 58.3, captain: cap,
+            atRisk: [{ id: 1, school: 'Ohio State', total: 34.4 }],
+            safeToWait: [{ id: 4, school: 'LSU', total: 25.6 }]
+        }, extra || {})
+    }));
+
+    it('says a first pick is also choosing the season captain, and prices it', async () => {
+        await loadPage(withCaptain({ enabled: true, gain: 24.0, settled: false, anchorSchool: null, anchorRegular: 0 }));
+        const t = txt('[db-advice]');
+        expect(t).toContain('34.3 projected  +  24.0 captain  =  58.3');
+        expect(t).toContain('This also picks your season captain');
+        expect(t).toContain('+24.0 points');
+    });
+
+    it('prices an upgrade over the anchor you already hold', async () => {
+        await loadPage(withCaptain({ enabled: true, gain: 4.0, settled: false, anchorSchool: 'Middling', anchorRegular: 20 }));
+        const t = txt('[db-advice]');
+        expect(t).toContain('Captain upgrade');
+        expect(t).toContain('+4.0 points');
+        expect(t).toContain('over Middling');
+    });
+
+    it('tells you to stop reading Cap/wk once the anchor cannot be beaten', async () => {
+        await loadPage(withCaptain({ enabled: true, gain: 0, settled: true, anchorSchool: 'Texas', anchorRegular: 24 }));
+        const t = txt('[db-advice]');
+        expect(t).toContain('Captain settled');
+        expect(t).toContain('Texas');
+        expect(t).toContain('ignore Cap/wk for the rest of the draft');
+        expect(t).not.toContain('captain  =');            // no effective-value maths to show
+    });
+
+    it('says nothing about the captain when the league has the mode off', async () => {
+        await loadPage(payload());                         // fixture default: captain disabled
+        expect(document.querySelector('.db-captain')).toBeNull();
+        expect(txt('[db-advice]')).toContain('34.4 projected');
+        expect(txt('[db-advice]')).not.toContain('captain');
+    });
+
+    it('highlights the recommended team even when it is not the top row', async () => {
+        await loadPage(withCaptain({ enabled: true, gain: 24.0, settled: false, anchorSchool: null, anchorRegular: 0 }));
+        const best = document.querySelector('[db-board] tr.db-best');
+        expect(best.querySelector('.db-team').textContent).toBe('Texas');
+        // Board stays in market order, so Texas is the SECOND row.
+        expect(document.querySelectorAll('[db-board] tr')[0].querySelector('.db-team').textContent).toBe('Ohio State');
     });
 });
 

--- a/tests/Logo.spec.js
+++ b/tests/Logo.spec.js
@@ -39,9 +39,13 @@ describe('pickLogo', () => {
     test('regression: does NOT return the tiny dark-16 that .at(-1) would', () => {
         expect(pickLogo(CFBD)).not.toContain('/16/');
     });
+    // The ESPN fixtures are stored as http://; the SELECTION here is unchanged
+    // (still dark-500 / light-500, matching the old .at(-1)) — only the scheme is
+    // upgraded on the way out, so the image isn't blocked as mixed content.
     test('ESPN back-compat: still the dark-500 (matches the old .at(-1))', () => {
-        expect(pickLogo(ESPN)).toBe('http://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png');
-        expect(pickLogo(ESPN, { dark: false })).toBe('http://a.espncdn.com/i/teamlogos/ncaa/500/333.png');
+        expect(pickLogo(ESPN)).toBe('https://a.espncdn.com/i/teamlogos/ncaa/500-dark/333.png');
+        expect(pickLogo(ESPN, { dark: false })).toBe('https://a.espncdn.com/i/teamlogos/ncaa/500/333.png');
+        expect(pickLogo(ESPN)).toContain('/500-dark/');
     });
     test('single-logo team: returns the only logo regardless of variant', () => {
         expect(pickLogo(['https://cdn.collegefootballdata.com/logos/500/1.png']))
@@ -55,5 +59,46 @@ describe('pickLogo', () => {
     test('drops falsy entries', () => {
         expect(pickLogo([null, '', 'https://cdn.collegefootballdata.com/logos-dark/500/1.png']))
             .toBe('https://cdn.collegefootballdata.com/logos-dark/500/1.png');
+    });
+});
+
+// Mixed content: the app is served over https in production, but every logo URL
+// CFBD/ESPN store is http://. A browser blocks those, so the logos silently
+// vanish everywhere at once — the failure looks like "the images are broken",
+// not like a protocol problem. pickLogo is the one selector every surface goes
+// through, so the upgrade belongs here.
+describe('https upgrade', () => {
+    const ESPN = 'a.espncdn.com/i/teamlogos/ncaa/500-dark/194.png';
+
+    it('upgrades an http logo so it is not blocked as mixed content', () => {
+        expect(pickLogo(['http://' + ESPN])).toBe('https://' + ESPN);
+    });
+
+    it('leaves an https logo alone', () => {
+        expect(pickLogo(['https://' + ESPN])).toBe('https://' + ESPN);
+    });
+
+    it('is case-insensitive about the scheme', () => {
+        expect(pickLogo(['HTTP://' + ESPN])).toBe('https://' + ESPN);
+    });
+
+    it('does not touch a protocol-relative URL', () => {
+        expect(pickLogo(['//' + ESPN])).toBe('//' + ESPN);
+    });
+
+    it('only rewrites the scheme, never an http substring elsewhere in the path', () => {
+        const tricky = 'https://cdn.example.com/logos/http://not-a-scheme/1.png';
+        expect(pickLogo([tricky])).toBe(tricky);
+    });
+
+    it('still returns empty for a team with no logos', () => {
+        expect(pickLogo([])).toBe('');
+        expect(pickLogo(null)).toBe('');
+    });
+
+    it('upgrades the winner, not merely the first entry', () => {
+        // dark-500 should win on variant+size, and come back upgraded.
+        const logos = ['http://x/logos/16/1.png', 'http://x/logos-dark/500/1.png', 'http://x/logos/500/1.png'];
+        expect(pickLogo(logos)).toBe('https://x/logos-dark/500/1.png');
     });
 });

--- a/tests/RoutesDraftBoard.spec.js
+++ b/tests/RoutesDraftBoard.spec.js
@@ -1,0 +1,136 @@
+// HTTP tests for the live draft board endpoint (routes/draft.js).
+//
+// The two things worth pinning: it is commissioner-gated (this is a draft-night
+// advantage, not a member feature), and the projections it hands out are scored
+// through the requesting league's OWN config — including powerConferences, which
+// is exactly the field that has now twice failed to reach a consumer.
+
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { useMongo } = require('./helpers/mongo');
+const Draft = require('../models/draft');
+const Team = require('../models/team');
+const Game = require('../models/game');
+const ScoringConfig = require('../models/scoringConfig');
+const draftRouter = require('../routes/draft');
+
+const TOKEN = 'draft-board-spec-token';
+const LEAGUE = 'graham-league';
+const SEASON = 2026;
+const ORDER = Array.from({ length: 6 }, () => String(new mongoose.Types.ObjectId()));
+const ME = ORDER[1];                                   // the 2nd seat: picks 2, 11, 14 …
+
+const app = express();
+app.use(express.json());
+app.use('/draft', draftRouter);
+
+useMongo();
+
+let prevToken;
+beforeAll(() => { prevToken = process.env.INTERNAL_API_TOKEN; process.env.INTERNAL_API_TOKEN = TOKEN; });
+afterAll(() => { process.env.INTERNAL_API_TOKEN = prevToken; });
+
+// Notre Dame (independent) plus an ACC opponent and a filler, so the
+// powerConferences setting has something to bite on.
+const ND = 87, BC = 103, MAC = 195;
+
+async function seed({ powerConferences, picks = [], currentOverall = 1 } = {}) {
+    // Team carries required descriptive fields of its own (colour, mascot,
+    // venue); team() supplies them so the fixtures stay about ratings, which is
+    // all the projection actually reads.
+    const team = (id, school, conference, ratings) => ({
+        id, school, conference,
+        color: '#000000', abbreviation: school.slice(0, 3).toUpperCase(), mascot: 'Xs',
+        location: { name: 'Stadium', city: 'City', state: 'ST' },
+        seasons: [Object.assign({ season: SEASON, conference }, ratings)]
+    });
+    await Team.create([
+        team(ND, 'Notre Dame', 'FBS Independents', { spRating: 25, expectedWins: 11.5, cfpMakeOdds: -200, cfpChampOdds: 500 }),
+        team(BC, 'Boston College', 'ACC', { spRating: -2, expectedWins: 5.5, cfpMakeOdds: 20000, cfpChampOdds: 100000 }),
+        team(MAC, 'Toledo', 'Mid-American', { spRating: -8, expectedWins: 7.5, cfpMakeOdds: 20000, cfpChampOdds: 100000 })
+    ]);
+    // One 12-game slate each so the projection has something to walk.
+    const games = [];
+    for (let wk = 1; wk <= 12; wk++) {
+        const base = { season: SEASON, seasonType: 'regular', week: wk,
+            neutralSite: false, startTimeTbd: false, startDate: `2026-09-${String(wk).padStart(2, '0')}T18:00:00.000Z` };
+        games.push(Object.assign({ id: 1000 + wk, conferenceGame: false,
+            homeId: ND, homeTeam: 'Notre Dame', homeConference: 'FBS Independents',
+            awayId: BC, awayTeam: 'Boston College', awayConference: 'ACC' }, base));
+        games.push(Object.assign({ id: 2000 + wk, conferenceGame: true,
+            homeId: MAC, homeTeam: 'Toledo', homeConference: 'Mid-American',
+            awayId: BC, awayTeam: 'Boston College', awayConference: 'ACC' }, base));
+    }
+    await Game.create(games);
+    await ScoringConfig.create(Object.assign(
+        { league: LEAGUE, model: 'graham', values: {}, disabled: [], enabled: [] },
+        powerConferences ? { powerConferences } : {}));
+    await Draft.create({ league: LEAGUE, season: SEASON, draftOrder: ORDER, snake: true, totalRounds: 10, status: 'active', currentOverall, picks });
+}
+
+const get = (q = '') => request(app).get(`/draft/board/${LEAGUE}/${SEASON}${q}`).set('X-Internal-Token', TOKEN);
+
+describe('GET /draft/board/:league/:season', () => {
+    it('refuses a caller who cannot manage the league', async () => {
+        await seed();
+        const res = await request(app).get(`/draft/board/${LEAGUE}/${SEASON}`);   // no token, no session
+        expect(res.status).toBe(403);
+    });
+
+    it('404s when the league has no draft', async () => {
+        expect((await request(app).get('/draft/board/nope-league/2026').set('X-Internal-Token', TOKEN)).status).toBe(404);
+    });
+
+    it('projects through the league config — powerConferences included', async () => {
+        await seed({ powerConferences: ['ACC', 'Big 12', 'Big Ten', 'SEC', 'FBS Independents'] });
+        const closed = await get(`?userId=${ME}`);
+        expect(closed.status).toBe(200);
+        const ndClosed = closed.body.projections.find(t => t.id === ND);
+
+        // Same fixture, no power list → the upset bonus fires on all 12 ND games.
+        await mongoose.connection.dropDatabase();
+        await seed();
+        const open = await get(`?userId=${ME}&refresh=1`);
+        const ndOpen = open.body.projections.find(t => t.id === ND);
+
+        // The bonus is probability-weighted, not per-game: the projection calibrates
+        // to Notre Dame's 11.5 expected wins, so closing the loophole removes
+        // 11.5 x 2 points, not 12 x 2.
+        expect(ndOpen.regular).toBeGreaterThan(ndClosed.regular);
+        expect(Math.round(ndOpen.regular - ndClosed.regular)).toBe(23);
+    });
+
+    it('reports which poll the ranked bonuses came from', async () => {
+        await seed();
+        expect((await get()).body.rankedSource).toMatch(/SP\+ stand-in/);
+    });
+
+    it('gives this manager their own schedule, advice and roster', async () => {
+        await seed({
+            currentOverall: 3,
+            picks: [
+                { overall: 1, round: 1, userId: ORDER[0], team: { id: MAC, school: 'Toledo' } },
+                { overall: 2, round: 1, userId: ME, team: { id: ND, school: 'Notre Dame' } }
+            ]
+        });
+        const res = await get(`?userId=${ME}`);
+        expect(res.body.schedule.next.overall).toBe(11);
+        expect(res.body.schedule.gap).toBe(2);            // picks 9 and 10 sit between 11 and 14... no: 12,13
+        expect(res.body.roster.map(r => r.school)).toEqual(['Notre Dame']);
+        // Drafted teams are off the board.
+        expect(res.body.advice.take.id).toBe(BC);
+    });
+
+    it('caches projections but still reflects new picks', async () => {
+        await seed();
+        const first = await get(`?userId=${ME}`);
+        expect(first.body.advice.take).not.toBeNull();
+        await Draft.findOneAndUpdate({ league: LEAGUE, season: SEASON },
+            { $set: { currentOverall: 3 }, $push: { picks: { overall: 2, round: 1, userId: ME, team: { id: ND, school: 'Notre Dame' } } } });
+        const second = await get(`?userId=${ME}`);
+        expect(second.body.roster.map(r => r.school)).toEqual(['Notre Dame']);
+        expect(second.body.projections.length).toBe(first.body.projections.length);
+        expect(second.body.advice.take.id).not.toBe(ND);
+    });
+});

--- a/tests/RoutesDraftBoard.spec.js
+++ b/tests/RoutesDraftBoard.spec.js
@@ -122,6 +122,32 @@ describe('GET /draft/board/:league/:season', () => {
         expect(res.body.advice.take.id).toBe(BC);
     });
 
+    // The route's own fallback for when the client sends no userId. req.effUser is
+    // the OIDC profile, so the id lives in nested metadata — reading a top-level
+    // _id yielded '' and silently reported "your draft is complete".
+    it('falls back to the signed-in user id from nested Auth0 metadata', async () => {
+        await seed();
+        const asUser = express();
+        asUser.use(express.json());
+        asUser.use((req, _res, next) => {
+            req.effUser = { sub: 'auth0|abc', user_metadata: { roles: ['Admin'], metadata: { league: 'gg', userId: ME } } };
+            next();
+        });
+        asUser.use('/draft', draftRouter);
+        const res = await request(asUser).get(`/draft/board/${LEAGUE}/${SEASON}`).set('X-Internal-Token', TOKEN);
+        expect(res.status).toBe(200);
+        expect(res.body.schedule.next.overall).toBe(2);      // the 2nd seat, resolved
+        expect(res.body.schedule.gap).toBe(8);
+    });
+
+    it('degrades to no schedule rather than erroring for an unknown user', async () => {
+        await seed();
+        const res = await get('?userId=not-in-this-draft');
+        expect(res.status).toBe(200);
+        expect(res.body.schedule.next).toBeNull();
+        expect(res.body.projections.length).toBeGreaterThan(0);
+    });
+
     it('caches projections but still reflects new picks', async () => {
         await seed();
         const first = await get(`?userId=${ME}`);

--- a/views/draftBoard.ejs
+++ b/views/draftBoard.ejs
@@ -42,7 +42,9 @@
     </div>
 
     <!-- The answer, up top: what to do with the next pick -->
-    <section class="db-advice" db-advice></section>
+    <div class="db-shell">
+        <section class="db-advice" db-advice></section>
+    </div>
 
     <div class="db-cols">
         <!-- Available board -->

--- a/views/draftBoard.ejs
+++ b/views/draftBoard.ejs
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="styles.css" rel="stylesheet">
+    <link href="draftBoard.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+    <script src="/socket.io/socket.io.js"></script>
+    <script defer src="draftBoard.js"></script>
+    <title>Campus Clash — Draft Board</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
+</head>
+<body>
+    <%- include('partials/navbar') %>
+    <script>
+        window.APP_YEAR = "<%= year %>";
+        window.LEAGUE_CODE = "<%= leagueCode %>";
+    </script>
+    <% if (userState) { %>
+        <script>
+            var userState = <%- userState %>;
+        </script>
+    <% } %>
+
+    <div class="header">
+        <div class="header-title" poll-name>Draft Board</div>
+    </div>
+
+    <!-- Connection + provenance strip -->
+    <div class="db-strip">
+        <span class="db-live" db-live><span class="db-dot"></span><span db-live-text>connecting…</span></span>
+        <span class="db-meta" db-source></span>
+        <button type="button" class="db-refresh" db-refresh title="Recompute projections from scratch">Recompute</button>
+    </div>
+
+    <!-- The answer, up top: what to do with the next pick -->
+    <section class="db-advice" db-advice></section>
+
+    <div class="db-cols">
+        <!-- Available board -->
+        <section class="db-panel db-panel-board">
+            <div class="db-panel-head">
+                <h2>On the board</h2>
+                <input class="db-search" db-search type="search" placeholder="Find a team…" aria-label="Find a team">
+                <span class="db-count" db-count></span>
+            </div>
+            <div class="db-tablewrap">
+                <table class="db-table">
+                    <thead>
+                        <tr>
+                            <th class="db-num">#</th>
+                            <th>Team</th>
+                            <th>Conf</th>
+                            <th class="db-num">Proj</th>
+                            <th class="db-num">Reg</th>
+                            <th class="db-num">Post</th>
+                            <th class="db-num">Cap/wk</th>
+                        </tr>
+                    </thead>
+                    <tbody db-board></tbody>
+                </table>
+            </div>
+        </section>
+
+        <aside class="db-side">
+            <section class="db-panel">
+                <div class="db-panel-head"><h2>Your roster</h2></div>
+                <ol class="db-roster" db-roster></ol>
+            </section>
+            <section class="db-panel">
+                <div class="db-panel-head"><h2>Picks so far</h2></div>
+                <ol class="db-log" db-log></ol>
+            </section>
+        </aside>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
A commissioner-only page at **`/draft-board`** that joins the same socket room the draft room uses and answers one question as picks land: *what should I do with my next pick?*

## What it shows

Every team projected through **this league's real scoring config** — the same engine behind draft grades, so the numbers agree with the app rather than with a spreadsheet. Drafted teams leave the board as picks come in.

Live, signed in, empty roster, on the clock at #2:

> **YOUR NEXT PICK — #2, ROUND 1**
> **TAKE — Texas** · 34.3 projected **+ 24.0 captain = 58.3**
> 8 picks before your next turn (#11). If you passed and waited, the best you should expect is **LSU** — costing you about **13.9 points**.
> *Assumes every other manager takes the best team left, which this league does not — treat it as a floor, not a forecast.*
> *This also picks your season captain: +24.0 points on top of its board value — the captain doubles regular-season points every week.*
>
> **Likely gone by your next turn:** Ohio State 34.4 · Texas 34.3 · Oregon 32.8 · Indiana 32.3 · Georgia 30.8 · Miami 30.6
> **Should still be there:** LSU 25.6 · Alabama 24.9 · Notre Dame 24.8 · Michigan 23.8 · Oklahoma 23.3 · USC 22.9

Plus the full available board, your roster with a running projected total, and a live pick log — all with team logos, and a proportional value bar behind each projection scaled to the best team still on the board.

## Two things it prices that a ranked list cannot

**Scarcity.** Every roster spot here is interchangeable — no positions, a roster is just the sum of its teams. That makes "who is best?" trivially the top of the board and pushes the real decision onto "who survives until my next turn?" The 2nd seat waits 8 picks after round 1 and 2 after round 2, so what waiting costs is entirely a function of that gap.

**The captain.** 2026 is the first season the mode is on. It doubles ONE rostered team's score, **regular season only**, so a roster's captain value is its best regular projection and a candidate is worth extra only when it raises that.

That is not cosmetic — it flips the first pick:

| | Proj | Regular | Captain adds | **Effective** |
|---|---|---|---|---|
| Ohio State | 34.4 | 21.9 | +21.9 | 56.3 |
| **Texas** | 34.3 | **24.0** | **+24.0** | **58.3** |

The multiplier never touches the 12.5 points Ohio State earns in the playoff. Two teams a tenth apart on the board are two points apart once it is applied. The board still lists Ohio State first — the highlight moves instead.

Ranking is deliberately split: the **market** prices on board value, which decides who is gone by the next turn; what to **buy** is priced on value to this roster. Ranking both the same way would assume the other five managers are drafting for my roster.

Once the anchor is set the advice says so and stops weighting per-week value. Holding Texas at 24.0 regular, **no team in the 138-team pool** would upgrade it, so Cap/wk is decoration for the remaining nine picks — and the page says that rather than leaving it to be worked out at the table.

## It is not SP+ order

21.6% of team pairs rank differently than SP+ would. Toledo (SP+ −11.5) projects above Auburn (SP+ +11.2), because 7.5 wins in the MAC monetise better under these rules than 6.5 in the SEC.

## Honesty on the page

It states its own weaknesses where you'll read them. The scarcity estimate assumes every other manager takes the best team left, which this league demonstrably does not — Indiana went 31st in 2025 and led the league at 58 points. The captain figure assumes you captain the anchor every week, when optimal play occasionally captains someone else. Both are floors, and both are labelled as such. It also names which poll the ranked-win bonuses came from, since 2026 currently has only a Coaches Poll stored and the projection falls back to an SP+ stand-in.

## Shape

- **`modules/draft-board.js`** — pure scarcity and captain math, no I/O
- **`GET /draft/board/:league/:season`** — commissioner-gated; projections cached per league+season since they don't change during a draft; captain settings read per season, so a league running the mode in 2026 and not 2027 prices picks differently in each
- **`/draft-board`** — page route, Admin or League Manager only, deliberately not linked from the navbar
- The page **re-fetches on each socket pick** rather than re-deriving advice in the browser, so there is exactly one copy of the math

## Three bugs fixed along the way

**Identity.** The board first reported "your draft is complete" before the draft started. Both sides read the app user id off `_id`, but `userState` and `req.effUser` are the Auth0 OIDC profile — the id is nested at `user_metadata.metadata.userId`. Nothing threw; the page rendered, the board was right, and the one thing it exists to say was wrong. The page-test fixture had invented a `userState` shape the app never produces, so it was complicit; it is now the real profile.

**Contradictory scarcity.** When the wait is longer than the remaining board, the survivor was clamped to the last team — so the advice priced the cost of waiting against a team it simultaneously listed as unavailable. An exhausted board now reports itself, and waiting costs the pick rather than a couple of points.

**Layout.** `body` is `display:flex; flex-direction:column; align-items:center`, so top-level sections are flex items that shrink to fit — `max-width + margin:auto + padding` never produced a gutter on any of them. All three sections now share one container rule that sets `width:100%` first.

`pickLogo` also upgrades `http://` logo URLs to `https://`. Defensive only: CFBD serves logos over https, so a refreshed `teams` collection has none — it covers older ESPN-era rows a stale database still holds.

## Testing

**1,179 tests across 59 suites**, parity test included. New: 22 for the board logic (snake-turn gap, exhausted board, the captain model including a non-2 multiplier and captain-off leaving rankings untouched), 8 for the endpoint (403 for non-commissioners, the Auth0 identity fallback, and that `powerConferences` reaches the projections), 26 browser tests for the page, and 7 added to the logo selector.

Verified **in a real signed-in session against live data**, including a socket-driven update: a pick made in the draft room removed the team from the board with no reload and the advice re-derived correctly, which I checked by hand against the board.

A full 6-manager mock draft ran through it — the board's seat finished first at 211.1 projected, with the entire margin coming from rounds 5–7. Worth reading with suspicion: the other five drafted in SP+ order, which is exactly the strategy this is built to exploit, and 5 points over second place is inside the model's own error bars.

## Caveat

The Group-of-5 block rests on the hand-maintained `expectedWins2026.json` — Toledo is SP+ −11.5 with 7.5 expected wins, a 78-rank disagreement. If those numbers are stale, that part of the board moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)