### PR TITLE
Stop readiness flagging unpublished CFBD data as an outstanding step

### DIFF
--- a/modules/season-readiness.js
+++ b/modules/season-readiness.js
@@ -28,9 +28,20 @@ function pct(n, total) {
 }
 
 // One check row. `required` marks a check the draft actually depends on;
-// informational rows report state but never hold the season back.
+// informational rows report state but never hold the season back. `noAction`
+// suppresses the Fix button for a row whose gap the commissioner cannot close.
 function check(key, label, status, detail, opts) {
     return Object.assign({ key, label, status, detail, required: true }, opts || {});
+}
+
+// Did the preseason enrichment run, even though talent came back empty?
+// Coaches and returning production are written by the same run and by the same
+// CFBD call batch, so either one present means the run reached CFBD and
+// succeeded — leaving an absent talent composite as an upstream fact rather
+// than a missed step. Requires BOTH that talent is absent and that the run
+// left its other fingerprints; a season nobody has enriched has neither.
+function awaitingTalent(w) {
+    return (w.talent || 0) === 0 && ((w.coach || 0) > 0 || (w.returning || 0) > 0);
 }
 
 // Coverage-style check: ready at >=90% of teams, partial if any, missing at 0.
@@ -60,10 +71,28 @@ function platformChecks({ season, teamTotal, teamsWith, scheduledTeams, gameCoun
             }),
             { detail: gameCount ? `${gameCount} games · ${scheduledTeams} of ${teamTotal} teams` : 'No games loaded' }
         ),
-        coverageCheck('enrichment', 'Preseason enrichment', w.talent || 0, teamTotal, {
-            fix: 'Refresh Ratings & Broadcasts',
-            whyItMatters: 'Talent, returning production and coaches are pulled once preseason. Missing, the pool and grades silently reuse last season.'
-        }),
+        // Talent is this row's coverage signal, but unlike every other check it
+        // is not always OBTAINABLE. CFBD publishes the 247 composite on its own
+        // schedule and answers 200 + [] until it lands, so a completely
+        // successful preseason run can still write zero talent — and the row
+        // then reads as a red, actionable gap that re-running cannot close.
+        //
+        // Coaches and returning production come from the SAME run, so their
+        // presence separates "never ran" (real, actionable) from "ran, upstream
+        // hasn't published" (nothing to do but wait). Same shape as the SP+ row
+        // below, which already handles CFBD lag this way.
+        Object.assign(
+            coverageCheck('enrichment', 'Preseason enrichment', w.talent || 0, teamTotal, {
+                fix: 'Refresh Ratings & Broadcasts',
+                whyItMatters: 'Talent, returning production and coaches are pulled once preseason. Missing, the pool and grades silently reuse last season.'
+            }),
+            awaitingTalent(w) ? {
+                required: false,
+                noAction: true,
+                detail: 'Coaches and returning production loaded · talent not published',
+                note: 'CFBD has not published the talent composite for this season yet. Re-running will not help; draft grades fall back to last season\'s talent until it lands.'
+            } : {}
+        ),
         coverageCheck('expectedWins', 'Expected wins', w.expectedWins || 0, teamTotal, {
             fix: 'Refresh Expected Wins',
             whyItMatters: 'Feeds the projection engine behind draft grades.'

--- a/public/admin.js
+++ b/public/admin.js
@@ -574,7 +574,10 @@ function readinessRow(c) {
     // themselves are listed directly below if someone wants to re-run one.
     // Also suppressed when the target tool isn't on the page — a League Manager
     // doesn't get the platform-wide tools, so they see state without a dead button.
-    var target = c.status !== 'ready' && READINESS_FIX[c.key];
+    // `noAction` is for a row whose gap the commissioner genuinely cannot close
+    // — enrichment waiting on a CFBD dataset that isn't published yet. A button
+    // there reads as "re-run this" and re-running changes nothing.
+    var target = !c.noAction && c.status !== 'ready' && READINESS_FIX[c.key];
     var canOpen = target && document.querySelector('[' + target[0] + ']');
     // The button navigates — it opens the tool and scrolls to it, it doesn't run
     // anything — so a real gap says "Fix" (where you go to fix it) and an

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -85,11 +85,15 @@ router.get('/readiness/:season', async (req, res) => {
         // drags every team's weeklyScore array along for no reason.
         const teams = await Team.find({}, {
             id: 1, 'seasons.season': 1, 'seasons.talent': 1, 'seasons.spRating': 1,
-            'seasons.expectedWins': 1, 'seasons.cfpMakeOdds': 1, 'seasons.cfpChampOdds': 1
+            'seasons.expectedWins': 1, 'seasons.cfpMakeOdds': 1, 'seasons.cfpChampOdds': 1,
+            // coach + returningProduction aren't shown anywhere; they're carried
+            // so readiness can tell an enrichment run that never happened from
+            // one that ran while CFBD had no talent composite to give.
+            'seasons.coach': 1, 'seasons.returningProduction': 1
         }).lean();
         const teamTotal = teams.length;
         const fbsIds = new Set(teams.map(t => t.id));
-        const teamsWith = { talent: 0, spRating: 0, expectedWins: 0, cfpOdds: 0 };
+        const teamsWith = { talent: 0, spRating: 0, expectedWins: 0, cfpOdds: 0, coach: 0, returning: 0 };
         teams.forEach(t => {
             const s = (t.seasons || []).find(x => Number(x.season) === seasonNum);
             if (!s) return;
@@ -97,6 +101,8 @@ router.get('/readiness/:season', async (req, res) => {
             if (s.spRating != null) teamsWith.spRating++;
             if (s.expectedWins != null) teamsWith.expectedWins++;
             if (s.cfpMakeOdds != null || s.cfpChampOdds != null) teamsWith.cfpOdds++;
+            if (s.coach != null) teamsWith.coach++;
+            if (s.returningProduction != null) teamsWith.returning++;
         });
 
         // Schedule coverage: a full ingest reaches essentially every team, so

--- a/tests/SeasonReadiness.spec.js
+++ b/tests/SeasonReadiness.spec.js
@@ -69,6 +69,42 @@ describe('platformChecks', () => {
         expect(byKey(platformChecks(loaded())).spPlus.label).toBe('SP+ ratings (2026)');
     });
 
+    // CFBD answers /talent with 200 + [] until it publishes the composite, so a
+    // fully successful preseason run can still write zero talent. Observed live
+    // on 2026: sp 139, fpi 138, returning 136, coaches 138, talent 0.
+    describe('enrichment that ran while CFBD had no talent to give', () => {
+        const ran = { talent: 0, coach: TEAMS, returning: TEAMS - 2, spRating: TEAMS, expectedWins: TEAMS, cfpOdds: 30 };
+
+        test('is not a required miss and offers no button to press', () => {
+            const c = byKey(platformChecks(loaded({ teamsWith: ran })));
+            expect(c.enrichment).toMatchObject({ required: false, noAction: true });
+            expect(c.enrichment.note).toMatch(/has not published the talent composite/);
+            expect(c.enrichment.detail).toMatch(/talent not published/);
+        });
+
+        test('does not count toward the outstanding-steps total', () => {
+            const r = computeSeasonReadiness(loaded({ teamsWith: ran, leagues: [leagueReady()] }));
+            expect(r.blocking).not.toContain('enrichment');
+        });
+
+        // The distinction has to survive in the other direction, or a season
+        // nobody enriched would quietly stop asking to be enriched.
+        test('a season that was never enriched is still a real, actionable gap', () => {
+            const c = byKey(platformChecks(loaded({ teamsWith: { talent: 0, coach: 0, returning: 0 } })));
+            expect(c.enrichment).toMatchObject({ status: 'missing', required: true });
+            expect(c.enrichment.noAction).toBeUndefined();
+            expect(c.enrichment.detail).toBe(`0 of ${TEAMS} teams`);
+        });
+
+        // Partial talent means the run is landing data; it should read as a
+        // normal partial load, not as waiting on CFBD.
+        test('partial talent is a normal partial, not the waiting state', () => {
+            const c = byKey(platformChecks(loaded({ teamsWith: { talent: 60, coach: TEAMS } })));
+            expect(c.enrichment).toMatchObject({ status: 'partial', required: true });
+            expect(c.enrichment.noAction).toBeUndefined();
+        });
+    });
+
     test('no teams on file at all degrades to missing rather than dividing by zero', () => {
         const c = byKey(platformChecks(loaded({ teamTotal: 0, teamsWith: {}, scheduledTeams: 0, gameCount: 0 })));
         expect(c.enrichment.status).toBe('missing');


### PR DESCRIPTION
The **Preseason enrichment** row reads its coverage from `talent` — the one readiness signal that isn't always *obtainable*. CFBD publishes the 247 composite on its own schedule and answers `200 + []` until it lands, so a completely successful run can write zero talent. The row then shows red with a `Fix →` button that re-running cannot satisfy.

Hit live on 2026 today, right after SP+ dropped:

```json
{"season":2026,"scope":"all","updated":138,
 "counts":{"sp":139,"fpi":138,"talent":0,"returning":136,"coaches":138}}
```

Everything landed except talent — `/talent?year=2026` returns `[]` while `/talent?year=2025` returns 134 entries.

## The discriminator

Coaches and returning production come from the same run and the same CFBD call batch, so either one present means the run reached CFBD and succeeded. That separates **never enriched** (real, actionable) from **enriched, upstream has nothing to give** (nothing to do but wait).

`awaitingTalent()` requires *both* that talent is absent *and* that the run left its other fingerprints. A season nobody has enriched has neither, so it keeps reading as the required gap it is — that inverse case is what makes this safe, and it's tested.

The waiting state follows the shape the **SP+ row already uses** for CFBD lag: amber, `required: false`, out of the blocking count, with a note explaining the fallback.

## Verified against live dev data

| | before | after |
|---|---|---|
| dot | `dot r` (red) | `dot a` (amber) |
| Fix button | present | gone |
| `attn` styling | yes | no |
| steps outstanding | 3 | **2** |

Detail becomes *"Coaches and returning production loaded · talent not published"*. **Season roster** and **Draft configured** still render `dot r` with live buttons, so genuine gaps still shout.

## Notes

- `noAction` is new on a check row and suppresses the Fix button. Without it the button still rendered, relabelled "Set up" — worse than "Fix," since it implies setup work exists when the blocker is entirely upstream.
- `routes/scores.js` carries `coach` and `returningProduction` counts. Neither is displayed; they exist purely as the run's fingerprint.
- 4 new tests, including the two inverse cases (un-enriched season stays required; partial talent stays a normal partial). Suite: 59 suites / 1,183 passing.

## Live consequence worth tracking separately

If talent never publishes before draft night, grades run on 2025 talent — quietly, which is exactly what this panel exists to surface. This PR makes the state legible; it doesn't decide what should happen if the data is still missing at draft time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
