### PR TITLE
Show the league's name on the pages it belongs on

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -667,6 +667,25 @@ window.onload = async function() {
     loadReadiness();
 };
 
+// A rename only reaches the rest of the page on the next render, since the
+// names are seeded server-side (views/partials/navbar.ejs). Patch the seed in
+// place and repaint, so the commissioner sees the new name take effect on the
+// switcher, the page title and the scoring header instead of doubting the save.
+function applyLeagueRename(code, name) {
+    ((window.CC_LEAGUE && window.CC_LEAGUE.all) || []).forEach(function (l) {
+        if (l.code === code) l.name = name;
+    });
+    var item = document.querySelector('[league-selector] a[value="' + code + '"]');
+    if (item) item.textContent = name;
+    if (typeof getDraftLeagueCode === 'function' && getDraftLeagueCode() === code) {
+        window.sessionStorage.setItem('league', name);
+        if ($('#dropdownMenuButton').length) $('#dropdownMenuButton').text(name);
+        var hdr = document.querySelector('[scoring-config-model]');
+        if (hdr && scoringConfigData) hdr.textContent = scoringHeaderLabel();
+    }
+    ccLeague.paint();
+}
+
 // League name: rename the active league (own-league enforced server-side).
 const leagueNameForm = document.getElementById('league-name-form');
 if (leagueNameForm) {
@@ -687,6 +706,7 @@ if (leagueNameForm) {
             });
             const data = await res.json().catch(() => ({}));
             if (res.status === 200) {
+                applyLeagueRename(data.code, data.name);
                 successToast.options.text = `League renamed to "${data.name}"`;
                 successToast.showToast();
             } else {
@@ -2120,13 +2140,19 @@ async function loadScoringConfig(model) {
 // Plain-language name for each rule shape (the league's `model`).
 var SHAPE_LABEL = { claunts: 'Fixed win values', graham: 'Stacking win values' };
 
+// "<League> — <rule shape>". The name comes from ccLeague rather than a
+// hardcoded map: League setup, a few sections up this same page, can rename a
+// league — and this header used to go on showing the old name forever.
+function scoringHeaderLabel() {
+    var leagueName = ccLeague.name(getDraftLeagueCode());
+    var shape = SHAPE_LABEL[scoringConfigData.model] || scoringConfigData.model;
+    return (leagueName ? leagueName + ' — ' : '') + shape;
+}
+
 // Reflects the loaded config into the UI: header, selected shape, rule rows,
 // and the worked example. Shared by load and save.
 function applyScoringConfig() {
-    var leagueCode = getDraftLeagueCode();
-    var leagueName = (leagueCode === 'graham-league' ? 'Graham' : 'Claunts') + ' League';
-    document.querySelector('[scoring-config-model]').textContent =
-        leagueName + ' — ' + (SHAPE_LABEL[scoringConfigData.model] || scoringConfigData.model);
+    document.querySelector('[scoring-config-model]').textContent = scoringHeaderLabel();
     setShape(scoringConfigData.model);
     renderScoringFields();
     renderShapeExample();

--- a/public/league.js
+++ b/public/league.js
@@ -1,0 +1,66 @@
+// Shared league identity (ccLeague): which league a page is showing, and what
+// that league is CALLED.
+//
+// Display names are commissioner-editable (models/league.js + PATCH
+// /leagues/:code), so nothing client-side may hardcode "Graham League" — a
+// rename has to reach every surface. views/partials/navbar.ejs seeds
+// window.CC_LEAGUE from the server on every render; this is its only reader.
+(function () {
+    var SEED = window.CC_LEAGUE || {};
+
+    function all() { return SEED.all || []; }
+
+    // The league this page is about, in priority order:
+    //   1. a league the server rendered the page FOR (/rules and /draft-board
+    //      pin it on <body>) — that can carry an Admin's ?league=, which storage
+    //      knows nothing about,
+    //   2. an Admin's sticky selection from the navbar switcher,
+    //   3. the viewer's own league.
+    // Step 2 is Admin-gated on purpose: leagueCode outlives a logout, so a
+    // member signing in on a shared browser must not inherit the last Admin's
+    // pick. It mirrors how the pages already choose which league's data to load.
+    function code() {
+        var pinned = document.body && document.body.getAttribute('data-league-code');
+        if (pinned) return pinned;
+        if (SEED.canSwitch) {
+            var stored = null;
+            try { stored = window.localStorage.getItem('leagueCode'); } catch (e) { stored = null; }
+            if (stored && all().some(function (l) { return l.code === stored; })) return stored;
+        }
+        return SEED.code || '';
+    }
+
+    // Display name for a league code (defaults to the current page's league).
+    // Empty string when it can't be resolved, so callers can treat "no name" as
+    // "render nothing" rather than printing a raw code at someone.
+    function name(which) {
+        var want = which || code();
+        var hit = all().filter(function (l) { return l.code === want; })[0];
+        return hit ? hit.name : '';
+    }
+
+    // Page title with the league in it, so two tabs on the same page in
+    // different leagues are tellable apart:
+    //   "Standings · Graham League · Campus Clash"
+    function title(page) {
+        return [page, name(), 'Campus Clash'].filter(Boolean).join(' · ');
+    }
+
+    // Fills every [league-label] on the page and applies the <title> of any view
+    // that opted in with [data-league-title]. Runs on DOMContentLoaded; exposed
+    // so a page that renders its header later can repaint.
+    function paint(root) {
+        var label = name();
+        var nodes = (root || document).querySelectorAll('[league-label]');
+        for (var i = 0; i < nodes.length; i++) {
+            nodes[i].textContent = label;
+            nodes[i].hidden = !label;
+        }
+        var t = document.querySelector('title[data-league-title]');
+        if (t) document.title = title(t.getAttribute('data-league-title'));
+    }
+
+    window.ccLeague = { code: code, name: name, title: title, paint: paint };
+
+    document.addEventListener('DOMContentLoaded', function () { paint(); });
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -468,6 +468,25 @@ body {
     justify-content: center;
     padding: 35px;
     font-size: 3rem;
+    text-align: center;
+    /* Inert for the block instances; Standings and My Team make this a flex row,
+       where it's what lets the league eyebrow below claim a line of its own. */
+    flex-wrap: wrap;
+}
+
+/* League eyebrow: names the league whose data the page is showing, above the
+   page title. Lives INSIDE .header-title so it inherits the title's centring
+   and can't disturb .header's flex row (which also holds "last updated").
+   Filled by ccLeague (public/league.js) and hidden until a name resolves. */
+.header-league {
+    display: block;
+    flex: 0 0 100%;   /* own line, whether the title is a block or a flex row */
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--cc-muted-2);
+    margin-bottom: 8px;
 }
 
 .team-item {
@@ -757,6 +776,11 @@ footer {
     .header-title {
         padding: 5px;
         font-size: 1.7rem;
+    }
+
+    .header-league {
+        font-size: 0.68rem;
+        margin-bottom: 4px;
     }
 
     .game-table {

--- a/public/team.js
+++ b/public/team.js
@@ -546,7 +546,7 @@ function renderTeamInfo(team, record, recruiting, seasonObj, schedule, owner, fa
     var outlookHtml = outlookChips.length ? `<div><h4>${window.ccIcon ? window.ccIcon('chart', { size: 21 }) : ''} Outlook</h4><div class="outlook-chips">${outlookChips.join('')}</div>${outlookNote}</div>` : '';
 
     // Set the tab title to the team being viewed.
-    document.title = `${team.school} ${team.mascot} · Campus Clash`;
+    document.title = ccLeague.title(`${team.school} ${team.mascot}`);
 
     const html = `
 

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -612,6 +612,7 @@ button.uh-tile:focus-visible { outline: 2px solid var(--cc-info); outline-offset
 .uh-hero { display: flex; align-items: center; gap: 16px; }
 .uh-hero-av { width: 56px; height: 56px; flex: none; }
 .uh-hero-meta { min-width: 0; flex: 1; }
+.uh-hero-league { font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--cc-muted-2); font-weight: 700; margin-bottom: 5px; }
 .uh-hero-name { font-size: 20px; font-weight: 800; color: var(--cc-text); line-height: 1.1; }
 .uh-hero-sub { font-size: 13px; color: var(--cc-muted-2); margin-top: 2px; }
 .uh-hero-stats { display: flex; gap: 18px; margin-top: 10px; flex-wrap: wrap; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -127,7 +127,7 @@ async function renderBento(data) {
     const season = uhSeasonFor(data, activeYear);
     const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
     const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
-    document.title = `${franchise || manager} · Campus Clash`;
+    document.title = ccLeague.title(franchise || manager);
     const own = currentUserId() && String(currentUserId()) === String(data._id);
     const pencil = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
 
@@ -150,6 +150,7 @@ async function renderBento(data) {
         `<div class="uh-tile span2 uh-hero">
             <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
             <div class="uh-hero-meta">
+                ${heroLeagueHtml()}
                 <div class="uh-hero-name">${escapeHtml(franchise)}</div>
                 <div class="uh-hero-sub">${escapeHtml(franchise ? ('Managed by ' + manager) : manager)}</div>
                 <div class="uh-hero-stats" id="uh-hero-stats"></div>
@@ -239,6 +240,7 @@ function renderPreseason(bento, data, activeYear, ctx) {
         `<div class="uh-tile span2 uh-hero">
             <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
             <div class="uh-hero-meta">
+                ${heroLeagueHtml()}
                 <div class="uh-hero-name">${escapeHtml(franchise)}</div>
                 <div class="uh-hero-sub">Managed by ${escapeHtml(manager)}</div>
                 <div class="uh-hero-stats"><span class="uh-preseason-pill">${escapeHtml(activeYear)} preseason</span></div>
@@ -1198,6 +1200,15 @@ async function computeRank(data) {
     } catch (e) { return null; }
 }
 
+// League eyebrow over the franchise name. The league a manager plays in is
+// otherwise invisible to them after their invite, and this is the one tile every
+// manager looks at. Its own line rather than appended to the "Managed by" line,
+// which wraps mid-name on a phone.
+function heroLeagueHtml() {
+    const league = ccLeague.name();
+    return league ? `<div class="uh-hero-league">${escapeHtml(league)}</div>` : '';
+}
+
 function statTile(valueHtml, label) {
     return `<div class="stat"><span class="stat-value">${valueHtml}</span><span class="stat-label">${escapeHtml(label)}</span></div>`;
 }
@@ -1220,7 +1231,7 @@ function refreshHeroIdentity(data, season) {
     if (nameEl) nameEl.textContent = franchise;
     const subEl = document.querySelector('.uh-hero-sub');
     if (subEl) subEl.textContent = franchise && season.franchiseName ? `Managed by ${manager}` : manager;
-    document.title = `${franchise || manager} · Campus Clash`;
+    document.title = ccLeague.title(franchise || manager);
 }
 
 // ---------- Edit modal (franchise name + avatar upload) ----------

--- a/server.js
+++ b/server.js
@@ -118,6 +118,15 @@ app.use(async (req, res, next) => {
             }
         }
     } catch (e) { /* fall back to defaults */ }
+    // Seed the client helper (public/league.js) off the same names, plus the
+    // viewer's own league and whether they may switch. Every page that shows a
+    // league name reads it from there, so a rename lands everywhere at once and
+    // no page has to re-derive the league from Auth0 metadata.
+    res.locals.leagueSeed = safeJson({
+        code: (req.oidc && req.oidc.isAuthenticated()) ? leagueCodeFor(req.effUser) : '',
+        canSwitch: devRole.effectiveRoles(req).includes('Admin'),
+        all: res.locals.leagues
+    });
     next();
 });
 

--- a/tests/LeagueIdentity.spec.js
+++ b/tests/LeagueIdentity.spec.js
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Coverage for public/league.js — ccLeague, the one place the client answers
+ * "which league is this page about, and what is it called".
+ *
+ * The names are commissioner-editable, so every surface that shows one reads
+ * them from here; the interesting behavior is which league wins. In particular
+ * the sticky `leagueCode` in localStorage outlives a logout, so it may only be
+ * honored for someone who can actually switch leagues — otherwise a member
+ * signing in on a shared browser is told they're in the last Admin's league.
+ *
+ * public/league.js is a classic script that wires itself to window on load, so
+ * it's evaluated into the global scope rather than required.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'public', 'league.js'), 'utf8');
+
+const ALL = [
+    { code: 'claunts-league', name: 'Claunts League' },
+    { code: 'graham-league', name: 'CFB Sickos' }   // renamed, as prod's is
+];
+
+// Stand up a page and (re-)evaluate the helper against it. `seed` is what
+// views/partials/navbar.ejs emits; `html` is the page it paints.
+function load({ seed, html = '', pinned = null, stored = null } = {}) {
+    window.localStorage.clear();
+    if (stored) window.localStorage.setItem('leagueCode', stored);
+    document.body.innerHTML = html;
+    if (pinned) document.body.setAttribute('data-league-code', pinned);
+    else document.body.removeAttribute('data-league-code');
+    window.CC_LEAGUE = seed;
+    (0, eval)(SRC);                                   // indirect eval → global scope
+    return window.ccLeague;
+}
+
+const member = { code: 'graham-league', canSwitch: false, all: ALL };
+const admin = { code: 'graham-league', canSwitch: true, all: ALL };
+
+describe('which league a page is about', () => {
+    it('is the viewer’s own league for a member', () => {
+        const cc = load({ seed: member });
+        expect(cc.code()).toBe('graham-league');
+        expect(cc.name()).toBe('CFB Sickos');
+    });
+
+    it('ignores a stale sticky selection for anyone who can’t switch', () => {
+        // The shared-browser case: an Admin left Claunts selected and logged
+        // out; the member who logs in next is still shown their own league.
+        const cc = load({ seed: member, stored: 'claunts-league' });
+        expect(cc.code()).toBe('graham-league');
+    });
+
+    it('follows an Admin’s sticky selection', () => {
+        const cc = load({ seed: admin, stored: 'claunts-league' });
+        expect(cc.code()).toBe('claunts-league');
+        expect(cc.name()).toBe('Claunts League');
+    });
+
+    it('falls back to the Admin’s own league when the stored code is unknown', () => {
+        const cc = load({ seed: admin, stored: 'retired-league' });
+        expect(cc.code()).toBe('graham-league');
+    });
+
+    it('lets a server-pinned league win over both (/rules with ?league=)', () => {
+        const cc = load({ seed: admin, stored: 'graham-league', pinned: 'claunts-league' });
+        expect(cc.code()).toBe('claunts-league');
+        expect(cc.name()).toBe('Claunts League');
+    });
+
+    it('names any league on request, not just the current one', () => {
+        const cc = load({ seed: member });
+        expect(cc.name('claunts-league')).toBe('Claunts League');
+    });
+});
+
+describe('an unresolvable league', () => {
+    it('yields an empty name rather than a raw code', () => {
+        expect(load({ seed: { code: 'ghost-league', canSwitch: false, all: ALL } }).name()).toBe('');
+        expect(load({ seed: {} }).name()).toBe('');
+        expect(load({ seed: undefined }).name()).toBe('');
+    });
+
+    it('leaves the label hidden and the title league-free', () => {
+        const cc = load({
+            seed: {},
+            html: '<span class="header-league" league-label hidden></span>'
+        });
+        cc.paint();
+        expect(document.querySelector('[league-label]').hidden).toBe(true);
+        expect(cc.title('Standings')).toBe('Standings · Campus Clash');
+    });
+});
+
+describe('painting', () => {
+    it('fills every label and reveals it', () => {
+        const cc = load({
+            seed: member,
+            html: '<span league-label hidden></span><span league-label hidden></span>'
+        });
+        cc.paint();
+        const labels = [...document.querySelectorAll('[league-label]')];
+        expect(labels.map(el => el.textContent)).toEqual(['CFB Sickos', 'CFB Sickos']);
+        expect(labels.every(el => el.hidden)).toBe(false);
+    });
+
+    it('builds the page title from the view’s page name', () => {
+        const cc = load({ seed: member });
+        expect(cc.title('Standings')).toBe('Standings · CFB Sickos · Campus Clash');
+        // Pages that title themselves (My Team, Team) pass their own subject.
+        expect(cc.title('Sicko Squad')).toBe('Sicko Squad · CFB Sickos · Campus Clash');
+    });
+
+    it('runs itself on DOMContentLoaded, so views need no wiring', () => {
+        load({
+            seed: member,
+            html: '<span league-label hidden></span>'
+        });
+        document.title = 'Standings · Campus Clash';   // creates the element in jsdom
+        document.querySelector('title').setAttribute('data-league-title', 'Standings');
+        document.dispatchEvent(new window.Event('DOMContentLoaded'));
+        expect(document.querySelector('[league-label]').textContent).toBe('CFB Sickos');
+        expect(document.title).toBe('Standings · CFB Sickos · Campus Clash');
+    });
+});

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script defer src="admin.js"></script>
-    <title>Campus Clash</title>
+    <title data-league-title="League Management">League Management · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />

--- a/views/draftBoard.ejs
+++ b/views/draftBoard.ejs
@@ -11,14 +11,16 @@
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <script src="/socket.io/socket.io.js"></script>
     <script defer src="draftBoard.js"></script>
-    <title>Campus Clash — Draft Board</title>
+    <title data-league-title="Draft Board">Draft Board · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
 </head>
-<body>
+<!-- Board is rendered for one league (the commissioner's own), so pin it for
+     ccLeague instead of leaning on the sticky navbar selection. -->
+<body data-league-code="<%= leagueCode %>">
     <%- include('partials/navbar') %>
     <script>
         window.APP_YEAR = "<%= year %>";
@@ -31,7 +33,7 @@
     <% } %>
 
     <div class="header">
-        <div class="header-title" poll-name>Draft Board</div>
+        <div class="header-title" poll-name><span class="header-league" league-label hidden></span>Draft Board</div>
     </div>
 
     <!-- Connection + provenance strip -->

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -15,7 +15,7 @@
     <script src="/socket.io/socket.io.js"></script>
     <script defer src="draftGrades.js"></script>
     <script defer src="draftRoom.js"></script>
-    <title>Campus Clash</title>
+    <title data-league-title="Draft Room">Draft Room · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
@@ -34,6 +34,7 @@
 
     <div class="header">
         <div class="header-title" poll-name>
+            <span class="header-league" league-label hidden></span>
             Draft Room
         </div>
     </div>

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap" rel="stylesheet">
     <script src="history.js" defer></script>
-    <title>Hall of Fame · Campus Clash</title>
+    <title data-league-title="Hall of Fame">Hall of Fame · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
@@ -28,7 +28,7 @@
     <% } %>
 
     <div class="header">
-        <div class="header-title">Hall of Fame</div>
+        <div class="header-title"><span class="header-league" league-label hidden></span>Hall of Fame</div>
     </div>
 
     <main class="hof" id="hof">

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -28,6 +28,13 @@
 <!-- Shared league placement (ccLeagueRank): competition ranking off the season
      total, so tied managers share a rank instead of being ordered by the DB. -->
 <script src="/league-rank.js"></script>
+<!-- Shared league identity (ccLeague): the display name of whichever league a
+     page is showing. Names are commissioner-editable, so they're seeded from the
+     server on every render instead of being hardcoded anywhere client-side. -->
+<script>
+    window.CC_LEAGUE = <%- (typeof leagueSeed !== 'undefined' && leagueSeed) || '{}' %>;
+</script>
+<script src="/league.js"></script>
 <!-- Weekly Recap: shared card rendering + the once-a-week popup, app-wide so the
      popup can greet the logged-in viewer on whatever page they land on. -->
 <link rel="stylesheet" type="text/css" href="/weekly-recap.css">

--- a/views/scoringRules.ejs
+++ b/views/scoringRules.ejs
@@ -12,13 +12,16 @@
     <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="scoringRules.js"></script>
-    <title>Campus Clash</title>
+    <title data-league-title="Scoring Rules">Scoring Rules · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png" />
 </head>
-<body>
+<!-- The rules shown are one league's, resolved server-side (an Admin's ?league=
+     included), so pin that league for ccLeague rather than letting it fall back
+     to the sticky selection — the two can disagree for a moment on arrival. -->
+<body data-league-code="<%= leagueCode %>">
     <%- include('partials/navbar') %>
     <% if (userState) { %>
         <script>
@@ -28,7 +31,7 @@
     <span id="scoring-league" data-code="<%= leagueCode %>" hidden></span>
 
   <div class="rules-container">
-    <h1 class="header-title"><span data-icon="book" data-icon-size="26"></span>Scoring Rules</h1>
+    <h1 class="header-title"><span class="header-league" league-label hidden></span><span data-icon="book" data-icon-size="26"></span>Scoring Rules</h1>
 
     <section class="rules-section draft-section">
       <h2 class="rule-header"><span data-icon="clipboard" data-icon-size="20"></span>Draft Rules</h2>

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -19,7 +19,7 @@
     <!-- JQuery -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
-    <title>Campus Clash</title>
+    <title data-league-title="Standings">Standings · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
@@ -48,6 +48,7 @@
 
     <div class="header">
         <div class="header-title">
+            <span class="header-league" league-label hidden></span>
             Standings
         </div>
         <div class="last-updated-container">

--- a/views/team.ejs
+++ b/views/team.ejs
@@ -13,7 +13,7 @@
     <!-- jQuery, popper and Bootstrap are loaded by the navbar partial; don't
          re-include (an older jQuery here used to clobber the navbar's copy). -->
     <script defer src="team.js"></script>
-    <title>Campus Clash</title>
+    <title data-league-title="Team">Team · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -17,7 +17,7 @@
     <script defer src="draftGrades.js"></script>
     <script src="win-reveal.js"></script>
     <script defer src="userHome.js"></script>
-    <title>Campus Clash</title>
+    <title data-league-title="My Team">My Team · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />


### PR DESCRIPTION
## Why

A commissioner can rename a league (`League setup → League Name`), but the name reached almost nobody. It showed up in exactly three places: the navbar switcher (Admin-only), the invite page (seen once), and the admin rename field itself. A member never saw their league named again after joining.

## What

**One source of truth.** `public/league.js` adds `ccLeague`, loaded by the navbar alongside `ccLogo`/`ccLeagueRank`. Names are commissioner-editable, so nothing derives them client-side — `server.js` seeds `window.CC_LEAGUE` with the editable names, the viewer's own league, and whether they may switch.

Resolution order:
1. a league the server rendered the page **for** — `/rules` and `/draft-board` pin it with `<body data-league-code>`, so an Admin's `?league=` is honored,
2. an Admin's sticky selection from the switcher,
3. the viewer's own league.

Step 2 is Admin-gated deliberately: `localStorage.leagueCode` outlives a logout, so honoring it for a non-Admin tells a member signing in on a shared browser that they're in the last Admin's league. It mirrors how the pages already pick which league's data to fetch.

**Surfaces**
- Eyebrow above the page title on Standings, Scoring Rules, Hall of Fame, Draft Room, Draft Board
- Eyebrow above the franchise name in the My Team hero tile (matches the `YOUR DRAFT` label idiom in the tile below it)
- Every page `<title>`: `Standings · Graham League · Campus Clash` — two tabs on the same page in different leagues are now tellable apart

**Bug fixed along the way.** The admin scoring-config header built its label from a hardcoded `graham-league → 'Graham'` map, so a rename left it showing the old name forever. It reads `ccLeague` now, and a successful rename repaints the switcher, the page title and that header in place rather than waiting for the next render.

## Testing

- Full suite green: 60 suites, 1194 tests
- New `tests/LeagueIdentity.spec.js` (11 tests) covers the resolution order, the shared-browser guard, the server-pinned case, unresolvable leagues, and painting
- Every page checked in the browser at desktop and mobile widths, no console errors. Verified the in-season My Team hero against a `YEAR=2025` server, and confirmed the member guard by spoofing Member with a stale `leagueCode` in storage

## Deliberately left alone

- The "League Highlights" heading on Standings — the name would then appear twice on one page
- The `GG`/`CL` audit-log chips in admin, kept short so a row stays on one line
- The weekly-recap popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)