### PR TITLE
Sound the draft chime only for the manager whose pick it is

### DIFF
--- a/public/draftRoom.js
+++ b/public/draftRoom.js
@@ -358,21 +358,26 @@ function onPickMade({ pick, state }) {
 
     var isOwn = String(pick.userId) === String(myUserId);
 
-    // Chime immediately — on YOUR click (makePick set _ownChimeAt) or here for
-    // other managers' picks — then hold the reveal for a 2s suspense beat:
-    // "the pick is in… [chime + 2s] … TEAM!". The board isn't advanced until
-    // then, so the pick isn't shown early.
+    // Chime only for a pick that's YOURS — either you clicked Draft (makePick
+    // already chimed, set _ownChimeAt) or someone picked on your behalf. Other
+    // managers' picks are silent here: leagues draft together on a call, and six
+    // open draft rooms all sounding at once is a wash, not a moment. Matches how
+    // the confetti below is already gated.
     // Suppress the confirm chime only if WE already chimed for THIS exact pick on
     // the local Draft click — matched by team id, not by whose turn it is, so a
     // commissioner picking for another manager doesn't double up.
+    // Either way we mark the start of a 1.2s suspense beat — "the pick is in…
+    // [beat] … TEAM!" — which runs for everyone, chime or not, so the reveal
+    // stays in step around the room. The board isn't advanced until then, so the
+    // pick isn't shown early.
     var pid = String(pick.team && pick.team.id);
     var chimedOnClick = onPickMade._ownPickTeamId === pid && onPickMade._ownChimeAt && (Date.now() - onPickMade._ownChimeAt < 6000);
-    var chimeStart;
+    var beatStart;
     if (chimedOnClick) {
-        chimeStart = onPickMade._ownChimeAt;
+        beatStart = onPickMade._ownChimeAt;
     } else {
-        if (typeof window.ccDraftStinger === 'function') window.ccDraftStinger();
-        chimeStart = Date.now();
+        if (isOwn && typeof window.ccDraftStinger === 'function') window.ccDraftStinger();
+        beatStart = Date.now();
     }
     onPickMade._ownChimeAt = 0;
     onPickMade._ownPickTeamId = null;
@@ -381,10 +386,10 @@ function onPickMade({ pick, state }) {
     var lc = (raw && window.ccLiftColor) ? window.ccLiftColor(raw)
            : (raw ? (raw.charAt(0) === '#' ? raw : '#' + raw) : null);
 
-    // Reveal 2s after the chime STARTED (so your own pick — chimed on click —
-    // still lands 2s later, not 2s after the server round-trip).
+    // Reveal after the beat STARTED (so your own pick — chimed on click — still
+    // lands 1.2s later, not 1.2s after the server round-trip).
     var REVEAL_DELAY = 1200;
-    var wait = Math.max(0, REVEAL_DELAY - (Date.now() - chimeStart));
+    var wait = Math.max(0, REVEAL_DELAY - (Date.now() - beatStart));
     setTimeout(function () {
         justPickedKey = String(pick.userId) + '-' + pick.round;
         renderAll();


### PR DESCRIPTION
## Why

Leagues draft together on a call. Every open draft room fired `ccDraftStinger()` on every `pick-made` broadcast, so with six managers connected the chime played six times per pick — each copy offset by that client's socket and call-audio latency, arriving as a smeared 5.3-second wash instead of a moment.

The confetti was already gated to your own pick ([`draftRoom.js`](../blob/main/public/draftRoom.js) `ownConfetti`); the chime was not. That asymmetry looks unintentional, and this brings the two in line.

## What changed

`public/draftRoom.js` — the confirm chime in `onPickMade` is now gated on `isOwn`.

Who hears a chime, per pick:

| Situation | Chimes? |
|---|---|
| You click Draft for your own team | Yes — on click, before the server round-trip; the confirm is suppressed so it doesn't double |
| Commissioner clicks Draft for another manager | On the commissioner's machine (they initiated it) and on that manager's (it's their pick) |
| Any other manager's pick | Silent |

The 1.2s suspense beat still runs on **every** client whether or not it chimed, so the board reveal stays in step around the room — nobody sees a pick early or late. `chimeStart` is renamed `beatStart` to reflect that it now times the reveal rather than the audio.

## Testing

Syntax-checked, and all three `ccDraftStinger` call sites accounted for (the third is the mute button's preview-on-unmute, unchanged).

Not exercised live — reproducing the real behavior needs an Auth0 login plus an active draft with several connected sockets. The gate is a single condition on an `isOwn` that was already computed and already trusted for the confetti, so the risk is contained, but **the six-way audio behavior is unverified until a real draft runs.**

## Not in scope

Two things from the same discussion, left alone deliberately:

- `draft-pick.mp3` is 5.33s, which still drones past the reveal on the one machine that plays it. Trimming to ~1.5s is a separate change.
- Sound still defaults **on** (`cc_draft_mute` is unset until someone taps 🔊). Lower stakes now that you only hear picks you triggered yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)