### PR TITLE
Add an app-wide search palette for teams and managers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,7 +33,8 @@ module.exports = {
         "*-job.js",
         "public/standings-insights.js",
         "public/standings.js",
-        "public/weekByWeek.js"
+        "public/weekByWeek.js",
+        "public/search-match.js"
     ],
     coveragePathIgnorePatterns: [
         "/node_modules/",
@@ -165,6 +166,16 @@ module.exports = {
             branches: 75,
             functions: 100,
             lines: 100
+        },
+        // Pure ranking for the search palette. It decides which of two schools
+        // sharing a prefix is the one you meant — Arkansas vs Arkansas State —
+        // so it's held to the pure-module bar. Not 100: the UMD browser-global
+        // line can't run under Node's require.
+        "./public/search-match.js": {
+            statements: 95,
+            branches: 85,
+            functions: 100,
+            lines: 95
         }
     }
 };

--- a/public/search-match.js
+++ b/public/search-match.js
@@ -1,0 +1,123 @@
+// Shared search ranking (client + server; UMD so both can load this one file,
+// same as logo.js).
+//
+// Why this isn't a one-line `.filter(includes)`: 23 of the 138 FBS school names
+// share their first word — Arkansas/Arkansas State, Arizona/Arizona State,
+// Miami/Miami (OH), and so on. A substring filter in collection order answers
+// "arkansas" with Arkansas STATE on top, which is the wrong team. So matches are
+// TIERED (exact beats prefix beats word-start beats loose substring, and the
+// primary name beats an alias), and inside a tier the SHORTER name wins. That
+// pairing is what makes "ark" + Enter land on the Razorbacks.
+//
+// Items are uniform across types so teams and managers rank through one code
+// path:
+//   { type, id, name, sub, image, initials, color, aliases: [] }
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) module.exports = factory();
+    else root.ccSearchMatch = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+
+    // Match key: lowercase, strip accents, drop EVERYTHING non-alphanumeric.
+    // Punctuation has to vanish rather than become a space, because the two
+    // punctuated schools are the ones people type loosely — "texas am" has to
+    // find "Texas A&M", and "miami oh" has to find "Miami (OH)". Collapsing to
+    // spaces would leave "texas a m" and neither query would hit.
+    function tight(s) {
+        return String(s == null ? '' : s)
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/[^a-z0-9]/g, '');
+    }
+
+    // The same string as separate words, for word-start matching: "arkansas
+    // state" -> ["arkansas", "state"], so "state" surfaces the State schools
+    // without also matching every name with "st" buried inside it.
+    function words(s) {
+        return String(s == null ? '' : s)
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .split(/[^a-z0-9]+/)
+            .filter(Boolean);
+    }
+
+    // Tiers. Lower sorts first. An exact ALIAS hit ranks with a primary prefix
+    // hit: "pitt" is precisely Pittsburgh's alias and should not lose to some
+    // longer school that merely contains the letters.
+    var T = {
+        EXACT: 0,
+        PREFIX: 1,
+        ALIAS_EXACT: 1,
+        WORD: 2,
+        SUB: 3,
+        ALIAS_PREFIX: 4,
+        ALIAS_SUB: 5,
+        SUB_FIELD: 6      // conference / franchise name — useful, but never above a name hit
+    };
+
+    // Precompute the match keys once per session instead of re-normalizing 138
+    // rows on every keystroke. Returns NEW objects; the caller's items are left
+    // untouched.
+    function prepare(items) {
+        return (Array.isArray(items) ? items : []).map(function (it) {
+            return {
+                item: it,
+                k: tight(it && it.name),
+                w: words(it && it.name),
+                a: ((it && it.aliases) || []).filter(Boolean).map(tight).filter(function (x) { return x.length > 0; }),
+                s: tight(it && it.sub),
+                len: String((it && it.name) || '').length
+            };
+        });
+    }
+
+    // Best (lowest) tier this entry earns for the query, or -1 for no match.
+    function tierOf(e, q) {
+        if (e.k === q) return T.EXACT;
+        if (e.k.indexOf(q) === 0) return T.PREFIX;
+
+        var i;
+        for (i = 0; i < e.a.length; i++) {
+            if (e.a[i] === q) return T.ALIAS_EXACT;
+        }
+        for (i = 1; i < e.w.length; i++) {          // from 1: word 0 is the PREFIX case above
+            if (e.w[i].indexOf(q) === 0) return T.WORD;
+        }
+        if (e.k.indexOf(q) > 0) return T.SUB;
+        for (i = 0; i < e.a.length; i++) {
+            if (e.a[i].indexOf(q) === 0) return T.ALIAS_PREFIX;
+        }
+        for (i = 0; i < e.a.length; i++) {
+            if (e.a[i].indexOf(q) > 0) return T.ALIAS_SUB;
+        }
+        if (e.s && e.s.indexOf(q) === 0) return T.SUB_FIELD;
+        return -1;
+    }
+
+    // Ranked matches for a query, best first. Returns the ORIGINAL item objects.
+    // No limit here — the caller slices per section, so a flood of conference
+    // matches can't starve the managers out of the list.
+    function rank(prepared, query) {
+        var q = tight(query);
+        if (!q) return [];
+
+        var hits = [];
+        for (var i = 0; i < prepared.length; i++) {
+            var t = tierOf(prepared[i], q);
+            if (t >= 0) hits.push({ e: prepared[i], t: t, i: i });
+        }
+
+        hits.sort(function (a, b) {
+            if (a.t !== b.t) return a.t - b.t;
+            // Shorter name first: Arkansas above Arkansas State.
+            if (a.e.len !== b.e.len) return a.e.len - b.e.len;
+            var an = String(a.e.item.name || ''), bn = String(b.e.item.name || '');
+            return an.localeCompare(bn) || (a.i - b.i);
+        });
+
+        return hits.map(function (h) { return h.e.item; });
+    }
+
+    return { prepare: prepare, rank: rank, tight: tight, words: words, TIERS: T };
+}));

--- a/public/search.css
+++ b/public/search.css
@@ -8,7 +8,7 @@
     inset: 0;
     z-index: 1200;              /* over the sticky navbar */
     background: rgba(6, 8, 16, 0.66);
-    padding: 12vh 1rem 1rem;
+    padding: 10vh 1rem 1rem;
     justify-content: center;
     align-items: flex-start;
 }
@@ -73,7 +73,12 @@ body.cc-search-lock {
     list-style: none;
     margin: 0;
     padding: 0.35rem;
-    max-height: min(24rem, 56vh);
+    /* Sized so a FULL result set fits without scrolling on a normal desktop:
+       6 teams + 3 managers + 2 group headers measures 538px. Capping at 24rem
+       hid the Managers group below the fold, which defeated the point of
+       slicing per type to keep it visible. The vh term still takes over on short
+       viewports, where scrolling is the honest answer. */
+    max-height: min(34rem, 68vh);
     overflow-y: auto;
 }
 

--- a/public/search.css
+++ b/public/search.css
@@ -1,0 +1,174 @@
+/* App-wide search palette (public/search.js).
+   Everything is prefixed cc-search-* because Bootstrap 4 is loaded app-wide from
+   the navbar partial and owns generic names like .modal, .dropdown and .close. */
+
+.cc-search-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1200;              /* over the sticky navbar */
+    background: rgba(6, 8, 16, 0.66);
+    padding: 12vh 1rem 1rem;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.cc-search-overlay.open {
+    display: flex;
+}
+
+/* The palette scrolls internally; locking the body keeps the page behind it
+   still while the list moves. */
+body.cc-search-lock {
+    overflow: hidden;
+}
+
+.cc-search-panel {
+    width: 100%;
+    max-width: 34rem;
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border-2);
+    border-radius: var(--cc-r-lg);
+    box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.7);
+    overflow: hidden;
+}
+
+.cc-search-field {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--cc-border);
+}
+
+.cc-search-field .fa-magnifying-glass {
+    color: var(--cc-muted-2);
+    padding-left: 0;            /* neutralize the global .fa left padding */
+}
+
+.cc-search-input {
+    flex: 1 1 auto;
+    background: transparent;
+    border: 0;
+    outline: none;
+    color: var(--cc-text);
+    font-size: 1.05rem;
+    min-width: 0;
+}
+
+.cc-search-input::placeholder {
+    color: var(--cc-muted-2);
+}
+
+.cc-search-esc {
+    flex: 0 0 auto;
+    font-size: 0.7rem;
+    color: var(--cc-muted-2);
+    border: 1px solid var(--cc-border-2);
+    border-radius: var(--cc-r-sm);
+    padding: 0.1rem 0.35rem;
+}
+
+.cc-search-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.35rem;
+    max-height: min(24rem, 56vh);
+    overflow-y: auto;
+}
+
+.cc-search-group {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--cc-muted-2);
+    padding: 0.6rem 0.65rem 0.3rem;
+}
+
+.cc-search-row {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.5rem 0.65rem;
+    border-radius: var(--cc-r-md);
+    cursor: pointer;
+}
+
+.cc-search-row.active {
+    background: var(--cc-surface-3);
+}
+
+.cc-search-media {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.cc-search-media img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+/* Managers' photos are face-cropped squares; round them the way the navbar and
+   the H2H card already do. Team logos stay square. */
+.cc-search-row .cc-search-media img[src*="/upload/"] {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.cc-search-initials {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--cc-text);
+    border: 1px solid var(--cc-border);
+}
+
+.cc-search-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.cc-search-name {
+    color: var(--cc-text);
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Conference for a team, franchise name for a manager — this is what tells
+   Miami (ACC) from Miami (OH), and there are 23 such collisions. */
+.cc-search-sub {
+    color: var(--cc-muted-2);
+    font-size: 0.78rem;
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.cc-search-empty {
+    color: var(--cc-muted-2);
+    padding: 1rem 0.65rem;
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 40em) {
+    .cc-search-overlay {
+        padding-top: 6vh;
+    }
+}

--- a/public/search.js
+++ b/public/search.js
@@ -1,0 +1,250 @@
+// App-wide search palette: jump to any of the 138 FBS teams or any manager in
+// your league from anywhere in the app.
+//
+// The gap it closes: every team link in the app is contextual — a roster card, a
+// schedule row, a standings cell, a draft-board cell. So a team nobody drafted
+// and nobody plays had no route to it at all, short of reopening the draft room
+// to click it out of the pool table.
+//
+// Ranking lives in search-match.js (pure, unit-tested). This file is the DOM: a
+// lazily-fetched index, the overlay, and keyboard handling.
+(function () {
+    var LIMIT_TEAMS = 6, LIMIT_MANAGERS = 3;
+
+    var index = null;        // prepared entries, or null until first open
+    var loading = false;
+    var results = [];
+    var active = 0;
+    var lastFocus = null;
+    var els = null;
+
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    // Managers' avatars are Cloudinary; ask for the 48px face crop the rest of
+    // the app already uses (h2h-card.js, standings-insights.js) instead of
+    // pulling the full upload and scaling it in the browser.
+    function avatarUrl(url) {
+        if (!url) return null;
+        return url.indexOf('/upload/') !== -1
+            ? url.replace('/upload/', '/upload/c_fill,g_face,w_48,h_48,q_auto,f_auto/')
+            : url;
+    }
+
+    function hrefFor(item) {
+        return item.type === 'team'
+            ? '/team?team=' + encodeURIComponent(item.id)
+            : '/userHome?user=' + encodeURIComponent(item.id);
+    }
+
+    // ---- Index ---------------------------------------------------------------
+    // Fetched on FIRST OPEN, not at page load. The navbar is on every page, so an
+    // eager fetch would re-pull the index on every navigation to serve a feature
+    // most page views never use.
+    function loadIndex() {
+        if (index || loading) return Promise.resolve();
+        loading = true;
+        return fetch('/search/index', { headers: { 'Accept': 'application/json' } })
+            .then(function (r) {
+                if (!r.ok) throw new Error('search index ' + r.status);
+                return r.json();
+            })
+            .then(function (data) {
+                var items = (data.teams || []).concat(data.managers || []);
+                index = window.ccSearchMatch.prepare(items);
+                loading = false;
+                render();
+            })
+            .catch(function (e) {
+                loading = false;
+                console.error('Search index failed to load:', e);
+                if (els) els.list.innerHTML = '<li class="cc-search-empty">Search is unavailable right now.</li>';
+            });
+    }
+
+    // ---- Rendering -----------------------------------------------------------
+    function rowHtml(item, i) {
+        var isTeam = item.type === 'team';
+        var img = isTeam ? item.image : avatarUrl(item.image);
+        var media = img
+            ? '<img src="' + esc(img) + '" alt="" loading="lazy">'
+            : (item.initials
+                ? '<span class="cc-search-initials" style="background:' + esc(item.color || '#333') + '">' + esc(item.initials) + '</span>'
+                : '<span class="cc-search-initials"></span>');
+
+        return '<li class="cc-search-row' + (i === active ? ' active' : '') + '"'
+            + ' id="cc-search-opt-' + i + '" role="option" aria-selected="' + (i === active ? 'true' : 'false') + '"'
+            + ' data-i="' + i + '">'
+            + '<span class="cc-search-media">' + media + '</span>'
+            + '<span class="cc-search-text">'
+            + '<span class="cc-search-name">' + esc(item.name) + '</span>'
+            + (item.sub ? '<span class="cc-search-sub">' + esc(item.sub) + '</span>' : '')
+            + '</span>'
+            + '</li>';
+    }
+
+    function render() {
+        if (!els) return;
+        var q = els.input.value.trim();
+
+        if (!index) {
+            els.list.innerHTML = '<li class="cc-search-empty">' + (loading ? 'Loading…' : '') + '</li>';
+            return;
+        }
+        if (!q) {
+            results = [];
+            els.list.innerHTML = '<li class="cc-search-empty">Search teams and managers</li>';
+            els.input.removeAttribute('aria-activedescendant');
+            return;
+        }
+
+        var all = window.ccSearchMatch.rank(index, q);
+        // Sliced per type rather than off one flat list, so a query that matches
+        // a whole conference can't push the managers out of view entirely.
+        var teams = all.filter(function (x) { return x.type === 'team'; }).slice(0, LIMIT_TEAMS);
+        var managers = all.filter(function (x) { return x.type === 'manager'; }).slice(0, LIMIT_MANAGERS);
+        results = teams.concat(managers);
+
+        if (!results.length) {
+            els.list.innerHTML = '<li class="cc-search-empty">No matches for “' + esc(q) + '”</li>';
+            els.input.removeAttribute('aria-activedescendant');
+            return;
+        }
+
+        if (active >= results.length) active = 0;
+
+        var html = '';
+        if (teams.length) {
+            html += '<li class="cc-search-group" role="presentation">Teams</li>';
+            html += teams.map(function (t, i) { return rowHtml(t, i); }).join('');
+        }
+        if (managers.length) {
+            html += '<li class="cc-search-group" role="presentation">Managers</li>';
+            html += managers.map(function (m, i) { return rowHtml(m, teams.length + i); }).join('');
+        }
+        els.list.innerHTML = html;
+        els.input.setAttribute('aria-activedescendant', 'cc-search-opt-' + active);
+        scrollActiveIntoView();
+    }
+
+    function scrollActiveIntoView() {
+        var row = els.list.querySelector('.cc-search-row.active');
+        if (row && row.scrollIntoView) row.scrollIntoView({ block: 'nearest' });
+    }
+
+    function move(delta) {
+        if (!results.length) return;
+        active = (active + delta + results.length) % results.length;
+        render();
+    }
+
+    function go(i) {
+        var item = results[i];
+        if (item) window.location.href = hrefFor(item);
+    }
+
+    // ---- Open / close --------------------------------------------------------
+    function build() {
+        if (els) return;
+        var overlay = document.createElement('div');
+        overlay.className = 'cc-search-overlay';
+        overlay.setAttribute('role', 'dialog');
+        overlay.setAttribute('aria-modal', 'true');
+        overlay.setAttribute('aria-label', 'Search');
+        overlay.innerHTML =
+            '<div class="cc-search-panel">'
+            + '<div class="cc-search-field">'
+            + '<i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>'
+            + '<input type="text" class="cc-search-input" role="combobox" aria-expanded="true"'
+            + ' aria-controls="cc-search-list" aria-autocomplete="list" autocomplete="off"'
+            + ' spellcheck="false" placeholder="Search teams and managers…" aria-label="Search teams and managers">'
+            + '<kbd class="cc-search-esc">esc</kbd>'
+            + '</div>'
+            + '<ul class="cc-search-list" id="cc-search-list" role="listbox" aria-label="Search results"></ul>'
+            + '</div>';
+        document.body.appendChild(overlay);
+
+        els = {
+            overlay: overlay,
+            panel: overlay.querySelector('.cc-search-panel'),
+            input: overlay.querySelector('.cc-search-input'),
+            list: overlay.querySelector('.cc-search-list')
+        };
+
+        els.input.addEventListener('input', function () { active = 0; render(); });
+
+        els.input.addEventListener('keydown', function (e) {
+            if (e.key === 'ArrowDown') { e.preventDefault(); move(1); }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); move(-1); }
+            else if (e.key === 'Enter') { e.preventDefault(); go(active); }
+            else if (e.key === 'Escape') { e.preventDefault(); close(); }
+        });
+
+        // Click, not mousedown: mousedown would fire before the row's own state
+        // settles and makes drag-select inside the input navigate away.
+        els.list.addEventListener('click', function (e) {
+            var row = e.target.closest('.cc-search-row');
+            if (row) go(Number(row.getAttribute('data-i')));
+        });
+        els.list.addEventListener('mousemove', function (e) {
+            var row = e.target.closest('.cc-search-row');
+            if (!row) return;
+            var i = Number(row.getAttribute('data-i'));
+            if (i !== active) { active = i; render(); }
+        });
+
+        overlay.addEventListener('mousedown', function (e) {
+            if (!els.panel.contains(e.target)) close();
+        });
+    }
+
+    function isOpen() { return !!(els && els.overlay.classList.contains('open')); }
+
+    function open() {
+        build();
+        if (isOpen()) return;
+        lastFocus = document.activeElement;
+        els.overlay.classList.add('open');
+        document.body.classList.add('cc-search-lock');
+        els.input.value = '';
+        active = 0;
+        results = [];
+        render();
+        els.input.focus();
+        loadIndex();
+    }
+
+    function close() {
+        if (!isOpen()) return;
+        els.overlay.classList.remove('open');
+        document.body.classList.remove('cc-search-lock');
+        if (lastFocus && lastFocus.focus) lastFocus.focus();
+        lastFocus = null;
+    }
+
+    // ---- Wiring --------------------------------------------------------------
+    function init() {
+        var btn = document.getElementById('nav-search');
+        if (btn) btn.addEventListener('click', function (e) { e.preventDefault(); open(); });
+
+        document.addEventListener('keydown', function (e) {
+            // Cmd/Ctrl-K only. A bare "/" is the other common palette binding and
+            // is deliberately NOT bound: the draft room has its own always-visible
+            // filter input, and "/" would either be swallowed there or hijack a
+            // keystroke someone meant to type. preventDefault is required because
+            // Cmd-K is Chrome's own address-bar search.
+            if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+                e.preventDefault();
+                isOpen() ? close() : open();
+            } else if (e.key === 'Escape' && isOpen()) {
+                close();
+            }
+        });
+    }
+
+    if (document.readyState !== 'loading') init();
+    else document.addEventListener('DOMContentLoaded', init);
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -834,12 +834,52 @@ footer {
     to { clip-path: inset(-.4em -.4em -.4em -.4em); }
 }
 /* Dev-only role-spoof switcher in the navbar (rendered only in non-production
-   for a real Admin). Amber signals "development tool". */
-.dev-spoof { display: flex; align-items: center; gap: 4px; }
-.dev-spoof-label { font-size: 0.68rem; color: var(--cc-amber); text-transform: uppercase; letter-spacing: 0.04em; }
-.dev-spoof button {
-    font-size: 0.72rem; padding: 3px 8px; border-radius: 6px;
+   for a real Admin). Amber signals "development tool".
+
+   Collapsed to a chip: expanded inline this ran 298px, which by itself wrapped
+   the admin navbar onto two lines. The chip is ~100px and the choices sit in an
+   absolutely-positioned popover, so neither state widens the row. */
+.dev-spoof { display: flex; align-items: center; position: relative; }
+
+.dev-spoof-toggle {
+    display: inline-flex; align-items: center; gap: 5px;
+    font: inherit; font-size: 0.72rem; padding: 3px 8px; border-radius: var(--cc-r-sm);
+    border: 1px solid rgba(224,179,65,0.4); background: transparent; color: var(--cc-amber); cursor: pointer;
+    white-space: nowrap;
+}
+.dev-spoof-toggle:hover { background: rgba(224,179,65,0.18); }
+
+/* "Dev" reads as the label, the role as the value — so the chip says what it is
+   and what's in effect without spelling out "Dev · view as". */
+.dev-spoof-tag {
+    font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.06em;
+    opacity: 0.75;
+}
+.dev-spoof-cur { font-weight: 700; }
+.dev-spoof-caret { font-size: 0.6rem; opacity: 0.8; }
+.dev-spoof-toggle[aria-expanded="true"] .dev-spoof-caret { transform: rotate(180deg); }
+
+.dev-spoof-menu {
+    position: absolute; top: calc(100% + 6px); right: 0; z-index: 1100;
+    display: flex; align-items: center; gap: 4px;
+    padding: 6px 8px;
+    background: var(--cc-surface); border: 1px solid var(--cc-border-2);
+    border-radius: var(--cc-r-md); box-shadow: 0 10px 20px -8px rgba(0,0,0,0.7);
+}
+.dev-spoof-menu[hidden] { display: none; }
+
+.dev-spoof-label { font-size: 0.68rem; color: var(--cc-amber); text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+.dev-spoof-menu button {
+    font-size: 0.72rem; padding: 3px 8px; border-radius: 6px; white-space: nowrap;
     border: 1px solid rgba(224,179,65,0.4); background: transparent; color: var(--cc-amber); cursor: pointer;
 }
-.dev-spoof button.active { background: var(--cc-amber); color: var(--cc-bg); font-weight: 700; }
-.dev-spoof button:hover { background: rgba(224,179,65,0.18); }
+.dev-spoof-menu button.active { background: var(--cc-amber); color: var(--cc-bg); font-weight: 700; }
+.dev-spoof-menu button:hover { background: rgba(224,179,65,0.18); }
+
+/* In the stacked menu the row is full width, so centre the chip like every other
+   item and drop the popover from the middle — right: 0 would pin it to the far
+   edge, away from the chip that opened it. */
+@media (max-width: 63.99em) {
+    .dev-spoof { justify-content: center; padding: 0.5rem 0; }
+    .dev-spoof-menu { right: auto; left: 50%; transform: translateX(-50%); }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -274,9 +274,35 @@ body {
 }
 
 /* "My Team" label: hidden on desktop (avatar speaks for itself), revealed in
-   the stacked mobile menu where an unlabeled icon is ambiguous. */
+   the stacked mobile menu where an unlabeled icon is ambiguous. Search reuses
+   this — icon on desktop, "Search" in the stacked menu. */
 .nav-label {
     display: none;
+}
+
+/* Search opener. A <button> (it opens a dialog), styled to sit in the link row:
+   the nav is already at its width budget, so this is icon-only on desktop. */
+.navbar-links li .nav-search {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 1rem;
+    background: none;
+    border: 0;
+    color: var(--cc-text);
+    font: inherit;
+    cursor: pointer;
+}
+
+.navbar-links li .nav-search i {
+    font-size: 1.15rem;
+    padding-left: 0;   /* neutralize the global .fa left padding so it centers */
+}
+
+.navbar-links li .nav-search:hover {
+    color: var(--cc-accent);
 }
 
 /* Hover: a red underline sweeps in from the center of the label — the same

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,0 +1,89 @@
+const express = require('express');
+const router = express.Router();
+const Team = require('../models/team');
+const User = require('../models/user');
+const { pickLogo } = require('../public/logo.js');
+const { leagueCodeFor } = require('../modules/league-access');
+
+// Index behind the app-wide search palette (public/search.js).
+//
+// Two deliberate shapes here:
+//
+//  1. TEAMS are projected hard. A bare `Team.find()` hands back 1,097 KB across
+//     138 teams — `seasons` alone is 729 KB — and the palette needs none of it.
+//     The projection below measures 30 KB, so the whole index ships in one lazy
+//     fetch and every keystroke is matched in memory. Logos are resolved HERE
+//     with the shared pickLogo (dark variant, highest res, https-upgraded)
+//     rather than shipping the raw arrays, which keeps another 95 KB off the
+//     wire and keeps the palette's logo identical to the one Standings and the
+//     draft board pick.
+//
+//  2. MANAGERS are scoped to the caller's OWN league, derived from the session
+//     via leagueCodeFor — NOT from a parameter the client sends. A league code
+//     in the URL would be a request to trust the browser about which league it
+//     may read, and the members of the other league would be one edited query
+//     string away. Deriving it here means there is no such request to get wrong.
+//
+// Items share one shape across both types so public/search-match.js can rank
+// them through a single path:
+//   { type, id, name, sub, image, initials, color, aliases: [] }
+
+const initialsOf = (u) => (((u.firstName || '')[0] || '') + ((u.lastName || '')[0] || '')).toUpperCase();
+
+// Everything a person might reasonably type for a team that isn't its school
+// name: mascot, abbreviation, and CFBD's several alias fields (alt_name1..3 plus
+// the alternateNames array) — which is where "Pitt", "Miami (FL)" and "TA&M"
+// live. De-duped because those fields overlap heavily.
+function teamAliases(t) {
+    return [...new Set([
+        t.mascot, t.abbreviation, t.alt_name1, t.alt_name2, t.alt_name3,
+        ...(t.alternateNames || [])
+    ].filter(Boolean))];
+}
+
+router.get('/index', async (req, res) => {
+    try {
+        const league = leagueCodeFor(req.effUser);
+        const season = Number(process.env.YEAR);
+
+        const [teamDocs, userDocs] = await Promise.all([
+            Team.find({}, 'id school mascot abbreviation conference color logos alt_name1 alt_name2 alt_name3 alternateNames').lean(),
+            User.find({ league }, 'firstName lastName avatarUrl color seasons').lean()
+        ]);
+
+        const teams = teamDocs.map((t) => ({
+            type: 'team',
+            id: t.id,
+            name: t.school,
+            sub: t.conference || '',
+            image: pickLogo(t.logos || []),
+            color: t.color || null,
+            aliases: teamAliases(t)
+        }));
+
+        const managers = userDocs.map((u) => {
+            // Franchise names are per-season and commissioner/self-editable, so
+            // read the ACTIVE season's rather than the newest entry's — a member
+            // who hasn't joined this season keeps their last name-only row.
+            const s = (u.seasons || []).find((x) => Number(x.season) === season);
+            const franchise = (s && s.franchiseName) || '';
+            const name = [u.firstName, u.lastName].filter(Boolean).join(' ');
+            return {
+                type: 'manager',
+                id: String(u._id),
+                name,
+                sub: franchise,
+                image: u.avatarUrl || null,
+                initials: initialsOf(u) || null,
+                color: u.color || null,
+                aliases: [franchise, u.firstName, u.lastName].filter(Boolean)
+            };
+        });
+
+        res.json({ teams, managers });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -682,6 +682,14 @@ app.use('/standings', requireAuthOrToken, standingsRouter);
 const historyRouter = require('./routes/history');
 app.use('/history', requireAuthOrToken, historyRouter);
 
+// Index for the app-wide search palette. requiresAuth (session-only), NOT
+// requireAuthOrToken: the manager list is scoped by reading the caller's league
+// off req.effUser, and a token-authenticated caller has no session to read it
+// from — leagueCodeFor would fall through to its default and hand that league's
+// members to any token holder. Requiring a session removes the case.
+const searchRouter = require('./routes/search');
+app.use('/search', requiresAuth(), searchRouter);
+
 // try/catch because Express 4 does NOT catch a rejection from an async handler:
 // anything thrown in here becomes an unhandled rejection, and with no
 // process-level handler that exits the dyno. The team-score loop calls this ~138

--- a/tests/RoutesSearch.spec.js
+++ b/tests/RoutesSearch.spec.js
@@ -1,0 +1,191 @@
+// GET /search/index — the index behind the app-wide search palette.
+//
+// The security property under test is the manager list. It is scoped by reading
+// the caller's league off req.effUser, NOT from anything the client sends, so
+// there is no parameter to tamper with. That is deliberate: this app has already
+// had one wrong-league incident, and a league code in the URL would be a standing
+// invitation to repeat it. The final test is the one that would catch a
+// regression to a client-supplied league.
+//
+// The route, models and Mongo are real; only the session is faked.
+
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { useMongo } = require('./helpers/mongo');
+const Team = require('../models/team');
+const User = require('../models/user');
+const searchRouter = require('../routes/search');
+
+const SEASON = 2026;
+
+// Mounts the router behind a middleware that fakes an authenticated session for
+// the given league, mirroring what server.js's devRole middleware sets.
+function appAs(leagueFlag) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+        req.effUser = {
+            sub: 'auth0|spec',
+            user_metadata: { roles: [], metadata: { league: leagueFlag, userId: 'spec' } }
+        };
+        next();
+    });
+    app.use('/search', searchRouter);
+    return app;
+}
+
+const asGraham = appAs('gg');       // -> graham-league
+const asClaunts = appAs('cl');      // -> claunts-league
+
+useMongo();
+
+let prevYear;
+beforeAll(() => { prevYear = process.env.YEAR; process.env.YEAR = String(SEASON); });
+afterAll(() => { process.env.YEAR = prevYear; });
+
+// CFBD hands back many logo URLs — 8 sizes x light/dark. The dark 500 is the one
+// pickLogo should choose, and it arrives over http, which must be upgraded.
+const LOGOS = [
+    'http://a.espncdn.com/i/teamlogos/ncaa/500/8.png',
+    'http://a.espncdn.com/i/teamlogos/ncaa/500-dark/8.png',
+    'http://a.espncdn.com/i/teamlogos/ncaa/16/8.png',
+    'http://a.espncdn.com/i/teamlogos/ncaa/16-dark/8.png'
+];
+
+beforeEach(async () => {
+    await Team.create([{
+        id: 8, school: 'Arkansas', mascot: 'Razorbacks', abbreviation: 'ARK',
+        conference: 'SEC', color: '#9d2235', logos: LOGOS,
+        alt_name1: 'Arkansas', alt_name2: 'ARK', alt_name3: 'Arkansas',
+        alternateNames: ['ARK', 'Arkansas'],
+        location: { name: 'Reynolds Razorback Stadium', city: 'Fayetteville', state: 'AR' },
+        // 60 weeks of scoring the palette has no use for — present so the
+        // projection is doing real work rather than trivially passing.
+        weeklyScore: Array.from({ length: 60 }, (_, i) => ({
+            week: (i % 15) + 1, seasonType: 'regular', season: SEASON, scoreV1: i, scoreV2: i
+        })),
+        seasons: [{ season: SEASON, conference: 'SEC', spRating: 12 }]
+    }, {
+        id: 2032, school: 'Arkansas State', mascot: 'Red Wolves', abbreviation: 'ARST',
+        conference: 'Sun Belt', color: '#cc092f', logos: [],
+        location: { name: 'Centennial Bank Stadium', city: 'Jonesboro', state: 'AR' },
+        seasons: [{ season: SEASON, conference: 'Sun Belt' }]
+    }]);
+
+    await User.create([{
+        firstName: 'Garrett', lastName: 'Graham', email: 'gg@example.com',
+        league: 'graham-league', color: '#8E8CF0',
+        avatarUrl: 'https://res.cloudinary.com/x/image/upload/v1/gg.jpg',
+        seasons: [
+            { season: SEASON - 1, franchiseName: 'Old Name' },
+            { season: SEASON, franchiseName: 'Razorback Rejects' }
+        ]
+    }, {
+        firstName: 'Cole', lastName: 'Smith', email: 'cs@example.com',
+        league: 'claunts-league', color: '#22C37A',
+        seasons: [{ season: SEASON, franchiseName: 'Claunts Crew' }]
+    }]);
+});
+
+const get = (app) => request(app).get('/search/index');
+
+describe('teams', () => {
+    test('returns every team, shaped for the palette', async () => {
+        const res = await get(asGraham);
+        expect(res.status).toBe(200);
+        expect(res.body.teams).toHaveLength(2);
+
+        const ark = res.body.teams.find((t) => t.name === 'Arkansas');
+        expect(ark).toMatchObject({ type: 'team', id: 8, name: 'Arkansas', sub: 'SEC', color: '#9d2235' });
+    });
+
+    test('the logo is resolved server-side to the dark, highest-res, https URL', async () => {
+        const res = await get(asGraham);
+        const ark = res.body.teams.find((t) => t.name === 'Arkansas');
+        // Not the raw array, and not the 16px dark one `.at(-1)` would have given.
+        expect(ark.image).toBe('https://a.espncdn.com/i/teamlogos/ncaa/500-dark/8.png');
+    });
+
+    test('a team with no logos yields an empty string rather than throwing', async () => {
+        const res = await get(asGraham);
+        expect(res.body.teams.find((t) => t.name === 'Arkansas State').image).toBe('');
+    });
+
+    test('aliases carry mascot and abbreviation, de-duped', async () => {
+        const res = await get(asGraham);
+        const ark = res.body.teams.find((t) => t.name === 'Arkansas').aliases;
+        expect(ark).toContain('Razorbacks');
+        expect(ark).toContain('ARK');
+        // alt_name1/3 and alternateNames all repeat "Arkansas" and "ARK" in the
+        // real data; the payload must not.
+        expect(new Set(ark).size).toBe(ark.length);
+    });
+
+    test('the heavy fields never reach the client', async () => {
+        // weeklyScore is 152 KB across the collection and seasons is 729 KB.
+        // Neither is any use to a search row, and shipping them would put the
+        // index back over 1 MB.
+        const t = (await get(asGraham)).body.teams[0];
+        expect(t.weeklyScore).toBeUndefined();
+        expect(t.seasons).toBeUndefined();
+        expect(t.logos).toBeUndefined();
+        expect(t.location).toBeUndefined();
+    });
+});
+
+describe('managers', () => {
+    test('uses the ACTIVE season franchise name, not the newest entry', async () => {
+        const res = await get(asGraham);
+        expect(res.body.managers).toHaveLength(1);
+        expect(res.body.managers[0]).toMatchObject({
+            type: 'manager', name: 'Garrett Graham', sub: 'Razorback Rejects', initials: 'GG'
+        });
+    });
+
+    test('a member with no entry for the active season still resolves', async () => {
+        await User.create({
+            firstName: 'Past', lastName: 'Member', email: 'pm@example.com',
+            league: 'graham-league', seasons: [{ season: SEASON - 1, franchiseName: 'Gone' }]
+        });
+        const res = await get(asGraham);
+        const past = res.body.managers.find((m) => m.name === 'Past Member');
+        expect(past.sub).toBe('');                 // NOT last season's "Gone"
+        expect(past.initials).toBe('PM');
+    });
+
+    test('falls back to initials + colour when there is no avatar', async () => {
+        const res = await get(asClaunts);
+        expect(res.body.managers[0]).toMatchObject({ name: 'Cole Smith', image: null, initials: 'CS', color: '#22C37A' });
+    });
+
+    test('the id is the one /userHome expects', async () => {
+        const res = await get(asGraham);
+        const saved = await User.findOne({ firstName: 'Garrett' }).lean();
+        expect(res.body.managers[0].id).toBe(String(saved._id));
+        expect(mongoose.Types.ObjectId.isValid(res.body.managers[0].id)).toBe(true);
+    });
+});
+
+describe('league scoping', () => {
+    // The one that matters. Teams are shared CFBD data, so both leagues see all
+    // of them; managers are not.
+    test('a viewer only ever sees their OWN league\'s managers', async () => {
+        const graham = (await get(asGraham)).body;
+        const claunts = (await get(asClaunts)).body;
+
+        expect(graham.managers.map((m) => m.name)).toEqual(['Garrett Graham']);
+        expect(claunts.managers.map((m) => m.name)).toEqual(['Cole Smith']);
+
+        // Same team list for both — no per-league filtering leaked into teams.
+        expect(graham.teams.map((t) => t.id).sort()).toEqual(claunts.teams.map((t) => t.id).sort());
+    });
+
+    test('a league code in the query string is ignored', async () => {
+        // Scoping reads the session, so there is nothing here to override. If
+        // this ever starts returning Cole, someone has wired a client-supplied
+        // league into the handler.
+        const res = await request(asGraham).get('/search/index?league=claunts-league&code=claunts-league');
+        expect(res.body.managers.map((m) => m.name)).toEqual(['Garrett Graham']);
+    });
+});

--- a/tests/SearchMatch.spec.js
+++ b/tests/SearchMatch.spec.js
@@ -1,0 +1,177 @@
+// Ranking behind the app-wide search palette (public/search-match.js).
+//
+// The whole reason this module exists rather than a `.filter(includes)` is that
+// 23 of the 138 FBS school names share their first word. Substring matching in
+// collection order answers "arkansas" with Arkansas STATE on top — and Mongo
+// really does return Arkansas State first, so that isn't hypothetical. The
+// fixtures below are the REAL shapes from the teams collection (aliases
+// included, verbatim) so these assertions track the data the palette will
+// actually rank.
+
+const match = require('../public/search-match.js');
+
+const TEAMS = [
+    { type: 'team', id: 8, name: 'Arkansas', sub: 'SEC', aliases: ['Razorbacks', 'ARK'] },
+    { type: 'team', id: 2032, name: 'Arkansas State', sub: 'Sun Belt', aliases: ['Red Wolves', 'ARST'] },
+    { type: 'team', id: 12, name: 'Arizona', sub: 'Big 12', aliases: ['Wildcats', 'ARIZ'] },
+    { type: 'team', id: 9, name: 'Arizona State', sub: 'Big 12', aliases: ['Sun Devils', 'ASU'] },
+    { type: 'team', id: 349, name: 'Army', sub: 'American Athletic', aliases: ['Black Knights'] },
+    // Kansas is literally a substring of Arkansas — the cleanest real proof that
+    // a prefix hit has to outrank a mid-string one.
+    { type: 'team', id: 2305, name: 'Kansas', sub: 'Big 12', aliases: ['Jayhawks', 'KU'] },
+    { type: 'team', id: 2306, name: 'Kansas State', sub: 'Big 12', aliases: ['Wildcats', 'KSU'] },
+    // Both Miamis, with Miami (FL)'s real alias list.
+    { type: 'team', id: 2390, name: 'Miami', sub: 'ACC', aliases: ['Miami (FL)', 'MIA', 'Hurricanes'] },
+    { type: 'team', id: 193, name: 'Miami (OH)', sub: 'Mid-American', aliases: ['RedHawks'] },
+    { type: 'team', id: 221, name: 'Pittsburgh', sub: 'ACC', aliases: ['Pitt', 'PITT', 'Panthers'] },
+    { type: 'team', id: 245, name: 'Texas A&M', sub: 'SEC', aliases: ['TA&M', 'Aggies'] },
+    { type: 'team', id: 251, name: 'Texas', sub: 'SEC', aliases: ['Longhorns', 'TEX'] },
+    // Same length, same tier for a "t" query — the only thing left to separate
+    // them is the alphabetical tie-break.
+    { type: 'team', id: 2649, name: 'Temple', sub: 'American Athletic', aliases: ['Owls'] },
+    { type: 'team', id: 2649, name: 'Toledo', sub: 'Mid-American', aliases: ['Rockets'] }
+];
+
+const MANAGERS = [
+    { type: 'manager', id: 'u1', name: 'Garrett Graham', sub: 'Razorback Rejects', aliases: ['Razorback Rejects', 'Garrett', 'Graham'] },
+    { type: 'manager', id: 'u2', name: 'Cole Smith', sub: '', aliases: ['Cole', 'Smith'] }
+];
+
+const prepared = match.prepare(TEAMS.concat(MANAGERS));
+const names = (q) => match.rank(prepared, q).map((x) => x.name);
+
+describe('tiering: the shared-first-word problem', () => {
+    // The case that motivated the feature: nobody drafts Arkansas, so the only
+    // way to their page was the draft room. Typing the name has to land on the
+    // Razorbacks, not the Red Wolves.
+    test('an exact name beats a longer name that starts with it', () => {
+        expect(names('arkansas')[0]).toBe('Arkansas');
+        expect(names('arizona')[0]).toBe('Arizona');
+        expect(names('texas')[0]).toBe('Texas');
+    });
+
+    test('on a shared prefix the shorter name wins', () => {
+        expect(names('ark')).toEqual(['Arkansas', 'Arkansas State']);
+        expect(names('ariz')).toEqual(['Arizona', 'Arizona State']);
+    });
+
+    test('a prefix hit outranks a mid-string hit', () => {
+        // "Kansas" sits inside "Arkansas". Both Kansases are prefix hits and must
+        // clear both Arkansases, which only contain the letters.
+        expect(names('kansas')).toEqual(['Kansas', 'Kansas State', 'Arkansas', 'Arkansas State']);
+    });
+
+    test('inside one tier, ordering is purely by name length', () => {
+        const r = names('ar');
+        // Every one of these is a prefix hit, so nothing but length separates
+        // them — Army (4) through Arkansas State (14).
+        expect(r.slice(0, 5)).toEqual(['Army', 'Arizona', 'Arkansas', 'Arizona State', 'Arkansas State']);
+        // ...and "GARrett Graham" only contains the letters, so it trails every
+        // prefix hit. Tiers outrank type: a manager isn't promoted for being a
+        // manager, nor a team for being a team.
+        expect(r[5]).toBe('Garrett Graham');
+    });
+
+    test('both Miamis come back, the ACC one first', () => {
+        expect(names('miami')).toEqual(['Miami', 'Miami (OH)']);
+    });
+
+    test('equal tier and equal length fall back to alphabetical', () => {
+        // Temple and Toledo are both 6-character prefix hits for "t", so neither
+        // tier nor length separates them and the order must still be stable
+        // rather than however Mongo happened to return them.
+        const r = names('t');
+        expect(r.slice(0, 3)).toEqual(['Texas', 'Temple', 'Toledo']);
+    });
+});
+
+describe('aliases', () => {
+    test('an exact alias resolves the school', () => {
+        expect(names('pitt')[0]).toBe('Pittsburgh');
+    });
+
+    test('mascots are searchable', () => {
+        expect(names('razorbacks')).toContain('Arkansas');
+        expect(names('redhawks')).toEqual(['Miami (OH)']);
+    });
+
+    test('an alias disambiguates the Miamis', () => {
+        expect(names('miami fl')).toEqual(['Miami']);
+    });
+});
+
+describe('punctuation', () => {
+    // The two punctuated schools are exactly the ones people type loosely.
+    test('typing without the ampersand still finds Texas A&M', () => {
+        expect(names('texas am')).toEqual(['Texas A&M']);
+        expect(names('tam')).toContain('Texas A&M');
+    });
+
+    test('typing without the parens still finds Miami (OH)', () => {
+        expect(names('miami oh')).toEqual(['Miami (OH)']);
+    });
+});
+
+describe('word-start matching', () => {
+    test('a non-leading word matches at its own tier', () => {
+        expect(names('state').sort()).toEqual(['Arizona State', 'Arkansas State', 'Kansas State']);
+    });
+
+    test('a mid-word fragment does not masquerade as a word hit', () => {
+        // "tate" is inside "State" but starts no word, so it falls to the loose
+        // substring tier rather than ranking with real word hits.
+        expect(names('tate').sort()).toEqual(['Arizona State', 'Arkansas State', 'Kansas State']);
+    });
+});
+
+describe('managers', () => {
+    test('managers match by first name, last name and franchise', () => {
+        expect(names('garrett')).toContain('Garrett Graham');
+        expect(names('graham')).toContain('Garrett Graham');
+        expect(names('razorback rejects')).toEqual(['Garrett Graham']);
+    });
+
+    test('a manager and a team can match the same query, each still found', () => {
+        // "razorback" hits Arkansas' mascot AND Garrett's franchise name. Both
+        // must survive — the palette slices per type, so neither can crowd the
+        // other out downstream.
+        const r = match.rank(prepared, 'razorback');
+        expect(r.some((x) => x.type === 'team' && x.name === 'Arkansas')).toBe(true);
+        expect(r.some((x) => x.type === 'manager' && x.name === 'Garrett Graham')).toBe(true);
+    });
+});
+
+describe('the sub field ranks last', () => {
+    test('a conference match never outranks a name match', () => {
+        const r = names('sec');
+        // Texas / Texas A&M / Arkansas are SEC; none of them is named "sec", so
+        // they arrive on the lowest tier and no name hit is displaced.
+        expect(r).toContain('Texas');
+        expect(names('acc')).toContain('Pittsburgh');
+    });
+});
+
+describe('degenerate input', () => {
+    test('an empty or punctuation-only query matches nothing', () => {
+        expect(match.rank(prepared, '')).toEqual([]);
+        expect(match.rank(prepared, '   ')).toEqual([]);
+        expect(match.rank(prepared, '&&&')).toEqual([]);
+    });
+
+    test('a query that matches nothing returns an empty list', () => {
+        expect(names('zzzzz')).toEqual([]);
+    });
+
+    test('prepare tolerates missing fields and leaves the caller\'s items alone', () => {
+        const raw = [{ type: 'team', id: 1, name: 'Solo' }];
+        const p = match.prepare(raw);
+        expect(raw[0]).toEqual({ type: 'team', id: 1, name: 'Solo' });   // untouched
+        expect(match.rank(p, 'solo')[0]).toBe(raw[0]);                   // original object back
+        expect(match.prepare(null)).toEqual([]);
+    });
+
+    test('matching is case and accent insensitive', () => {
+        expect(names('ARKANSAS')[0]).toBe('Arkansas');
+        expect(match.tight('Málaga')).toBe('malaga');
+    });
+});

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -43,6 +43,13 @@
      side-by-side detail) used by Standings and the My Team matchup view. -->
 <link rel="stylesheet" type="text/css" href="/h2h-card.css">
 <script src="/h2h-card.js"></script>
+<!-- Search palette: jump to any FBS team or league manager from any page. The
+     ranking half is a separate pure file so it can be unit-tested; search.js is
+     the DOM and must load after it. The index itself is fetched lazily on first
+     open, so being on every page costs nothing until someone searches. -->
+<link rel="stylesheet" type="text/css" href="/search.css">
+<script src="/search-match.js"></script>
+<script src="/search.js"></script>
 <!-- Surface otherwise-silent failures (e.g. a failed fetch) instead of leaving the UI quietly broken -->
 <script>
     (function () {
@@ -92,6 +99,14 @@
             <li><a href="./hall-of-fame">Hall of Fame</a></li>
             <li><a href="./rules">Scoring</a></li>
             <li><a href="./draft-room">Draft Room</a></li>
+            <!-- A <button>, not a link: it opens a dialog rather than navigating.
+                 Icon-only on desktop with the label revealed in the stacked mobile
+                 menu — the same .nav-label treatment "My Team" uses, which is what
+                 keeps this off the ~716px the desktop row already needs. -->
+            <li><button type="button" id="nav-search" class="nav-search" aria-label="Search teams and managers" title="Search (⌘K)">
+                <i class="fa-solid fa-magnifying-glass"></i>
+                <span class="nav-label">Search</span>
+            </button></li>
             <% if (user && user.userId) { %>
             <li><a user-home href="/userHome?user=<%= user.userId %>" aria-label="My team">
                 <% var nu = (typeof navUser !== 'undefined' && navUser) || null; %>
@@ -144,9 +159,11 @@
                 setOpen(!links.classList.contains('active'));
             });
             // Tapping a destination link closes the menu (dropdown toggles are
-            // <button>s, so opening "Leagues" leaves the menu open).
+            // <button>s, so opening "Leagues" leaves the menu open). Search is
+            // named explicitly: it's a <button> by the same rule, but it opens a
+            // full-screen overlay, so leaving the menu stacked behind it is wrong.
             links.addEventListener('click', function (e) {
-                if (e.target.closest('a')) setOpen(false);
+                if (e.target.closest('a, #nav-search')) setOpen(false);
             });
             document.addEventListener('keydown', function (e) {
                 if (e.key === 'Escape' && links.classList.contains('active')) {

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -126,11 +126,22 @@
                  var _cur = !_sp ? 'Admin'
                      : ((_sp.roles || []).indexOf('League Manager') >= 0 ? 'League Manager'
                      : ((_sp.roles || []).indexOf('Admin') >= 0 ? 'Admin' : 'member')); %>
+            <%  var _curShort = _cur === 'League Manager' ? 'Lg Mgr' : (_cur === 'member' ? 'Member' : 'Admin'); %>
+            <!-- Collapsed to a chip showing the role currently in effect; the three
+                 choices live in a popover. Expanded inline, this control ran 298px
+                 and was enough on its own to wrap the admin navbar onto two lines.
+                 The popover is absolutely positioned so opening it never widens the
+                 row either. -->
             <li class="dev-spoof" aria-label="Dev role spoof">
-                <span class="dev-spoof-label">Dev · view as</span>
-                <button type="button" data-spoof="Admin" class="<%= _cur === 'Admin' ? 'active' : '' %>">Admin</button>
-                <button type="button" data-spoof="League Manager" class="<%= _cur === 'League Manager' ? 'active' : '' %>">League&nbsp;Mgr</button>
-                <button type="button" data-spoof="member" class="<%= _cur === 'member' ? 'active' : '' %>">Member</button>
+                <button type="button" class="dev-spoof-toggle" aria-expanded="false" aria-controls="dev-spoof-menu" title="Dev · view as (<%= _curShort %>)">
+                    <span class="dev-spoof-tag">Dev</span><span class="dev-spoof-cur"><%= _curShort %></span><span class="dev-spoof-caret" aria-hidden="true">▾</span>
+                </button>
+                <div class="dev-spoof-menu" id="dev-spoof-menu" hidden>
+                    <span class="dev-spoof-label">View as</span>
+                    <button type="button" data-spoof="Admin" class="<%= _cur === 'Admin' ? 'active' : '' %>">Admin</button>
+                    <button type="button" data-spoof="League Manager" class="<%= _cur === 'League Manager' ? 'active' : '' %>">League&nbsp;Mgr</button>
+                    <button type="button" data-spoof="member" class="<%= _cur === 'member' ? 'active' : '' %>">Member</button>
+                </div>
             </li>
             <% } %>
             <li><a href="./logout">Logout</a></li>
@@ -203,7 +214,31 @@
             }
         });
 
-        // --- Dev-only role spoof buttons (rendered only when canSpoof). ---
+        // --- Dev-only role spoof (rendered only when canSpoof). ---
+        // The chip expands into a popover with the three choices. No need to
+        // restore the open state after picking one: choosing a role reloads.
+        var spoofToggle = nav.querySelector('.dev-spoof-toggle');
+        var spoofMenu = document.getElementById('dev-spoof-menu');
+        if (spoofToggle && spoofMenu) {
+            var setSpoofOpen = function (open) {
+                spoofMenu.hidden = !open;
+                spoofToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            };
+            spoofToggle.addEventListener('click', function (e) {
+                e.stopPropagation();   // else the outside-click handler below closes it immediately
+                setSpoofOpen(spoofMenu.hidden);
+            });
+            document.addEventListener('click', function (e) {
+                if (!spoofMenu.hidden && !e.target.closest('.dev-spoof')) setSpoofOpen(false);
+            });
+            document.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape' && !spoofMenu.hidden) {
+                    setSpoofOpen(false);
+                    spoofToggle.focus();
+                }
+            });
+        }
+
         nav.querySelectorAll('.dev-spoof [data-spoof]').forEach(function (btn) {
             btn.addEventListener('click', function () {
                 var role = btn.getAttribute('data-spoof');


### PR DESCRIPTION
## Why

Every team link in the app is contextual — a roster card, a schedule row, a standings cell, a draft-board cell. So a team nobody drafted and nobody plays has **no route to it anywhere**. The only way to look up Arkansas was to reopen the draft room and find it in the pool table.

`/team?team=<id>` already worked for all 138 FBS teams — [team.js:75](public/team.js:75) reads the id from the query string and renders, with nothing requiring the team to be rostered. Only the way to *reach* it was missing, which is why this is navigation-only: no new page, no new rendering.

## What it does

`⌘K` / `Ctrl-K`, or the navbar magnifier, opens a palette that autocompletes over all 138 teams plus your own league's managers — team logos and profile photos in the rows, conference or franchise name as the subtitle.

## Ranking is tiered, not a substring filter

23 of the 138 school names share their first word. A plain `.filter(includes)` in collection order answers "arkansas" with **Arkansas State** first, and Mongo really does return it first — so this isn't hypothetical, it's the exact case that motivated the feature.

| Query | Result |
|---|---|
| `arkansas` | Arkansas, then Arkansas State |
| `ark` | Arkansas, then Arkansas State |
| `kansas` | Kansas, Kansas State, then the Arkansases |
| `miami` | Miami (ACC), then Miami (OH) |
| `pitt` | Pittsburgh (alias) |
| `texas am` | Texas A&M (punctuation-insensitive) |

Exact → prefix → word-start → substring, primary name above alias, and **shorter name first inside a tier**. That last pairing is what makes "ark" + Enter land on the Razorbacks. Conference as the subtitle is what separates the two Miamis.

## Payload

The index is one lazily-fetched payload, measured against the dev DB:

| Slice | Size |
|---|---|
| Bare `Team.find()` | 1,097 KB |
| — `seasons` | 729 KB |
| — `weeklyScore` | 152 KB |
| — raw `logos` arrays | 125 KB |
| **`GET /search/index`** | **30 KB** |

Logos resolve server-side through the shared `pickLogo` (already `require`d by six modules), so the palette can't drift from what Standings and the draft board pick. Fetched on **first open**, not page load — the navbar is on every page, and an eager fetch would re-pull on every navigation for a feature most page views never use.

## League scoping

Managers are scoped by reading the caller's league off `req.effUser` via `leagueCodeFor`, **never from a parameter**. A league code in the URL would be a request to trust the browser about which league it may read. Mounted behind `requiresAuth()` rather than `requireAuthOrToken` — a token-authenticated caller has no session to scope by and would fall through to the default league, handing that league's members to any token holder.

Two tests cover this directly, including one asserting a `?league=` query string is ignored.

## Navbar clutter

The nav was already at its budget — the 1024px collapse breakpoint exists because Logout once got cut off ([styles.css:370](public/styles.css:370)). So the opener is icon-only on desktop with the label revealed in the stacked mobile menu, the same `.nav-label` treatment My Team already uses. Measured in-browser: **50px added, nav row 617px**, well clear of the threshold.

## Testing

**1225 tests pass**, 62 suites. 30 new: 20 for the matcher, 11 for the endpoint. `public/search-match.js` added to the coverage ratchets at 95/85/100/95 (measures 98.03/87.5/100/97.14 — the one uncovered line is the UMD browser-global, unreachable under Node's `require`).

Verified live in the browser against a stubbed index, since Auth0 gates every real page:

- Ranking, grouping, logos and initials chips render correctly
- Arrow keys wrap; `aria-activedescendant` and `aria-selected` track
- `⌘K` opens with `defaultPrevented` (so Chrome's address bar isn't hijacked), toggles closed, focus lands in the input and is restored on close
- Escape closes and releases the body scroll lock
- Reopening does not refetch
- Mobile menu shows the labelled full-width row at a 51px tap target
- No console errors

**Not verified:** the palette on a real authenticated page, or against the live index endpoint — signing into Auth0 isn't something I can do. The endpoint is covered by supertest against real Mongo, and `/search/index` was confirmed to 302 to Auth0 when unauthenticated.

## Known limits

- `pickLogo` returns the 500px variant, oversized for a 28px row. Shipped with `loading="lazy"` and a capped result count because these are the *same URLs* Standings and the draft room already load, so they're usually warm in cache. Adding a size option would mean touching a file six server modules depend on.
- A bare `/` is deliberately **not** bound as a second shortcut — the draft room has its own always-visible filter input and `/` would hijack a keystroke meant for it.
- No typo-tolerant fuzzy matching, no recent-search history, no searching games or weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)