### PR TITLE
Project ranked wins off the current poll; log the enrichment job's runs

### DIFF
--- a/modules/job-mailer.js
+++ b/modules/job-mailer.js
@@ -64,4 +64,15 @@ async function sendJobEmail(opts) {
     }
 }
 
-module.exports = { sendJobEmail, buildJobEmailHtml };
+// Emails on a SUCCESSFUL run only when explicitly opted in. Default is
+// failure-only: a healthy run is the norm (~50/month in season) and just adds
+// inbox noise — the admin status strip and standings "last updated" badge cover
+// the healthy state. Failures always email. Set JOB_EMAIL_ON_SUCCESS=true to
+// restore a report on every run.
+//
+// Lives here, not in score-job, so a job can share the policy without importing
+// the whole scoring pipeline (score-update pulls in the CFBD client at require
+// time). score-job re-exports it for its existing callers.
+function emailOnSuccess() { return process.env.JOB_EMAIL_ON_SUCCESS === 'true'; }
+
+module.exports = { sendJobEmail, buildJobEmailHtml, emailOnSuccess };

--- a/modules/score-job.js
+++ b/modules/score-job.js
@@ -1,13 +1,8 @@
 const { runFullUpdate } = require('./score-update');
 const { startRun, finishRun } = require('./job-logger');
-const { sendJobEmail } = require('./job-mailer');
-
-// Emails on a successful run only when explicitly opted in. Default is
-// failure-only: a healthy run is the norm (~50/month in season) and just adds
-// inbox noise — the admin status strip and standings "last updated" badge cover
-// the healthy state. Failures always email. Set JOB_EMAIL_ON_SUCCESS=true to
-// restore a report on every run.
-function emailOnSuccess() { return process.env.JOB_EMAIL_ON_SUCCESS === 'true'; }
+// emailOnSuccess (the failure-only default) lives in job-mailer so jobs that
+// don't need the scoring pipeline can share it; re-exported here unchanged.
+const { sendJobEmail, emailOnSuccess } = require('./job-mailer');
 
 // Builds a job's run(): logs the run (start -> success/error), executes the
 // shared pipeline, and emails a run report on failure (and on success only when

--- a/public/admin.js
+++ b/public/admin.js
@@ -269,7 +269,7 @@ function timeAgo(iso) {
 
 var JOB_LABELS = {
     'daily-scores': 'Daily', 'saturday-scores': 'Saturday', 'sunday-scores': 'Sunday',
-    'live-scores': 'Live'
+    'live-scores': 'Live', 'enrichment': 'SP+ / media'
 };
 
 function renderAdminStatus(el, s, api, year, jobs) {
@@ -294,7 +294,10 @@ function renderAdminStatus(el, s, api, year, jobs) {
     // Automated-job last-run summary (green success, red error, amber running).
     var jobsBlock = '';
     if (jobs && jobs.length) {
-        var order = ['daily-scores', 'saturday-scores', 'sunday-scores', 'live-scores'];
+        // Any job missing from this list sorts to indexOf -1, i.e. AHEAD of the
+        // scoring jobs — so a new job name has to be added here, not just to
+        // JOB_LABELS, or it silently jumps the queue.
+        var order = ['daily-scores', 'saturday-scores', 'sunday-scores', 'live-scores', 'enrichment'];
         // Collapse to the latest run per job — the live poller writes a run every
         // few minutes on game days, so showing raw history would bury the others.
         var latest = {};

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -48,6 +48,12 @@ router.get('/grades/:league/:season', async (req, res) => {
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
         const config = resolveConfig(league, overridesFromDoc(cfgDoc));
 
+        // week 1 = the PRESEASON AP poll, and deliberately frozen there. A grade
+        // is a judgment about a roster as drafted; if it read the current poll it
+        // would drift all season and a manager's "A-" could quietly become a "B"
+        // for reasons that have nothing to do with their draft. The standings
+        // projections do the opposite on purpose — see projectionPoll in
+        // routes/standings.js.
         const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
         const apPoll = apDoc && Array.isArray(apDoc.polls)
             ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
@@ -99,6 +105,8 @@ router.get('/board/:league/:season', async (req, res) => {
             const cfgDoc = await ScoringConfig.findOne({ league }).lean();
             const config = resolveConfig(league, overridesFromDoc(cfgDoc));
 
+            // Preseason poll, like the grades above — the board only runs during
+            // the draft, when week 1 IS the latest poll anyway.
             const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
             const apPoll = apDoc && Array.isArray(apDoc.polls)
                 ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -19,7 +19,29 @@ const { buildWeeklyRecaps, indexUpsets } = require('../modules/weekly-recap');
 const { competitionRanks } = require('../public/league-rank.js');
 const { gameStatus, matchupWinProb, H2H_MAX_WEEK, baseWeekScore, persistedBonus,
         h2hRoster, pinnedH2HIds, computeH2HAwards } = require('../modules/h2h');
+const { findPoll } = require('../modules/scoring-detectors');
 const { pickLogo } = require('../public/logo.js');
+
+// The poll the PROJECTIONS should value a hypothetical ranked win against: the
+// most recent regular-season poll on file.
+//
+// Draft grades and the draft board (routes/draft.js) deliberately do the
+// opposite — they read week 1 and stay there — because a grade is a preseason
+// judgment about a preseason roster and must not drift as the top 25 reshuffles.
+// A projection is the opposite kind of claim: it forecasts what the REMAINING
+// schedule is worth, so a team that climbed into the top 10 in October should
+// have its wins valued at October's rank, not August's.
+//
+// Uses the engine's own findPoll rather than plucking 'AP Top 25' directly, so
+// the projection prefers the Playoff Committee Rankings exactly when scoring
+// does. Picking AP by hand meant that from the committee's first release onward,
+// a projected "beat a ranked team" bonus could be worth something different than
+// the same win actually banked. Returns null when no poll is stored, which
+// buildRankingProxy answers with its SP+-derived stand-in.
+async function projectionPoll(season) {
+    const doc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: -1 }).lean();
+    return findPoll(doc);
+}
 
 // The scoring jobs that actually refresh standings data (see modules/score-job.js
 // and modules/live-poll.js). 'live-scores' is the game-day live poller, so the
@@ -167,10 +189,7 @@ router.get('/projections/:league/:season', async (req, res) => {
 
         const cfgDoc = await ScoringConfig.findOne({ league }).lean();
         const cfg = resolveConfig(league, overridesFromDoc(cfgDoc));
-        const apDoc = await Ranking.findOne({ season, seasonType: 'regular' }).sort({ week: 1 }).lean();
-        const apPoll = apDoc && Array.isArray(apDoc.polls) ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
-
-        const rankings = buildRankingProxy(season, teamsById, apPoll);
+        const rankings = buildRankingProxy(season, teamsById, await projectionPoll(season));
         const poolCtx = buildPoolContext(teamsById, season);
         const managers = buildProjections(users, teamsById, gamesByTeam, cfg, rankings, poolCtx, season);
         // Forward-looking only: if the regular season has no games left (season
@@ -397,9 +416,12 @@ router.get('/h2h/:league/:season', async (req, res) => {
                 });
             });
             const cfg = resolveConfig(league, overridesFromDoc(cfgDoc));
-            const apDoc = await Ranking.findOne({ season: seasonNum, seasonType: 'regular' }).sort({ week: 1 }).lean();
-            const apPoll = apDoc && Array.isArray(apDoc.polls) ? apDoc.polls.find(p => p.poll === 'AP Top 25') : null;
-            const rankings = buildRankingProxy(seasonNum, teamsById, apPoll);
+            // Latest poll, same as the standings projection. The H2H win probs
+            // for ALREADY-PLAYED weeks are retrospective, so strictly they'd want
+            // that week's own poll — but they're a "what were the odds" garnish,
+            // and the live bar on the in-progress week is what this actually
+            // drives. One poll read beats one per week.
+            const rankings = buildRankingProxy(seasonNum, teamsById, await projectionPoll(seasonNum));
             const poolCtx = buildPoolContext(teamsById, seasonNum);
             draftedIds.forEach(tid => {
                 const team = teamsById[String(tid)];

--- a/tests/EnrichmentJob.spec.js
+++ b/tests/EnrichmentJob.spec.js
@@ -3,7 +3,15 @@
 // dependency is the global fetch, which we stub and route by URL — the same
 // pattern the scoring-module tests use — so no server or CFBD call is needed.
 
+// The run report is the mailer's job (tests/JobEmail.spec.js); stub it so this
+// suite never builds a real SMTP transport.
+jest.mock('../modules/job-mailer', () => ({
+    sendJobEmail: jest.fn(() => Promise.resolve()),
+    emailOnSuccess: () => false
+}));
+
 const { internalFetch } = require('../modules/internal-api');
+const { sendJobEmail } = require('../modules/job-mailer');
 const enrichmentJob = require('../update-enrichment-job');
 
 const OLD_ENV = process.env;
@@ -38,29 +46,42 @@ describe('internalFetch', () => {
 });
 
 describe('update-enrichment-job run()', () => {
-    // Route the two internal POSTs the job makes to their fake responses.
-    function stubFetch() {
+    // Route the job's internal calls to fake responses: the two data POSTs plus
+    // the job-run start/finish the logger writes around them.
+    function stubFetch(over = {}) {
         global.fetch = jest.fn((url, opts) => {
-            const body = { status: 200 };
-            if (url.includes('/enrich')) body.json = () => Promise.resolve({ updated: 130 });
-            else if (url.includes('/media')) body.json = () => Promise.resolve({ updated: 55 });
-            else body.json = () => Promise.resolve({});
-            body.__opts = opts;
-            return Promise.resolve(body);
+            const res = { status: 200, __opts: opts };
+            if (url.includes('/job-runs')) {
+                res.status = opts && opts.method === 'POST' ? 201 : 200;
+                res.json = () => Promise.resolve({ _id: 'run-1' });
+            } else if (url.includes('/enrich')) {
+                res.status = over.enrichStatus || 200;
+                res.json = () => Promise.resolve(over.enrichBody || { updated: 130 });
+            } else if (url.includes('/media')) {
+                res.status = over.mediaStatus || 200;
+                res.json = () => Promise.resolve({ updated: 55 });
+            } else {
+                res.json = () => Promise.resolve({});
+            }
+            return Promise.resolve(res);
         });
     }
+
+    // The data calls only — job-run bookkeeping is asserted separately.
+    const dataCalls = () => global.fetch.mock.calls.filter(c => !c[0].includes('/job-runs'));
 
     test('posts enrich + media to the season endpoints with the internal token', async () => {
         stubFetch();
         const results = await enrichmentJob.run();
 
-        expect(global.fetch).toHaveBeenCalledTimes(2);
-        const urls = global.fetch.mock.calls.map(c => c[0]);
+        const calls = dataCalls();
+        expect(calls).toHaveLength(2);
+        const urls = calls.map(c => c[0]);
         expect(urls).toContain('http://test.local/teams/2025/enrich');
         expect(urls).toContain('http://test.local/games/2025/media');
 
         // Every internal call carries the token and is a POST.
-        global.fetch.mock.calls.forEach(([, opts]) => {
+        calls.forEach(([, opts]) => {
             expect(opts.method).toBe('POST');
             expect(opts.headers['X-Internal-Token']).toBe('secret-token');
         });
@@ -85,10 +106,41 @@ describe('update-enrichment-job run()', () => {
         process.argv = ['node', 'update-enrichment-job.js', '2026'];
         stubFetch();
         await enrichmentJob.run();
-        expect(global.fetch.mock.calls[0][0]).toContain('/teams/2026/enrich');
+        expect(dataCalls()[0][0]).toContain('/teams/2026/enrich');
     });
 
     test('exposes a stable JOB_NAME for the scheduler/logger', () => {
         expect(enrichmentJob.JOB_NAME).toBe('enrichment');
+    });
+
+    test('records a job run: start under the job name, then success with a summary', async () => {
+        stubFetch();
+        await enrichmentJob.run();
+
+        const start = global.fetch.mock.calls.find(c => c[0].endsWith('/job-runs'));
+        expect(JSON.parse(start[1].body)).toMatchObject({ jobName: 'enrichment', season: '2025' });
+
+        const finish = global.fetch.mock.calls.find(c => c[0].includes('/job-runs/run-1'));
+        expect(finish[1].method).toBe('PATCH');
+        const done = JSON.parse(finish[1].body);
+        expect(done.status).toBe('success');
+        expect(done.message).toContain('130 teams enriched');
+    });
+
+    // The whole point of the logging: a leg that didn't land must not be filed
+    // as a healthy run, or stale SP+ stays as invisible as it was before.
+    test('a non-200 from either leg is recorded as an error, not a success', async () => {
+        stubFetch({ enrichStatus: 500, enrichBody: { message: 'CFBD timeout' } });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await expect(enrichmentJob.run()).rejects.toThrow(/enrich -> 500/);
+
+        const finish = global.fetch.mock.calls.find(c => c[0].includes('/job-runs/run-1'));
+        const done = JSON.parse(finish[1].body);
+        expect(done.status).toBe('error');
+        expect(done.message).toContain('CFBD timeout');
+
+        // Failures always email, regardless of JOB_EMAIL_ON_SUCCESS.
+        expect(sendJobEmail).toHaveBeenCalledWith(expect.objectContaining({ ok: false }));
     });
 });

--- a/tests/RoutesStandingsPoll.spec.js
+++ b/tests/RoutesStandingsPoll.spec.js
@@ -1,0 +1,123 @@
+// Which poll the standings PROJECTIONS value a hypothetical ranked win against.
+//
+// The projections and the draft grades share one engine but want opposite things
+// from the poll: a grade is a frozen preseason judgment (routes/draft.js reads
+// week 1 and stays there), while a projection forecasts the REMAINING schedule
+// and so must follow the current top 25. Both used to read week 1, which meant
+// the October projection still priced every ranked-win bonus off the August AP
+// poll. These tests pin the new split, and the committee-poll preference that
+// keeps a projected bonus worth the same as the one actually banked.
+//
+// The route, models and Mongo are real; win probabilities are pinned by giving
+// every team an expectedWins, so the only thing that can move projectedFinal
+// between cases is the points-if-win the poll decides.
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const Team = require('../models/team');
+const User = require('../models/user');
+const Ranking = require('../models/ranking');
+const standingsRouter = require('../routes/standings');
+
+const LEAGUE = 'graham-league';
+const SEASON = 2026;
+const MINE = 1, OPP = 2;
+
+const app = express();
+app.use(express.json());
+app.use('/standings', standingsRouter);
+
+useMongo();
+
+function fullTeam(id, school, extra) {
+    return {
+        id, school, mascot: 'M', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'Big Ten', color: '#000', logos: [`${school}.png`],
+        location: { venue_id: id, name: 'V', city: 'C', state: 'ST', zip: '1',
+                    latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false },
+        seasons: [Object.assign({ season: SEASON, conference: 'Big Ten' }, extra)]
+    };
+}
+
+// One manager rostering MINE, whose four remaining games are all against OPP.
+// Non-conference so the ranked-win rules the 'graham' model has ON by default
+// (nonConfWinRanked + the additive top-10 bonus) are the ones in play.
+async function seed() {
+    await Team.create([
+        fullTeam(MINE, 'Mine U', { spRating: 10, expectedWins: 8, cfpMakeOdds: 500, cfpChampOdds: 5000 }),
+        fullTeam(OPP, 'Opponent U', { spRating: 0, expectedWins: 6, cfpMakeOdds: 2000, cfpChampOdds: 50000 }),
+        fullTeam(3, 'Other U', { spRating: 5, expectedWins: 7, cfpMakeOdds: 1500, cfpChampOdds: 40000 })
+    ]);
+    const Game = require('../models/game');
+    await Game.create([1, 2, 3, 4].map(wk => ({
+        id: 100 + wk, season: SEASON, seasonType: 'regular', week: wk,
+        neutralSite: false, conferenceGame: false, completed: false,
+        startTimeTbd: false, startDate: `2026-09-0${wk}T18:00:00.000Z`,
+        homeId: MINE, homeTeam: 'Mine U', homeConference: 'Big Ten',
+        awayId: OPP, awayTeam: 'Opponent U', awayConference: 'Big Ten'
+    })));
+    await User.create({
+        firstName: 'Pat', lastName: 'Tester', league: LEAGUE,
+        seasons: [{ season: SEASON, cumulativeScore: 0, teams: [fullTeam(MINE, 'Mine U')] }]
+    });
+}
+
+const poll = (name, ranks) => ({ poll: name, ranks });
+const rankingDoc = (week, polls) => Ranking.create({ season: SEASON, seasonType: 'regular', week, polls });
+
+async function projectedFinal() {
+    const res = await request(app).get(`/standings/projections/${LEAGUE}/${SEASON}`);
+    expect(res.status).toBe(200);
+    expect(res.body.managers).toHaveLength(1);
+    return res.body.managers[0].projectedFinal;
+}
+
+describe('GET /standings/projections — poll selection', () => {
+    beforeEach(seed);
+
+    it('values ranked wins off the LATEST poll, not the preseason one', async () => {
+        // August: the opponent is #1. That is the only poll on file, so it is
+        // both the preseason and the latest — the projection prices it as ranked.
+        await rankingDoc(1, [poll('AP Top 25', [{ school: 'Opponent U', rank: 1 }])]);
+        const preseasonOnly = await projectedFinal();
+
+        // October: the opponent has fallen out of the top 25. Reading week 1
+        // would leave the projection stuck on the August valuation.
+        await rankingDoc(8, [poll('AP Top 25', [{ school: 'Other U', rank: 1 }])]);
+        const withLatest = await projectedFinal();
+
+        expect(withLatest).toBeLessThan(preseasonOnly);
+    });
+
+    it('picks a team back up when the latest poll ranks it', async () => {
+        await rankingDoc(1, [poll('AP Top 25', [{ school: 'Other U', rank: 1 }])]);
+        const unranked = await projectedFinal();
+
+        await rankingDoc(8, [poll('AP Top 25', [{ school: 'Opponent U', rank: 1 }])]);
+        expect(await projectedFinal()).toBeGreaterThan(unranked);
+    });
+
+    // Reusing the engine's findPoll (rather than plucking 'AP Top 25' by hand)
+    // is what keeps a PROJECTED ranked-win bonus worth the same as the one the
+    // scoring job will actually bank once the game is played.
+    it('prefers the Playoff Committee Rankings over AP, exactly as scoring does', async () => {
+        await rankingDoc(1, [poll('AP Top 25', [{ school: 'Other U', rank: 1 }])]);
+        const unranked = await projectedFinal();
+
+        await rankingDoc(14, [
+            poll('AP Top 25', [{ school: 'Other U', rank: 1 }]),           // AP: opponent unranked
+            poll('Playoff Committee Rankings', [{ school: 'Opponent U', rank: 1 }])
+        ]);
+        expect(await projectedFinal()).toBeGreaterThan(unranked);
+    });
+
+    // No poll at all is the preseason state every year until the AP poll drops;
+    // buildRankingProxy answers it with an SP+-derived stand-in rather than
+    // treating the whole country as unranked.
+    it('still projects when no poll is stored yet', async () => {
+        const res = await request(app).get(`/standings/projections/${LEAGUE}/${SEASON}`);
+        expect(res.status).toBe(200);
+        expect(res.body.managers[0].projectedFinal).toBeGreaterThan(0);
+    });
+});

--- a/update-enrichment-job.js
+++ b/update-enrichment-job.js
@@ -3,6 +3,8 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 const { internalFetch } = require('./modules/internal-api');
+const { startRun, finishRun } = require('./modules/job-logger');
+const { sendJobEmail, emailOnSuccess } = require('./modules/job-mailer');
 
 // Pulls opponent-agnostic CFBD data onto each team's season, plus broadcast
 // outlets onto games. Two cadences (the enrich route splits by `scope`):
@@ -15,13 +17,22 @@ const { internalFetch } = require('./modules/internal-api');
 // directly is a manual fallback:
 //   node update-enrichment-job.js 2026            (weekly: ratings + media)
 //   node update-enrichment-job.js 2026 preseason  (full: adds talent/returning/coaches)
+//
+// Like the scoring jobs, every run is recorded as a JobRun (start -> success/
+// error) and a failure emails the run report. Without that this job was the one
+// piece of automation with NO outward sign it had run: a broken weekly pull just
+// left last week's SP+ sitting on the team docs, and the only symptom was
+// standings projections that quietly stopped responding to results.
 const JOB_NAME = 'enrichment';
 
 async function run(opts = {}) {
+    const startMs = Date.now();
+    const when = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
     const season = parseInt(process.argv[2], 10) || parseInt(process.env.YEAR, 10);
     // Weekly by default; 'preseason' (via opts or CLI arg) pulls everything.
     const preseason = opts.preseason || process.argv[3] === 'preseason';
     const scope = preseason ? 'all' : 'weekly';
+    const label = `Enrichment (${scope})`;
     const results = {};
 
     async function post(path, body) {
@@ -32,16 +43,56 @@ async function run(opts = {}) {
         });
         const resBody = await res.json().catch(() => ({}));
         if (res.status !== 200) console.log(`${path} -> ${res.status}:`, resBody.message || resBody);
-        return { status: res.status, body: resBody };
+        return { status: res.status, path, body: resBody };
     }
 
-    results.teams = await post(`/teams/${season}/enrich`, { scope });
-    results.media = await post(`/games/${season}/media`);
+    const id = await startRun(JOB_NAME, { season: String(season) });
+    try {
+        results.teams = await post(`/teams/${season}/enrich`, { scope });
+        results.media = await post(`/games/${season}/media`);
 
-    console.log(`[${JOB_NAME}] season ${season} (scope=${scope}):`,
-        `teams enriched=${results.teams.body.updated}`,
-        `media updated=${results.media.body.updated}`);
-    return results;
+        // A non-200 from either leg means the data did NOT land. Recording that
+        // as a success would reproduce the exact blind spot this logging exists
+        // to close, so surface it as an error the same way a thrown one is.
+        const failed = [results.teams, results.media].filter(r => r.status !== 200);
+        if (failed.length) {
+            throw new Error(failed.map(r => `${r.path} -> ${r.status}`
+                + (r.body && r.body.message ? ` (${r.body.message})` : '')).join('; '));
+        }
+
+        const secs = Math.round((Date.now() - startMs) / 1000);
+        const summary = `${scope} · ${results.teams.body.updated} teams enriched · `
+            + `${results.media.body.updated} games given media (${secs}s)`;
+        console.log(`[${JOB_NAME}] season ${season} (scope=${scope}):`,
+            `teams enriched=${results.teams.body.updated}`,
+            `media updated=${results.media.body.updated}`);
+        await finishRun(id, 'success', summary);
+
+        if (emailOnSuccess()) {
+            await sendJobEmail({
+                label, when, ok: true,
+                rows: [
+                    ['Season', String(season)],
+                    ['Scope', scope],
+                    ['Teams enriched', String(results.teams.body.updated)],
+                    ['Games w/ media', String(results.media.body.updated)],
+                    ['Duration', `${secs}s`]
+                ]
+            });
+        }
+        return results;
+    } catch (err) {
+        const secs = Math.round((Date.now() - startMs) / 1000);
+        const msg = (err && err.message) ? err.message : String(err);
+        console.error(`❌ ${label} failed:`, err);
+        await finishRun(id, 'error', msg);
+        await sendJobEmail({
+            label, when, ok: false,
+            rows: [['Season', String(season)], ['Scope', scope], ['Failed after', `${secs}s`]],
+            error: (err && err.stack) ? err.stack : msg
+        });
+        throw err;
+    }
 }
 
 module.exports = { run, JOB_NAME };


### PR DESCRIPTION
Two independent fixes that came out of asking what actually happens to the AP poll and SP+ each week. Split into a commit each.

## 1. Projections read the current poll, not the preseason one

`routes/standings.js` and `routes/draft.js` share one projection engine, but both were reading the *earliest* regular-season rankings doc. Draft grades are right to freeze there — a grade judges a roster as drafted, and shouldn't drift into a different letter because the top 25 reshuffled in October. Projections are the opposite claim: they forecast what the remaining schedule is worth, so from September on they were pricing every ranked-win bonus off the August AP poll.

The new `projectionPoll` helper reads the latest poll, and the two draft call sites keep `week: 1` with comments saying why, so the split reads as deliberate.

**It also fixes a poll-preference mismatch.** The helper delegates to the engine's own `findPoll` instead of plucking `AP Top 25` by name, so it prefers `Playoff Committee Rankings` exactly when scoring does. Hand-picking AP meant that from the committee's first November release, a *projected* "beat a ranked team" bonus could be worth a different number than the one the scoring job actually banked for that same win.

That isn't theoretical. What scoring cares about is the bucket (unranked / #11–25 / #1–10), and on each season's final regular-season poll the two disagree on:

| Season | Teams in a different bucket |
|---|---|
| 2023 w15 | 4 — Clemson, Kansas State ranked by committee only; Tulane, James Madison AP only |
| 2024 w16 | 2 — SMU top-10 committee vs #11–25 AP; Arizona State the reverse |
| 2025 w16 | 6 — Alabama/Notre Dame swap top-10 and #11–25; Houston, Iowa committee-only; Navy, Missouri AP-only |

Committee rankings land around week 11 each year, so for 2026 this is inert until early November.

`tests/RoutesStandingsPoll.spec.js` covers it. Three of its four tests fail against the old `week: 1` sort — verified, not assumed.

## 2. The enrichment job records its runs

The weekly SP+/FPI pull (Tuesdays 5:30am CT) was the one piece of automation with no outward sign it had run: no `JobRun` row, so nothing in the admin status strip, and no failure email. A broken pull just left last week's SP+ on the team docs, and the only symptom was standings projections quietly not responding to results.

It now brackets the run with `startRun`/`finishRun` and emails on failure, matching `modules/score-job.js`. **A non-200 from either leg is now an error rather than a logged line and a normal return** — filing a run that didn't land as a `success` would rebuild the exact blind spot this closes.

Two supporting changes:
- `emailOnSuccess` moves from `score-job` to `job-mailer`, where the policy belongs, so a job can share it without importing `score-update` and its require-time CFBD client init. `score-job` re-exports it unchanged.
- The admin strip needs both a `JOB_LABELS` entry and an `order` entry — a job missing from `order` sorts to `indexOf === -1` and jumps ahead of the scoring jobs. That list now says so.

## Testing

`npx jest` — 1231 passing with the per-file coverage ratchets.

One caveat: the full coverage run intermittently fails a *different* DB-backed suite each time (`RoutesScoringConfig`, then `RoutesInvite`), always with a ~24s duration vs ~1.2s in isolation. Both pass alone and on `origin/main`, so it's mongodb-memory-server startup contention under parallel load, not these changes — but it's worth someone looking at separately.

Not verified in a browser: the admin strip label. It needs a running server, seeded job runs, and admin auth to see, and the change is a map entry plus an array element.