### PR TITLE
Show the whole H2H schedule, not just the weeks already played

### DIFF
--- a/public/h2h-card.css
+++ b/public/h2h-card.css
@@ -9,6 +9,9 @@
 
 .h2h-mcard { background: var(--cc-surface); border: 1px solid var(--cc-border); border-radius: 12px; }
 .h2h-mcard.live { border-color: var(--cc-border-2); }
+/* Not played yet: same card, dialed back so it reads as a preview next to a
+   live or settled one. The em-dash scoreline is muted rather than bold. */
+.h2h-mcard.upcoming .h2h-msc { font-weight: 600; color: var(--cc-muted-2); }
 .h2h-msum { display: flex; align-items: center; gap: 0.5rem; padding: 0.55rem 0.75rem; cursor: pointer; }
 .h2h-mwk { font-size: 0.58rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-muted-2); flex-shrink: 0; min-width: 2.2rem; }
 .h2h-mside { display: flex; align-items: center; gap: 0.4rem; flex: 1; min-width: 0; }

--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -7,7 +7,7 @@
 //   window.ccH2H.wire(containerEl)                               -> attach toggles
 //
 // `game` is one entry from the /standings/h2h payload's schedule[].games:
-//   { aId, bId, aScore, bScore, aTeams, bTeams, winner, winP, final }
+//   { aId, bId, aScore, bScore, aTeams, bTeams, winner, winP, final, upcoming }
 // `byId` maps userId -> manager ({ franchise, name, avatarUrl, initials, color }).
 // Pass `youId` to orient that manager to the left and label them "You" (My Team);
 // pass `youLabel` to override that label with a name (viewing another's profile);
@@ -56,10 +56,11 @@
         return right ? '<div class="h2h-trow">' + teamVal(t) + idcol + img + '</div>'
             : '<div class="h2h-trow">' + img + idcol + teamVal(t) + '</div>';
     }
-    // Final weeks show only teams that scored; a live week shows every team with
-    // a game (so upcoming/in-progress ones are visible, not mistaken for 0).
-    function teamList(teams, live, right) {
-        var list = live ? (teams || []) : (teams || []).filter(function (t) { return t.score > 0; });
+    // Final weeks show only teams that scored; an unplayed week (live or still
+    // to come) shows every team with a game, so in-progress and upcoming ones
+    // are visible with their kickoff times instead of being mistaken for 0.
+    function teamList(teams, unplayed, right) {
+        var list = unplayed ? (teams || []) : (teams || []).filter(function (t) { return t.score > 0; });
         return list.length ? list.map(function (t) { return teamRow(t, right); }).join('')
             : '<div class="h2h-trow empty">no points</div>';
     }
@@ -97,7 +98,7 @@
             aTeams: g.bTeams, bTeams: g.aTeams,
             winner: g.winner === 'a' ? 'b' : g.winner === 'b' ? 'a' : g.winner,
             winP: g.winP ? { a: g.winP.b, b: g.winP.a } : g.winP,
-            final: g.final
+            final: g.final, upcoming: g.upcoming
         };
     }
 
@@ -111,24 +112,32 @@
         // name); default keeps the first-person "You" for the viewer's own pages.
         var aName = youLeft ? (opts.youLabel || 'You') : nameOf(A);
         var bName = nameOf(B);
-        var live = g.final === false;
+        // Three states, not two: a week that hasn't kicked off yet is neither
+        // final nor live. It shows the same per-team view as a live week (so
+        // kickoff times are visible) but reads as a preview — no LIVE badge, and
+        // no 0-0 scoreline pretending the matchup is already under way.
+        var upcoming = !!g.upcoming;
+        var live = g.final === false && !upcoming;
+        var unplayed = live || upcoming;
+        var score = function (v) { return upcoming ? '&ndash;' : v; };
         var remaining = (g.aTeams || []).concat(g.bTeams || []).filter(function (t) { return t.status && t.status !== 'final'; }).length;
         var sep = live ? '<span class="h2h-mlive">LIVE</span>' : (g.winner === 'tie' ? 'T' : 'vs');
         var wk = opts.week != null ? '<span class="h2h-mwk">Wk ' + opts.week + '</span>' : '';
-        return '<div class="h2h-mcard' + (live ? ' live' : '') + (opts.open ? ' open' : '') + '">'
+        return '<div class="h2h-mcard' + (live ? ' live' : '') + (upcoming ? ' upcoming' : '') + (opts.open ? ' open' : '') + '">'
             + '<div class="h2h-msum" role="button" tabindex="0" aria-expanded="' + (opts.open ? 'true' : 'false') + '">'
             + wk
-            + '<div class="h2h-mside' + (g.winner === 'a' ? ' win' : '') + '">' + manLink(g.aId, avatar(A) + '<span class="h2h-mnm">' + aName + '</span>') + '<span class="h2h-msc">' + g.aScore + '</span></div>'
+            + '<div class="h2h-mside' + (g.winner === 'a' ? ' win' : '') + '">' + manLink(g.aId, avatar(A) + '<span class="h2h-mnm">' + aName + '</span>') + '<span class="h2h-msc">' + score(g.aScore) + '</span></div>'
             + '<span class="h2h-msep">' + sep + '</span>'
-            + '<div class="h2h-mside r' + (g.winner === 'b' ? ' win' : '') + '"><span class="h2h-msc">' + g.bScore + '</span>' + manLink(g.bId, '<span class="h2h-mnm">' + bName + '</span>' + avatar(B)) + '</div>'
+            + '<div class="h2h-mside r' + (g.winner === 'b' ? ' win' : '') + '"><span class="h2h-msc">' + score(g.bScore) + '</span>' + manLink(g.bId, '<span class="h2h-mnm">' + bName + '</span>' + avatar(B)) + '</div>'
             + '<i class="fa-solid fa-chevron-down h2h-mcaret" aria-hidden="true"></i>'
             + '</div>'
             + winBar(g)
             + '<div class="h2h-mdetail">'
-            + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, live, false) + '</div>'
-            + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, live, true) + '</div>'
+            + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, unplayed, false) + '</div>'
+            + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, unplayed, true) + '</div>'
             + pregameLine(g, aName, bName)
             + (live ? '<div class="h2h-mfoot">In progress · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' to play · scores update as they finish</div>' : '')
+            + (upcoming ? '<div class="h2h-mfoot">Not started · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' scheduled · odds are projected</div>' : '')
             + '</div></div>';
     }
 

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -733,7 +733,7 @@ async function hydrateH2H(user, activeYear) {
     (data.managers || []).forEach(m => { byId[m.userId] = m; });
     const uid = String(user._id);
     const mine = [];
-    (data.schedule || []).forEach(s => { const g = s.games.find(x => x.aId === uid || x.bId === uid); if (g) mine.push({ week: s.week, final: s.final !== false, g }); });
+    (data.schedule || []).forEach(s => { const g = s.games.find(x => x.aId === uid || x.bId === uid); if (g) mine.push({ week: s.week, final: s.final !== false, upcoming: !!s.upcoming, g }); });
     if (!mine.length) return hide();
 
     // Win reveal: play the moment once when your latest matchup goes final —
@@ -779,9 +779,14 @@ async function hydrateH2H(user, activeYear) {
     }
 
     const liveWk = (data.currentWeek != null && mine.some(x => x.week === data.currentWeek)) ? data.currentWeek : null;
-    const featuredWk = liveWk != null ? liveWk : mine[mine.length - 1].week;
+    // The payload now carries weeks that haven't been played yet, so "latest"
+    // has to mean the last PLAYED week — otherwise a manager sitting out the
+    // current week (a bye, on an odd-sized league) would be featured with a
+    // matchup that hasn't happened.
+    const played = mine.filter(x => !x.upcoming);
+    const featuredWk = liveWk != null ? liveWk
+        : (played.length ? played[played.length - 1].week : mine[mine.length - 1].week);
     const featured = mine.find(x => x.week === featuredWk);
-    const rest = mine.slice().sort((a, b) => b.week - a.week);
     const cardOf = (x, open) => window.ccH2H.matchupCard(x.g, { byId, youId: uid, youLabel, week: x.week, open });
     // My-perspective summary of a matchup (for glances).
     const summary = (x) => {
@@ -828,9 +833,16 @@ async function hydrateH2H(user, activeYear) {
         } else sg.innerHTML = `<span class="uh-mu-opp">Full schedule</span>${me ? ` <span class="uh-glance-sub">${escapeHtml(me.record)}</span>` : ''}`;
     }
     uhDrawer.schedule = (body) => {
-        const listWeeks = liveWk != null ? rest.filter(x => x.week !== featuredWk) : rest;
+        // Two groups, each in the order you'd read it: what's still to come
+        // ascending (next opponent first), what's already happened descending
+        // (most recent result first). The live week is the lead card, so it's
+        // left out of both; when there is no live week nothing is pulled out.
+        const ahead = mine.filter(x => x.upcoming).sort((a, b) => a.week - b.week);
+        const behind = mine.filter(x => !x.upcoming && x.week !== liveWk).sort((a, b) => b.week - a.week);
         const lead = liveWk != null ? `<div class="uh-drawer-lead">This week</div>` + cardOf(featured, true) : '';
-        body.innerHTML = lead + `<div class="uh-drawer-cap">Full schedule · tap a week</div><div class="uh-h2h-log">${listWeeks.map(x => cardOf(x, false)).join('')}</div>`;
+        const group = (cap, list) => list.length
+            ? `<div class="uh-drawer-cap">${cap}</div><div class="uh-h2h-log">${list.map(x => cardOf(x, false)).join('')}</div>` : '';
+        body.innerHTML = lead + group('Upcoming · tap a week', ahead) + group('Results · tap a week', behind);
         window.ccH2H.wire(body);
     };
 }

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -447,7 +447,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // Which weeks have settled, the pairings, and each manager's result —
         // from the SAME function the scoring job uses to bank the bonus, so the
         // table and cumulativeScore can never tell different stories.
-        const { awards, weekFinal, finalWeeks, currentWeek, schedule: scheduleAll } = computeH2HAwards({
+        const { awards, weeks: h2hWeeks, weekFinal, finalWeeks, currentWeek, schedule: scheduleAll } = computeH2HAwards({
             users, games, season, winBonus, tieBonus, maxWeek: H2H_MAX_WEEK, pinnedIds
         });
 
@@ -553,22 +553,32 @@ router.get('/h2h/:league/:season', async (req, res) => {
         };
         const oddsFor = (a, b, w) => oddsFrom(entriesFor(a, w), entriesFor(b, w));
         const liveOddsFor = (a, b, w) => oddsFrom(liveEntriesFor(a, w), liveEntriesFor(b, w));
-        const gameFor = (a, b, w, live) => {
-            const sa = round(totals[a][w] || 0), sb = round(totals[b][w] || 0);
+        // `unplayed` covers both the in-progress week and the weeks still to
+        // come: neither has a decided winner, and both want the per-team view
+        // that shows kickoff times rather than the scored-teams-only one.
+        const gameFor = (a, b, w, unplayed, upcoming) => {
+            const sa = round((totals[a] || {})[w] || 0), sb = round((totals[b] || {})[w] || 0);
             return {
-                aId: a, aScore: sa, aTeams: live ? teamsLive(a, w) : teamsFinal(a, w),
-                bId: b, bScore: sb, bTeams: live ? teamsLive(b, w) : teamsFinal(b, w),
-                winner: live ? null : (sa > sb ? 'a' : (sb > sa ? 'b' : 'tie')),
-                winP: live ? liveOddsFor(a, b, w) : oddsFor(a, b, w),
-                final: !live
+                aId: a, aScore: sa, aTeams: unplayed ? teamsLive(a, w) : teamsFinal(a, w),
+                bId: b, bScore: sb, bTeams: unplayed ? teamsLive(b, w) : teamsFinal(b, w),
+                winner: unplayed ? null : (sa > sb ? 'a' : (sb > sa ? 'b' : 'tie')),
+                winP: unplayed ? liveOddsFor(a, b, w) : oddsFor(a, b, w),
+                final: !unplayed,
+                upcoming: !!upcoming
             };
         };
-        const schedWeeks = finalWeeks.slice();
-        if (currentWeek && !schedWeeks.includes(currentWeek)) schedWeeks.push(currentWeek);
-        schedWeeks.sort((a, b) => a - b);
+        // EVERY derived H2H week, not just the played ones. The pairings are
+        // deterministic (positional round-robin over the pinned roster), so a
+        // week that hasn't happened yet is fully knowable: opponent, kickoff
+        // times, and pre-game odds. Emitting only final-plus-current is what
+        // left My Team's "Full schedule" drawer empty in week 1 — there was
+        // nothing to list once the featured week was pulled out — and limited
+        // the Standings week picker to weeks already behind you.
+        const schedWeeks = h2hWeeks.slice().sort((a, b) => a - b);
         const schedule = schedWeeks.map(w => {
             const live = (w === currentWeek) && !weekFinal[w];
-            return { week: w, final: !live, games: (scheduleAll[w] || []).map(([a, b]) => gameFor(a, b, w, live)) };
+            const upcoming = !weekFinal[w] && !live;
+            return { week: w, final: !!weekFinal[w], upcoming, games: (scheduleAll[w] || []).filter(([a, b]) => meta[a] && meta[b]).map(([a, b]) => gameFor(a, b, w, live || upcoming, upcoming)) };
         });
         let featuredWeek = currentWeek || (finalWeeks.length ? finalWeeks[finalWeeks.length - 1] : (schedWeeks[schedWeeks.length - 1] || null));
         let currentWeekOut = currentWeek;
@@ -579,7 +589,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // some live, some upcoming).
         if (req.query.h2hSim && process.env.NODE_ENV !== 'production' && schedule.length) {
             const mode = String(req.query.h2hSim);
-            const w = schedule[schedule.length - 1];
+            const w = schedule.find(x => x.week === featuredWeek) || schedule[schedule.length - 1];
             w.final = false;
             const doctor = (arr) => (arr || []).map((t, j) => {
                 const status = mode === 'pregame' ? 'scheduled' : (j === 0 ? 'final' : (j === 1 ? 'live' : 'scheduled'));

--- a/tests/H2HSchedule.spec.js
+++ b/tests/H2HSchedule.spec.js
@@ -1,0 +1,183 @@
+// GET /standings/h2h returns the WHOLE H2H schedule, not just the played part.
+//
+// The payload used to carry final weeks plus the in-progress one and nothing
+// else. That was enough for the standings panel's "this week" view, but it made
+// a full-season schedule impossible to render: in week 1 the only entry was
+// week 1 itself, so My Team's "Full schedule" drawer — which lists every week
+// except the featured one — had nothing left to show and came up blank.
+//
+// The pairings are deterministic (a positional round robin over the pinned
+// manager list), so a week that hasn't happened is fully knowable. Weeks still
+// to come now ride along flagged `upcoming`, carrying their opponent and each
+// rostered team's kickoff time, with no winner and no scores.
+//
+// Runs against an in-memory Mongo with the real models and the real route.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const ScoringConfig = require('../models/scoringConfig');
+const standingsRouter = require('../routes/standings');
+
+const app = express();
+app.use(express.json());
+app.use('/standings', standingsRouter);
+
+useMongo();
+
+const SEASON = 2026;
+const LEAGUE = 'graham-league';
+
+function team(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+
+async function manager(firstName, teams, weeks) {
+    return User.create({
+        firstName, lastName: 'Test', league: LEAGUE,
+        seasons: [{
+            season: SEASON, teams,
+            weeklyScore: weeks.map(([week, score]) => ({ week, score, scoreByTeam: [{ teamId: teams[0].id, team: teams[0].school, score }] })),
+            cumulativeScore: weeks.reduce((s, [, score]) => s + score, 0)
+        }]
+    });
+}
+
+// `startDate` decides live-vs-upcoming at read time, so the unplayed weeks use a
+// date that can never drift into the past on a later test run.
+const PAST = '2026-09-05T23:00:00.000Z';
+const FUTURE = '2099-09-12T23:30:00.000Z';
+function game(id, week, homeId, awayId, completed) {
+    return {
+        id, season: SEASON, week, seasonType: 'regular',
+        startDate: completed ? PAST : FUTURE, startTimeTbd: false,
+        neutralSite: false, conferenceGame: false,
+        homeId, homeTeam: 'Home', awayId, awayTeam: 'Away',
+        homePoints: completed ? 30 : null, awayPoints: completed ? 10 : null,
+        completed
+    };
+}
+
+// Week 1 played and scored; weeks 2 and 3 scheduled but not kicked off. Two
+// managers, one rostered team each, so every week pairs them.
+async function seed() {
+    await ScoringConfig.create({
+        league: LEAGUE, model: 'graham', values: {},
+        engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0 } }
+    });
+    const a = await manager('Ann', [team(1, 'Oregon')], [[1, 20]]);
+    const b = await manager('Bob', [team(2, 'Duke')], [[1, 14]]);
+    await Game.create([
+        game(101, 1, 1, 99, true), game(102, 1, 2, 98, true),
+        game(201, 2, 1, 97, false), game(202, 2, 2, 96, false),
+        game(301, 3, 1, 95, false), game(302, 3, 2, 94, false)
+    ]);
+    return { a, b };
+}
+
+const get = () => request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}`).then(r => r.body);
+const weekOf = (body, w) => body.schedule.find(s => s.week === w);
+
+describe('GET /standings/h2h schedule', () => {
+    test('carries every derived H2H week, not just the played ones', async () => {
+        await seed();
+        const body = await get();
+
+        expect(body.schedule.map(s => s.week)).toEqual([1, 2, 3]);
+        expect(body.weeks).toEqual([1, 2, 3]);
+        // The current week is still the first unsettled one, and it is what the
+        // clients feature — future weeks arriving must not move it.
+        expect(body.currentWeek).toBe(2);
+        expect(body.featuredWeek).toBe(2);
+        expect(body.scheduleComplete).toBe(false);
+    });
+
+    test('marks a settled week final, the live week neither, and later weeks upcoming', async () => {
+        await seed();
+        const body = await get();
+
+        expect(weekOf(body, 1)).toMatchObject({ final: true, upcoming: false });
+        expect(weekOf(body, 2)).toMatchObject({ final: false, upcoming: false });
+        expect(weekOf(body, 3)).toMatchObject({ final: false, upcoming: true });
+    });
+
+    test('a settled week keeps its result', async () => {
+        await seed();
+        const g = weekOf(await get(), 1).games[0];
+
+        expect(g).toMatchObject({ final: true, upcoming: false, winner: 'a', aScore: 20, bScore: 14 });
+    });
+
+    test('an upcoming week carries the pairing and kickoff times, but no result', async () => {
+        await seed();
+        const g = weekOf(await get(), 3).games[0];
+
+        expect(g).toMatchObject({ final: false, upcoming: true, winner: null, aScore: 0, bScore: 0 });
+        // Both managers still appear, so the card can render the matchup.
+        expect([g.aId, g.bId].filter(Boolean)).toHaveLength(2);
+        // Each side shows its rostered team with a kickoff rather than a score —
+        // the same shape the live week uses, which is what lets one card
+        // renderer handle both.
+        expect(g.aTeams).toHaveLength(1);
+        expect(g.aTeams[0]).toMatchObject({ teamId: 1, school: 'Oregon', status: 'scheduled', score: null });
+        expect(g.aTeams[0].kickoff).toBeTruthy();
+        expect(g.aTeams[0].kickoff).not.toBe('TBD');
+    });
+
+    test('unplayed weeks add no records or bonus', async () => {
+        await seed();
+        const body = await get();
+
+        // Only week 1 is decided: 1-0-0 and 0-1-0, nothing banked for 2 or 3.
+        expect(body.managers.find(m => m.name.startsWith('Ann'))).toMatchObject({ record: '1-0-0', h2hBonus: 3 });
+        expect(body.managers.find(m => m.name.startsWith('Bob'))).toMatchObject({ record: '0-1-0', h2hBonus: 0 });
+    });
+
+    test('week 1 before kickoff lists the weeks still to come — the reported bug', async () => {
+        await ScoringConfig.create({
+            league: LEAGUE, model: 'graham', values: {},
+            engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0 } }
+        });
+        // The nightly job seeds a zero week before anything is played, which is
+        // the state the league is actually in on opening week.
+        await manager('Ann', [team(1, 'Oregon')], [[1, 0]]);
+        await manager('Bob', [team(2, 'Duke')], [[1, 0]]);
+        await Game.create([
+            game(101, 1, 1, 99, false), game(102, 1, 2, 98, false),
+            game(201, 2, 1, 97, false), game(202, 2, 2, 96, false)
+        ]);
+
+        const body = await get();
+        // This used to be a single entry — week 1 — which the drawer then pulled
+        // out as the featured card, leaving its list with nothing to render.
+        expect(body.schedule.map(s => s.week)).toEqual([1, 2]);
+        expect(body.currentWeek).toBe(1);
+        expect(weekOf(body, 1)).toMatchObject({ final: false, upcoming: false });
+        expect(weekOf(body, 2).upcoming).toBe(true);
+    });
+
+    // Deliberate, and unchanged: h2hManagerIds excludes managers with no scored
+    // week, so a league that has never been scored stays empty rather than
+    // showing a table of 0-0-0 rows against a schedule nobody is on yet.
+    test('a league with no scored week at all stays empty', async () => {
+        await ScoringConfig.create({
+            league: LEAGUE, model: 'graham', values: {},
+            engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0 } }
+        });
+        await manager('Ann', [team(1, 'Oregon')], []);
+        await manager('Bob', [team(2, 'Duke')], []);
+        await Game.create([game(101, 1, 1, 99, false), game(102, 1, 2, 98, false)]);
+
+        const body = await get();
+        expect(body.schedule).toEqual([]);
+        expect(body.managers).toEqual([]);
+    });
+});


### PR DESCRIPTION
## The bug

On My Team, the Schedule drawer's **"Full schedule · tap a week"** section renders nothing. Reported in prod; it's structural, not a data problem, so dev has it too.

`GET /standings/h2h` only ever returned weeks that had already been played:

```js
const schedWeeks = finalWeeks.slice();
if (currentWeek && !schedWeeks.includes(currentWeek)) schedWeeks.push(currentWeek);
```

It's week 1 and nothing is final, so the payload holds exactly one week. The drawer features that week as its lead card and lists "everything else" — which is empty. Later in the season it would show weeks 1..N-1: past results only, never the upcoming weeks the heading promises.

## The fix

The pairings are deterministic (a positional round robin over the pinned manager list) and the season's games are already loaded, so a week that hasn't happened is fully knowable. The payload now carries **every derived H2H week** (1–13 for 2026), with the ones still to come flagged `upcoming` — opponent, each rostered team's kickoff time, and projected odds, with no winner and no scores.

- **`routes/standings.js`** — emit all of `h2hWeeks`; tag each week `final` / `upcoming`.
- **`public/h2h-card.js`** — the renderer only knew two states (anything not final rendered as **LIVE**), so it grew a third. Upcoming cards are dimmed, show a muted en-dash instead of `0–0`, and read "Not started · N games scheduled · odds are projected".
- **`public/userHome.js`** — the drawer splits into **Upcoming** (ascending, next opponent first) and **Results** (descending, most recent first), each hidden when empty.
- **Standings** — the week picker inherits the fuller payload with no code change, so it now offers weeks ahead of you as well as behind.

Two things fixed in passing: the `?h2hSim` dev preview indexed `schedule[length-1]`, which is now a future week, so it targets the featured week instead; and My Team's "latest" week now means the last *played* week, so a manager on a bye during the current week isn't featured with a matchup that hasn't happened.

## Deliberately unchanged

A league that has never been scored still returns an empty payload — that's intentional in `h2hManagerIds` ("keeps the preseason empty rather than a table of 0-0-0 rows"), and is now pinned by a test.

## Verification

Full suite passes (64 suites, 1238 tests), including 7 new route tests in `tests/H2HSchedule.spec.js` covering settled / live / upcoming weeks and the reported week-1 state.

This couldn't be reproduced end-to-end locally: the dev tenant's 2026 league has **no drafted rosters**, so the derivation yields nothing regardless of this change. Verified instead by replaying the real 2025 season through the route — 14 weeks, all still `final`, `scheduleComplete` true, unchanged — and by rendering the three card states against the real CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)