### PR TITLE
Show both games when a team plays twice in one API week

### DIFF
--- a/modules/draft-projection.js
+++ b/modules/draft-projection.js
@@ -179,7 +179,9 @@ function expectedCfpPoints(teamId, m, beta, q, rankings, cfg) {
 // opts.expectedWins: calibration target for the games passed (default: the
 //   team's season expected wins — used for a full-season projection; the
 //   standings projection passes REMAINING expected wins for a remaining subset).
-// opts.perGame: also return perGame [{ winProb, pointsIfWin }] for Monte-Carlo.
+// opts.perGame: also return perGame [{ week, gameId, winProb, pointsIfWin }] for
+//   Monte-Carlo. Carrying the game id matters because a team can play twice in
+//   one API week — callers keying these by team alone lose one of the two.
 function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season, opts = {}) {
     const teamId = team.id;
     const sp = spFor(team, season);
@@ -204,7 +206,7 @@ function projectTeamPoints(team, teamGames, poolCtx, rankings, cfg, season, opts
     reg.forEach((g, i) => {
         const pts = evaluate(cfg.model, teamId, synthWin(g, teamId), rankings, cfg);
         regular += probs[i] * pts;
-        if (opts.perGame) perGame.push({ week: g.week, winProb: probs[i], pointsIfWin: pts });
+        if (opts.perGame) perGame.push({ week: g.week, gameId: g.id, winProb: probs[i], pointsIfWin: pts });
     });
     const projWins = probs.reduce((a, b) => a + b, 0);
 

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -330,6 +330,10 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const ids = h2hRoster(users, season, pinnedIds);
         const idSet = new Set(ids);
         const meta = {}, totals = {}, teamDetail = {}, caps = {}, banked = {};
+        // teamDetail is keyed per (team, game) so a doubleheader keeps both
+        // results apart. scoreByTeam only started carrying gameId in 2024, so
+        // older entries key on the team alone — one row per team, as before.
+        const detailKey = (teamId, gameId) => gameId == null ? String(teamId) : teamId + ':' + gameId;
         const draftedSet = new Set();
         users.forEach(u => {
             const s = (u.seasons || []).find(x => String(x.season) === String(season));
@@ -360,11 +364,17 @@ router.get('/h2h/:league/:season', async (req, res) => {
                 // BASE total (score minus any bonus already banked into it), so a
                 // week's own bonus never feeds back into deciding that week.
                 tw[w] = (tw[w] || 0) + baseWeekScore(e);
-                const byTeam = twTeams[w] || (twTeams[w] = {});
+                // Keyed per GAME, because a team can play twice in one API
+                // week — CFBD has no week 0, it folds the opening weekend into
+                // week 1 (12 draftable teams in 2026, 8 in 2025). Summing those
+                // into one row produced a two-game total labelled with one
+                // game's opponent. Entries from before scoreByTeam carried a
+                // gameId still aggregate per team, the way they always have.
+                const byGame = twTeams[w] || (twTeams[w] = {});
                 (e.scoreByTeam || []).forEach(st => {
-                    const k = st.teamId;
-                    if (!byTeam[k]) byTeam[k] = { teamId: st.teamId, school: st.team, abbr: abbrBy[st.teamId] || null, logo: logoBy[st.teamId] || null, score: 0 };
-                    byTeam[k].score += (st.score || 0);
+                    const k = detailKey(st.teamId, st.gameId);
+                    if (!byGame[k]) byGame[k] = { teamId: st.teamId, gameId: st.gameId == null ? null : st.gameId, school: st.team, abbr: abbrBy[st.teamId] || null, logo: logoBy[st.teamId] || null, score: 0 };
+                    byGame[k].score += (st.score || 0);
                 });
             });
             totals[id] = tw;
@@ -427,21 +437,44 @@ router.get('/h2h/:league/:season', async (req, res) => {
                 const team = teamsById[String(tid)];
                 if (!team) return;
                 const proj = projectTeamPoints(team, gamesByTeam[tid] || [], poolCtx, rankings, cfg, seasonNum, { perGame: true });
+                // { [week]: { [teamId]: { [gameId]: proj } } } — nested by game
+                // rather than flat by team. Keying by team alone meant a team's
+                // second game in an API week silently overwrote its first, so
+                // half of that team's week never reached the odds.
                 (proj.perGame || []).forEach(pg => {
-                    if (pg.week == null) return;
-                    (projByWeek[pg.week] = projByWeek[pg.week] || {})[tid] = { winProb: pg.winProb, pointsIfWin: pg.pointsIfWin };
+                    if (pg.week == null || pg.gameId == null) return;
+                    const byTeam = projByWeek[pg.week] = projByWeek[pg.week] || {};
+                    (byTeam[tid] = byTeam[tid] || {})[pg.gameId] = { winProb: pg.winProb, pointsIfWin: pg.pointsIfWin };
                 });
             });
         }
 
+        // EVERY game a rostered team plays that week, in kickoff order. This
+        // used to keep one game per team per week, which silently dropped the
+        // other half of a doubleheader — and picked the survivor by document
+        // order, so which game showed was effectively arbitrary.
         const gameTW = {};
         games.forEach(g => {
             [g.homeId, g.awayId].forEach(tid => {
                 if (!draftedSet.has(tid)) return;
                 const m = gameTW[tid] || (gameTW[tid] = {});
-                if (!m[g.week] || (m[g.week].completed && !g.completed)) m[g.week] = g;   // prefer the unfinished game
+                (m[g.week] = m[g.week] || []).push(g);
             });
         });
+        Object.values(gameTW).forEach(byWeek => Object.values(byWeek).forEach(list =>
+            list.sort((a, b) => String(a.startDate || '').localeCompare(String(b.startDate || '')))));
+        const gamesOf = (teamId, w) => (gameTW[teamId] && gameTW[teamId][w]) || [];
+        const gameById = {};
+        games.forEach(g => { gameById[g.id] = g; });
+        // A team's scored points for ONE game. The legacy per-team fallback is
+        // only safe when that team played once that week — otherwise it would
+        // report the same two-game total against each of the two rows.
+        const scoredFor = (id, w, teamId, gameId) => {
+            const detail = (teamDetail[id] && teamDetail[id][w]) || {};
+            return detail[detailKey(teamId, gameId)]
+                || (gamesOf(teamId, w).length === 1 ? detail[String(teamId)] : null)
+                || null;
+        };
         const now = Date.now();
 
         // Which weeks have settled, the pairings, and each manager's result —
@@ -490,7 +523,9 @@ router.get('/h2h/:league/:season', async (req, res) => {
             .map(t => {
                 // Opponent + final CFB score for the retrospective sub-line (same
                 // source the live week uses), so past matchup rows aren't bare.
-                const g = gameTW[t.teamId] && gameTW[t.teamId][w];
+                // The row knows its own game; only legacy rows (no gameId) fall
+                // back to the team's single game that week.
+                const g = t.gameId != null ? gameById[t.gameId] : gamesOf(t.teamId, w)[0];
                 let opp = '', ha = 'vs', gameScore = null;
                 if (g) {
                     const isHome = g.homeId === t.teamId;
@@ -509,11 +544,12 @@ router.get('/h2h/:league/:season', async (req, res) => {
             return d.toLocaleDateString('en-US', { weekday: 'short' }) + ' ' + d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
         };
         const statusOrder = { final: 0, live: 1, scheduled: 2 };
-        const teamsLive = (id, w) => (meta[id].teams || []).map(t => {
-            const g = gameTW[t.id] && gameTW[t.id][w];
-            if (!g) return null;   // bye / no game this week
+        // flatMap, not map: a team with two games that week gets a row for each,
+        // so neither is hidden and the footer's game count is honest. A team with
+        // no game contributes nothing (a bye).
+        const teamsLive = (id, w) => (meta[id].teams || []).flatMap(t => gamesOf(t.id, w).map(g => {
             const st = gameStatus(g, now);
-            const scored = teamDetail[id] && teamDetail[id][w] && teamDetail[id][w][t.id];
+            const scored = scoredFor(id, w, t.id, g.id);
             const isHome = g.homeId === t.id;
             const oppId = isHome ? g.awayId : g.homeId;
             const opp = oppAbbrById[oppId] || (isHome ? g.awayTeam : g.homeTeam) || '';
@@ -522,29 +558,26 @@ router.get('/h2h/:league/:season', async (req, res) => {
                 gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
             }
             return { teamId: t.id, school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? fmtKick(g) : null, opp, ha: isHome ? 'vs' : '@', gameScore, captain: !!(caps[id] && caps[id][w] === t.id) };
-        }).filter(Boolean).sort((a, b) => (statusOrder[a.status] - statusOrder[b.status]) || ((b.score || 0) - (a.score || 0)));
+        })).sort((a, b) => (statusOrder[a.status] - statusOrder[b.status]) || ((b.score || 0) - (a.score || 0)));
 
         // Projected pre-game odds for a matchup: each manager's teams that play
         // that week, run through the win-probability model. Integer percents that
         // sum to 100 (or null when neither side has a projectable game).
         const entriesFor = (id, w) => (meta[id].teams || [])
-            .map(t => projByWeek[w] && projByWeek[w][t.id])
-            .filter(Boolean);
+            .flatMap(t => Object.values((projByWeek[w] && projByWeek[w][t.id]) || {}));
         // Live odds recompute as the week plays out: a team whose game is already
         // FINAL contributes its actual scored points as a certainty; teams still
         // to play (live/upcoming) keep their projected win-prob × points-if-win.
         // So the bar shifts toward whoever's banked results are stronger, and by
         // the time every game is final it reads as the settled 100/0.
-        const liveEntriesFor = (id, w) => (meta[id].teams || []).map(t => {
-            const g = gameTW[t.id] && gameTW[t.id][w];
-            if (!g) return null;                                  // bye — no game this week
+        const liveEntriesFor = (id, w) => (meta[id].teams || []).flatMap(t => gamesOf(t.id, w).map(g => {
             if (gameStatus(g, now) === 'final') {
-                const s = teamDetail[id] && teamDetail[id][w] && teamDetail[id][w][t.id];
+                const s = scoredFor(id, w, t.id, g.id);
                 return { winProb: 1, pointsIfWin: s ? s.score : 0 };   // result locked in
             }
-            const p = projByWeek[w] && projByWeek[w][t.id];
+            const p = projByWeek[w] && projByWeek[w][t.id] && projByWeek[w][t.id][g.id];
             return p ? { winProb: p.winProb, pointsIfWin: p.pointsIfWin } : null;
-        }).filter(Boolean);
+        })).filter(Boolean);
         const oddsFrom = (ea, eb) => {
             const r = matchupWinProb(ea, eb);
             if (!r) return null;

--- a/tests/H2HMultiGameWeek.spec.js
+++ b/tests/H2HMultiGameWeek.spec.js
@@ -1,0 +1,207 @@
+// A team can play TWICE inside one API week, and the H2H matchup card has to
+// show both games.
+//
+// CFBD has no week 0 — the opening weekend is folded into week 1 — so a team
+// that opens on the Saturday before Labor Day and plays again the following
+// weekend has two week-1 games (12 draftable teams in 2026, 8 in 2025).
+//
+// Scoring always handled this correctly: modules/scoring.js loops every game a
+// team plays that week and pushes one scoreByTeam entry per game. The READ
+// model didn't. It kept one game per team per week, which meant:
+//   - only one of the two games appeared on the card, and which one won was
+//     decided by document order,
+//   - a finished week showed the two-game TOTAL on a row labelled with one
+//     game's opponent,
+//   - the win-probability bar dropped the second game entirely, because the
+//     per-game projections were keyed by team and the second overwrote the first.
+//
+// Runs against an in-memory Mongo with the real models and the real route.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const Team = require('../models/team');
+const ScoringConfig = require('../models/scoringConfig');
+const standingsRouter = require('../routes/standings');
+
+const app = express();
+app.use(express.json());
+app.use('/standings', standingsRouter);
+
+useMongo();
+
+const SEASON = 2026;
+const LEAGUE = 'graham-league';
+
+// Ann rosters USC, which plays twice in week 1 (the opening weekend and the
+// following Saturday). Everyone else plays once.
+const OREGON = 1, USC = 2, DUKE = 3, MIAMI = 4;
+const G_OREGON = 101, G_USC_A = 102, G_USC_B = 103, G_DUKE = 104, G_MIAMI = 105;
+
+function rosterTeam(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+
+async function manager(firstName, teams, weeklyScore) {
+    return User.create({
+        firstName, lastName: 'Test', league: LEAGUE,
+        seasons: [{ season: SEASON, teams, weeklyScore, cumulativeScore: weeklyScore.reduce((s, e) => s + e.score, 0) }]
+    });
+}
+
+const OPENING = '2026-08-29T23:00:00.000Z';     // the "week 0" Saturday
+const REGULAR = '2099-09-05T23:30:00.000Z';     // far future so it never drifts past
+function game(id, homeId, awayId, awayTeam, startDate, completed) {
+    return {
+        id, season: SEASON, week: 1, seasonType: 'regular',
+        startDate, startTimeTbd: false, neutralSite: false, conferenceGame: false,
+        homeId, homeTeam: 'Home', awayId, awayTeam,
+        homePoints: completed ? 42 : null, awayPoints: completed ? 10 : null, completed
+    };
+}
+
+async function enableH2H() {
+    await ScoringConfig.create({
+        league: LEAGUE, model: 'graham', values: {},
+        engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0 } }
+    });
+}
+
+// SP+ for everyone on the field, so the projection model has something to work
+// with and the win-probability bar is populated.
+async function seedTeams() {
+    const docs = [[OREGON, 'Oregon', 'ORE', 20], [USC, 'USC', 'USC', 18], [DUKE, 'Duke', 'DUKE', 8], [MIAMI, 'Miami', 'MIA', 6],
+                  [95, 'Opp95', 'O95', -4], [96, 'Opp96', 'O96', -4], [97, 'Fresno State', 'FRES', -6],
+                  [98, 'San Jose State', 'SJSU', -8], [99, 'Opp99', 'O99', -10]];
+    await Team.create(docs.map(([id, school, abbr, sp]) => Object.assign(rosterTeam(id, school), {
+        abbreviation: abbr,
+        seasons: [{ season: SEASON, conference: 'SEC', spRating: sp, expectedWins: 6 }]
+    })));
+}
+
+// Week 1 with nothing played: everyone seeded at zero the way the nightly job
+// leaves it before kickoff.
+async function seedUnplayed() {
+    await enableH2H();
+    await seedTeams();
+    const ann = await manager('Ann', [rosterTeam(OREGON, 'Oregon'), rosterTeam(USC, 'USC')], [{ week: 1, score: 0, scoreByTeam: [] }]);
+    const bob = await manager('Bob', [rosterTeam(DUKE, 'Duke'), rosterTeam(MIAMI, 'Miami')], [{ week: 1, score: 0, scoreByTeam: [] }]);
+    await Game.create([
+        game(G_OREGON, OREGON, 99, 'Opp99', REGULAR, false),
+        game(G_USC_A, USC, 98, 'San Jose State', OPENING, false),
+        game(G_USC_B, USC, 97, 'Fresno State', REGULAR, false),
+        game(G_DUKE, DUKE, 96, 'Opp96', REGULAR, false),
+        game(G_MIAMI, MIAMI, 95, 'Opp95', REGULAR, false)
+    ]);
+    return { ann, bob };
+}
+
+const get = () => request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}`).then(r => r.body);
+// The pairing is positional, so orient the week's only matchup around Ann.
+function mine(body, annId) {
+    const g = body.schedule.find(s => s.week === 1).games[0];
+    const iAmA = String(g.aId) === String(annId);
+    return { mineTeams: iAmA ? g.aTeams : g.bTeams, myWinP: g.winP && (iAmA ? g.winP.a : g.winP.b), game: g };
+}
+
+describe('a team playing twice in one API week', () => {
+    test('gets a row per game on the live card, not one row for the week', async () => {
+        const { ann } = await seedUnplayed();
+        const { mineTeams } = mine(await get(), ann._id);
+
+        // Oregon once, USC twice — three rows off a two-team roster.
+        expect(mineTeams).toHaveLength(3);
+        const usc = mineTeams.filter(t => t.teamId === USC);
+        expect(usc).toHaveLength(2);
+        // Each row is its own game: distinct opponent and distinct kickoff.
+        expect(usc.map(t => t.opp).sort()).toEqual(['FRES', 'SJSU']);
+        expect(new Set(usc.map(t => t.kickoff)).size).toBe(2);
+        usc.forEach(t => expect(t.status).toBe('scheduled'));
+    });
+
+    test('both games feed the win probability', async () => {
+        const { ann } = await seedUnplayed();
+        const withBoth = mine(await get(), ann._id).myWinP;
+
+        // Drop USC's second game and nothing else. If the odds were only ever
+        // counting one of the two, this would come back unchanged.
+        await Game.deleteOne({ id: G_USC_B });
+        const withOne = mine(await get(), ann._id).myWinP;
+
+        expect(withBoth).not.toBeNull();
+        expect(withOne).not.toBeNull();
+        expect(withBoth).toBeGreaterThan(withOne);
+    });
+
+    test('a settled week shows each game its own points, not the two-game total on one row', async () => {
+        await enableH2H();
+        await seedTeams();
+        const ann = await manager('Ann', [rosterTeam(OREGON, 'Oregon'), rosterTeam(USC, 'USC')], [{
+            week: 1, score: 30, scoreByTeam: [
+                { team: 'Oregon', teamId: OREGON, gameId: G_OREGON, score: 10 },
+                { team: 'USC', teamId: USC, gameId: G_USC_A, score: 12 },
+                { team: 'USC', teamId: USC, gameId: G_USC_B, score: 8 }
+            ]
+        }]);
+        await manager('Bob', [rosterTeam(DUKE, 'Duke'), rosterTeam(MIAMI, 'Miami')], [{
+            week: 1, score: 14, scoreByTeam: [
+                { team: 'Duke', teamId: DUKE, gameId: G_DUKE, score: 7 },
+                { team: 'Miami', teamId: MIAMI, gameId: G_MIAMI, score: 7 }
+            ]
+        }]);
+        await Game.create([
+            game(G_OREGON, OREGON, 99, 'Opp99', OPENING, true),
+            game(G_USC_A, USC, 98, 'San Jose State', OPENING, true),
+            game(G_USC_B, USC, 97, 'Fresno State', OPENING, true),
+            game(G_DUKE, DUKE, 96, 'Opp96', OPENING, true),
+            game(G_MIAMI, MIAMI, 95, 'Opp95', OPENING, true)
+        ]);
+
+        const body = await get();
+        expect(body.schedule.find(s => s.week === 1).final).toBe(true);
+        const { mineTeams } = mine(body, ann._id);
+
+        const usc = mineTeams.filter(t => t.teamId === USC).sort((a, b) => b.score - a.score);
+        expect(usc).toHaveLength(2);
+        expect(usc.map(t => t.score)).toEqual([12, 8]);     // not a single row of 20
+        expect(usc.map(t => t.opp).sort()).toEqual(['FRES', 'SJSU']);
+        usc.forEach(t => expect(t.gameScore).toBe('42–10'));
+        // The matchup total is unchanged — scoring was always right.
+        expect(mineTeams.reduce((s, t) => s + t.score, 0)).toBe(30);
+    });
+
+    test('legacy entries with no gameId still collapse to one row per team', async () => {
+        await enableH2H();
+        await seedTeams();
+        // Pre-2024 scoreByTeam carried no gameId. Those weeks have no way to tell
+        // two games apart, so they stay aggregated rather than inventing rows.
+        const ann = await manager('Ann', [rosterTeam(OREGON, 'Oregon'), rosterTeam(USC, 'USC')], [{
+            week: 1, score: 30, scoreByTeam: [
+                { team: 'Oregon', teamId: OREGON, score: 10 },
+                { team: 'USC', teamId: USC, score: 20 }
+            ]
+        }]);
+        await manager('Bob', [rosterTeam(DUKE, 'Duke'), rosterTeam(MIAMI, 'Miami')], [{
+            week: 1, score: 14, scoreByTeam: [{ team: 'Duke', teamId: DUKE, score: 14 }]
+        }]);
+        await Game.create([
+            game(G_OREGON, OREGON, 99, 'Opp99', OPENING, true),
+            game(G_USC_A, USC, 98, 'San Jose State', OPENING, true),
+            game(G_USC_B, USC, 97, 'Fresno State', OPENING, true),
+            game(G_DUKE, DUKE, 96, 'Opp96', OPENING, true),
+            game(G_MIAMI, MIAMI, 95, 'Opp95', OPENING, true)
+        ]);
+
+        const { mineTeams } = mine(await get(), ann._id);
+        expect(mineTeams.filter(t => t.teamId === USC)).toHaveLength(1);
+        expect(mineTeams.find(t => t.teamId === USC).score).toBe(20);
+    });
+});


### PR DESCRIPTION
## The bug

On the H2H matchup card, USC shows only its Aug 29 game against San José State — its Sep 5 game against Fresno State is missing.

CFBD has **no week 0**. The opening weekend is folded into week 1, so a team that opens early and plays again the following Saturday has two week-1 games:

| Season | Draftable teams playing twice in week 1 |
|---|---|
| 2025 | 8 |
| 2026 | 12 — incl. **USC** and **Memphis** |

## Scoring was never wrong

[`modules/scoring.js:111`](../blob/main/modules/scoring.js#L111) loops **every** game a team plays that week and pushes one `scoreByTeam` entry per game, each with its own `gameId`. Weekly totals, captain doubling, and the week-final gate have all been correct. Nothing needs rescoring.

## What the read model got wrong

`GET /standings/h2h` assumed one game per team per week, and collapsed the pair in three places:

1. **Only one game rendered** — and which one survived was decided by document order, not kickoff. That's why USC showed its Aug 29 game while Memphis showed its Sep 5 one.
2. **A settled week mislabelled its own points** — the two-game *total* landed on a row carrying one game's opponent and one game's final score. USC would read `20` next to `vs SJSU · 38–7`.
3. **The win-probability bar dropped the second game** — per-game projections were keyed by team, so the second overwrote the first and contributed nothing to the odds. In the reported screenshot that understates Big Mac, who rosters both affected teams.

## The fix

The read model is per game throughout: `gameTW` keeps every game a team plays that week in kickoff order, `teamDetail` keys on `(team, game)`, and `projByWeek` nests by game under each team. Rows, points, opponents, kickoff times, the footer's game count, and both the pre-game and live odds all follow from that. `perGame` projections now carry their `gameId` (additive — the Monte-Carlo consumer ignores it).

Before / after for a settled week — one row of `20` labelled `vs SJSU`, versus two rows carrying their own results:

```
USC   vs SJSU · 38-7    12
USC   vs FRES · 24-21    8
```

## Legacy data

`scoreByTeam` only started carrying `gameId` in 2024. Entries without one still aggregate per team, exactly as before — a legacy week has no way to tell two games apart, and inventing rows for it would be worse than leaving it alone. Pinned by a test.

## Verification

Full suite passes (65 suites, 1242 tests), including 4 new tests in `tests/H2HMultiGameWeek.spec.js`. The odds test is comparative — it reads the win probability, deletes USC's second game, reads again, and asserts the number moved, which fails against the old team-keyed projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)