### PR TITLE
Show each team's slate in the Captain picker

### DIFF
--- a/public/userHome.css
+++ b/public/userHome.css
@@ -566,11 +566,18 @@
 .uh-captain { width: 92%; max-width: 720px; margin: 0 auto; overflow: hidden; max-height: 0; transition: max-height 0.32s ease; }
 .uh-captain.is-open { max-height: 1600px; margin-top: 1.1rem; }
 .captain-note { margin: 0 0 0.9em; color: var(--cc-muted); font-size: 0.9rem; }
-.captain-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); gap: 0.6rem; }
-.captain-team { display: flex; align-items: center; gap: 0.5rem; background: var(--cc-bg); border: 1px solid var(--cc-border); border-radius: 10px; padding: 0.5rem 0.7rem; color: var(--cc-text); font: inherit; font-size: 0.85rem; cursor: pointer; text-align: left; transition: border-color 0.15s ease, background 0.15s ease; }
+.captain-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.6rem; }
+.captain-team { display: flex; align-items: flex-start; gap: 0.5rem; background: var(--cc-bg); border: 1px solid var(--cc-border); border-radius: 10px; padding: 0.5rem 0.7rem; color: var(--cc-text); font: inherit; font-size: 0.85rem; cursor: pointer; text-align: left; transition: border-color 0.15s ease, background 0.15s ease; }
 .captain-team img { height: 24px; width: 24px; object-fit: contain; flex-shrink: 0; }
 .captain-team span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .captain-team:hover { border-color: var(--cc-border-2); background: #151a2e; }
+/* Tile body: team name (with a "2 games" flag when the week has a doubleheader)
+   over one line per game — opponent and kickoff, so the pick is informed. */
+.cap-tid { display: flex; flex-direction: column; gap: 0.1rem; min-width: 0; }
+.cap-tnm { display: flex; align-items: center; gap: 0.35rem; min-width: 0; }
+.cap-nm { min-width: 0; }
+.cap-2g { flex-shrink: 0; font-size: 0.55rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-accent); border: 1px solid var(--cc-accent); border-radius: 4px; padding: 0 0.22rem; line-height: 1.5; }
+.cap-tg { font-size: 0.68rem; color: var(--cc-muted-2); font-weight: 400; }
 .captain-team.is-captain { border-color: var(--cc-interactive); background: rgba(142, 140, 240, 0.14); font-weight: 700; }
 /* Locked week: cells are read-only (no pointer, no hover lift). */
 .captain-team.is-locked { cursor: default; opacity: 0.6; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -914,25 +914,40 @@ async function hydrateCaptain(user, activeYear) {
         else sub = 'Doubles this week’s points';
         g.innerHTML = lead + `<span class="uh-cap-sub">${sub}</span>`;
     };
+    // A team's slate for the focus week, drawn under its name in the picker.
+    // Two games is the case worth flagging: CFBD folds the opening weekend into
+    // week 1, so a few teams play twice — and the captain doubles BOTH of them,
+    // which a grid of bare logos gives no way to see.
+    const slateBy = {};
+    (state.slate || []).forEach(x => { slateBy[x.teamId] = x.games || []; });
+    const tileBody = (t) => {
+        const games = slateBy[t.id] || [];
+        const badge = games.length > 1 ? `<span class="cap-2g">${games.length} games</span>` : '';
+        const lines = games.length
+            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff)) : ' · TBD'}</span>`).join('')
+            : `<span class="cap-tg">No game this week</span>`;
+        return `<img src="${ccLogo(t.logos)}" alt="">
+            <span class="cap-tid"><span class="cap-tnm"><span class="cap-nm">${escapeHtml(t.school)}</span>${badge}</span>${lines}</span>`;
+    };
     const paint = (container) => {
         if (state.locked) {
             const t = state.teamId != null ? teamById[state.teamId] : null;
             container.innerHTML = `<p class="captain-note">Locked — your first team of Week ${state.week} has kicked off. `
                 + (t ? `<b>${escapeHtml(t.school)}</b> is your 2× this week.` : `No captain was set (your best team auto-doubles).`) + `</p>`
                 + `<div class="captain-grid">${(season.teams || []).map(tm => `
-                    <div class="captain-team is-locked${Number(state.teamId) === Number(tm.id) ? ' is-captain' : ''}">
-                        <img src="${ccLogo(tm.logos)}" alt=""><span>${escapeHtml(tm.school)}</span>
-                    </div>`).join('')}</div>`;
+                    <div class="captain-team is-locked${Number(state.teamId) === Number(tm.id) ? ' is-captain' : ''}">${tileBody(tm)}</div>`).join('')}</div>`;
             return;
         }
         const lockLine = state.lockAt
             ? ` Locks ${uhFmtLock(state.lockAt)} — when your first team kicks off${uhTimeLeft(state.lockAt) ? ` (${uhTimeLeft(state.lockAt)} left)` : ''}.`
             : ' Locks when your first team kicks off.';
-        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}</p>
+        const twoGamers = (season.teams || []).filter(t => (slateBy[t.id] || []).length > 1);
+        const twoLine = twoGamers.length
+            ? ` <b>${twoGamers.map(t => escapeHtml(t.school)).join('</b>, <b>')}</b> play twice this week — captaining one doubles both games.`
+            : '';
+        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}${twoLine}</p>
             <div class="captain-grid">${(season.teams || []).map(t => `
-                <button type="button" class="captain-team${Number(state.teamId) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(state.teamId) === Number(t.id)}">
-                    <img src="${ccLogo(t.logos)}" alt=""><span>${escapeHtml(t.school)}</span>
-                </button>`).join('')}</div>`;
+                <button type="button" class="captain-team${Number(state.teamId) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(state.teamId) === Number(t.id)}">${tileBody(t)}</button>`).join('')}</div>`;
         container.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {
             const teamId = Number(btn.getAttribute('data-team'));
             const next = Number(state.teamId) === teamId ? null : teamId;   // click current to clear

--- a/routes/users.js
+++ b/routes/users.js
@@ -26,7 +26,7 @@ const CAPTAIN_WEEK_GRACE_MS = 6 * 60 * 60 * 1000;
 function captainGamesQuery(season, teamIds) {
     return Game.find(
         { season, seasonType: 'regular', $or: [{ homeId: { $in: teamIds } }, { awayId: { $in: teamIds } }] },
-        { week: 1, homeId: 1, awayId: 1, startDate: 1, startTimeTbd: 1, seasonType: 1, completed: 1 }
+        { id: 1, week: 1, homeId: 1, homeTeam: 1, awayId: 1, awayTeam: 1, startDate: 1, startTimeTbd: 1, seasonType: 1, completed: 1 }
     ).lean();
 }
 
@@ -116,12 +116,45 @@ router.get('/me/captain', async (req, res) => {
         if (!focus) return res.json(none);
 
         const pick = ((season.captains || []).find(c => Number(c.week) === focus.week) || {}).teamId;
+
+        // Each rostered team's slate for the focus week, so the picker can show
+        // who they play and when — and mark the teams playing TWICE. CFBD has no
+        // week 0 (the opening weekend is folded into week 1), so a handful of
+        // teams have two games in one week; captaining one of those doubles both
+        // of them, which is invisible from a grid of logos alone.
+        const weekGames = games
+            .filter(g => g.seasonType === 'regular' && Number(g.week) === focus.week)
+            .sort((a, b) => String(a.startDate || '').localeCompare(String(b.startDate || '')));
+        const mine = new Set(teamIds);
+        const oppIds = [...new Set(weekGames.flatMap(g => [g.homeId, g.awayId]).filter(id => id != null && !mine.has(Number(id))))];
+        const abbrById = {};
+        if (oppIds.length) {
+            (await Team.find({ id: { $in: oppIds } }, { id: 1, abbreviation: 1, _id: 0 }).lean())
+                .forEach(t => { abbrById[t.id] = t.abbreviation || null; });
+        }
+        const slate = teamIds.map(tid => ({
+            teamId: tid,
+            games: weekGames
+                .filter(g => Number(g.homeId) === tid || Number(g.awayId) === tid)
+                .map(g => {
+                    const isHome = Number(g.homeId) === tid;
+                    const oppId = isHome ? g.awayId : g.homeId;
+                    return {
+                        gameId: g.id,
+                        opp: abbrById[oppId] || (isHome ? g.awayTeam : g.homeTeam) || '',
+                        ha: isHome ? 'vs' : '@',
+                        kickoff: g.startTimeTbd ? null : (g.startDate || null)
+                    };
+                })
+        }));
+
         res.json({
             season: seasonYear,
             week: focus.week,
             lockAt: new Date(focus.first).toISOString(),
             teamId: pick != null ? Number(pick) : null,
-            locked: Date.now() >= focus.first
+            locked: Date.now() >= focus.first,
+            slate
         });
     } catch (err) {
         res.status(500).json({ message: err.message });

--- a/tests/CaptainSlate.spec.js
+++ b/tests/CaptainSlate.spec.js
@@ -1,0 +1,136 @@
+// GET /users/me/captain carries each rostered team's slate for the focus week.
+//
+// The Captain picker used to be a grid of bare logos, which hid the one thing
+// that most changes the pick: CFBD has no week 0 — the opening weekend is folded
+// into week 1 — so a few teams play TWICE in that week, and the captain doubles
+// BOTH of their games (see modules/captain.js captainWeeklyBonus). A manager had
+// no way to see that from the picker.
+//
+// The route already loads the manager's season games to resolve the lock, so the
+// slate costs one extra lookup for opponent abbreviations and nothing else.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const Team = require('../models/team');
+const usersRouter = require('../routes/users');
+
+useMongo();
+
+const SEASON = 2026;
+const LEAGUE = 'graham-league';
+const USC = 2, OREGON = 1, SJSU = 98, FRESNO = 97, OPP = 99;
+
+function fullTeam(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+
+// Far future so the week never locks under the test's own clock.
+const OPENING = '2099-08-29T21:00:00.000Z';
+const REGULAR = '2099-09-05T23:30:00.000Z';
+function game(id, homeId, awayId, awayTeam, startDate, startTimeTbd) {
+    return {
+        id, season: SEASON, week: 1, seasonType: 'regular',
+        startDate, startTimeTbd: !!startTimeTbd, neutralSite: false, conferenceGame: false,
+        homeId, homeTeam: 'Home', awayId, awayTeam, completed: false
+    };
+}
+
+let app;
+async function seed() {
+    const user = await User.create({
+        firstName: 'Ann', lastName: 'Test', league: LEAGUE,
+        seasons: [{ season: SEASON, teams: [fullTeam(OREGON, 'Oregon'), fullTeam(USC, 'USC')], weeklyScore: [], cumulativeScore: 0 }]
+    });
+    await Team.create([
+        Object.assign(fullTeam(SJSU, 'San Jose State'), { abbreviation: 'SJSU' }),
+        Object.assign(fullTeam(FRESNO, 'Fresno State'), { abbreviation: 'FRES' }),
+        Object.assign(fullTeam(OPP, 'Opponent'), { abbreviation: 'OPP' })
+    ]);
+    await Game.create([
+        // USC opens on the "week 0" Saturday and plays again the next weekend.
+        game(102, USC, SJSU, 'San Jose State', OPENING),
+        game(103, USC, FRESNO, 'Fresno State', REGULAR),
+        game(101, OREGON, OPP, 'Opponent', REGULAR)
+    ]);
+
+    app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+        req.oidc = { isAuthenticated: () => true, user: { user_metadata: { metadata: { userId: String(user._id) } } } };
+        next();
+    });
+    app.use('/users', usersRouter);
+    return user;
+}
+
+const slateOf = (body, teamId) => (body.slate || []).find(s => s.teamId === teamId);
+
+describe('GET /users/me/captain slate', () => {
+    test('lists every game each rostered team plays in the focus week', async () => {
+        await seed();
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+
+        expect(res.status).toBe(200);
+        expect(res.body.week).toBe(1);
+        expect((res.body.slate || []).map(s => s.teamId).sort()).toEqual([OREGON, USC]);
+        // The whole point: USC's week is two games, not one.
+        expect(slateOf(res.body, USC).games).toHaveLength(2);
+        expect(slateOf(res.body, OREGON).games).toHaveLength(1);
+    });
+
+    test('each game carries opponent, home/away and kickoff, in kickoff order', async () => {
+        await seed();
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+        const usc = slateOf(res.body, USC).games;
+
+        expect(usc.map(g => g.opp)).toEqual(['SJSU', 'FRES']);   // opening weekend first
+        usc.forEach(g => expect(g.ha).toBe('vs'));
+        expect(new Date(usc[0].kickoff).getTime()).toBeLessThan(new Date(usc[1].kickoff).getTime());
+        expect(usc.map(g => g.gameId)).toEqual([102, 103]);
+    });
+
+    test('an away game reads as away', async () => {
+        const user = await seed();
+        await Game.updateOne({ id: 103 }, { $set: { homeId: FRESNO, homeTeam: 'Fresno State', awayId: USC, awayTeam: 'USC' } });
+
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+        const away = slateOf(res.body, USC).games.find(g => g.gameId === 103);
+        expect(away).toMatchObject({ ha: '@', opp: 'FRES' });
+        expect(user).toBeTruthy();
+    });
+
+    test('a TBD kickoff reports no time rather than a placeholder', async () => {
+        await seed();
+        await Game.updateOne({ id: 103 }, { $set: { startTimeTbd: true } });
+
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+        expect(slateOf(res.body, USC).games.find(g => g.gameId === 103).kickoff).toBeNull();
+    });
+
+    test('a team on a bye that week reports an empty slate, not a missing entry', async () => {
+        await seed();
+        await Game.deleteOne({ id: 101 });
+
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+        expect(slateOf(res.body, OREGON)).toBeTruthy();
+        expect(slateOf(res.body, OREGON).games).toEqual([]);
+    });
+
+    test('the lock rule is untouched — still the manager\'s earliest kickoff', async () => {
+        await seed();
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+
+        // USC's opening-weekend game is the earliest, so it locks the whole week.
+        expect(res.body.lockAt).toBe(new Date(OPENING).toISOString());
+        expect(res.body.locked).toBe(false);
+    });
+});


### PR DESCRIPTION
## Why

The Captain picker is a grid of bare logos. That hides the thing that most changes the pick.

CFBD has no week 0 — the opening weekend is folded into week 1 — so a few teams play **twice** in that week, and [`captainWeeklyBonus`](../blob/main/modules/captain.js#L48) sums *every* one of the captained team's games. Captaining a two-game team doubles both.

Running the real projection model on the 2026 opening week for one league's roster:

```
USC        +1.93 expected bonus   << both games doubled
Memphis    +1.13 expected bonus   << both games doubled
Indiana    +1.00                  (best single-game option)
Illinois   +0.98
```

USC is worth roughly double the best single-game pick, and nothing in the UI said so — you had to already know the schedule to spot it. That made it a hidden-information edge rather than a strategic one.

## What changed

Each tile now shows that team's games for the focus week — opponent, home/away, kickoff — with a **2 games** badge when there are two. The note above the grid names the teams playing twice. A team on a bye says "No game this week" instead of looking like every other tile.

`GET /users/me/captain` already loads the manager's season games to resolve the lock, so the slate costs one extra lookup for opponent abbreviations and no additional game query. Response gains a `slate` array:

```js
slate: [{ teamId, games: [{ gameId, opp, ha, kickoff }] }]
```

## Lock rule untouched

Still the manager's own earliest kickoff. Worth noting it interacts with the same quirk: a roster holding an opening-weekend team locks its week-1 captain at *that* game, days before the main slate. Showing kickoffs on the tiles makes that legible rather than surprising. Pinned by a test.

## Verification

Full suite passes (66 suites, 1248 tests), including 6 new tests in `tests/CaptainSlate.spec.js` covering the two-game week, kickoff ordering, away games, TBD kickoffs, byes, and the unchanged lock. Picker rendered against the real CSS with the actual 2026 week-1 slate to confirm the taller tiles still lay out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)