### PR TITLE
Fix H2H kickoff times, count the Captain in the win bar, and name the time zone

### DIFF
--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -161,8 +161,8 @@
             + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, unplayed, false, dated) + '</div>'
             + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, unplayed, true, dated) + '</div>'
             + pregameLine(g, aName, bName)
-            + (live ? '<div class="h2h-mfoot">In progress · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' to play · scores update as they finish</div>' : '')
-            + (upcoming ? '<div class="h2h-mfoot">Not started · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' scheduled · odds are projected</div>' : '')
+            + (live ? '<div class="h2h-mfoot">In progress · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' to play · kickoffs Central · scores update as they finish</div>' : '')
+            + (upcoming ? '<div class="h2h-mfoot">Not started · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' scheduled · kickoffs Central · odds are projected</div>' : '')
             + '</div></div>';
     }
 

--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -35,15 +35,38 @@
     function manLink(id, inner) { return id != null ? '<a class="h2h-mlink" href="/userHome?user=' + esc(id) + '">' + inner + '</a>' : inner; }
     function teamLink(id, inner) { return id != null ? '<a class="h2h-tlink" href="/team?team=' + esc(id) + '">' + inner + '</a>' : inner; }
 
+    // Kickoffs render in Central, the way every other date in the app does —
+    // the payload carries the instant (ISO), not a rendered string. `dated`
+    // adds the calendar date, for a week whose games don't all sit on one
+    // weekend (see spansWeekends): "Sat 2:00 PM" can't tell Aug 29 from Sep 5.
+    var CT = 'America/Chicago';
+    function fmtKick(iso, dated) {
+        if (!iso) return 'TBD';
+        var d = new Date(iso);
+        if (isNaN(d.getTime())) return 'TBD';
+        var day = d.toLocaleDateString('en-US', dated
+            ? { weekday: 'short', month: 'numeric', day: 'numeric', timeZone: CT }
+            : { weekday: 'short', timeZone: CT });
+        return day + ' ' + d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: CT });
+    }
+    // Does this matchup's slate straddle more than one weekend? Only then is the
+    // date worth the width. A team playing twice in an API week is exactly the
+    // case that needs it.
+    function spansWeekends(teams) {
+        var ts = (teams || []).map(function (t) { return t.kickoff ? Date.parse(t.kickoff) : NaN; })
+            .filter(function (n) { return !isNaN(n); });
+        if (ts.length < 2) return false;
+        return (Math.max.apply(null, ts) - Math.min.apply(null, ts)) > 3 * 864e5;
+    }
     // A team's value: final points, LIVE, or kickoff time.
-    function teamVal(t) {
+    function teamVal(t, dated) {
         return t.status === 'live' ? '<span class="h2h-tv live">LIVE</span>'
-            : t.status === 'scheduled' ? '<span class="h2h-tv sched">' + esc(t.kickoff || 'TBD') + '</span>'
+            : t.status === 'scheduled' ? '<span class="h2h-tv sched">' + esc(fmtKick(t.kickoff, dated)) + '</span>'
             : '<span class="h2h-tv">' + (t.score != null ? t.score : 0) + '</span>';
     }
     // One team row; the right column mirrors (value → name → logo) so both teams'
     // scores hug the center divider, like a Sleeper matchup.
-    function teamRow(t, right) {
+    function teamRow(t, right, dated) {
         var img = teamLink(t.teamId, '<img class="h2h-tlogo" src="' + esc(t.logo) + '" alt="">');
         // Captain doubles this team's points — mark it so the inflated score reads.
         var cap = t.captain ? '<span class="h2h-capx" title="Captain — points doubled">★2×</span>' : '';
@@ -53,15 +76,15 @@
             ? '<span class="h2h-tsub">' + esc(t.ha) + ' ' + esc(t.opp) + (t.status === 'final' && t.gameScore ? ' · ' + esc(t.gameScore) : '') + '</span>'
             : '';
         var idcol = '<span class="h2h-tid">' + nm + sub + '</span>';
-        return right ? '<div class="h2h-trow">' + teamVal(t) + idcol + img + '</div>'
-            : '<div class="h2h-trow">' + img + idcol + teamVal(t) + '</div>';
+        return right ? '<div class="h2h-trow">' + teamVal(t, dated) + idcol + img + '</div>'
+            : '<div class="h2h-trow">' + img + idcol + teamVal(t, dated) + '</div>';
     }
     // Final weeks show only teams that scored; an unplayed week (live or still
     // to come) shows every team with a game, so in-progress and upcoming ones
     // are visible with their kickoff times instead of being mistaken for 0.
-    function teamList(teams, unplayed, right) {
+    function teamList(teams, unplayed, right, dated) {
         var list = unplayed ? (teams || []) : (teams || []).filter(function (t) { return t.score > 0; });
-        return list.length ? list.map(function (t) { return teamRow(t, right); }).join('')
+        return list.length ? list.map(function (t) { return teamRow(t, right, dated); }).join('')
             : '<div class="h2h-trow empty">no points</div>';
     }
     // Bar values: a finished matchup is settled (100/0 to the winner, tie 50/50);
@@ -120,7 +143,9 @@
         var live = g.final === false && !upcoming;
         var unplayed = live || upcoming;
         var score = function (v) { return upcoming ? '&ndash;' : v; };
-        var remaining = (g.aTeams || []).concat(g.bTeams || []).filter(function (t) { return t.status && t.status !== 'final'; }).length;
+        var both = (g.aTeams || []).concat(g.bTeams || []);
+        var dated = spansWeekends(both);
+        var remaining = both.filter(function (t) { return t.status && t.status !== 'final'; }).length;
         var sep = live ? '<span class="h2h-mlive">LIVE</span>' : (g.winner === 'tie' ? 'T' : 'vs');
         var wk = opts.week != null ? '<span class="h2h-mwk">Wk ' + opts.week + '</span>' : '';
         return '<div class="h2h-mcard' + (live ? ' live' : '') + (upcoming ? ' upcoming' : '') + (opts.open ? ' open' : '') + '">'
@@ -133,8 +158,8 @@
             + '</div>'
             + winBar(g)
             + '<div class="h2h-mdetail">'
-            + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, unplayed, false) + '</div>'
-            + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, unplayed, true) + '</div>'
+            + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, unplayed, false, dated) + '</div>'
+            + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, unplayed, true, dated) + '</div>'
             + pregameLine(g, aName, bName)
             + (live ? '<div class="h2h-mfoot">In progress · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' to play · scores update as they finish</div>' : '')
             + (upcoming ? '<div class="h2h-mfoot">Not started · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' scheduled · odds are projected</div>' : '')

--- a/public/team.css
+++ b/public/team.css
@@ -165,6 +165,13 @@
       font-size: 1.4rem;
     }
 
+    /* Which zone the times on this page are in — the browser's, not Central. */
+    .schedule-tz {
+      font-size: 0.72rem;
+      color: var(--cc-muted-2);
+      margin: 0.15rem 0 0.5rem;
+    }
+
     .games-container {
         display: none;
     }

--- a/public/team.js
+++ b/public/team.js
@@ -631,6 +631,30 @@ function renderWeeklyScores(seasonObj, scoreCode) {
     `;
 }
 
+// This page renders game times in the BROWSER's zone, not Central like the rest
+// of the app — so it has to say which zone that is. The league spans two of
+// them, and "2:30 PM" means different things to different managers.
+//
+// Prefers the generic label (CT) over the seasonal one (CDT / CST): a schedule
+// runs August to January, straddling the November DST change, and both halves
+// are still "CT". Anything that isn't a US-style abbreviation — "GMT+2", "UTC" —
+// is shown exactly as the browser reported it.
+function tzGenericLabel(shortName) {
+    var name = String(shortName == null ? '' : shortName).trim();
+    var m = /^([A-Z]{1,3})[SD]T$/.exec(name);
+    return m ? m[1] + 'T' : name;
+}
+function localTzLabel(when) {
+    try {
+        var parts = new Intl.DateTimeFormat('en-US', { hour: 'numeric', timeZoneName: 'short' })
+            .formatToParts(when ? new Date(when) : new Date());
+        var found = parts.find(function (p) { return p.type === 'timeZoneName'; });
+        return tzGenericLabel(found && found.value);
+    } catch (e) {
+        return '';   // no label beats a wrong one
+    }
+}
+
 // Render schedule info
 function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, teamData) {
     const container = document.getElementById("schedule-container");
@@ -638,11 +662,15 @@ function renderTeamScheduleInfo(schedule, logos, rankings, bettingLines, year, t
 
     var nextGameHtml = renderNextGame(schedule, logos, teamId);
 
+    // Sits under the heading so it covers both the next-game card and the
+    // games list, and stays visible while the list is collapsed.
+    const tz = localTzLabel();
     var html = `
         <div class="schedule-head">
             <h2><i class="fa-solid fa-calendar-days fa-rank-stand"></i>${year} Schedule</h2>
             <i class="fa-solid fa-caret-down drop"></i>
         </div>
+        ${tz ? `<div class="schedule-tz">All times ${tz}</div>` : ''}
         ${nextGameHtml}
         <div class="games-container">
     `;

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -936,7 +936,7 @@ async function hydrateCaptain(user, activeYear) {
             const t = state.teamId != null ? teamById[state.teamId] : null;
             container.innerHTML = `<p class="captain-note">Locked — your first team of Week ${state.week} has kicked off. `
                 + (t ? `<b>${escapeHtml(t.school)}</b> is your 2× this week.` : `No captain was set (your best team auto-doubles).`)
-                + ` All kickoffs below are Central.</p>`
+                + ` All times Central.</p>`
                 + `<div class="captain-grid">${(season.teams || []).map(tm => `
                     <div class="captain-team is-locked${Number(state.teamId) === Number(tm.id) ? ' is-captain' : ''}">${tileBody(tm)}</div>`).join('')}</div>`;
             return;
@@ -948,7 +948,7 @@ async function hydrateCaptain(user, activeYear) {
         const twoLine = twoGamers.length
             ? ` <b>${twoGamers.map(t => escapeHtml(t.school)).join('</b>, <b>')}</b> play twice this week — captaining one doubles both games.`
             : '';
-        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}${twoLine} All kickoffs below are Central.</p>
+        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}${twoLine} All times Central.</p>
             <div class="captain-grid">${(season.teams || []).map(t => `
                 <button type="button" class="captain-team${Number(state.teamId) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(state.teamId) === Number(t.id)}">${tileBody(t)}</button>`).join('')}</div>`;
         container.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -407,7 +407,9 @@ async function hydratePreseasonDraft(user, activeYear) {
     const myPick = order.indexOf(String(user._id));
     const managers = order.length;
     const when = draft.scheduledAt ? new Date(draft.scheduledAt) : null;
-    const fmtDate = when ? when.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' }) : null;
+    // Central, and said so — the league spans time zones and every other date
+    // in the app is Central too.
+    const fmtDate = when ? when.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' }) + ' CT' : null;
     const meta = [
         fmtDate ? `<span>📅 <b>${escapeHtml(fmtDate)}</b></span>` : '',
         `<span>${draft.snake ? '🐍 <b>Snake</b>' : '<b>Linear</b>'} · ${draft.totalRounds || 10} rounds</span>`,
@@ -855,12 +857,12 @@ async function hydrateH2H(user, activeYear) {
 // Captain on (or ?captain=1). Glance shows the current pick; drawer is the team
 // picker (set/clear a 2× team for the current open week).
 // Kickoff-lock display helpers (Central time, matching the app's schedule).
-function uhFmtLock(iso) {
+function uhFmtLock(iso, withTz) {
     if (!iso) return '';
     const d = new Date(iso);
     const day = d.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'America/Chicago' });
     const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' });
-    return `${day} ${time}`;
+    return `${day} ${time}${withTz ? ' CT' : ''}`;
 }
 function uhTimeLeft(iso) {
     if (!iso) return '';
@@ -910,7 +912,7 @@ async function hydrateCaptain(user, activeYear) {
             : `<span class="captain-unset">${state.locked ? 'No pick · Wk ' + state.week : 'Set for Wk ' + state.week}</span>`;
         let sub;
         if (state.locked) sub = 'Locked for this week';
-        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt)}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
+        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt, true)}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
         else sub = 'Doubles this week’s points';
         g.innerHTML = lead + `<span class="uh-cap-sub">${sub}</span>`;
     };
@@ -933,7 +935,8 @@ async function hydrateCaptain(user, activeYear) {
         if (state.locked) {
             const t = state.teamId != null ? teamById[state.teamId] : null;
             container.innerHTML = `<p class="captain-note">Locked — your first team of Week ${state.week} has kicked off. `
-                + (t ? `<b>${escapeHtml(t.school)}</b> is your 2× this week.` : `No captain was set (your best team auto-doubles).`) + `</p>`
+                + (t ? `<b>${escapeHtml(t.school)}</b> is your 2× this week.` : `No captain was set (your best team auto-doubles).`)
+                + ` All kickoffs below are Central.</p>`
                 + `<div class="captain-grid">${(season.teams || []).map(tm => `
                     <div class="captain-team is-locked${Number(state.teamId) === Number(tm.id) ? ' is-captain' : ''}">${tileBody(tm)}</div>`).join('')}</div>`;
             return;
@@ -945,7 +948,7 @@ async function hydrateCaptain(user, activeYear) {
         const twoLine = twoGamers.length
             ? ` <b>${twoGamers.map(t => escapeHtml(t.school)).join('</b>, <b>')}</b> play twice this week — captaining one doubles both games.`
             : '';
-        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}${twoLine}</p>
+        container.innerHTML = `<p class="captain-note">Pick one team to score <b>2×</b> in Week ${state.week}. Tap the current pick to clear.${lockLine}${twoLine} All kickoffs below are Central.</p>
             <div class="captain-grid">${(season.teams || []).map(t => `
                 <button type="button" class="captain-team${Number(state.teamId) === Number(t.id) ? ' is-captain' : ''}" data-team="${t.id}" aria-pressed="${Number(state.teamId) === Number(t.id)}">${tileBody(t)}</button>`).join('')}</div>`;
         container.querySelectorAll('.captain-team').forEach(btn => btn.addEventListener('click', async () => {

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -262,7 +262,7 @@ router.post('/', async (req, res) => {
         );
 
         const when = draft.scheduledAt
-            ? new Date(draft.scheduledAt).toLocaleString('en-US', { timeZone: 'America/Chicago', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+            ? new Date(draft.scheduledAt).toLocaleString('en-US', { timeZone: 'America/Chicago', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) + ' CT'
             : 'no date';
         await audit.record(req, {
             action: 'draft.config', league, season: String(season),

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -21,6 +21,7 @@ const { gameStatus, matchupWinProb, H2H_MAX_WEEK, baseWeekScore, persistedBonus,
         h2hRoster, pinnedH2HIds, computeH2HAwards } = require('../modules/h2h');
 const { findPoll } = require('../modules/scoring-detectors');
 const { pickLogo } = require('../public/logo.js');
+const { resolveCaptain } = require('../modules/captain');
 
 // The poll the PROJECTIONS should value a hypothetical ranked win against: the
 // most recent regular-season poll on file.
@@ -329,7 +330,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const pinnedIds = pinnedH2HIds(cfgDoc, season);
         const ids = h2hRoster(users, season, pinnedIds);
         const idSet = new Set(ids);
-        const meta = {}, totals = {}, teamDetail = {}, caps = {}, banked = {};
+        const meta = {}, totals = {}, teamDetail = {}, caps = {}, banked = {}, seasonById = {};
         // teamDetail is keyed per (team, game) so a doubleheader keeps both
         // results apart. scoreByTeam only started carrying gameId in 2024, so
         // older entries key on the team alone — one row per team, as before.
@@ -381,6 +382,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             teamDetail[id] = twTeams;
             caps[id] = {};
             (s.captains || []).forEach(c => { if (c && c.week != null) caps[id][c.week] = c.teamId; });
+            seasonById[id] = s;
         });
         if (!ids.length) return res.json({ league, season: seasonNum, enabled: eng.h2hEnabled, winBonus, tieBonus, weeks: [], managers: [], schedule: [] });
 
@@ -466,6 +468,35 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const gamesOf = (teamId, w) => (gameTW[teamId] && gameTW[teamId][w]) || [];
         const gameById = {};
         games.forEach(g => { gameById[g.id] = g; });
+
+        // The captain doubles a team for the week, and that doubling is already
+        // folded into the weekly total the card shows — so the win bar has to
+        // count it too, or the number and the bar tell different stories.
+        //
+        // Resolved with resolveCaptain, NOT the raw `captains` array: a manager
+        // who never picks still gets an auto-captain at scoring time (their best
+        // team, or the first rostered one in week 1). Reading only explicit picks
+        // would leave the bar disagreeing with the score for everyone who didn't
+        // set one.
+        const capEnabled = !!eng.captainEnabled;
+        const capMult = eng.captainMultiplier || 2;
+        const capCache = {};
+        const captainOf = (id, w) => {
+            if (!capEnabled) return null;
+            const key = id + ':' + w;
+            if (key in capCache) return capCache[key];
+            const s = seasonById[id];
+            if (!s) return (capCache[key] = null);
+            const prior = (s.weeklyScore || []).filter(e => e.season !== 'postseason' && Number(e.week) < Number(w));
+            return (capCache[key] = resolveCaptain(s.captains, w, s.teams, prior));
+        };
+        const isCaptain = (id, w, teamId) => {
+            const c = captainOf(id, w);
+            return c != null && Number(c) === Number(teamId);
+        };
+        // A projection entry with the captain's multiplier applied to its points.
+        const capped = (id, w, teamId, e) => (e && isCaptain(id, w, teamId))
+            ? { winProb: e.winProb, pointsIfWin: e.pointsIfWin * capMult } : e;
         // A team's scored points for ONE game. The legacy per-team fallback is
         // only safe when that team played once that week — otherwise it would
         // report the same two-game total against each of the two rows.
@@ -535,14 +566,15 @@ router.get('/h2h/:league/:season', async (req, res) => {
                         gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
                     }
                 }
-                return { teamId: t.teamId, school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: !!(caps[id] && caps[id][w] === t.teamId), opp, ha, gameScore };
+                return { teamId: t.teamId, school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: isCaptain(id, w, t.teamId), opp, ha, gameScore };
             })
             .sort((a, b) => b.score - a.score);
-        const fmtKick = (g) => {
-            if (!g || !g.startDate || g.startTimeTbd) return 'TBD';
-            const d = new Date(g.startDate); if (isNaN(d.getTime())) return 'TBD';
-            return d.toLocaleDateString('en-US', { weekday: 'short' }) + ' ' + d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-        };
+        // The kickoff INSTANT, not a rendered string. This used to format here
+        // with no timeZone, so it came out in the dyno's zone (UTC) — every
+        // kickoff five hours late, and night games landing on the wrong weekday
+        // entirely. Every other date in the app renders in Central; the client
+        // now does that for these too, off the ISO. null = time not yet firm.
+        const kickAt = (g) => (!g || !g.startDate || g.startTimeTbd) ? null : g.startDate;
         const statusOrder = { final: 0, live: 1, scheduled: 2 };
         // flatMap, not map: a team with two games that week gets a row for each,
         // so neither is hidden and the footer's game count is honest. A team with
@@ -557,14 +589,14 @@ router.get('/h2h/:league/:season', async (req, res) => {
             if (g.completed && g.homePoints != null && g.awayPoints != null) {
                 gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
             }
-            return { teamId: t.id, school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? fmtKick(g) : null, opp, ha: isHome ? 'vs' : '@', gameScore, captain: !!(caps[id] && caps[id][w] === t.id) };
+            return { teamId: t.id, school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? kickAt(g) : null, opp, ha: isHome ? 'vs' : '@', gameScore, captain: isCaptain(id, w, t.id) };
         })).sort((a, b) => (statusOrder[a.status] - statusOrder[b.status]) || ((b.score || 0) - (a.score || 0)));
 
         // Projected pre-game odds for a matchup: each manager's teams that play
         // that week, run through the win-probability model. Integer percents that
         // sum to 100 (or null when neither side has a projectable game).
         const entriesFor = (id, w) => (meta[id].teams || [])
-            .flatMap(t => Object.values((projByWeek[w] && projByWeek[w][t.id]) || {}));
+            .flatMap(t => Object.values((projByWeek[w] && projByWeek[w][t.id]) || {}).map(e => capped(id, w, t.id, e)));
         // Live odds recompute as the week plays out: a team whose game is already
         // FINAL contributes its actual scored points as a certainty; teams still
         // to play (live/upcoming) keep their projected win-prob × points-if-win.
@@ -573,10 +605,10 @@ router.get('/h2h/:league/:season', async (req, res) => {
         const liveEntriesFor = (id, w) => (meta[id].teams || []).flatMap(t => gamesOf(t.id, w).map(g => {
             if (gameStatus(g, now) === 'final') {
                 const s = scoredFor(id, w, t.id, g.id);
-                return { winProb: 1, pointsIfWin: s ? s.score : 0 };   // result locked in
+                return capped(id, w, t.id, { winProb: 1, pointsIfWin: s ? s.score : 0 });   // result locked in
             }
             const p = projByWeek[w] && projByWeek[w][t.id] && projByWeek[w][t.id][g.id];
-            return p ? { winProb: p.winProb, pointsIfWin: p.pointsIfWin } : null;
+            return p ? capped(id, w, t.id, { winProb: p.winProb, pointsIfWin: p.pointsIfWin }) : null;
         })).filter(Boolean);
         const oddsFrom = (ea, eb) => {
             const r = matchupWinProb(ea, eb);
@@ -626,7 +658,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             w.final = false;
             const doctor = (arr) => (arr || []).map((t, j) => {
                 const status = mode === 'pregame' ? 'scheduled' : (j === 0 ? 'final' : (j === 1 ? 'live' : 'scheduled'));
-                return { teamId: t.teamId, school: t.school, abbr: t.abbr, logo: t.logo, status, score: status === 'final' ? t.score : null, kickoff: status === 'scheduled' ? 'Sat 3:30' : null, opp: j % 2 ? 'UGA' : 'ARK', ha: j % 2 ? '@' : 'vs', gameScore: status === 'final' ? '31–20' : null, captain: j === 0 };
+                return { teamId: t.teamId, school: t.school, abbr: t.abbr, logo: t.logo, status, score: status === 'final' ? t.score : null, kickoff: status === 'scheduled' ? new Date(Date.now() + 864e5).toISOString() : null, opp: j % 2 ? 'UGA' : 'ARK', ha: j % 2 ? '@' : 'vs', gameScore: status === 'final' ? '31–20' : null, captain: j === 0 };
             });
             // Live odds from the doctored slate: final games lock their actual
             // points, everything else is a neutral coin-flip projection — so the

--- a/tests/H2HCaptainOdds.spec.js
+++ b/tests/H2HCaptainOdds.spec.js
@@ -1,0 +1,175 @@
+// The H2H win bar counts the Captain.
+//
+// The captain multiplies one rostered team's points for the week, and scoring
+// folds that bonus straight into the weekly total — the number the matchup card
+// shows. The odds, though, were computed from raw per-game points and never
+// looked at the captain at all. So setting or changing your pick moved the score
+// and not the bar, and mid-week a captained team's finished game read doubled in
+// the number and single in the bar.
+//
+// The bar now applies the multiplier, resolved through resolveCaptain — the same
+// call the scoring job makes. That matters because EVERY manager has a captain
+// once the mode is on: a manager who never picks is auto-captained at scoring
+// time (their best team by prior average, or the first rostered one in week 1).
+// Reading only explicit picks would leave the bar disagreeing with the score for
+// everyone who never sets one.
+//
+// The fixture gives each team its own expectedWins, which on a one-game season
+// is that team's win probability — so Ann's roster is deliberately lopsided
+// (Oregon 90%, USC 20%) and the choice of captain actually matters.
+//
+// Runs against an in-memory Mongo with the real models and the real route.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const Team = require('../models/team');
+const ScoringConfig = require('../models/scoringConfig');
+const standingsRouter = require('../routes/standings');
+
+const app = express();
+app.use(express.json());
+app.use('/standings', standingsRouter);
+
+useMongo();
+
+const SEASON = 2026;
+const LEAGUE = 'graham-league';
+const OREGON = 1, USC = 2, DUKE = 3, MIAMI = 4;
+
+function fullTeam(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 3).toUpperCase(),
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+const KICK = '2099-09-05T23:30:00.000Z';
+function game(id, homeId, awayId, completed) {
+    return {
+        id, season: SEASON, week: 1, seasonType: 'regular',
+        startDate: KICK, startTimeTbd: false, neutralSite: false, conferenceGame: false,
+        homeId, homeTeam: 'Home', awayId, awayTeam: 'Away',
+        homePoints: completed ? 40 : null, awayPoints: completed ? 3 : null, completed
+    };
+}
+async function config(over) {
+    await ScoringConfig.create({
+        league: LEAGUE, model: 'graham', values: {},
+        engagementBySeason: { '2026': Object.assign({ h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0, captainEnabled: true, captainMultiplier: 2 }, over || {}) }
+    });
+}
+// expectedWins doubles as each team's win probability here — one game apiece.
+async function seedTeams() {
+    await Team.create([[OREGON, 'Oregon', 22, 0.9], [USC, 'USC', 18, 0.2], [DUKE, 'Duke', 4, 0.5], [MIAMI, 'Miami', 2, 0.5],
+                       [96, 'Opp96', -8, 0.5], [97, 'Opp97', -8, 0.5], [98, 'Opp98', -8, 0.5], [99, 'Opp99', -8, 0.5]]
+        .map(([id, school, sp, ew]) => Object.assign(fullTeam(id, school), {
+            seasons: [{ season: SEASON, conference: 'SEC', spRating: sp, expectedWins: ew }]
+        })));
+}
+async function seed(annCaptains, cfgOver) {
+    await config(cfgOver);
+    await seedTeams();
+    const ann = await User.create({
+        firstName: 'Ann', lastName: 'Test', league: LEAGUE,
+        seasons: [{ season: SEASON, teams: [fullTeam(OREGON, 'Oregon'), fullTeam(USC, 'USC')], captains: annCaptains || [], weeklyScore: [{ week: 1, score: 0, scoreByTeam: [] }], cumulativeScore: 0 }]
+    });
+    await User.create({
+        firstName: 'Bob', lastName: 'Test', league: LEAGUE,
+        seasons: [{ season: SEASON, teams: [fullTeam(DUKE, 'Duke'), fullTeam(MIAMI, 'Miami')], weeklyScore: [{ week: 1, score: 0, scoreByTeam: [] }], cumulativeScore: 0 }]
+    });
+    await Game.create([game(101, OREGON, 99, false), game(102, USC, 98, false), game(103, DUKE, 97, false), game(104, MIAMI, 96, false)]);
+    return ann;
+}
+
+function mine(body, annId) {
+    const g = body.schedule.find(s => s.week === 1).games[0];
+    const iAmA = String(g.aId) === String(annId);
+    return { teams: iAmA ? g.aTeams : g.bTeams, winP: g.winP && (iAmA ? g.winP.a : g.winP.b), game: g };
+}
+const odds = (ann) => request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}`).then(r => mine(r.body, ann._id).winP);
+
+describe('the win bar counts the Captain', () => {
+    test('captaining your strongest team lifts your odds', async () => {
+        const ann = await seed([{ week: 1, teamId: OREGON }]);
+        const on = await odds(ann);
+
+        // Same rosters, same games, mode off for the season.
+        await ScoringConfig.updateOne({ league: LEAGUE }, { $set: { 'engagementBySeason.2026.captainEnabled': false } });
+        const off = await odds(ann);
+
+        expect(off).toBe(54);
+        expect(on).toBe(62);
+    });
+
+    test('spending it on a weak team costs you, since your rival still doubles', async () => {
+        const ann = await seed([{ week: 1, teamId: USC }]);       // USC wins 20% of the time
+        // Below the 54 they'd have with the mode off: Ann's captain is nearly
+        // worthless while Bob's auto-captain doubles a coin-flip.
+        expect(await odds(ann)).toBe(45);
+    });
+
+    test('changing the pick changes the bar', async () => {
+        const ann = await seed([{ week: 1, teamId: USC }]);
+        const onUsc = await odds(ann);
+
+        await User.updateOne({ _id: ann._id }, { $set: { 'seasons.0.captains': [{ week: 1, teamId: OREGON }] } });
+        const onOregon = await odds(ann);
+
+        expect(onOregon).toBeGreaterThan(onUsc);
+    });
+
+    test('a manager who never picks is modelled with their auto-captain', async () => {
+        const ann = await seed([]);                                // no pick at all
+        const res = await request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        const { teams, winP } = mine(res.body, ann._id);
+
+        // resolveCaptain's week-1 fallback is the first rostered team, and the
+        // card marks whichever team actually doubles — so this reads exactly as
+        // if Oregon had been picked by hand.
+        expect(teams.filter(t => t.captain).map(t => t.teamId)).toEqual([OREGON]);
+        expect(winP).toBe(62);
+    });
+
+    test('no captain marker at all when the league has the mode off', async () => {
+        const ann = await seed([{ week: 1, teamId: OREGON }], { captainEnabled: false });
+        const res = await request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        expect(mine(res.body, ann._id).teams.some(t => t.captain)).toBe(false);
+    });
+
+    test('a settled week keeps the banked bonus in the score', async () => {
+        await config();
+        await seedTeams();
+        const ann = await User.create({
+            firstName: 'Ann', lastName: 'Test', league: LEAGUE,
+            seasons: [{
+                season: SEASON, teams: [fullTeam(OREGON, 'Oregon'), fullTeam(USC, 'USC')],
+                captains: [{ week: 1, teamId: OREGON }],
+                // 10 + 6 raw, +10 for doubling Oregon = 26 banked.
+                weeklyScore: [{ week: 1, score: 26, captainTeamId: OREGON, captainBonus: 10, scoreByTeam: [
+                    { team: 'Oregon', teamId: OREGON, gameId: 101, score: 10 },
+                    { team: 'USC', teamId: USC, gameId: 102, score: 6 }
+                ] }],
+                cumulativeScore: 26
+            }]
+        });
+        await User.create({
+            firstName: 'Bob', lastName: 'Test', league: LEAGUE,
+            seasons: [{ season: SEASON, teams: [fullTeam(DUKE, 'Duke')], weeklyScore: [{ week: 1, score: 20, scoreByTeam: [{ team: 'Duke', teamId: DUKE, gameId: 103, score: 20 }] }], cumulativeScore: 20 }]
+        });
+        await Game.create([game(101, OREGON, 99, true), game(102, USC, 98, true), game(103, DUKE, 97, true)]);
+
+        const res = await request(app).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        const { game: g, teams } = mine(res.body, ann._id);
+        // The card's score already carried the captain bonus — 26, not the 16 of
+        // raw per-game points — and the bar now agrees rather than contradicting it.
+        expect(res.body.schedule.find(s => s.week === 1).final).toBe(true);
+        expect(String(g.aId) === String(ann._id) ? g.aScore : g.bScore).toBe(26);
+        expect(g.winner).toBe(String(g.aId) === String(ann._id) ? 'a' : 'b');
+        expect(teams.filter(t => t.captain).map(t => t.teamId)).toEqual([OREGON]);
+    });
+});

--- a/tests/H2HCardKickoffs.spec.js
+++ b/tests/H2HCardKickoffs.spec.js
@@ -83,4 +83,15 @@ describe('H2H card kickoffs', () => {
     test('an unparseable kickoff degrades to TBD rather than Invalid Date', () => {
         expect(kicks(card([team('USC', 'not-a-date')], [team('Duke', USC_SJSU)]))[0]).toBe('TBD');
     });
+
+    // The league spans time zones (one manager is Eastern) and the app renders
+    // every date in Central. A card can carry 20+ kickoff rows, so the zone is
+    // named once in the footer rather than repeated on each line.
+    test('names the zone once, in the footer', () => {
+        document.body.innerHTML = card([team('USC', USC_SJSU)], [team('Duke', USC_SJSU)]);
+        const foot = document.querySelector('.h2h-mfoot').textContent;
+        expect(foot).toContain('kickoffs Central');
+        // Not repeated on every row — that is what the footer is for.
+        expect(kicks(card([team('USC', USC_SJSU)], [team('Duke', USC_SJSU)]))[0]).toBe('Sat 2:00 PM');
+    });
 });

--- a/tests/H2HCardKickoffs.spec.js
+++ b/tests/H2HCardKickoffs.spec.js
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Browser-side tests for the kickoff times on the shared H2H matchup card
+ * (public/h2h-card.js).
+ *
+ * These used to be formatted server-side with no timeZone option, so they came
+ * out in the dyno's zone — UTC on Heroku. Every kickoff read five hours late,
+ * and a night game landed on the wrong weekday outright: Memphis @ UNLV, a
+ * Saturday 9pm Central kickoff, displayed as "Sun 2:00 AM". Meanwhile the
+ * Captain picker rendered the same games in Central, so the two surfaces
+ * disagreed about when a team played.
+ *
+ * The payload now carries the kickoff INSTANT and the card renders it in
+ * Central, matching every other date in the app. The date is added only when a
+ * matchup's games straddle more than one weekend — which is exactly the API
+ * week that folds in the opening weekend, where "Sat 2:00 PM" can't tell Aug 29
+ * from Sep 5.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function loadCard() {
+    (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'h2h-card.js'), 'utf8'));
+    return window.ccH2H;
+}
+
+const BY_ID = {
+    u1: { userId: 'u1', name: 'Ann T.', franchise: 'Big Mac', initials: 'AT', color: '#111' },
+    u2: { userId: 'u2', name: 'Bob R.', franchise: 'Always Next Year', initials: 'BR', color: '#222' }
+};
+function team(school, kickoff) {
+    return { teamId: school.length, school, abbr: school.slice(0, 3).toUpperCase(), logo: '', score: null, status: 'scheduled', kickoff, opp: 'OPP', ha: 'vs', gameScore: null, captain: false };
+}
+function card(aTeams, bTeams) {
+    const g = { aId: 'u1', bId: 'u2', aScore: 0, bScore: 0, aTeams, bTeams, winner: null, winP: { a: 50, b: 50 }, final: false, upcoming: true };
+    return loadCard().matchupCard(g, { byId: BY_ID });
+}
+// The rendered kickoff cells, in order.
+function kicks(html) {
+    document.body.innerHTML = html;
+    return [...document.querySelectorAll('.h2h-tv.sched')].map(el => el.textContent);
+}
+
+// Real 2026 week-1 kickoffs, as stored (UTC instants).
+const USC_SJSU = '2026-08-29T19:00:00.000Z';    // Sat Aug 29, 2:00 PM Central
+const USC_FRES = '2026-09-05T01:00:00.000Z';    // Fri Sep 4,  8:00 PM Central
+const MEM_UNLV = '2026-08-30T02:00:00.000Z';    // Sat Aug 29, 9:00 PM Central
+
+describe('H2H card kickoffs', () => {
+    test('render in Central, not the server zone', () => {
+        // Same weekend on both sides, so no dates — just the corrected time.
+        const out = kicks(card([team('USC', USC_SJSU)], [team('Duke', '2026-08-29T23:30:00.000Z')]));
+        expect(out[0]).toBe('Sat 2:00 PM');       // was "Sat 7:00 PM" (UTC)
+        expect(out[1]).toBe('Sat 6:30 PM');
+    });
+
+    test('a night game keeps its own weekday instead of rolling over in UTC', () => {
+        const out = kicks(card([team('Memphis', MEM_UNLV)], [team('Duke', '2026-08-29T23:30:00.000Z')]));
+        // Stored as Aug 30 UTC; it is a SATURDAY night game in Central.
+        expect(out[0]).toBe('Sat 9:00 PM');       // was "Sun 2:00 AM"
+    });
+
+    test('adds the date when the matchup straddles more than one weekend', () => {
+        const out = kicks(card([team('USC', USC_SJSU), team('USC2', USC_FRES)], [team('Duke', '2026-09-05T23:30:00.000Z')]));
+        // Both USC games said "Sat" before — and one of them is a Friday.
+        expect(out[0]).toBe('Sat, 8/29 2:00 PM');
+        expect(out[1]).toBe('Fri, 9/4 8:00 PM');
+        // The date applies to the whole card, so the two columns read alike.
+        expect(out[2]).toBe('Sat, 9/5 6:30 PM');
+    });
+
+    test('leaves the date off an ordinary single-weekend week', () => {
+        const out = kicks(card([team('USC', USC_SJSU)], [team('Duke', '2026-08-30T00:00:00.000Z')]));
+        out.forEach(k => expect(k).toMatch(/^[A-Z][a-z]{2} \d{1,2}:\d{2} [AP]M$/));
+    });
+
+    test('a kickoff with no firm time reads TBD', () => {
+        expect(kicks(card([team('USC', null)], [team('Duke', null)]))).toEqual(['TBD', 'TBD']);
+    });
+
+    test('an unparseable kickoff degrades to TBD rather than Invalid Date', () => {
+        expect(kicks(card([team('USC', 'not-a-date')], [team('Duke', USC_SJSU)]))[0]).toBe('TBD');
+    });
+});

--- a/tests/H2HSchedule.spec.js
+++ b/tests/H2HSchedule.spec.js
@@ -128,8 +128,10 @@ describe('GET /standings/h2h schedule', () => {
         // renderer handle both.
         expect(g.aTeams).toHaveLength(1);
         expect(g.aTeams[0]).toMatchObject({ teamId: 1, school: 'Oregon', status: 'scheduled', score: null });
-        expect(g.aTeams[0].kickoff).toBeTruthy();
-        expect(g.aTeams[0].kickoff).not.toBe('TBD');
+        // The kickoff INSTANT — the card renders it in Central; the server no
+        // longer formats it (and used to do so in the dyno's zone).
+        expect(Number.isNaN(Date.parse(g.aTeams[0].kickoff))).toBe(false);
+        expect(new Date(g.aTeams[0].kickoff).toISOString()).toBe(FUTURE);
     });
 
     test('unplayed weeks add no records or bonus', async () => {

--- a/tests/TeamPageTimezone.spec.js
+++ b/tests/TeamPageTimezone.spec.js
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ *
+ * The team page's schedule renders game times in the BROWSER's zone, not
+ * Central like the rest of the app. That is fine — it is the one page where a
+ * local time is what you want — but it has to SAY so, because the league spans
+ * two zones and "2:30 PM" means different things to different managers.
+ *
+ * The label is the generic form (CT, ET) rather than the seasonal one (CDT,
+ * CST): a schedule runs August to January, straddling the November DST change,
+ * and both halves of it are still "CT".
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// team.js only assigns window.onload at the top level, so evaluating it defines
+// the helpers without booting the page.
+function load() {
+    (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'team.js'), 'utf8'));
+}
+
+describe('tzGenericLabel', () => {
+    beforeEach(load);
+
+    test('collapses a US abbreviation to its year-round form', () => {
+        expect(tzGenericLabel('CDT')).toBe('CT');
+        expect(tzGenericLabel('CST')).toBe('CT');
+        expect(tzGenericLabel('EDT')).toBe('ET');
+        expect(tzGenericLabel('EST')).toBe('ET');
+        expect(tzGenericLabel('MDT')).toBe('MT');
+        expect(tzGenericLabel('PST')).toBe('PT');
+    });
+
+    test('handles the longer US abbreviations', () => {
+        expect(tzGenericLabel('AKDT')).toBe('AKT');
+    });
+
+    test('passes through anything that is not a US abbreviation', () => {
+        // A manager abroad, or a browser that reports an offset.
+        expect(tzGenericLabel('GMT+2')).toBe('GMT+2');
+        expect(tzGenericLabel('UTC')).toBe('UTC');
+        expect(tzGenericLabel('GMT')).toBe('GMT');
+    });
+
+    test('is empty rather than wrong when there is nothing to report', () => {
+        expect(tzGenericLabel('')).toBe('');
+        expect(tzGenericLabel(null)).toBe('');
+        expect(tzGenericLabel(undefined)).toBe('');
+    });
+});
+
+describe('localTzLabel', () => {
+    beforeEach(load);
+
+    test('reports the environment zone in the generic form', () => {
+        // Jest runs under TZ=UTC unless told otherwise; either way the label is
+        // a short token and never a seasonal S/D variant.
+        const label = localTzLabel();
+        expect(typeof label).toBe('string');
+        expect(label).not.toMatch(/^[A-Z]{1,3}[SD]T$/);
+    });
+
+    test('degrades to no label rather than throwing', () => {
+        const real = global.Intl;
+        global.Intl = { DateTimeFormat: function () { throw new Error('unavailable'); } };
+        try {
+            expect(localTzLabel()).toBe('');
+        } finally {
+            global.Intl = real;
+        }
+    });
+});


### PR DESCRIPTION
Three fixes to what the H2H card and My Team tell you about time and captains.

## 1. Kickoffs were in the wrong timezone

`fmtKick` formatted server-side with **no `timeZone` option**, so it rendered in the dyno's zone — UTC on Heroku. Every other date in the app pins `America/Chicago`.

Verified against the ESPN Central schedule for the Sep 5 slate: **33 of 34 games** now match exactly, and every one was off by +5 hours before.

| | ESPN (CT) | After this PR | Prod today |
|---|---|---|---|
| Oregon vs BOIS | 2:30 PM | Sat 2:30 PM ✓ | Sat 7:30 PM |
| Indiana vs UNT | 11:00 AM | Sat 11:00 AM ✓ | Sat 4:00 PM |
| LSU vs CLEM | 6:30 PM | Sat 6:30 PM ✓ | Sat 11:30 PM |
| BYU vs Utah Tech | 7:00 PM | Sat 7:00 PM ✓ | **Sun** 12:00 AM |
| Hawai'i vs UNLV | 9:00 PM | Sat 9:00 PM ✓ | **Sun** 2:00 AM |

Night games rolled past midnight UTC and displayed on the **wrong weekday**. The 34th (Miami OH @ Pitt, 11:00 vs 11:30) is a 30-minute staleness in CFBD's own data, unrelated to this change.

The payload now carries the kickoff **instant**; the card renders it. It also adds the calendar date when a matchup's games straddle more than one weekend — the API week that folds in the opening weekend, where USC's two games both read "Sat" though one is a Friday six days later.

## 2. The win bar ignored the Captain

The captain multiplies a team's points and scoring folds that bonus into the weekly total — the number **on the card**. The odds were computed from raw per-game points, so setting or changing a pick moved the score and not the bar, and mid-week a captained team's finished game read doubled in the number and single in the bar.

The bar now applies the multiplier through `resolveCaptain`, the same call the scoring job makes. That matters because once the mode is on **every** manager has a captain — anyone who never picks is auto-captained at scoring time. Reading only explicit picks would leave the bar disagreeing with the score for exactly those managers.

| | Ann's odds |
|---|---|
| Captain mode off | 54% |
| Captains her 90% team | **62%** |
| Captains her 20% team | **45%** |

Spending it badly *costs* you, because your rival's captain doubles either way.

## 3. Nothing said which zone the times were in

The league spans zones. Labelled by density, so it lands where it helps:

- **standalone times name the zone inline** — the captain lock ("Locks Sat 2:30 PM CT"), the pinned draft date, the draft-config audit line;
- **dense lists name it once at the container** — the matchup card carries "kickoffs Central" in its footer rather than on each of 20+ rows; the Captain picker says "All times Central" above the grid instead of on every tile.

Settled cards show no kickoffs, so they gain no label.

### The team page is the exception, and now says so

`public/team.js` renders game times in the **browser's** zone — right for that page, but silent about it. A line under the schedule heading now names the zone, resolved from the browser:

| Viewer | Browser reports | Line reads |
|---|---|---|
| Central | CDT | All times **CT** |
| Eastern | EDT | All times **ET** |
| Pacific | PDT | All times **PT** |
| Abroad | GMT+2 | All times **GMT+2** |

The generic form, not the seasonal one: a schedule runs August to January across the November DST change, and a label that flipped CDT→CST mid-season would raise the question it exists to answer. A browser that can't report a zone gets no line rather than a wrong one.

## Verification

Full suite passes (69 suites, 1267 tests), including 19 new tests:

- `tests/H2HCardKickoffs.spec.js` — Central conversion, the night-game weekday rollover, dates only on multi-weekend matchups, TBD, an unparseable date degrading rather than printing `Invalid Date`, and the footer label.
- `tests/H2HCaptainOdds.spec.js` — the numbers above, the auto-captain fallback matching an explicit pick, and no marker when the mode is off.
- `tests/TeamPageTimezone.spec.js` — the abbreviation mapping, non-US passthrough, and graceful degradation when `Intl` is unavailable.

Card states and the Captain picker rendered against the real CSS to confirm layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)