### PR TITLE
Say which team actually locks the Captain pick

### DIFF
--- a/public/userHome.js
+++ b/public/userHome.js
@@ -857,12 +857,21 @@ async function hydrateH2H(user, activeYear) {
 // Captain on (or ?captain=1). Glance shows the current pick; drawer is the team
 // picker (set/clear a 2× team for the current open week).
 // Kickoff-lock display helpers (Central time, matching the app's schedule).
-function uhFmtLock(iso, withTz) {
+function uhFmtLock(iso, opts) {
     if (!iso) return '';
+    const o = opts || {};
     const d = new Date(iso);
-    const day = d.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'America/Chicago' });
+    const day = d.toLocaleDateString('en-US', o.dated
+        ? { weekday: 'short', month: 'numeric', day: 'numeric', timeZone: 'America/Chicago' }
+        : { weekday: 'short', timeZone: 'America/Chicago' });
     const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' });
-    return `${day} ${time}${withTz ? ' CT' : ''}`;
+    return `${day} ${time}${o.tz ? ' CT' : ''}`;
+}
+// "NC State", "NC State and LSU", "NC State, LSU and Duke".
+function uhAndList(names) {
+    const a = (names || []).filter(Boolean);
+    if (a.length <= 1) return a[0] || '';
+    return a.slice(0, -1).join(', ') + ' and ' + a[a.length - 1];
 }
 function uhTimeLeft(iso) {
     if (!iso) return '';
@@ -903,6 +912,28 @@ async function hydrateCaptain(user, activeYear) {
     if (!(season.teams || []).length) return hide();
     if (tile) tile.hidden = false;
 
+    const slateBy = {};
+    (state.slate || []).forEach(x => { slateBy[x.teamId] = x.games || []; });
+    // API week 1 folds in the opening weekend, so a manager can hold a team that
+    // plays a full week before the rest — and then "Sat 2:30 PM" names two
+    // different Saturdays. Date the times when this week's slate straddles more
+    // than one weekend, the same rule the matchup card uses.
+    const kicks = (state.slate || []).flatMap(x => (x.games || [])
+        .map(gm => Date.parse(gm.kickoff)).filter(n => !Number.isNaN(n)));
+    const datedSlate = kicks.length > 1 && (Math.max(...kicks) - Math.min(...kicks)) > 3 * 864e5;
+    // Which team actually closes the pick. The lock is the manager's EARLIEST
+    // kickoff, which on an opening-weekend roster is rarely the team they were
+    // looking at — so name it rather than leaving "your first team" to be
+    // guessed from a grid where every tile reads the same time.
+    const lockMs = state.lockAt ? Date.parse(state.lockAt) : NaN;
+    const lockNames = (state.slate || [])
+        .filter(x => (x.games || []).some(gm => Date.parse(gm.kickoff) === lockMs))
+        .map(x => (teamById[x.teamId] || {}).school)
+        .filter(Boolean);
+    const lockWho = lockNames.length
+        ? `<b>${escapeHtml(uhAndList(lockNames))}</b> kick${lockNames.length === 1 ? 's' : ''} off`
+        : 'your first team kicks off';
+
     const g = document.getElementById('uh-glance-captain');
     const setGlance = () => {
         if (!g) return;
@@ -912,7 +943,7 @@ async function hydrateCaptain(user, activeYear) {
             : `<span class="captain-unset">${state.locked ? 'No pick · Wk ' + state.week : 'Set for Wk ' + state.week}</span>`;
         let sub;
         if (state.locked) sub = 'Locked for this week';
-        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt, true)}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
+        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt, { tz: true, dated: datedSlate })}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
         else sub = 'Doubles this week’s points';
         g.innerHTML = lead + `<span class="uh-cap-sub">${sub}</span>`;
     };
@@ -920,13 +951,11 @@ async function hydrateCaptain(user, activeYear) {
     // Two games is the case worth flagging: CFBD folds the opening weekend into
     // week 1, so a few teams play twice — and the captain doubles BOTH of them,
     // which a grid of bare logos gives no way to see.
-    const slateBy = {};
-    (state.slate || []).forEach(x => { slateBy[x.teamId] = x.games || []; });
     const tileBody = (t) => {
         const games = slateBy[t.id] || [];
         const badge = games.length > 1 ? `<span class="cap-2g">${games.length} games</span>` : '';
         const lines = games.length
-            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff)) : ' · TBD'}</span>`).join('')
+            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff, { dated: datedSlate })) : ' · TBD'}</span>`).join('')
             : `<span class="cap-tg">No game this week</span>`;
         return `<img src="${ccLogo(t.logos)}" alt="">
             <span class="cap-tid"><span class="cap-tnm"><span class="cap-nm">${escapeHtml(t.school)}</span>${badge}</span>${lines}</span>`;
@@ -942,7 +971,7 @@ async function hydrateCaptain(user, activeYear) {
             return;
         }
         const lockLine = state.lockAt
-            ? ` Locks ${uhFmtLock(state.lockAt)} — when your first team kicks off${uhTimeLeft(state.lockAt) ? ` (${uhTimeLeft(state.lockAt)} left)` : ''}.`
+            ? ` Locks ${uhFmtLock(state.lockAt, { dated: datedSlate })} — when ${lockWho}${uhTimeLeft(state.lockAt) ? ` (${uhTimeLeft(state.lockAt)} left)` : ''}.`
             : ' Locks when your first team kicks off.';
         const twoGamers = (season.teams || []).filter(t => (slateBy[t.id] || []).length > 1);
         const twoLine = twoGamers.length

--- a/tests/CaptainLockDisplay.spec.js
+++ b/tests/CaptainLockDisplay.spec.js
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ *
+ * How the Captain tile states the lock (public/userHome.js).
+ *
+ * The captain locks at the manager's OWN earliest kickoff. API week 1 folds in
+ * the opening weekend, so a manager holding one team that plays a week early
+ * gets locked a week before the rest of their roster plays — and every tile in
+ * the picker read the same bare "Sat 2:30 PM", so there was no way to see which
+ * game closed the pick. A real roster had NC State on Aug 29 and Texas on Sep 5,
+ * both rendering as "Sat 2:30 PM", with the note quoting that string directly
+ * above a grid whose FIRST tile was Texas.
+ *
+ * So the times gain a date when the week straddles more than one weekend (the
+ * rule the matchup card already uses), and the note names the team that closes
+ * the pick instead of leaving "your first team" to be inferred.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// userHome.js runs a little jQuery at the top level; the page itself only boots
+// from window.onload, which jsdom has already fired past.
+function load() {
+    const node = new Proxy(function () { return node; }, {
+        get(t, k) { return k === 'length' ? 0 : node; },
+        apply() { return node; }
+    });
+    global.$ = window.$ = function () { return node; };
+    (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'userHome.js'), 'utf8'));
+}
+
+// NC State @ Virginia — Sat Aug 29, 2:30 PM Central. The lock.
+const NCSTATE = '2026-08-29T19:30:00.000Z';
+// Texas vs Texas State — Sat Sep 5, 2:30 PM Central. Same clock, a week later.
+const TEXAS = '2026-09-05T19:30:00.000Z';
+
+describe('uhFmtLock', () => {
+    beforeEach(load);
+
+    test('is bare weekday + time by default', () => {
+        expect(uhFmtLock(TEXAS)).toBe('Sat 2:30 PM');
+    });
+
+    test('names the zone when asked', () => {
+        expect(uhFmtLock(TEXAS, { tz: true })).toBe('Sat 2:30 PM CT');
+    });
+
+    test('dates the time when asked — the whole point of this fix', () => {
+        // Without the date these two are indistinguishable, though they are a
+        // week apart.
+        expect(uhFmtLock(NCSTATE)).toBe(uhFmtLock(TEXAS));
+        expect(uhFmtLock(NCSTATE, { dated: true })).toBe('Sat, 8/29 2:30 PM');
+        expect(uhFmtLock(TEXAS, { dated: true })).toBe('Sat, 9/5 2:30 PM');
+        expect(uhFmtLock(NCSTATE, { dated: true })).not.toBe(uhFmtLock(TEXAS, { dated: true }));
+    });
+
+    test('combines date and zone', () => {
+        expect(uhFmtLock(NCSTATE, { dated: true, tz: true })).toBe('Sat, 8/29 2:30 PM CT');
+    });
+
+    test('renders Central regardless of the machine running it', () => {
+        // Stored as 19:30 UTC; Central is what a manager should read.
+        expect(uhFmtLock(NCSTATE)).toContain('2:30 PM');
+    });
+
+    test('is empty for a missing time rather than "Invalid Date"', () => {
+        expect(uhFmtLock(null)).toBe('');
+        expect(uhFmtLock('')).toBe('');
+    });
+});
+
+describe('uhAndList', () => {
+    beforeEach(load);
+
+    test('names one, two, or several teams', () => {
+        expect(uhAndList(['NC State'])).toBe('NC State');
+        expect(uhAndList(['NC State', 'LSU'])).toBe('NC State and LSU');
+        expect(uhAndList(['NC State', 'LSU', 'Duke'])).toBe('NC State, LSU and Duke');
+    });
+
+    test('is empty when there is nobody to name', () => {
+        expect(uhAndList([])).toBe('');
+        expect(uhAndList(null)).toBe('');
+        // A roster can hold both sides of one game (LSU vs Clemson), so blanks
+        // are filtered rather than rendered as "and undefined".
+        expect(uhAndList(['LSU', null, undefined])).toBe('LSU');
+    });
+});


### PR DESCRIPTION
## The confusion

> "Why does this say that my captain decision locks at 2:30PM? It feels like it is implying that it locks at 'Sat 2:30PM' because that's when Texas plays. However, I'm thinking in reality it means it locks Aug 29 at 2:30PM because that's when NC State plays."

Correct. Verified against the data for that roster:

```
Sat, Aug 29 2:30 PM   NC State       @ Virginia      <- sets the lock
Thu, Sep 3  7:00 PM   Missouri       vs Arkansas-Pine Bluff
Sat, Sep 5 11:00 AM   James Madison  vs Liberty
Sat, Sep 5 11:00 AM   Miami (OH)     @ Pittsburgh
Sat, Sep 5  2:30 PM   Texas          vs Texas State
Sat, Sep 5  5:00 PM   Old Dominion   vs Norfolk State
Sat, Sep 5  6:30 PM   LSU            vs Clemson
Sat, Sep 5  6:30 PM   Michigan       vs Western Michigan
Sat, Sep 5  6:45 PM   Florida        vs Florida Atlantic
```

`captainWeekWindow` returns Aug 29 2:30 PM — NC State. Texas is a coincidence: same clock time, exactly one week later. The tile's own "11d 14h left" confirms Aug 29 rather than Sep 5.

The lock rule is working as specified (the manager's own earliest kickoff). The **display** was the problem: API week 1 folds in the opening weekend, so two different Saturdays both rendered as the bare string `Sat 2:30 PM` — and the note quoted that string directly above a grid whose first tile was Texas.

## The fix

**Dates when the week straddles more than one weekend** — the rule the matchup card already uses. `Sat, 8/29 2:30 PM` beside `Sat, 9/5 2:30 PM` can't be misread. An ordinary single-weekend week is unchanged, so no width is spent on an ambiguity that isn't there.

**The note names the team**, instead of leaving "your first team" to be inferred:

> Locks **Sat, 8/29 2:30 PM** — when **NC State** kicks off (11d 14h left).

A roster can hold both sides of one game (LSU vs Clemson here), and two teams can share the earliest kickoff, so the name is a list with the verb agreeing — "NC State and LSU kick off".

## Verification

Full suite passes (70 suites, 1275 tests), including 8 new tests in `tests/CaptainLockDisplay.spec.js` covering the dated/zoned format combinations, the specific NC State vs Texas collision that prompted this, and the team-name list. Rendered against the real CSS with this exact roster to confirm the note and the tiles now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)