### PR TITLE
Opponent ranks on matchups and the Captain picker, and tighter dating on mobile

### DIFF
--- a/public/h2h-card.css
+++ b/public/h2h-card.css
@@ -44,6 +44,10 @@
 .h2h-capx { flex: none; font-size: 0.5rem; font-weight: 800; letter-spacing: .02em; color: var(--cc-amber); border: 1px solid rgba(224,179,65,.45); border-radius: 99px; padding: 0 4px; line-height: 1.5; }
 .h2h-tsub { min-width: 0; max-width: 100%; font-size: 0.6rem; color: var(--cc-muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .h2h-mdcol.right .h2h-tnm, .h2h-mdcol.right .h2h-tsub { text-align: right; }
+/* Opponent's poll rank on the sub-line. Tiered like the scoring: a top-10 win
+   pays double, 11–25 single, so the two read differently at a glance. */
+.h2h-trk { font-weight: 800; color: var(--cc-info); }
+.h2h-trk.top10 { color: var(--cc-amber); }
 /* Full school name on desktop; team abbreviation on mobile (tight columns). */
 .tnm-abbr { display: none; }
 @media (max-width: 560px) { .tnm-full { display: none; } .tnm-abbr { display: inline; } }

--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -64,6 +64,14 @@
             : t.status === 'scheduled' ? '<span class="h2h-tv sched">' + esc(fmtKick(t.kickoff, dated)) + '</span>'
             : '<span class="h2h-tv">' + (t.score != null ? t.score : 0) + '</span>';
     }
+    // A ranked opponent, tiered the way the scoring tiers it: rankValue pays
+    // double for a top-10 win and single for 11–25, so the two look different
+    // at a glance. Unranked opponents get no marker.
+    function rankTag(rank) {
+        var n = Number(rank);
+        if (!n || n < 1) return '';
+        return '<span class="h2h-trk' + (n <= 10 ? ' top10' : '') + '">#' + n + '</span> ';
+    }
     // One team row; the right column mirrors (value → name → logo) so both teams'
     // scores hug the center divider, like a Sleeper matchup.
     function teamRow(t, right, dated) {
@@ -73,7 +81,7 @@
         var tnm = teamLink(t.teamId, '<span class="h2h-tnm"><span class="tnm-full">' + esc(t.school) + '</span><span class="tnm-abbr">' + esc(t.abbr || t.school) + '</span></span>');
         var nm = '<span class="h2h-tnmline">' + tnm + cap + '</span>';
         var sub = t.opp
-            ? '<span class="h2h-tsub">' + esc(t.ha) + ' ' + esc(t.opp) + (t.status === 'final' && t.gameScore ? ' · ' + esc(t.gameScore) : '') + '</span>'
+            ? '<span class="h2h-tsub">' + esc(t.ha) + ' ' + rankTag(t.oppRank) + esc(t.opp) + (t.status === 'final' && t.gameScore ? ' · ' + esc(t.gameScore) : '') + '</span>'
             : '';
         var idcol = '<span class="h2h-tid">' + nm + sub + '</span>';
         return right ? '<div class="h2h-trow">' + teamVal(t, dated) + idcol + img + '</div>'

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -566,7 +566,7 @@
 .uh-captain { width: 92%; max-width: 720px; margin: 0 auto; overflow: hidden; max-height: 0; transition: max-height 0.32s ease; }
 .uh-captain.is-open { max-height: 1600px; margin-top: 1.1rem; }
 .captain-note { margin: 0 0 0.9em; color: var(--cc-muted); font-size: 0.9rem; }
-.captain-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.6rem; }
+.captain-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(205px, 1fr)); gap: 0.6rem; }
 .captain-team { display: flex; align-items: flex-start; gap: 0.5rem; background: var(--cc-bg); border: 1px solid var(--cc-border); border-radius: 10px; padding: 0.5rem 0.7rem; color: var(--cc-text); font: inherit; font-size: 0.85rem; cursor: pointer; text-align: left; transition: border-color 0.15s ease, background 0.15s ease; }
 .captain-team img { height: 24px; width: 24px; object-fit: contain; flex-shrink: 0; }
 .captain-team span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -578,6 +578,9 @@
 .cap-nm { min-width: 0; }
 .cap-2g { flex-shrink: 0; font-size: 0.55rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.04em; color: var(--cc-accent); border: 1px solid var(--cc-accent); border-radius: 4px; padding: 0 0.22rem; line-height: 1.5; }
 .cap-tg { font-size: 0.68rem; color: var(--cc-muted-2); font-weight: 400; }
+/* Opponent's poll rank, tiered like the scoring: top-10 wins pay double. */
+.cap-rk { font-weight: 800; color: var(--cc-info); }
+.cap-rk.top10 { color: var(--cc-amber); }
 .captain-team.is-captain { border-color: var(--cc-interactive); background: rgba(142, 140, 240, 0.14); font-weight: 700; }
 /* Locked week: cells are read-only (no pointer, no hover lift). */
 .captain-team.is-locked { cursor: default; opacity: 0.6; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -867,6 +867,14 @@ function uhFmtLock(iso, opts) {
     const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' });
     return `${day} ${time}${o.tz ? ' CT' : ''}`;
 }
+// A ranked opponent, tiered the way the scoring tiers it: rankValue pays double
+// for a top-10 win and single for 11–25. Beating ranked teams is where much of
+// the model's value sits, so the pick shouldn't be made blind to it.
+function uhRankTag(rank) {
+    const n = Number(rank);
+    if (!n || n < 1) return '';
+    return `<span class="cap-rk${n <= 10 ? ' top10' : ''}">#${n}</span> `;
+}
 // "NC State", "NC State and LSU", "NC State, LSU and Duke".
 function uhAndList(names) {
     const a = (names || []).filter(Boolean);
@@ -955,7 +963,7 @@ async function hydrateCaptain(user, activeYear) {
         const games = slateBy[t.id] || [];
         const badge = games.length > 1 ? `<span class="cap-2g">${games.length} games</span>` : '';
         const lines = games.length
-            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff, { dated: datedSlate })) : ' · TBD'}</span>`).join('')
+            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${uhRankTag(g.oppRank)}${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff, { dated: datedSlate })) : ' · TBD'}</span>`).join('')
             : `<span class="cap-tg">No game this week</span>`;
         return `<img src="${ccLogo(t.logos)}" alt="">
             <span class="cap-tid"><span class="cap-tnm"><span class="cap-nm">${escapeHtml(t.school)}</span>${badge}</span>${lines}</span>`;

--- a/routes/standings.js
+++ b/routes/standings.js
@@ -395,6 +395,15 @@ router.get('/h2h/:league/:season', async (req, res) => {
             { season: seasonNum, seasonType: 'regular', week: { $lte: H2H_MAX_WEEK }, $or: [{ homeId: { $in: draftedIds } }, { awayId: { $in: draftedIds } }] },
             { id: 1, week: 1, startDate: 1, startTimeTbd: 1, completed: 1, homeId: 1, homeTeam: 1, homePoints: 1, awayId: 1, awayTeam: 1, awayPoints: 1, _id: 0 }
         ).lean() : [];
+        // Opponent rankings, read from the SAME poll the scorer reads (the
+        // Playoff Committee's, else AP — see scoring-detectors findPoll). So a
+        // rank on a card means that win pays the ranked bonus, and a week with
+        // only a Coaches Poll stored shows no ranks at all rather than numbers
+        // that won't match what the week actually scores. Keyed by team NAME,
+        // the same join rankValue makes.
+        const pollDoc = standingsOnly ? null : await projectionPoll(seasonNum);
+        const rankByName = {};
+        ((pollDoc && pollDoc.ranks) || []).forEach(r => { if (r && r.school) rankByName[r.school] = r.rank; });
         // Opponent abbreviations (opponents aren't always rostered, so look them
         // up from the Team collection).
         const oppAbbrById = {};
@@ -433,7 +442,7 @@ router.get('/h2h/:league/:season', async (req, res) => {
             // that week's own poll — but they're a "what were the odds" garnish,
             // and the live bar on the in-progress week is what this actually
             // drives. One poll read beats one per week.
-            const rankings = buildRankingProxy(seasonNum, teamsById, await projectionPoll(seasonNum));
+            const rankings = buildRankingProxy(seasonNum, teamsById, pollDoc);
             const poolCtx = buildPoolContext(teamsById, seasonNum);
             draftedIds.forEach(tid => {
                 const team = teamsById[String(tid)];
@@ -557,16 +566,18 @@ router.get('/h2h/:league/:season', async (req, res) => {
                 // The row knows its own game; only legacy rows (no gameId) fall
                 // back to the team's single game that week.
                 const g = t.gameId != null ? gameById[t.gameId] : gamesOf(t.teamId, w)[0];
-                let opp = '', ha = 'vs', gameScore = null;
+                let opp = '', ha = 'vs', gameScore = null, oppRank = null;
                 if (g) {
                     const isHome = g.homeId === t.teamId;
-                    opp = oppAbbrById[isHome ? g.awayId : g.homeId] || (isHome ? g.awayTeam : g.homeTeam) || '';
+                    const oppName = isHome ? g.awayTeam : g.homeTeam;
+                    opp = oppAbbrById[isHome ? g.awayId : g.homeId] || oppName || '';
+                    oppRank = rankByName[oppName] || null;
                     ha = isHome ? 'vs' : '@';
                     if (g.completed && g.homePoints != null && g.awayPoints != null) {
                         gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
                     }
                 }
-                return { teamId: t.teamId, school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: isCaptain(id, w, t.teamId), opp, ha, gameScore };
+                return { teamId: t.teamId, school: t.school, abbr: t.abbr, logo: t.logo, score: round(t.score), status: 'final', captain: isCaptain(id, w, t.teamId), opp, ha, oppRank, gameScore };
             })
             .sort((a, b) => b.score - a.score);
         // The kickoff INSTANT, not a rendered string. This used to format here
@@ -584,12 +595,13 @@ router.get('/h2h/:league/:season', async (req, res) => {
             const scored = scoredFor(id, w, t.id, g.id);
             const isHome = g.homeId === t.id;
             const oppId = isHome ? g.awayId : g.homeId;
-            const opp = oppAbbrById[oppId] || (isHome ? g.awayTeam : g.homeTeam) || '';
+            const oppName = isHome ? g.awayTeam : g.homeTeam;
+            const opp = oppAbbrById[oppId] || oppName || '';
             let gameScore = null;
             if (g.completed && g.homePoints != null && g.awayPoints != null) {
                 gameScore = `${isHome ? g.homePoints : g.awayPoints}–${isHome ? g.awayPoints : g.homePoints}`;
             }
-            return { teamId: t.id, school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? kickAt(g) : null, opp, ha: isHome ? 'vs' : '@', gameScore, captain: isCaptain(id, w, t.id) };
+            return { teamId: t.id, school: t.school, abbr: t.abbr, logo: t.logo, score: scored ? round(scored.score) : null, status: st, kickoff: st === 'scheduled' ? kickAt(g) : null, opp, ha: isHome ? 'vs' : '@', oppRank: rankByName[oppName] || null, gameScore, captain: isCaptain(id, w, t.id) };
         })).sort((a, b) => (statusOrder[a.status] - statusOrder[b.status]) || ((b.score || 0) - (a.score || 0)));
 
         // Projected pre-game odds for a matchup: each manager's teams that play

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,6 +4,7 @@ const User = require('../models/user');
 const Game = require('../models/game');
 const Team = require('../models/team');
 const Draft = require('../models/draft');
+const Ranking = require('../models/ranking');
 const scoring = require('../modules/scoring');
 const rosterCorrection = require('../modules/roster-correction');
 const audit = require('../modules/audit-log');
@@ -15,6 +16,7 @@ const { hasScoredGames } = require('../modules/season-status');
 const inviteToken = require('../modules/invite-token');
 const { LEAGUES } = require('../modules/scoring-defaults');
 const { captainLockMs, captainFocusWeek } = require('../modules/captain');
+const { findPoll } = require('../modules/scoring-detectors');
 
 // A week's Captain edits close when the manager's earliest game finishes; the
 // tile keeps that week in focus for this long after its last kickoff before
@@ -132,6 +134,15 @@ router.get('/me/captain', async (req, res) => {
             (await Team.find({ id: { $in: oppIds } }, { id: 1, abbreviation: 1, _id: 0 }).lean())
                 .forEach(t => { abbrById[t.id] = t.abbreviation || null; });
         }
+        // Opponent rankings from the poll the SCORER reads (Playoff Committee,
+        // else AP), so a rank here means that win pays the ranked bonus — much
+        // of the model's value sits in beating ranked teams, and the pick is
+        // made blind without it. A season with only a Coaches Poll stored shows
+        // no ranks rather than ones that won't match the scoring.
+        const rankDoc = await Ranking.findOne({ season: seasonYear, seasonType: 'regular' }).sort({ week: -1 }).lean();
+        const poll = findPoll(rankDoc);
+        const rankByName = {};
+        ((poll && poll.ranks) || []).forEach(r => { if (r && r.school) rankByName[r.school] = r.rank; });
         const slate = teamIds.map(tid => ({
             teamId: tid,
             games: weekGames
@@ -139,9 +150,11 @@ router.get('/me/captain', async (req, res) => {
                 .map(g => {
                     const isHome = Number(g.homeId) === tid;
                     const oppId = isHome ? g.awayId : g.homeId;
+                    const oppName = isHome ? g.awayTeam : g.homeTeam;
                     return {
                         gameId: g.id,
-                        opp: abbrById[oppId] || (isHome ? g.awayTeam : g.homeTeam) || '',
+                        opp: abbrById[oppId] || oppName || '',
+                        oppRank: rankByName[oppName] || null,
                         ha: isHome ? 'vs' : '@',
                         kickoff: g.startTimeTbd ? null : (g.startDate || null)
                     };

--- a/tests/CaptainLockDisplay.spec.js
+++ b/tests/CaptainLockDisplay.spec.js
@@ -70,6 +70,23 @@ describe('uhFmtLock', () => {
     });
 });
 
+describe('uhRankTag', () => {
+    beforeEach(load);
+
+    // Tiered the way rankValue tiers the bonus: a top-10 win pays double.
+    test('marks a ranked opponent and flags the top ten', () => {
+        expect(uhRankTag(23)).toBe('<span class="cap-rk">#23</span> ');
+        expect(uhRankTag(10)).toBe('<span class="cap-rk top10">#10</span> ');
+        expect(uhRankTag(1)).toBe('<span class="cap-rk top10">#1</span> ');
+    });
+
+    test('is nothing at all for an unranked opponent', () => {
+        expect(uhRankTag(null)).toBe('');
+        expect(uhRankTag(undefined)).toBe('');
+        expect(uhRankTag(0)).toBe('');
+    });
+});
+
 describe('uhAndList', () => {
     beforeEach(load);
 

--- a/tests/H2HCardKickoffs.spec.js
+++ b/tests/H2HCardKickoffs.spec.js
@@ -87,6 +87,26 @@ describe('H2H card kickoffs', () => {
     // The league spans time zones (one manager is Eastern) and the app renders
     // every date in Central. A card can carry 20+ kickoff rows, so the zone is
     // named once in the footer rather than repeated on each line.
+    // The rank marker is tiered the way rankValue tiers the bonus: top-10 wins
+    // pay double, 11-25 single, unranked nothing.
+    test('marks a ranked opponent, and tiers the top ten differently', () => {
+        const ranked = (rank) => Object.assign(team('USC', USC_SJSU), { opp: 'CLEM', oppRank: rank });
+        document.body.innerHTML = card([ranked(23)], [ranked(3)]);
+        const tags = [...document.querySelectorAll('.h2h-trk')];
+        expect(tags.map(t => t.textContent)).toEqual(['#23', '#3']);
+        expect(tags[0].classList.contains('top10')).toBe(false);
+        expect(tags[1].classList.contains('top10')).toBe(true);
+        // It sits with the opponent, not adrift.
+        expect(document.querySelector('.h2h-tsub').textContent).toContain('vs #23 CLEM');
+    });
+
+    test('leaves an unranked opponent unmarked', () => {
+        const plain = Object.assign(team('USC', USC_SJSU), { opp: 'SJSU', oppRank: null });
+        document.body.innerHTML = card([plain], [plain]);
+        expect(document.querySelectorAll('.h2h-trk')).toHaveLength(0);
+        expect(document.querySelector('.h2h-tsub').textContent).toContain('vs SJSU');
+    });
+
     test('names the zone once, in the footer', () => {
         document.body.innerHTML = card([team('USC', USC_SJSU)], [team('Duke', USC_SJSU)]);
         const foot = document.querySelector('.h2h-mfoot').textContent;

--- a/tests/OpponentRanks.spec.js
+++ b/tests/OpponentRanks.spec.js
@@ -1,0 +1,180 @@
+// Opponent poll rankings on the matchup card and the Captain picker.
+//
+// Much of the scoring model's value is in beating ranked teams — rankValue pays
+// double for a top-10 win and single for 11-25 — but neither surface showed who
+// was ranked, so both the weekly read and the Captain pick were made blind to
+// the thing that most moves the points.
+//
+// The rank comes from the poll the SCORER reads: the Playoff Committee's, else
+// AP (scoring-detectors findPoll). Not the Coaches Poll, which the app stores
+// too — a rank on a card has to mean "this win pays the ranked bonus", and a
+// number from a poll the scorer ignores would promise a bonus that never lands.
+//
+// Runs against an in-memory Mongo with the real models and the real routes.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const User = require('../models/user');
+const Game = require('../models/game');
+const Team = require('../models/team');
+const Ranking = require('../models/ranking');
+const ScoringConfig = require('../models/scoringConfig');
+const standingsRouter = require('../routes/standings');
+const usersRouter = require('../routes/users');
+
+useMongo();
+
+const SEASON = 2026;
+const LEAGUE = 'graham-league';
+const LSU = 1, TEXAS = 2, DUKE = 3, MIAMI = 4;
+const CLEMSON = 97, GEORGIA = 98, TXST = 99, CUPCAKE = 96;
+
+function fullTeam(id, school) {
+    return {
+        id, school, mascot: 'Mascot', abbreviation: school.slice(0, 4).toUpperCase(),
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false }
+    };
+}
+const KICK = '2099-09-05T23:30:00.000Z';
+function game(id, homeId, homeTeam, awayId, awayTeam) {
+    return {
+        id, season: SEASON, week: 1, seasonType: 'regular',
+        startDate: KICK, startTimeTbd: false, neutralSite: false, conferenceGame: false,
+        homeId, homeTeam, awayId, awayTeam, homePoints: null, awayPoints: null, completed: false
+    };
+}
+// Georgia top-10, Clemson in the 11-25 band, Texas State unranked.
+async function poll(name) {
+    await Ranking.create({
+        season: SEASON, seasonType: 'regular', week: 1,
+        polls: [{ poll: name, ranks: [
+            { rank: 3, school: 'Georgia', conference: 'SEC' },
+            { rank: 23, school: 'Clemson', conference: 'ACC' }
+        ] }]
+    });
+}
+async function seedTeams() {
+    await Team.create([[LSU,'LSU'],[TEXAS,'Texas'],[DUKE,'Duke'],[MIAMI,'Miami'],
+                       [CLEMSON,'Clemson'],[GEORGIA,'Georgia'],[TXST,'Texas State'],[CUPCAKE,'Cupcake']]
+        .map(([id, school]) => Object.assign(fullTeam(id, school), {
+            seasons: [{ season: SEASON, conference: 'SEC', spRating: 10, expectedWins: 0.5 }]
+        })));
+}
+async function seedGames() {
+    await Game.create([
+        game(101, LSU, 'LSU', CLEMSON, 'Clemson'),        // ranked #23 opponent, at home
+        game(102, GEORGIA, 'Georgia', TEXAS, 'Texas'),     // Texas on the road at #3
+        game(103, DUKE, 'Duke', TXST, 'Texas State'),      // unranked opponent
+        game(104, MIAMI, 'Miami', CUPCAKE, 'Cupcake')
+    ]);
+}
+
+// ---- the matchup card's payload -------------------------------------------
+const h2hApp = express();
+h2hApp.use(express.json());
+h2hApp.use('/standings', standingsRouter);
+
+async function seedH2H() {
+    await ScoringConfig.create({
+        league: LEAGUE, model: 'graham', values: {},
+        engagementBySeason: { '2026': { h2hEnabled: true, h2hWinBonus: 3, h2hTieBonus: 0 } }
+    });
+    await seedTeams();
+    await seedGames();
+    const ann = await User.create({
+        firstName: 'Ann', lastName: 'Test', league: LEAGUE,
+        seasons: [{ season: SEASON, teams: [fullTeam(LSU, 'LSU'), fullTeam(TEXAS, 'Texas')], weeklyScore: [{ week: 1, score: 0, scoreByTeam: [] }], cumulativeScore: 0 }]
+    });
+    await User.create({
+        firstName: 'Bob', lastName: 'Test', league: LEAGUE,
+        seasons: [{ season: SEASON, teams: [fullTeam(DUKE, 'Duke'), fullTeam(MIAMI, 'Miami')], weeklyScore: [{ week: 1, score: 0, scoreByTeam: [] }], cumulativeScore: 0 }]
+    });
+    return ann;
+}
+function rowsFor(body, annId) {
+    const g = body.schedule.find(s => s.week === 1).games[0];
+    return String(g.aId) === String(annId) ? g.aTeams : g.bTeams;
+}
+
+describe('opponent ranks on the matchup card', () => {
+    test('carry the rank from the AP poll, and null when unranked', async () => {
+        const ann = await seedH2H();
+        await poll('AP Top 25');
+
+        const res = await request(h2hApp).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        const rows = rowsFor(res.body, ann._id);
+
+        expect(rows.find(t => t.teamId === LSU)).toMatchObject({ opp: 'CLEM', oppRank: 23 });
+        expect(rows.find(t => t.teamId === TEXAS)).toMatchObject({ opp: 'GEOR', ha: '@', oppRank: 3 });
+    });
+
+    test('the Playoff Committee poll wins when both are stored', async () => {
+        const ann = await seedH2H();
+        await poll('AP Top 25');
+        await Ranking.updateOne({ season: SEASON, week: 1 }, {
+            $push: { polls: { poll: 'Playoff Committee Rankings', ranks: [{ rank: 8, school: 'Clemson', conference: 'ACC' }] } }
+        });
+
+        const res = await request(h2hApp).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        // Committee has Clemson at 8, AP at 23 — the scorer reads the committee.
+        expect(rowsFor(res.body, ann._id).find(t => t.teamId === LSU).oppRank).toBe(8);
+    });
+
+    test('a Coaches-Poll-only season shows no ranks rather than ones that will not score', async () => {
+        const ann = await seedH2H();
+        await poll('Coaches Poll');   // the preseason state — no AP ingested yet
+
+        const res = await request(h2hApp).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        rowsFor(res.body, ann._id).forEach(t => expect(t.oppRank).toBeNull());
+    });
+
+    test('no poll at all is not an error', async () => {
+        const ann = await seedH2H();
+        const res = await request(h2hApp).get(`/standings/h2h/${LEAGUE}/${SEASON}`);
+        expect(res.status).toBe(200);
+        rowsFor(res.body, ann._id).forEach(t => expect(t.oppRank).toBeNull());
+    });
+});
+
+// ---- the Captain picker's slate -------------------------------------------
+describe('opponent ranks on the Captain slate', () => {
+    async function seedCaptain() {
+        await seedTeams();
+        await seedGames();
+        const user = await User.create({
+            firstName: 'Ann', lastName: 'Test', league: LEAGUE,
+            seasons: [{ season: SEASON, teams: [fullTeam(LSU, 'LSU'), fullTeam(TEXAS, 'Texas')], weeklyScore: [], cumulativeScore: 0 }]
+        });
+        const app = express();
+        app.use(express.json());
+        app.use((req, res, next) => {
+            req.oidc = { isAuthenticated: () => true, user: { user_metadata: { metadata: { userId: String(user._id) } } } };
+            next();
+        });
+        app.use('/users', usersRouter);
+        return app;
+    }
+    const slateOf = (body, teamId) => (body.slate || []).find(s => s.teamId === teamId);
+
+    test('each game carries its opponent rank', async () => {
+        const app = await seedCaptain();
+        await poll('AP Top 25');
+
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+        expect(slateOf(res.body, LSU).games[0]).toMatchObject({ opp: 'CLEM', oppRank: 23 });
+        expect(slateOf(res.body, TEXAS).games[0]).toMatchObject({ ha: '@', oppRank: 3 });
+    });
+
+    test('unranked and no-poll both read as null', async () => {
+        const app = await seedCaptain();
+        await poll('Coaches Poll');
+
+        const res = await request(app).get('/users/me/captain?season=' + SEASON);
+        expect(slateOf(res.body, LSU).games[0].oppRank).toBeNull();
+        expect(slateOf(res.body, TEXAS).games[0].oppRank).toBeNull();
+    });
+});


### PR DESCRIPTION
Two changes to the same rows, one adding information and one making room for it.

## 1. Opponent poll rankings

Beating ranked teams is where much of the scoring model's value sits — `rankValue` pays **double** for a top-10 win and single for 11–25 — but neither the matchup card nor the Captain picker showed who was ranked. `vs CLEM` and `vs SJSU` looked identical, though one is worth twice the other. The Captain pick in particular was being made blind to the single biggest driver of its value.

```
LSU        vs #23 CLEM · Sat 6:30 PM      <- 11-25, single bonus (blue)
Clemson    @  #9 LSU   · Sat 6:30 PM      <- top 10, double bonus (amber)
Texas      vs TXST     · Sat 2:30 PM      <- unranked, unmarked
```

The amber/blue split reuses the existing `.rank-badge top10 / top25` convention from the draft room, so the tiers look the same wherever they appear.

**Which poll:** the one the *scorer* reads — Playoff Committee, else AP ([`scoring-detectors.js:33`](../blob/main/modules/scoring-detectors.js#L33)) — and deliberately not the Coaches Poll, which the app also stores. A rank on a card has to mean "this win pays the ranked bonus"; a number from a poll the scorer ignores would promise a bonus that never lands. A season with no qualifying poll shows no ranks, which is covered by a test.

Nearly free server-side: the H2H route already loaded that poll for its projections, so it is hoisted and reused rather than fetched twice; the Captain route adds one lookup.

## 2. Dating only the strays

Adding ranks made an existing width problem obvious on a phone. Dating was all-or-nothing per card: any card spanning more than one weekend dated **every** row. On the real week-1 card that is 16 rows sitting on Sep 5, all carrying "Sat, 9/5" to disambiguate the handful that don't.

At 390px `.h2h-tv` is `flex-shrink: 0`, so the kickoff takes what it needs and the name column absorbs the entire truncation — `N. vs WIS`, `MISS vs #24 ...`, `JXST vs Easte...`.

The weekend nearly every game sits on is the implicit default, so only the strays need saying. Same card now: **3 dated rows** (the Aug 29 openers) instead of 23, everything else back to a bare `Sun 7:30 PM`.

Grouping is by **week**, not by day — epoch day 0 was a Thursday, so plain 7-day buckets already run Thu→Wed, which is how a college week runs from the Thursday night game through the Monday one. A Thu/Fri/Sat/Sun/Mon slate is one weekend and needs no dates; its weekdays already differ.

Two edge cases the rule handles: a single weekend dates nothing, and a card where no weekend carries a majority dates everything, since then none can be implicit.

Applied to the Captain picker too, so the surfaces date alike. The lock time keeps its date whenever it is the stray — the case that prompted naming it (NC State on Aug 29 while the rest of the roster plays Sep 5).

## Verification

Full suite passes (71 suites, 1287 tests), including 12 new tests:

- `tests/OpponentRanks.spec.js` — ranks on both payloads, Playoff Committee winning over AP, a Coaches-Poll-only season yielding nothing, no poll not erroring.
- `tests/H2HCardKickoffs.spec.js` — dating only the strays, dating everything when no weekend carries the card, treating Thu-through-Mon as one weekend, and the rank markers and their tiering.

Rendered at 390px with the real week-1 slate to confirm the truncation actually clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)