### PR TITLE
Date only the games away from a card's main weekend, and give FCS opponents abbreviations

### DIFF
--- a/models/team.js
+++ b/models/team.js
@@ -142,6 +142,12 @@ const teamSchema = new mongoose.Schema({
         type: String,
         required: true
     },
+    // 'fbs' | 'fcs'. FCS teams are stored only as opponent reference data — see
+    // modules/team-scope.js. Absent on docs written before the field existed,
+    // all of which came from CFBD's /teams/fbs endpoint.
+    classification: {
+        type: String
+    },
     alt_name1: {
         type: String
     },

--- a/modules/team-scope.js
+++ b/modules/team-scope.js
@@ -1,0 +1,12 @@
+// FCS teams share the `teams` collection with FBS ones, but they are REFERENCE
+// DATA, not part of the league's team universe. They exist so an opponent can be
+// rendered properly — its abbreviation on a matchup row, its logo — and for
+// nothing else. They must never reach the draft pool, roster assignment, site
+// search, the CFP-odds name matcher, or the enrichment-readiness denominator.
+//
+// `$ne: 'fcs'` rather than `$eq: 'fbs'` on purpose: every doc that predates the
+// classification field was pulled from CFBD's /teams/fbs endpoint, so an absent
+// value means FBS. That keeps the filter correct without a backfill migration.
+const FBS_ONLY = Object.freeze({ classification: { $ne: 'fcs' } });
+
+module.exports = { FBS_ONLY };

--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -49,19 +49,47 @@
             : { weekday: 'short', timeZone: CT });
         return day + ' ' + d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: CT });
     }
-    // Does this matchup's slate straddle more than one weekend? Only then is the
-    // date worth the width. A team playing twice in an API week is exactly the
-    // case that needs it.
-    function spansWeekends(teams) {
-        var ts = (teams || []).map(function (t) { return t.kickoff ? Date.parse(t.kickoff) : NaN; })
-            .filter(function (n) { return !isNaN(n); });
-        if (ts.length < 2) return false;
-        return (Math.max.apply(null, ts) - Math.min.apply(null, ts)) > 3 * 864e5;
+    // Which football week a kickoff belongs to, in Central. Epoch day 0 was a
+    // Thursday, so plain 7-day buckets already run Thu→Wed — which is how a
+    // college week runs, from the Thursday night game through the Monday one.
+    function weekKey(iso) {
+        if (!iso) return '';
+        var d = new Date(iso);
+        if (isNaN(d.getTime())) return '';
+        // en-CA gives YYYY-MM-DD; reading it back as UTC midnight makes the day
+        // arithmetic exact regardless of where the viewer is.
+        var ymd = new Intl.DateTimeFormat('en-CA', { timeZone: CT, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d);
+        var day = Math.floor(Date.parse(ymd + 'T00:00:00Z') / 864e5);
+        return String(Math.floor(day / 7));
+    }
+    // Which rows need a calendar date, as the week they must NOT match.
+    //
+    // Dating every row of a card that straddles two weekends is most of the
+    // width on a phone, and it is unnecessary: if all but a few games sit on one
+    // weekend, that weekend is the implicit default and only the strays need
+    // saying. API week 1 folds in the opening weekend, so on a real card that is
+    // two or three rows out of twenty-plus.
+    //
+    // null → never date (one weekend, nothing to disambiguate).
+    // '*'  → date everything (no weekend carries the card, so none is implicit).
+    function datingPlan(teams) {
+        var count = {};
+        (teams || []).forEach(function (t) {
+            var k = weekKey(t.kickoff);
+            if (k) count[k] = (count[k] || 0) + 1;
+        });
+        var weeks = Object.keys(count);
+        if (weeks.length < 2) return null;
+        weeks.sort(function (a, b) { return count[b] - count[a]; });
+        return count[weeks[0]] > 1 ? weeks[0] : '*';
+    }
+    function needsDate(iso, plan) {
+        return plan !== null && weekKey(iso) !== plan;
     }
     // A team's value: final points, LIVE, or kickoff time.
-    function teamVal(t, dated) {
+    function teamVal(t, plan) {
         return t.status === 'live' ? '<span class="h2h-tv live">LIVE</span>'
-            : t.status === 'scheduled' ? '<span class="h2h-tv sched">' + esc(fmtKick(t.kickoff, dated)) + '</span>'
+            : t.status === 'scheduled' ? '<span class="h2h-tv sched">' + esc(fmtKick(t.kickoff, needsDate(t.kickoff, plan))) + '</span>'
             : '<span class="h2h-tv">' + (t.score != null ? t.score : 0) + '</span>';
     }
     // A ranked opponent, tiered the way the scoring tiers it: rankValue pays
@@ -74,7 +102,7 @@
     }
     // One team row; the right column mirrors (value → name → logo) so both teams'
     // scores hug the center divider, like a Sleeper matchup.
-    function teamRow(t, right, dated) {
+    function teamRow(t, right, plan) {
         var img = teamLink(t.teamId, '<img class="h2h-tlogo" src="' + esc(t.logo) + '" alt="">');
         // Captain doubles this team's points — mark it so the inflated score reads.
         var cap = t.captain ? '<span class="h2h-capx" title="Captain — points doubled">★2×</span>' : '';
@@ -84,15 +112,15 @@
             ? '<span class="h2h-tsub">' + esc(t.ha) + ' ' + rankTag(t.oppRank) + esc(t.opp) + (t.status === 'final' && t.gameScore ? ' · ' + esc(t.gameScore) : '') + '</span>'
             : '';
         var idcol = '<span class="h2h-tid">' + nm + sub + '</span>';
-        return right ? '<div class="h2h-trow">' + teamVal(t, dated) + idcol + img + '</div>'
-            : '<div class="h2h-trow">' + img + idcol + teamVal(t, dated) + '</div>';
+        return right ? '<div class="h2h-trow">' + teamVal(t, plan) + idcol + img + '</div>'
+            : '<div class="h2h-trow">' + img + idcol + teamVal(t, plan) + '</div>';
     }
     // Final weeks show only teams that scored; an unplayed week (live or still
     // to come) shows every team with a game, so in-progress and upcoming ones
     // are visible with their kickoff times instead of being mistaken for 0.
-    function teamList(teams, unplayed, right, dated) {
+    function teamList(teams, unplayed, right, plan) {
         var list = unplayed ? (teams || []) : (teams || []).filter(function (t) { return t.score > 0; });
-        return list.length ? list.map(function (t) { return teamRow(t, right, dated); }).join('')
+        return list.length ? list.map(function (t) { return teamRow(t, right, plan); }).join('')
             : '<div class="h2h-trow empty">no points</div>';
     }
     // Bar values: a finished matchup is settled (100/0 to the winner, tie 50/50);
@@ -152,7 +180,7 @@
         var unplayed = live || upcoming;
         var score = function (v) { return upcoming ? '&ndash;' : v; };
         var both = (g.aTeams || []).concat(g.bTeams || []);
-        var dated = spansWeekends(both);
+        var plan = datingPlan(both);
         var remaining = both.filter(function (t) { return t.status && t.status !== 'final'; }).length;
         var sep = live ? '<span class="h2h-mlive">LIVE</span>' : (g.winner === 'tie' ? 'T' : 'vs');
         var wk = opts.week != null ? '<span class="h2h-mwk">Wk ' + opts.week + '</span>' : '';
@@ -166,8 +194,8 @@
             + '</div>'
             + winBar(g)
             + '<div class="h2h-mdetail">'
-            + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, unplayed, false, dated) + '</div>'
-            + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, unplayed, true, dated) + '</div>'
+            + '<div class="h2h-mdcol"><span class="h2h-mdcap">' + aName + '</span>' + teamList(g.aTeams, unplayed, false, plan) + '</div>'
+            + '<div class="h2h-mdcol right"><span class="h2h-mdcap">' + bName + '</span>' + teamList(g.bTeams, unplayed, true, plan) + '</div>'
             + pregameLine(g, aName, bName)
             + (live ? '<div class="h2h-mfoot">In progress · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' to play · kickoffs Central · scores update as they finish</div>' : '')
             + (upcoming ? '<div class="h2h-mfoot">Not started · ' + remaining + ' game' + (remaining === 1 ? '' : 's') + ' scheduled · kickoffs Central · odds are projected</div>' : '')

--- a/public/h2h-card.js
+++ b/public/h2h-card.js
@@ -40,14 +40,19 @@
     // adds the calendar date, for a week whose games don't all sit on one
     // weekend (see spansWeekends): "Sat 2:00 PM" can't tell Aug 29 from Sep 5.
     var CT = 'America/Chicago';
+    // Built once. A week-1 card carries 20+ kickoff rows and the schedule drawer
+    // renders thirteen such cards in a pass, so constructing these per row (which
+    // is what toLocaleDateString does internally) is hundreds of the most
+    // expensive call in this file, on exactly the phones the dating rule is for.
+    var DAY_FMT = new Intl.DateTimeFormat('en-US', { weekday: 'short', timeZone: CT });
+    var DATED_FMT = new Intl.DateTimeFormat('en-US', { weekday: 'short', month: 'numeric', day: 'numeric', timeZone: CT });
+    var TIME_FMT = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit', timeZone: CT });
+    var YMD_FMT = new Intl.DateTimeFormat('en-CA', { timeZone: CT, year: 'numeric', month: '2-digit', day: '2-digit' });
     function fmtKick(iso, dated) {
         if (!iso) return 'TBD';
         var d = new Date(iso);
         if (isNaN(d.getTime())) return 'TBD';
-        var day = d.toLocaleDateString('en-US', dated
-            ? { weekday: 'short', month: 'numeric', day: 'numeric', timeZone: CT }
-            : { weekday: 'short', timeZone: CT });
-        return day + ' ' + d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: CT });
+        return (dated ? DATED_FMT : DAY_FMT).format(d) + ' ' + TIME_FMT.format(d);
     }
     // Which football week a kickoff belongs to, in Central. Epoch day 0 was a
     // Thursday, so plain 7-day buckets already run Thu→Wed — which is how a
@@ -58,8 +63,7 @@
         if (isNaN(d.getTime())) return '';
         // en-CA gives YYYY-MM-DD; reading it back as UTC midnight makes the day
         // arithmetic exact regardless of where the viewer is.
-        var ymd = new Intl.DateTimeFormat('en-CA', { timeZone: CT, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d);
-        var day = Math.floor(Date.parse(ymd + 'T00:00:00Z') / 864e5);
+        var day = Math.floor(Date.parse(YMD_FMT.format(d) + 'T00:00:00Z') / 864e5);
         return String(Math.floor(day / 7));
     }
     // Which rows need a calendar date, as the week they must NOT match.
@@ -72,16 +76,21 @@
     //
     // null → never date (one weekend, nothing to disambiguate).
     // '*'  → date everything (no weekend carries the card, so none is implicit).
-    function datingPlan(teams) {
+    function datingPlan(kickoffs) {
         var count = {};
-        (teams || []).forEach(function (t) {
-            var k = weekKey(t.kickoff);
+        (kickoffs || []).forEach(function (iso) {
+            var k = weekKey(iso);
             if (k) count[k] = (count[k] || 0) + 1;
         });
         var weeks = Object.keys(count);
         if (weeks.length < 2) return null;
         weeks.sort(function (a, b) { return count[b] - count[a]; });
-        return count[weeks[0]] > 1 ? weeks[0] : '*';
+        // A weekend can only be the implicit default if it clearly carries the
+        // card. One game apiece, or two weekends tied, and nothing is implicit —
+        // date them all rather than letting object key order decide which half
+        // reads as "the normal one".
+        if (count[weeks[0]] < 2 || count[weeks[1]] === count[weeks[0]]) return '*';
+        return weeks[0];
     }
     function needsDate(iso, plan) {
         return plan !== null && weekKey(iso) !== plan;
@@ -180,7 +189,7 @@
         var unplayed = live || upcoming;
         var score = function (v) { return upcoming ? '&ndash;' : v; };
         var both = (g.aTeams || []).concat(g.bTeams || []);
-        var plan = datingPlan(both);
+        var plan = datingPlan(both.map(function (t) { return t.kickoff; }));
         var remaining = both.filter(function (t) { return t.status && t.status !== 'final'; }).length;
         var sep = live ? '<span class="h2h-mlive">LIVE</span>' : (g.winner === 'tie' ? 'T' : 'vs');
         var wk = opts.week != null ? '<span class="h2h-mwk">Wk ' + opts.week + '</span>' : '';
@@ -219,5 +228,10 @@
         });
     }
 
-    window.ccH2H = { matchupCard: matchupCard, wire: wire, avatar: avatar, nameOf: nameOf };
+    // weekKey/datingPlan/needsDate are exported because the Captain picker has
+    // to date its tiles by the same rule — the two surfaces show the same games,
+    // and a copy in userHome.js could drift so that one dates a kickoff the
+    // other leaves bare.
+    window.ccH2H = { matchupCard: matchupCard, wire: wire, avatar: avatar, nameOf: nameOf,
+        weekKey: weekKey, datingPlan: datingPlan, needsDate: needsDate };
 })();

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -875,29 +875,15 @@ function uhRankTag(rank) {
     if (!n || n < 1) return '';
     return `<span class="cap-rk${n <= 10 ? ' top10' : ''}">#${n}</span> `;
 }
-// Which football week a kickoff belongs to, in Central. Epoch day 0 was a
-// Thursday, so plain 7-day buckets already run Thu→Wed, the way a college week
-// runs. Mirrors weekKey in h2h-card.js so the two surfaces date alike.
-function uhWeekKey(iso) {
-    if (!iso) return '';
-    const d = new Date(iso);
-    if (isNaN(d.getTime())) return '';
-    const ymd = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Chicago', year: 'numeric', month: '2-digit', day: '2-digit' }).format(d);
-    return String(Math.floor(Math.floor(Date.parse(ymd + 'T00:00:00Z') / 864e5) / 7));
-}
-// Which rows need a calendar date, as the week they must NOT match. Dating every
-// tile of a week that straddles two weekends is mostly wasted width on a phone —
-// if all but a few games sit on one weekend, only the strays need saying.
-// null → never date. '*' → date everything (no weekend carries the week).
+// The picker dates its tiles by the same rule the matchup card uses, from the
+// same code — h2h-card.js ships in the navbar on every page, so ccH2H is always
+// there. Guarded anyway: no helper means no dates, never a thrown picker.
 function uhDatingPlan(kickoffs) {
-    const count = {};
-    (kickoffs || []).forEach(k => { const w = uhWeekKey(k); if (w) count[w] = (count[w] || 0) + 1; });
-    const weeks = Object.keys(count);
-    if (weeks.length < 2) return null;
-    weeks.sort((a, b) => count[b] - count[a]);
-    return count[weeks[0]] > 1 ? weeks[0] : '*';
+    return (window.ccH2H && window.ccH2H.datingPlan) ? window.ccH2H.datingPlan(kickoffs) : null;
 }
-const uhNeedsDate = (iso, plan) => plan !== null && uhWeekKey(iso) !== plan;
+function uhNeedsDate(iso, plan) {
+    return !!(window.ccH2H && window.ccH2H.needsDate) && window.ccH2H.needsDate(iso, plan);
+}
 // "NC State", "NC State and LSU", "NC State, LSU and Duke".
 function uhAndList(names) {
     const a = (names || []).filter(Boolean);

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -875,6 +875,29 @@ function uhRankTag(rank) {
     if (!n || n < 1) return '';
     return `<span class="cap-rk${n <= 10 ? ' top10' : ''}">#${n}</span> `;
 }
+// Which football week a kickoff belongs to, in Central. Epoch day 0 was a
+// Thursday, so plain 7-day buckets already run Thu→Wed, the way a college week
+// runs. Mirrors weekKey in h2h-card.js so the two surfaces date alike.
+function uhWeekKey(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    const ymd = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Chicago', year: 'numeric', month: '2-digit', day: '2-digit' }).format(d);
+    return String(Math.floor(Math.floor(Date.parse(ymd + 'T00:00:00Z') / 864e5) / 7));
+}
+// Which rows need a calendar date, as the week they must NOT match. Dating every
+// tile of a week that straddles two weekends is mostly wasted width on a phone —
+// if all but a few games sit on one weekend, only the strays need saying.
+// null → never date. '*' → date everything (no weekend carries the week).
+function uhDatingPlan(kickoffs) {
+    const count = {};
+    (kickoffs || []).forEach(k => { const w = uhWeekKey(k); if (w) count[w] = (count[w] || 0) + 1; });
+    const weeks = Object.keys(count);
+    if (weeks.length < 2) return null;
+    weeks.sort((a, b) => count[b] - count[a]);
+    return count[weeks[0]] > 1 ? weeks[0] : '*';
+}
+const uhNeedsDate = (iso, plan) => plan !== null && uhWeekKey(iso) !== plan;
 // "NC State", "NC State and LSU", "NC State, LSU and Duke".
 function uhAndList(names) {
     const a = (names || []).filter(Boolean);
@@ -926,9 +949,7 @@ async function hydrateCaptain(user, activeYear) {
     // plays a full week before the rest — and then "Sat 2:30 PM" names two
     // different Saturdays. Date the times when this week's slate straddles more
     // than one weekend, the same rule the matchup card uses.
-    const kicks = (state.slate || []).flatMap(x => (x.games || [])
-        .map(gm => Date.parse(gm.kickoff)).filter(n => !Number.isNaN(n)));
-    const datedSlate = kicks.length > 1 && (Math.max(...kicks) - Math.min(...kicks)) > 3 * 864e5;
+    const datePlan = uhDatingPlan((state.slate || []).flatMap(x => (x.games || []).map(gm => gm.kickoff)));
     // Which team actually closes the pick. The lock is the manager's EARLIEST
     // kickoff, which on an opening-weekend roster is rarely the team they were
     // looking at — so name it rather than leaving "your first team" to be
@@ -951,7 +972,7 @@ async function hydrateCaptain(user, activeYear) {
             : `<span class="captain-unset">${state.locked ? 'No pick · Wk ' + state.week : 'Set for Wk ' + state.week}</span>`;
         let sub;
         if (state.locked) sub = 'Locked for this week';
-        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt, { tz: true, dated: datedSlate })}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
+        else if (state.lockAt) sub = `Locks ${uhFmtLock(state.lockAt, { tz: true, dated: uhNeedsDate(state.lockAt, datePlan) })}${uhTimeLeft(state.lockAt) ? ' · ' + uhTimeLeft(state.lockAt) + ' left' : ''}`;
         else sub = 'Doubles this week’s points';
         g.innerHTML = lead + `<span class="uh-cap-sub">${sub}</span>`;
     };
@@ -963,7 +984,7 @@ async function hydrateCaptain(user, activeYear) {
         const games = slateBy[t.id] || [];
         const badge = games.length > 1 ? `<span class="cap-2g">${games.length} games</span>` : '';
         const lines = games.length
-            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${uhRankTag(g.oppRank)}${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff, { dated: datedSlate })) : ' · TBD'}</span>`).join('')
+            ? games.map(g => `<span class="cap-tg">${escapeHtml(g.ha)} ${uhRankTag(g.oppRank)}${escapeHtml(g.opp)}${g.kickoff ? ' · ' + escapeHtml(uhFmtLock(g.kickoff, { dated: uhNeedsDate(g.kickoff, datePlan) })) : ' · TBD'}</span>`).join('')
             : `<span class="cap-tg">No game this week</span>`;
         return `<img src="${ccLogo(t.logos)}" alt="">
             <span class="cap-tid"><span class="cap-tnm"><span class="cap-nm">${escapeHtml(t.school)}</span>${badge}</span>${lines}</span>`;
@@ -979,7 +1000,7 @@ async function hydrateCaptain(user, activeYear) {
             return;
         }
         const lockLine = state.lockAt
-            ? ` Locks ${uhFmtLock(state.lockAt, { dated: datedSlate })} — when ${lockWho}${uhTimeLeft(state.lockAt) ? ` (${uhTimeLeft(state.lockAt)} left)` : ''}.`
+            ? ` Locks ${uhFmtLock(state.lockAt, { dated: uhNeedsDate(state.lockAt, datePlan) })} — when ${lockWho}${uhTimeLeft(state.lockAt) ? ` (${uhTimeLeft(state.lockAt)} left)` : ''}.`
             : ' Locks when your first team kicks off.';
         const twoGamers = (season.teams || []).filter(t => (slateBy[t.id] || []).length > 1);
         const twoLine = twoGamers.length

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -4,6 +4,7 @@ const audit = require('../modules/audit-log');
 const Draft = require('../models/draft');
 const User = require('../models/user');
 const Team = require('../models/team');
+const { FBS_ONLY } = require('../modules/team-scope');
 const Game = require('../models/game');
 const Ranking = require('../models/ranking');
 const ScoringConfig = require('../models/scoringConfig');
@@ -33,7 +34,7 @@ router.get('/grades/:league/:season', async (req, res) => {
         users.forEach(u => { usersById[String(u._id)] = u; });
 
         // SP+ / expected wins / CFP odds / conference live on the Team docs.
-        const teams = await Team.find({}, { id: 1, school: 1, alternateNames: 1, seasons: 1 }).lean();
+        const teams = await Team.find(FBS_ONLY, { id: 1, school: 1, alternateNames: 1, seasons: 1 }).lean();
         const teamsById = {};
         teams.forEach(t => { teamsById[String(t.id)] = t; });
 
@@ -93,7 +94,7 @@ router.get('/board/:league/:season', async (req, res) => {
         if (req.query.refresh === '1') boardCache.delete(key);
         let cached = boardCache.get(key);
         if (!cached) {
-            const teams = await Team.find({}, { id: 1, school: 1, alternateNames: 1, logos: 1, seasons: 1 }).lean();
+            const teams = await Team.find(FBS_ONLY, { id: 1, school: 1, alternateNames: 1, logos: 1, seasons: 1 }).lean();
             const teamsById = {};
             teams.forEach(t => { if (t.id != null) teamsById[String(t.id)] = t; });
 

--- a/routes/scores.js
+++ b/routes/scores.js
@@ -5,6 +5,7 @@ const User = require('../models/user');
 const Game = require('../models/game');
 const ScoringConfig = require('../models/scoringConfig');
 const Team = require('../models/team');
+const { FBS_ONLY } = require('../modules/team-scope');
 const Draft = require('../models/draft');
 const League = require('../models/league');
 const { computeAdminStatus, pendingRegularWeek } = require('../modules/admin-status');
@@ -83,7 +84,7 @@ router.get('/readiness/:season', async (req, res) => {
 
         // Only the readiness fields off each season subdoc — a bare `seasons: 1`
         // drags every team's weeklyScore array along for no reason.
-        const teams = await Team.find({}, {
+        const teams = await Team.find(FBS_ONLY, {
             id: 1, 'seasons.season': 1, 'seasons.talent': 1, 'seasons.spRating': 1,
             'seasons.expectedWins': 1, 'seasons.cfpMakeOdds': 1, 'seasons.cfpChampOdds': 1,
             // coach + returningProduction aren't shown anywhere; they're carried

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const Team = require('../models/team');
+const { FBS_ONLY } = require('../modules/team-scope');
 const User = require('../models/user');
 const { pickLogo } = require('../public/logo.js');
 const { leagueCodeFor } = require('../modules/league-access');
@@ -47,7 +48,7 @@ router.get('/index', async (req, res) => {
         const season = Number(process.env.YEAR);
 
         const [teamDocs, userDocs] = await Promise.all([
-            Team.find({}, 'id school mascot abbreviation conference color logos alt_name1 alt_name2 alt_name3 alternateNames').lean(),
+            Team.find(FBS_ONLY, 'id school mascot abbreviation conference color logos alt_name1 alt_name2 alt_name3 alternateNames').lean(),
             User.find({ league }, 'firstName lastName avatarUrl color seasons').lean()
         ]);
 

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const fs = require('fs');
 const path = require('path');
 const Team = require('../models/team');
+const { FBS_ONLY } = require('../modules/team-scope');
 const User = require('../models/user');
 const Draft = require('../models/draft');
 const { parseOdds, americanToProb, buildTeamMatcher } = require('../modules/cfp-odds');
@@ -386,7 +387,7 @@ router.post('/:season/cfp-odds', async (req, res) => {
             return res.status(400).json({ message: 'No odds could be parsed from the input' });
         }
 
-        const teams = await Team.find({}, 'id school alt_name1 alt_name2 alt_name3 alternateNames conference seasons');
+        const teams = await Team.find(FBS_ONLY, 'id school alt_name1 alt_name2 alt_name3 alternateNames conference seasons');
         const match = buildTeamMatcher(teams);
 
         const matched = [], unmatched = [], seen = new Set();
@@ -422,7 +423,15 @@ router.post('/:season/cfp-odds', async (req, res) => {
 //Refreshing All
 router.post('/refresh', async (req, res) => {
     try {
-        const response = await fetch(`https://api.collegefootballdata.com/teams/fbs?year=${req.body.year}`, {
+        // /teams (not /teams/fbs) so FCS opponents come along — they are what
+        // most week-1 cupcakes are, and without them a matchup row falls back to
+        // the full school name and truncates ("vs Eastern Kent…"). CFBD carries a
+        // real abbreviation for 127 of the 128, which is the whole point.
+        //
+        // Still ONE call: the endpoint returns every division, so D-II and D-III
+        // (400+ rows the app has no use for) are dropped here rather than paid
+        // for in a second request.
+        const response = await fetch(`https://api.collegefootballdata.com/teams?year=${req.body.year}`, {
             method: 'GET',
             headers: {
             'Accept': 'application/json',
@@ -430,7 +439,22 @@ router.post('/refresh', async (req, res) => {
             }
         });
 
-        var allTeams = await response.json();
+        const everyDivision = await response.json();
+        if (!Array.isArray(everyDivision)) {
+            return res.status(502).json({ message: 'CFBD returned no teams' });
+        }
+        // `abbreviation` is required on the model, and a stray FCS school can
+        // arrive without one — skip it rather than fail the whole refresh or
+        // invent a value.
+        const noAbbr = [];
+        var allTeams = everyDivision.filter(t => {
+            const c = (t.classification || 'fbs').toLowerCase();
+            if (c !== 'fbs' && c !== 'fcs') return false;
+            t.classification = c;
+            if (!t.abbreviation) { noAbbr.push(t.school); return false; }
+            return true;
+        });
+        if (noAbbr.length) console.log('Skipping ' + noAbbr.length + ' team(s) with no abbreviation:', noAbbr.join(', '));
 
         var refreshedTeams = [];
         var newTeams = [];
@@ -442,6 +466,7 @@ router.post('/refresh', async (req, res) => {
                 existingTeam.school = team.school;
                 existingTeam.mascot = team.mascot;
                 existingTeam.abbreviation = team.abbreviation;
+                existingTeam.classification = team.classification;
                 existingTeam.alternateNames = team.alternateNames;
                 existingTeam.color = team.color;
                 existingTeam.alt_color = team.alt_color;
@@ -482,7 +507,8 @@ router.post('/refresh', async (req, res) => {
         }
 
         try {
-            console.log("Refreshing " + refreshedTeams.length + " teams and adding " + newTeams.length + " new teams");
+            const fcsCount = allTeams.filter(t => t.classification === 'fcs').length;
+            console.log("Refreshing " + refreshedTeams.length + " teams and adding " + newTeams.length + " new teams (" + fcsCount + " FCS, stored as opponent reference data)");
             const newCreatedTeams = await Team.insertMany(newTeams);
 
             // Propagate the fresh team fields (logos, school, mascot, colors, …)

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -443,18 +443,34 @@ router.post('/refresh', async (req, res) => {
         if (!Array.isArray(everyDivision)) {
             return res.status(502).json({ message: 'CFBD returned no teams' });
         }
-        // `abbreviation` is required on the model, and a stray FCS school can
-        // arrive without one — skip it rather than fail the whole refresh or
-        // invent a value.
-        const noAbbr = [];
+        // A row is usable only if it can satisfy the model's required fields.
+        // Asked of the schema rather than hand-listed, so this cannot drift from
+        // models/team.js — and it has to be ALL of them, not just abbreviation:
+        // CFBD ships at least one FCS school with an abbreviation but no logos
+        // (West Florida) and another missing logos, location and abbreviation
+        // (Chicago State). insertMany is ordered, so a single invalid doc aborts
+        // the whole insert, 400s the refresh, and skips the roster/draft
+        // propagation that follows it.
+        const invalidFields = (t) => {
+            const err = new Team(Object.assign({}, t, {
+                seasons: [{ season: req.body.year, conference: t.conference }]
+            })).validateSync();
+            return err ? Object.keys(err.errors) : null;
+        };
+        const skipped = [];
         var allTeams = everyDivision.filter(t => {
-            const c = (t.classification || 'fbs').toLowerCase();
+            // Unknown classification is skipped, never assumed FBS: /teams
+            // returns every division, and guessing wrong would put a D-III
+            // school in the draft pool. A payload that lost the field entirely
+            // yields a visible "Refreshing 0 teams" rather than that.
+            const c = String(t.classification || '').toLowerCase();
             if (c !== 'fbs' && c !== 'fcs') return false;
             t.classification = c;
-            if (!t.abbreviation) { noAbbr.push(t.school); return false; }
+            const bad = invalidFields(t);
+            if (bad) { skipped.push(t.school + ' (' + bad.join(', ') + ')'); return false; }
             return true;
         });
-        if (noAbbr.length) console.log('Skipping ' + noAbbr.length + ' team(s) with no abbreviation:', noAbbr.join(', '));
+        if (skipped.length) console.log('Skipping ' + skipped.length + ' team(s) missing required fields: ' + skipped.join('; '));
 
         var refreshedTeams = [];
         var newTeams = [];

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const User = require('../models/user');
 const Game = require('../models/game');
 const Team = require('../models/team');
+const { FBS_ONLY } = require('../modules/team-scope');
 const Draft = require('../models/draft');
 const Ranking = require('../models/ranking');
 const scoring = require('../modules/scoring');
@@ -644,7 +645,7 @@ router.get('/league/:league/roster-teams', async (req, res) => {
             };
         }).sort((a, b) => a.name.localeCompare(b.name));
 
-        const allTeams = await Team.find({}, { id: 1, school: 1, conference: 1, logos: 1 }).lean();
+        const allTeams = await Team.find(FBS_ONLY, { id: 1, school: 1, conference: 1, logos: 1 }).lean();
         const available = allTeams
             .filter(t => !taken.has(Number(t.id)))
             .map(t => ({ id: t.id, school: t.school, conference: t.conference || '', logo: pickLogo(t.logos) || null }))

--- a/tests/CaptainLockDisplay.spec.js
+++ b/tests/CaptainLockDisplay.spec.js
@@ -21,12 +21,15 @@ const path = require('path');
 
 // userHome.js runs a little jQuery at the top level; the page itself only boots
 // from window.onload, which jsdom has already fired past.
-function load() {
+function load({ withCard = true } = {}) {
     const node = new Proxy(function () { return node; }, {
         get(t, k) { return k === 'length' ? 0 : node; },
         apply() { return node; }
     });
     global.$ = window.$ = function () { return node; };
+    delete window.ccH2H;
+    // The navbar ships h2h-card.js on every page, ahead of userHome.js.
+    if (withCard) (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'h2h-card.js'), 'utf8'));
     (0, eval)(fs.readFileSync(path.join(__dirname, '..', 'public', 'userHome.js'), 'utf8'));
 }
 
@@ -102,5 +105,36 @@ describe('uhAndList', () => {
         // A roster can hold both sides of one game (LSU vs Clemson), so blanks
         // are filtered rather than rendered as "and undefined".
         expect(uhAndList(['LSU', null, undefined])).toBe('LSU');
+    });
+});
+
+// The picker and the matchup card show the same games, so they must date them
+// alike. The picker now calls the card's helpers rather than keeping a copy that
+// could drift into dating a kickoff the card leaves bare.
+describe('the picker dates from the card\'s rule', () => {
+    const AUG29 = '2026-08-29T19:30:00.000Z';
+    const SEP5 = '2026-09-05T19:30:00.000Z';
+
+    test('delegates to ccH2H rather than reimplementing it', () => {
+        load();
+        const kicks = [AUG29, SEP5, SEP5, SEP5];
+        expect(uhDatingPlan(kicks)).toBe(window.ccH2H.datingPlan(kicks));
+        // The Aug 29 stray is dated; the September majority is not.
+        const plan = uhDatingPlan(kicks);
+        expect(uhNeedsDate(AUG29, plan)).toBe(true);
+        expect(uhNeedsDate(SEP5, plan)).toBe(false);
+    });
+
+    test('a single weekend dates nothing', () => {
+        load();
+        const plan = uhDatingPlan([SEP5, SEP5]);
+        expect(plan).toBeNull();
+        expect(uhNeedsDate(SEP5, plan)).toBe(false);
+    });
+
+    test('degrades to no dates rather than throwing if the card script is absent', () => {
+        load({ withCard: false });
+        expect(uhDatingPlan([AUG29, SEP5])).toBeNull();
+        expect(uhNeedsDate(AUG29, null)).toBe(false);
     });
 });

--- a/tests/H2HCardKickoffs.spec.js
+++ b/tests/H2HCardKickoffs.spec.js
@@ -83,6 +83,17 @@ describe('H2H card kickoffs', () => {
         expect(out[1]).toBe('Fri, 9/4 8:00 PM');
     });
 
+    // Two weekends of equal size: neither carries the card, so neither can be
+    // the implicit "normal" one. Picking a winner would leave half the rows bare
+    // with no way to tell which weekend they belong to — and which half won
+    // would come down to object key order.
+    test('dates everything when two weekends are tied', () => {
+        const out = kicks(card(
+            [team('A', USC_SJSU), team('B', '2026-08-29T23:30:00.000Z')],
+            [team('C', USC_FRES), team('D', '2026-09-05T23:30:00.000Z')]));
+        out.forEach(k => expect(k).toMatch(/^[A-Z][a-z]{2}, \d{1,2}\/\d{1,2} /));
+    });
+
     test('treats a Thursday-through-Monday slate as one weekend', () => {
         // A college week runs Thu night through the Monday game; none of these
         // need a date, their weekdays already differ.

--- a/tests/H2HCardKickoffs.spec.js
+++ b/tests/H2HCardKickoffs.spec.js
@@ -62,13 +62,34 @@ describe('H2H card kickoffs', () => {
         expect(out[0]).toBe('Sat 9:00 PM');       // was "Sun 2:00 AM"
     });
 
-    test('adds the date when the matchup straddles more than one weekend', () => {
-        const out = kicks(card([team('USC', USC_SJSU), team('USC2', USC_FRES)], [team('Duke', '2026-09-05T23:30:00.000Z')]));
-        // Both USC games said "Sat" before — and one of them is a Friday.
+    // Dating EVERY row of a two-weekend card is most of the width on a phone,
+    // and it is unnecessary: the weekend nearly all the games sit on is the
+    // implicit default, so only the strays need a date. On a real week-1 card
+    // that is two or three rows out of twenty-plus instead of all of them.
+    test('dates only the games away from the card\'s main weekend', () => {
+        const out = kicks(card(
+            [team('USC', USC_SJSU), team('USC2', USC_FRES)],
+            [team('Duke', '2026-09-05T23:30:00.000Z')]));
+        expect(out[0]).toBe('Sat, 8/29 2:00 PM');   // the stray — dated
+        expect(out[1]).toBe('Fri 8:00 PM');          // main weekend — bare
+        expect(out[2]).toBe('Sat 6:30 PM');          // main weekend — bare
+        // Still unmistakable: the two USC games read Sat 8/29 and Fri.
+    });
+
+    test('dates everything when no weekend carries the card', () => {
+        // One game each weekend — neither can be the implicit default.
+        const out = kicks(card([team('USC', USC_SJSU)], [team('Duke', USC_FRES)]));
         expect(out[0]).toBe('Sat, 8/29 2:00 PM');
         expect(out[1]).toBe('Fri, 9/4 8:00 PM');
-        // The date applies to the whole card, so the two columns read alike.
-        expect(out[2]).toBe('Sat, 9/5 6:30 PM');
+    });
+
+    test('treats a Thursday-through-Monday slate as one weekend', () => {
+        // A college week runs Thu night through the Monday game; none of these
+        // need a date, their weekdays already differ.
+        const out = kicks(card(
+            [team('A', '2026-09-04T00:00:00.000Z'), team('B', '2026-09-05T23:30:00.000Z')],
+            [team('C', '2026-09-07T00:00:00.000Z'), team('D', '2026-09-08T00:30:00.000Z')]));
+        out.forEach(k => expect(k).toMatch(/^[A-Z][a-z]{2} \d{1,2}:\d{2} [AP]M$/));
     });
 
     test('leaves the date off an ordinary single-weekend week', () => {

--- a/tests/TeamScope.spec.js
+++ b/tests/TeamScope.spec.js
@@ -1,0 +1,96 @@
+// FCS teams are opponent REFERENCE DATA, not part of the league's team universe.
+//
+// They were added so a matchup row can render "vs EKU" instead of falling back
+// to the full school name and truncating on a phone ("vs Eastern Kent…"). CFBD
+// carries a real abbreviation for 127 of the 128, which is the only reason this
+// is worth storing at all.
+//
+// But they share the `teams` collection with FBS teams, and several places read
+// that collection unfiltered as "every team we care about" — most importantly
+// the DRAFT POOL. Ingesting 128 FCS schools without scoping those reads would
+// have put Eastern Kentucky on the draft board. These tests pin the scoping.
+//
+// Runs against an in-memory Mongo with the real models and the real routes.
+
+process.env.YEAR = '2026';
+
+const express = require('express');
+const request = require('supertest');
+const { useMongo } = require('./helpers/mongo');
+const Team = require('../models/team');
+const User = require('../models/user');
+const { FBS_ONLY } = require('../modules/team-scope');
+
+useMongo();
+
+const SEASON = 2026;
+
+function team(id, school, abbr, classification) {
+    const doc = {
+        id, school, mascot: 'Mascot', abbreviation: abbr,
+        conference: 'SEC', color: '#000', logos: ['http://x/logo.png'],
+        location: { venue_id: id, name: 'Stadium', city: 'City', state: 'ST', zip: '00000', latitude: 1, longitude: 1, capacity: 100, grass: true, dome: false },
+        seasons: [{ season: SEASON, conference: 'SEC', spRating: 5, expectedWins: 6 }]
+    };
+    if (classification) doc.classification = classification;
+    return doc;
+}
+
+async function seed() {
+    await Team.create([
+        team(1, 'Texas', 'TEX', 'fbs'),
+        team(2, 'LSU', 'LSU', 'fbs'),
+        // Pre-dates the field entirely — every such doc came from /teams/fbs.
+        team(3, 'Oregon', 'ORE', null),
+        team(98, 'Eastern Kentucky', 'EKU', 'fcs'),
+        team(99, 'Abilene Christian', 'ACU', 'fcs')
+    ]);
+}
+
+describe('the FBS_ONLY scope', () => {
+    test('keeps FBS teams and legacy docs, drops FCS', async () => {
+        await seed();
+        const schools = (await Team.find(FBS_ONLY, { school: 1, _id: 0 }).lean()).map(t => t.school).sort();
+        // Oregon has no classification at all and must survive — the field was
+        // added after those docs were written, so absent means FBS.
+        expect(schools).toEqual(['LSU', 'Oregon', 'Texas']);
+    });
+
+    test('the FCS teams are still there to look up as opponents', async () => {
+        await seed();
+        const eku = await Team.findOne({ id: 98 }, { abbreviation: 1, _id: 0 }).lean();
+        expect(eku.abbreviation).toBe('EKU');
+    });
+});
+
+describe('FCS teams stay out of the league surfaces', () => {
+    test('the roster-assignment list offers only FBS teams', async () => {
+        await seed();
+        const app = express();
+        app.use(express.json());
+        app.use('/users', require('../routes/users'));
+
+        const res = await request(app).get('/users/league/graham-league/roster-teams?season=' + SEASON);
+        expect(res.status).toBe(200);
+        const offered = (res.body.available || []).map(t => t.school).sort();
+        // Assignable teams are the draft pool by another name — an FCS school
+        // showing up here is the same bug as one showing up on the draft board.
+        expect(offered).toEqual(['LSU', 'Oregon', 'Texas']);
+    });
+
+    test('enrichment readiness counts FBS teams only', async () => {
+        await seed();
+        const app = express();
+        app.use(express.json());
+        app.use('/scores', require('../routes/scores'));
+
+        const res = await request(app).get('/scores/readiness/' + SEASON);
+        expect(res.status).toBe(200);
+        // All three FBS teams carry SP+, so coverage is complete. Had the two
+        // FCS teams counted, this would read "3 of 5" and report a false alarm
+        // on the admin readiness board every preseason.
+        const sp = res.body.platform.find(c => c.key === 'spPlus');
+        expect(sp.detail).toBe('3 of 3 teams');
+        expect(sp.status).toBe('ready');
+    });
+});

--- a/tests/TeamScope.spec.js
+++ b/tests/TeamScope.spec.js
@@ -94,3 +94,52 @@ describe('FCS teams stay out of the league surfaces', () => {
         expect(sp.status).toBe('ready');
     });
 });
+
+// The refresh reads CFBD's /teams, which returns every division and is not
+// uniformly populated. A row that cannot satisfy the model's required fields
+// must be dropped BEFORE insertMany — that call is ordered, so one invalid doc
+// aborts the whole insert, 400s the refresh, and skips the roster/draft
+// propagation that runs after it. Both of these are real 2026 rows: Chicago
+// State has no abbreviation, logos or location; West Florida has an
+// abbreviation but no logos, which an abbreviation-only guard would let through.
+describe('the refresh drops rows it cannot insert', () => {
+    const cfbdTeam = (over) => Object.assign({
+        id: 500, school: 'Somebody', mascot: 'Mascot', abbreviation: 'SMB',
+        classification: 'fcs', conference: 'Big Sky', color: '#123456',
+        logos: ['http://x/logo.png'],
+        location: { venue_id: 500, name: 'Field', city: 'Town', state: 'ST' }
+    }, over);
+
+    test('keeps the valid fbs+fcs rows and skips the rest', async () => {
+        const payload = [
+            cfbdTeam({ id: 1, school: 'Texas', abbreviation: 'TEX', classification: 'fbs' }),
+            cfbdTeam({ id: 2, school: 'Eastern Kentucky', abbreviation: 'EKU' }),
+            // logos: null, not undefined — mongoose defaults a missing array to []
+        // and `required` accepts that, so only an explicit null reproduces it.
+        cfbdTeam({ id: 3, school: 'West Florida', abbreviation: 'UWF', logos: null }),
+            cfbdTeam({ id: 4, school: 'Chicago State', abbreviation: null, logos: null, location: null }),
+            cfbdTeam({ id: 5, school: 'Some D3 School', classification: 'iii' }),
+            cfbdTeam({ id: 6, school: 'No Division', classification: undefined })
+        ];
+        const realFetch = global.fetch;
+        global.fetch = async () => ({ ok: true, json: async () => payload });
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        const app = express();
+        app.use(express.json());
+        app.use('/teams', require('../routes/teams'));
+        try {
+            const res = await request(app).post('/teams/refresh').send({ year: SEASON });
+            expect(res.status).toBe(201);
+        } finally {
+            global.fetch = realFetch;
+            console.log.mockRestore();
+        }
+
+        const stored = (await Team.find({}, { school: 1, classification: 1, _id: 0 }).lean())
+            .map(t => t.school).sort();
+        // Texas and Eastern Kentucky only. West Florida would have thrown inside
+        // insertMany and taken the whole refresh down with it.
+        expect(stored).toEqual(['Eastern Kentucky', 'Texas']);
+    });
+});


### PR DESCRIPTION
Two commits that were pushed to #332's branch *after* it merged, so they never reached main — reopened here off current main, plus one real bug found reviewing them.

## 1. Dating only the strays (mobile width)

Dating was all-or-nothing per card: any card spanning more than one weekend dated **every** row. On the real week-1 card that is 16 rows sitting on Sep 5, all carrying "Sat, 9/5" to disambiguate the handful that aren't.

At 390px `.h2h-tv` is `flex-shrink: 0`, so the kickoff takes what it needs and the name column absorbs the entire truncation — `N. vs WIS`, `MISS vs #24 ...`, `JXST vs Easte...`.

The weekend nearly every game sits on is the implicit default, so only the strays need saying. Same card now: **3 dated rows** instead of 23, everything else back to a bare `Sun 7:30 PM`.

Grouping is by **week**, not day — epoch day 0 was a Thursday, so plain 7-day buckets already run Thu→Wed, which is how a college week runs from the Thursday night game through the Monday one. Two edge cases handled: a single weekend dates nothing, and a card where no weekend carries a majority dates everything.

Applied to the Captain picker too. The lock time keeps its date whenever it is the stray — the case that prompted naming it (NC State on Aug 29 while the rest of the roster plays Sep 5).

## 2. FCS opponents get abbreviations

Week-1 cupcakes are mostly FCS schools, and the ingest only pulled `/teams/fbs` — so an FCS opponent had no Team doc, no abbreviation, and the row fell back to the full school name. CFBD carries a real abbreviation for 127 of the 128 (EKU, ACU, UNA, UAPB).

The refresh now reads `/teams`, filters to fbs+fcs, and tags each doc's classification. Still one API call.

**FCS teams are reference data, not part of the league's team universe.** They share the collection with FBS teams, and several reads treat that collection as "every team we care about" — the draft pool among them. `modules/team-scope.js` `FBS_ONLY` scopes the six that mean the league's own teams: draft pool, draft board, roster assignment, readiness denominator, site search, CFP-odds matcher. The two id-based opponent lookups stay unscoped, which is the point.

The filter is `$ne: 'fcs'`, not `$eq: 'fbs'` — all 138 existing docs have the field unset, so `$eq` would have emptied the draft pool on deploy.

## 3. The bug this review caught

Guarding only `abbreviation` was not enough. CFBD ships **West Florida** with an abbreviation but `logos: null`, and `logos` is required on the model — that row passed the filter, reached `Team.insertMany`, and threw. `insertMany` is ordered, so one invalid doc aborts the whole insert, 400s the refresh, and skips the roster/draft propagation after it. **The first refresh after this shipped would have failed.**

The check now asks the schema (`validateSync`) instead of hand-listing fields, so it can't drift from the model. Verified against the live payload: keeps 264 of 266, skips exactly Chicago State (no abbreviation, logos or location) and West Florida (no logos), and `insertMany` succeeds.

Unknown classification is now skipped rather than assumed FBS — `/teams` returns every division, so guessing wrong puts a D-III school in the draft pool.

## Verification

72 suites, 1292 tests. New coverage in `tests/TeamScope.spec.js` (FBS_ONLY keeps legacy docs, FCS stays off the assignable list and out of the readiness denominator, the refresh drops un-insertable rows) and `tests/H2HCardKickoffs.spec.js` (dates only the strays, dates everything when no weekend carries the card, Thu-through-Mon is one weekend).

Note: `tests/RoutesInvite.spec.js` and three other pre-existing suites flake together roughly 1 run in 8 under parallel in-memory Mongo — unrelated to this change, passes on rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)