### PR TITLE
A week is only LIVE once a game has actually kicked off

### DIFF
--- a/routes/standings.js
+++ b/routes/standings.js
@@ -652,8 +652,22 @@ router.get('/h2h/:league/:season', async (req, res) => {
         // nothing to list once the featured week was pulled out — and limited
         // the Standings week picker to weeks already behind you.
         const schedWeeks = h2hWeeks.slice().sort((a, b) => a - b);
+        // Has a ball actually been kicked off in this week yet? `currentWeek` only
+        // means "the first week that hasn't settled", which is true of week 1 all
+        // preseason — so on its own it marked every matchup LIVE with an "In
+        // progress · N games to play" footer weeks before anyone played. The
+        // per-game status was always right (rows showed kickoff times, not LIVE);
+        // it was the week-level flag that never asked.
+        //
+        // A TBD kickoff reads as 'scheduled' and so can never start a week by
+        // itself, which is correct — nobody knows when it begins.
+        const startedByWeek = {};
+        games.forEach(g => {
+            if (g.week == null) return;
+            if (gameStatus(g, now) !== 'scheduled') startedByWeek[g.week] = true;
+        });
         const schedule = schedWeeks.map(w => {
-            const live = (w === currentWeek) && !weekFinal[w];
+            const live = (w === currentWeek) && !weekFinal[w] && !!startedByWeek[w];
             const upcoming = !weekFinal[w] && !live;
             return { week: w, final: !!weekFinal[w], upcoming, games: (scheduleAll[w] || []).filter(([a, b]) => meta[a] && meta[b]).map(([a, b]) => gameFor(a, b, w, live || upcoming, upcoming)) };
         });

--- a/tests/H2HSchedule.spec.js
+++ b/tests/H2HSchedule.spec.js
@@ -55,10 +55,18 @@ async function manager(firstName, teams, weeks) {
 // date that can never drift into the past on a later test run.
 const PAST = '2026-09-05T23:00:00.000Z';
 const FUTURE = '2099-09-12T23:30:00.000Z';
-function game(id, week, homeId, awayId, completed) {
+// Deliberately ancient. Whether a game has KICKED OFF is decided against the
+// real clock, so "started" needs a date already elapsed no matter when the suite
+// runs — PAST above is only ever used on completed games, where gameStatus reads
+// `completed` and never looks at the date at all.
+const STARTED = '2020-09-05T23:00:00.000Z';
+// `started` = kicked off but not finished, which is the only thing that makes a
+// week LIVE. Without it every unfinished game sits in the future and the week is
+// merely upcoming.
+function game(id, week, homeId, awayId, completed, started) {
     return {
         id, season: SEASON, week, seasonType: 'regular',
-        startDate: completed ? PAST : FUTURE, startTimeTbd: false,
+        startDate: completed ? PAST : (started ? STARTED : FUTURE), startTimeTbd: false,
         neutralSite: false, conferenceGame: false,
         homeId, homeTeam: 'Home', awayId, awayTeam: 'Away',
         homePoints: completed ? 30 : null, awayPoints: completed ? 10 : null,
@@ -100,12 +108,15 @@ describe('GET /standings/h2h schedule', () => {
         expect(body.scheduleComplete).toBe(false);
     });
 
-    test('marks a settled week final, the live week neither, and later weeks upcoming', async () => {
+    test('marks a settled week final, and an unstarted current week upcoming', async () => {
         await seed();
         const body = await get();
 
         expect(weekOf(body, 1)).toMatchObject({ final: true, upcoming: false });
-        expect(weekOf(body, 2)).toMatchObject({ final: false, upcoming: false });
+        // Week 2 is the current week but nothing in it has kicked off, so it is
+        // upcoming rather than live — being the week you are IN is not the same
+        // as being under way.
+        expect(weekOf(body, 2)).toMatchObject({ final: false, upcoming: true });
         expect(weekOf(body, 3)).toMatchObject({ final: false, upcoming: true });
     });
 
@@ -162,8 +173,32 @@ describe('GET /standings/h2h schedule', () => {
         // out as the featured card, leaving its list with nothing to render.
         expect(body.schedule.map(s => s.week)).toEqual([1, 2]);
         expect(body.currentWeek).toBe(1);
-        expect(weekOf(body, 1)).toMatchObject({ final: false, upcoming: false });
+        // Nothing has kicked off, so week 1 is upcoming — not LIVE with an "in
+        // progress" footer, which is what it used to claim all preseason.
+        expect(weekOf(body, 1)).toMatchObject({ final: false, upcoming: true });
         expect(weekOf(body, 2).upcoming).toBe(true);
+    });
+
+    test('a week goes live once one of its games has kicked off', async () => {
+        await seed();
+        // Week 2's first game is now under way; its second has not started.
+        await Game.updateOne({ id: 201 }, { $set: { startDate: STARTED } });
+
+        const body = await get();
+        expect(body.currentWeek).toBe(2);
+        expect(weekOf(body, 2)).toMatchObject({ final: false, upcoming: false });
+        // The rest of the week rides along — the matchup itself is under way even
+        // though later games have not started.
+        expect(weekOf(body, 3).upcoming).toBe(true);
+    });
+
+    test('a TBD kickoff cannot make a week live on its own', async () => {
+        await seed();
+        // A placeholder start date that has drifted into the past must not count
+        // as a kickoff; nobody knows when the game actually begins.
+        await Game.updateOne({ id: 201 }, { $set: { startDate: STARTED, startTimeTbd: true } });
+
+        expect(weekOf(await get(), 2).upcoming).toBe(true);
     });
 
     // Deliberate, and unchanged: h2hManagerIds excludes managers with no scored


### PR DESCRIPTION
## The bug

Every matchup on Standings shows **LIVE**, `0`–`0`, and "In progress · 23 games to play" — eleven days before anyone plays.

```js
const live = (w === currentWeek) && !weekFinal[w];
```

`currentWeek` only means *"the first week that has games and hasn't settled"* ([modules/h2h.js:277](../blob/main/modules/h2h.js#L277)), which is week 1 for the entire preseason. Being the week you are *in* is not the same as being under way, and nothing checked whether a ball had been kicked.

The app already knew how to tell. `gameStatus()` classifies each game `scheduled` / `live` / `final` against the clock, and the team rows use it correctly — that's why each row showed "Sat 2:30 PM" while the card around it claimed to be in progress. Only the week-level flag never asked.

This has been wrong since H2H shipped. The `upcoming` state added later covered weeks *after* the current one but left the current week always-live.

## The fix

The week now needs a game that has actually started. It falls into `upcoming` instead — a state the card already renders correctly:

| | Before | After |
|---|---|---|
| Badge | `LIVE` | `vs` |
| Score | `0` – `0` | `–` – `–` |
| Footer | In progress · 23 games to play | Not started · 23 games scheduled · odds are projected |

`currentWeek` itself is untouched, so the featured week, My Team's "This week" lead card, and `scheduleComplete` all behave exactly as before.

Two edge cases, both deliberate:

- **A TBD kickoff cannot start a week on its own.** It reads as `scheduled` forever, which is right — nobody knows when it begins.
- **Once the first game kicks off, the whole week goes live**, later games included. The matchup *is* under way even if some of its games haven't started. For week 1 that means LIVE from Aug 29 through Sep 7.

## Verification

72 suites, 1298 tests. Two new cases in `tests/H2HSchedule.spec.js` (a week goes live once a game kicks off; a TBD kickoff can't do it), and two existing assertions updated to the corrected behavior — including the one literally named "week 1 before kickoff", which had been asserting it was live.

One trap worth noting: the spec's `PAST` constant is **Sep 5 2026**, still ahead of the real clock. It was only ever applied to *completed* games, where `gameStatus` reads the `completed` flag and ignores the date — so it worked by accident. Testing a genuinely kicked-off game needed a date that has actually elapsed, so `started` games get an ancient one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)