### PR TITLE
Ignore sync script and sleeper-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 *.css.map
 main.css
 coverage
+scripts/sync-prod-to-dev.sh
+sleeper-data/


### PR DESCRIPTION
## Summary
- Adds `scripts/sync-prod-to-dev.sh` and `sleeper-data/` to `.gitignore`

## Test plan
- [x] No code changes, gitignore only

🤖 Generated with [Claude Code](https://claude.com/claude-code)