### PR TITLE
Past-season viewer + per-season scoring config snapshots

### DIFF
--- a/models/scoringConfig.js
+++ b/models/scoringConfig.js
@@ -53,6 +53,12 @@ const scoringConfigSchema = new mongoose.Schema({
     // list is pinned the first time a week settles and read verbatim after that.
     // See modules/h2h.js h2hRoster.
     h2hScheduleBySeason: { type: mongoose.Schema.Types.Mixed, default: {} },
+    // Frozen scoring config per completed season, keyed by year string, e.g.
+    // { "2025": { model, values, combineMode, disabled, enabled, powerConferences } }.
+    // Snapshotted at end-of-season so the "Why these points?" breakdown can
+    // recalculate past games with the rules that were in effect when they were
+    // scored. Seasons without an entry fall back to the live config.
+    configBySeason: { type: mongoose.Schema.Types.Mixed, default: {} },
     updatedAt: { type: Date, default: Date.now }
 });
 

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -21,22 +21,26 @@ var _frozenCheck = false;
 async function freezePriorSeasonConfig(currentYear) {
     if (_frozenCheck) return;
     _frozenCheck = true;
-    const priorYear = String(Number(currentYear) - 1);
-    const docs = await ScoringConfig.find({});
-    for (const doc of docs) {
-        if (doc.configBySeason && doc.configBySeason[priorYear]) continue;
-        if (!doc.configBySeason) doc.configBySeason = {};
-        doc.configBySeason[priorYear] = {
-            model: doc.model,
-            values: doc.values ? JSON.parse(JSON.stringify(doc.values)) : {},
-            combineMode: doc.combineMode,
-            disabled: (doc.disabled || []).slice(),
-            enabled: (doc.enabled || []).slice(),
-            ...(doc.powerConferences ? { powerConferences: doc.powerConferences.slice() } : {})
-        };
-        doc.markModified('configBySeason');
-        await doc.save();
-        console.log(`Froze ${doc.league} scoring config for ${priorYear}`);
+    try {
+        const priorYear = String(Number(currentYear) - 1);
+        const docs = await ScoringConfig.find({});
+        for (const doc of docs) {
+            if (doc.configBySeason && doc.configBySeason[priorYear]) continue;
+            if (!doc.configBySeason) doc.configBySeason = {};
+            doc.configBySeason[priorYear] = {
+                model: doc.model,
+                values: doc.values ? JSON.parse(JSON.stringify(doc.values)) : {},
+                combineMode: doc.combineMode,
+                disabled: (doc.disabled || []).slice(),
+                enabled: (doc.enabled || []).slice(),
+                ...(doc.powerConferences ? { powerConferences: doc.powerConferences.slice() } : {})
+            };
+            doc.markModified('configBySeason');
+            await doc.save();
+            console.log(`Froze ${doc.league} scoring config for ${priorYear}`);
+        }
+    } catch (err) {
+        console.error('freezePriorSeasonConfig failed (non-fatal):', err.message);
     }
 }
 

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -3,6 +3,7 @@ const { resolveConfig, MODELS, engagementForSeason, ruleEnabled, overridesFromDo
 const { CONDITIONS, buildContext } = require('./scoring-detectors');
 const { factsForGame } = require('./cfp-bracket');
 const { resolveCaptain, captainWeeklyBonus } = require('./captain');
+const ScoringConfig = require('../models/scoringConfig');
 // Configure API key authorization: ApiKeyAuth
 const CFBD_API_KEY = process.env.CFBD_API_KEY;
 var cfb = require('cfb.js');
@@ -11,6 +12,33 @@ var ApiKeyAuth = defaultClient.authentications['ApiKeyAuth'];
 ApiKeyAuth.apiKey = CFBD_API_KEY;
 
 var rankingsApi = new cfb.RankingsApi();
+
+// On the first scoring run of a new season, freeze the previous season's config
+// so past-season "Why these points?" breakdowns stay accurate even if the
+// commissioner later changes point values. Idempotent: skips if already frozen.
+// Runs once per process to avoid repeated DB reads on every scoring pass.
+var _frozenCheck = false;
+async function freezePriorSeasonConfig(currentYear) {
+    if (_frozenCheck) return;
+    _frozenCheck = true;
+    const priorYear = String(Number(currentYear) - 1);
+    const docs = await ScoringConfig.find({});
+    for (const doc of docs) {
+        if (doc.configBySeason && doc.configBySeason[priorYear]) continue;
+        if (!doc.configBySeason) doc.configBySeason = {};
+        doc.configBySeason[priorYear] = {
+            model: doc.model,
+            values: doc.values ? JSON.parse(JSON.stringify(doc.values)) : {},
+            combineMode: doc.combineMode,
+            disabled: (doc.disabled || []).slice(),
+            enabled: (doc.enabled || []).slice(),
+            ...(doc.powerConferences ? { powerConferences: doc.powerConferences.slice() } : {})
+        };
+        doc.markModified('configBySeason');
+        await doc.save();
+        console.log(`Froze ${doc.league} scoring config for ${priorYear}`);
+    }
+}
 
 module.exports= {
 
@@ -73,6 +101,8 @@ module.exports= {
     },
 
     updateScores: async function(season, week) {
+        await freezePriorSeasonConfig(process.env.YEAR);
+
         // One ranking cache per call: every game in the week shares its poll doc
         // instead of re-reading it from Mongo per game.
         var rankingCache = new Map();

--- a/public/standings.css
+++ b/public/standings.css
@@ -730,7 +730,7 @@
 /* ---------- H2H featured view: week selector + matchup scoreboards ---------- */
 .h2h-week-bar { display: flex; align-items: center; gap: 0.6rem; margin: 0.2rem 0 0.7rem; }
 .h2h-week-cap { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--cc-muted-2); }
-.h2h-week-bar select { background: var(--cc-bg); border: 1px solid var(--cc-border-2); border-radius: 8px; color: var(--cc-text); font: inherit; font-size: 0.85rem; padding: 5px 9px; cursor: pointer; }
+.h2h-week-bar select { background: var(--cc-bg); border: 1px solid var(--cc-border-2); border-radius: 8px; color: var(--cc-text); color-scheme: dark; font: inherit; font-size: 0.85rem; padding: 5px 9px; cursor: pointer; }
 .h2h-matches { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 0.6rem; margin-bottom: 1.1rem; }
 .h2h-empty { color: var(--cc-muted-2); font-size: 0.85rem; }
 

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -715,7 +715,7 @@ body.uh-drawer-open { overflow: hidden; }
 
 /* Games drawer (#230 redesign) */
 .uh-games-pick { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; font-size: 11px; color: var(--cc-muted-2); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; }
-.uh-games-pick select { background: #12162A; border: 1px solid var(--cc-border); border-radius: 8px; color: var(--cc-text); font: inherit; padding: 6px 8px; text-transform: none; letter-spacing: 0; }
+.uh-games-pick select { background: #12162A; border: 1px solid var(--cc-border); border-radius: 8px; color: var(--cc-text); color-scheme: dark; font: inherit; padding: 6px 8px; text-transform: none; letter-spacing: 0; }
 .uh-drawer-body .schedule-grid { display: flex; flex-direction: column; gap: 10px; }
 
 /* Enriched tile glances (#230 redesign polish) */
@@ -770,7 +770,7 @@ body.uh-drawer-open { overflow: hidden; }
 .uh-games-logos img { width: 24px; height: 24px; object-fit: contain; }
 .uh-games-wk { display: block; margin-top: 8px; }
 .uh-games-pick { display: block; margin-bottom: 14px; }
-.uh-games-pick select { background: #12162A; border: 1px solid var(--cc-border); border-radius: 8px; color: var(--cc-text); font: inherit; padding: 8px 10px; }
+.uh-games-pick select { background: #12162A; border: 1px solid var(--cc-border); border-radius: 8px; color: var(--cc-text); color-scheme: dark; font: inherit; padding: 8px 10px; }
 /* In the drawer the grid is a vertical column, so the card's flex-basis (340px)
    must not become its height — size cards to content, full width. */
 .uh-drawer-body .schedule-grid { display: flex; flex-direction: column; gap: 10px; padding: 0; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -637,6 +637,10 @@ button.uh-tile:focus-visible { outline: 2px solid var(--cc-info); outline-offset
 .uh-hero-stats .stat-value { font-size: 1.15rem; font-weight: 800; color: var(--cc-text); display: flex; align-items: center; gap: 6px; }
 .uh-hero-stats .stat-value img { height: 1.1rem; width: auto; }
 .uh-hero-stats .stat-label { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-muted-2); margin-top: 2px; }
+.uh-season-picker { display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }
+.uh-season-pill { all: unset; cursor: pointer; font-size: 0.72rem; font-weight: 700; padding: 3px 10px; border-radius: 99px; border: 1px solid var(--cc-border); color: var(--cc-muted-2); transition: background 0.15s, color 0.15s, border-color 0.15s; }
+.uh-season-pill:hover { color: var(--cc-text); border-color: var(--cc-muted); }
+.uh-season-pill.active { background: var(--cc-text); color: var(--cc-bg); border-color: var(--cc-text); }
 /* Preseason / undrafted-window empty state (active season not yet drafted). */
 .uh-preseason-pill { display: inline-block; font-size: 0.62rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; color: var(--cc-amber); border: 1px solid rgba(224,179,65,0.4); border-radius: 99px; padding: 3px 10px; }
 .uh-preseason { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 8px; padding: 40px 24px; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -6,6 +6,7 @@ var isMobile;
 // displaySchedule/ensureWeekSelected) read it instead of guessing with
 // seasons.at(-1), so every part of the page keys off the same season.
 var uhActiveYear;
+var uhHasFrozenConfig = true;
 
 // Escapes HTML special chars before interpolating values into innerHTML.
 function escapeHtml(value) {
@@ -126,6 +127,17 @@ async function renderBento(data, yearOverride) {
     const activeYear = yearOverride ? String(yearOverride) : currentYear;
     uhActiveYear = activeYear;   // reused renderers read this (see var decl)
     const isPastSeason = activeYear !== currentYear;
+    if (isPastSeason && data.league) {
+        try {
+            const cfgRes = await fetch('/scoring-config/' + encodeURIComponent(data.league), { headers: { Accept: 'application/json' } });
+            if (cfgRes.ok) {
+                const cfgData = await cfgRes.json();
+                uhHasFrozenConfig = (cfgData.frozenSeasons || []).includes(activeYear);
+            } else { uhHasFrozenConfig = false; }
+        } catch (_) { uhHasFrozenConfig = false; }
+    } else {
+        uhHasFrozenConfig = true;
+    }
     const season = uhSeasonFor(data, activeYear);
     const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
     const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
@@ -1881,6 +1893,9 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
         // The badge is a button: tap to reveal WHY this team earned these points
         // (which scoring rule fired). See the delegated handler below.
         if (pts <= 0) return '';
+        if (uhActiveYear !== String(window.APP_YEAR) && !uhHasFrozenConfig) {
+            return `<td class="score-added"><strong>+${pts}</strong></td>`;
+        }
         return `<td class="score-added"><button type="button" class="score-explain" data-team="${id}" data-game="${game.id}" data-pts="${pts}" title="Why these points?"><strong>+${pts}</strong></button></td>`;
     };
     const caret = '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i>';

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -118,12 +118,14 @@ function uhSeasonFor(user, year) {
 // ---------- My Team bento (#230 redesign, feat/my-team-redesign) ----------
 // Renders the tile grid; each tile is a glance that opens a slide-over drawer,
 // all keyed off the one active season (uhSeasonFor).
-async function renderBento(data) {
+async function renderBento(data, yearOverride) {
     const bento = document.getElementById('uh-bento');
     if (!bento || !data) return;
-    const activeYear = (window.APP_YEAR && String(window.APP_YEAR))
+    const currentYear = (window.APP_YEAR && String(window.APP_YEAR))
         || (data.seasons && data.seasons.length ? String(data.seasons[data.seasons.length - 1].season) : String(new Date().getFullYear()));
+    const activeYear = yearOverride ? String(yearOverride) : currentYear;
     uhActiveYear = activeYear;   // reused renderers read this (see var decl)
+    const isPastSeason = activeYear !== currentYear;
     const season = uhSeasonFor(data, activeYear);
     const manager = `${data.firstName || ''} ${data.lastName || ''}`.trim();
     const franchise = season.franchiseName || `${data.firstName || 'Unnamed'}'s Team`;
@@ -146,6 +148,18 @@ async function renderBento(data) {
 
     const tile = (k, label, glance, span, affordance) => `<button class="uh-tile${span === 2 ? ' span2' : ''}" id="uh-tile-${k}" data-tile="${k}"><span class="uh-tlabel">${label}<span class="uh-chev">${affordance || '›'}</span></span><span class="uh-glance" id="uh-glance-${k}">${glance}</span></button>`;
 
+    const draftedSeasons = (data.seasons || [])
+        .filter(s => (s.teams || []).length)
+        .sort((a, b) => Number(b.season) - Number(a.season));
+    const showPicker = draftedSeasons.length > 1;
+    const seasonPills = showPicker
+        ? `<div class="uh-season-picker">${draftedSeasons.map(s => {
+            const y = String(s.season);
+            const isCurrent = y === activeYear;
+            return '<button type="button" class="uh-season-pill' + (isCurrent ? ' active' : '') + '" data-season="' + escapeHtml(y) + '">' + escapeHtml(y) + '</button>';
+        }).join('')}</div>`
+        : '';
+
     bento.innerHTML =
         `<div class="uh-tile span2 uh-hero">
             <div class="uh-hero-av avatar avatar-lg" id="uh-hero-av"></div>
@@ -154,15 +168,16 @@ async function renderBento(data) {
                 <div class="uh-hero-name">${escapeHtml(franchise)}</div>
                 <div class="uh-hero-sub">${escapeHtml(franchise ? ('Managed by ' + manager) : manager)}</div>
                 <div class="uh-hero-stats" id="uh-hero-stats"></div>
+                ${seasonPills}
             </div>
-            ${own ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
+            ${own && !isPastSeason ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
         </div>`
-        + tile('matchup', 'This week · matchup', uhPoss(own, true) + ' current H2H matchup', 2, 'Lineups ›')
+        + tile('matchup', isPastSeason ? 'H2H results' : 'This week · matchup', isPastSeason ? (activeYear + ' matchups') : (uhPoss(own, true) + ' current H2H matchup'), 2, isPastSeason ? 'Results ›' : 'Lineups ›')
         + tile('roster', 'Roster · top performers', uhPoss(own, true) + ' 10 teams', 2, 'All 10 teams ›')
-        + tile('captain', 'Captain', 'Double a team each week', 1)
-        + tile('recap', own ? 'Your week' : 'Their week', 'Latest recap', 1)
-        + tile('schedule', 'Schedule', 'Up next', 1, 'Full schedule ›')
-        + tile('games', 'Games', 'This week’s games', 1, 'This week ›')
+        + (isPastSeason ? '' : tile('captain', 'Captain', 'Double a team each week', 1))
+        + (isPastSeason ? '' : tile('recap', own ? 'Your week' : 'Their week', 'Latest recap', 1))
+        + tile('schedule', 'Schedule', isPastSeason ? (activeYear + ' schedule') : 'Up next', 1, 'Full schedule ›')
+        + tile('games', 'Games', isPastSeason ? (activeYear + ' games') : "This week's games", 1, isPastSeason ? 'Games ›' : 'This week ›')
         + tile('trajectory', 'Trajectory', 'Season points', 1)
         + tile('draft', 'Draft grade', 'Preseason projection', 1);
 
@@ -172,7 +187,7 @@ async function renderBento(data) {
     // Rank only once the season has really been played, and share a placement on
     // a tie ("T-3rd") — computeRank owns both calls, since both need the league.
     try {
-        const rank = await computeRank(data);
+        const rank = await computeRank(data, activeYear);
         if (rank) sh += statTile(escapeHtml((rank.tie ? 'T-' : '') + ordinal(rank.rank)), `of ${rank.total} teams`);
     } catch (e) { /* rank optional */ }
     sh += statTile(String(season.cumulativeScore || 0), 'Total points');
@@ -180,28 +195,28 @@ async function renderBento(data) {
     if (bt && bt.total > 0) sh += statTile(`<img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
     statsEl.innerHTML = sh;
 
-    if (own) setupEditModal(data, season, true);
+    if (own && !isPastSeason) setupEditModal(data, season, true);
 
     bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
     setupDrawer();
 
-    // Recap drawer title tracks whose profile this is (the tile itself is
-    // hidden on other managers' profiles — see hydrateRecap).
+    bento.querySelectorAll('.uh-season-pill').forEach(pill => {
+        pill.addEventListener('click', () => renderBento(data, pill.getAttribute('data-season')));
+    });
+
     UH_DRAWERS.recap = own ? 'Your week' : 'Their week';
 
-    // Hydrate each tile's glance + drawer from the one active season.
     hydrateH2H(data, activeYear);
-    hydrateCaptain(data, activeYear);
-    hydrateRecap(data, activeYear);
+    if (!isPastSeason) {
+        hydrateCaptain(data, activeYear);
+        hydrateRecap(data, activeYear);
+    }
     hydrateDraft(data, activeYear);
     hydrateRoster(data, activeYear);
     hydrateTrajectory(data, activeYear);
     hydrateGames(data, activeYear);
 
-    // Preview only: ?win=win|loss|tie plays a sample Win reveal so the moment
-    // can be previewed anytime. The real trigger lives in hydrateH2H (fires once
-    // when your weekly matchup goes final).
-    maybePreviewWinReveal();
+    if (!isPastSeason) maybePreviewWinReveal();
 }
 
 function maybePreviewWinReveal() {
@@ -558,7 +573,7 @@ function hydrateTrajectory(user, activeYear) {
         let html = statTile(String(season.cumulativeScore || 0), 'Total points');
         if (bestWk > 0) html += statTile(String(bestWk), 'Best week');
         try {
-            const res = await fetch(`/users/league/${encodeURIComponent(user.league)}`, { headers: { Accept: 'application/json' } });
+            const res = await fetch(`/users/league/${encodeURIComponent(user.league)}?season=${encodeURIComponent(activeYear)}`, { headers: { Accept: 'application/json' } });
             if (res.ok) {
                 const ranked = (await res.json())
                     .map(u => ({ id: u._id, score: (u.seasons && u.seasons[0] && u.seasons[0].cumulativeScore) || 0 }))
@@ -1305,10 +1320,11 @@ function bestTeam(season) {
 // asked, too — before the season starts every cumulativeScore is 0, and any
 // placement drawn from that is really just each manager's position in the DB
 // result order wearing a rank's clothes.
-async function computeRank(data) {
+async function computeRank(data, year) {
     try {
         if (!data.league) return null;
-        const res = await fetch(`/users/league/${data.league}`, { headers: { 'Accept': 'application/json' } });
+        const seasonParam = year ? `?season=${encodeURIComponent(year)}` : '';
+        const res = await fetch(`/users/league/${data.league}${seasonParam}`, { headers: { 'Accept': 'application/json' } });
         if (!res.ok) return null;
         const users = await res.json();
         // Not "does this manager have a weekly entry" — the nightly scoring job
@@ -1608,7 +1624,8 @@ function renderProfileChart(data) {
 
 async function getGame(season, week, team) {
 
-    var gamePromise = await fetch(`/games/seasonType/${season}/week/${week}/team/${team.id}`, {
+    var seasonQ = uhActiveYear ? '?season=' + encodeURIComponent(uhActiveYear) : '';
+    var gamePromise = await fetch(`/games/seasonType/${season}/week/${week}/team/${team.id}${seasonQ}`, {
         method: 'GET',
         headers: {
         'Accept': 'application/json'
@@ -1770,16 +1787,18 @@ document.addEventListener('click', async function (e) {
     card.appendChild(box);
     btn.classList.add('is-open');
     try {
+        var seasonParam = uhActiveYear ? '&season=' + encodeURIComponent(uhActiveYear) : '';
         var res = await fetch('/scoring-config/' + encodeURIComponent(league) + '/explain?teamId='
-            + encodeURIComponent(teamId) + '&gameId=' + encodeURIComponent(gameId), { headers: { Accept: 'application/json' } });
+            + encodeURIComponent(teamId) + '&gameId=' + encodeURIComponent(gameId) + seasonParam, { headers: { Accept: 'application/json' } });
         var data = await res.json();
         if (!res.ok || !data || !Array.isArray(data.matched)) { box.textContent = 'Breakdown unavailable.'; return; }
         if (!data.matched.length) { box.textContent = 'No scoring rule applied to this game.'; return; }
         var rows = data.matched.map(function (m) {
             return '<div class="bd-row"><span class="bd-pts">+' + m.points + '</span><span class="bd-label">' + m.label + '</span></div>';
         }).join('');
+        var isPast = uhActiveYear !== String(window.APP_YEAR);
         var note = (typeof data.total === 'number' && data.total !== banked)
-            ? '<div class="bd-note">Scoring rules or rankings changed since this game was scored, so this differs from the banked +' + banked + '.</div>'
+            ? '<div class="bd-note">' + (isPast ? 'Scored under ' + uhActiveYear + ' rules.' : 'Scoring rules or rankings changed since this game was scored, so this differs from the banked +' + banked + '.') + '</div>'
             : '';
         box.innerHTML = rows + note;
     } catch (err) {
@@ -1861,7 +1880,8 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
         const pts = teamGameScoreById(uhSeasonFor(userData, uhActiveYear).weeklyScore, id, game.id);
         // The badge is a button: tap to reveal WHY this team earned these points
         // (which scoring rule fired). See the delegated handler below.
-        return pts > 0 ? `<td class="score-added"><button type="button" class="score-explain" data-team="${id}" data-game="${game.id}" data-pts="${pts}" title="Why these points?"><strong>+${pts}</strong></button></td>` : '';
+        if (pts <= 0) return '';
+        return `<td class="score-added"><button type="button" class="score-explain" data-team="${id}" data-game="${game.id}" data-pts="${pts}" title="Why these points?"><strong>+${pts}</strong></button></td>`;
     };
     const caret = '<i class="fa-solid fa-caret-left" style="padding-left: 2px;"></i>';
 

--- a/routes/games.js
+++ b/routes/games.js
@@ -26,8 +26,9 @@ router.get('/seasonType/:seasonType/week/:weekNum/team/:team', async (req, res) 
     var week = req.params.weekNum;
     var teamId = req.params.team;
     var seasonType = req.params.seasonType;
+    var year = req.query.season || process.env.YEAR;
     try {
-        const game = await Game.find({$and: [ { $or: [{"homeId":teamId}, {"awayId":teamId}]}, {"season":process.env.YEAR}, {seasonType: seasonType}, {week: week}]});
+        const game = await Game.find({$and: [ { $or: [{"homeId":teamId}, {"awayId":teamId}]}, {"season":year}, {seasonType: seasonType}, {week: week}]});
 
         // "This team had no game that week" is an empty result, not a client
         // error. It used to 400, which put one console error per rostered team

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -98,6 +98,7 @@ router.get('/:league', async (req, res) => {
 // for one game. Reuses the EXACT engine inputs (resolved config + the game's
 // week rankings) the scoring jobs use, so the breakdown reconciles with the
 // banked per-game score (barring rankings/rules changing after it was scored).
+// Pass ?season= to use a frozen per-season config (for past-season breakdowns).
 router.get('/:league/explain', async (req, res) => {
     try {
         const teamId = Number(req.query.teamId);
@@ -107,7 +108,19 @@ router.get('/:league/explain', async (req, res) => {
         }
         const game = await Game.findOne({ id: gameId }).lean();
         if (!game) return res.status(404).json({ message: 'Game not found' });
-        const cfg = await getScoringConfig(req.params.league);
+
+        const season = req.query.season;
+        let cfg;
+        if (season && String(season) !== String(process.env.YEAR)) {
+            const doc = await ScoringConfig.findOne({ league: req.params.league }).lean();
+            const frozen = doc && doc.configBySeason && doc.configBySeason[String(season)];
+            cfg = frozen
+                ? resolveConfig(req.params.league, frozen)
+                : await getScoringConfig(req.params.league);
+        } else {
+            cfg = await getScoringConfig(req.params.league);
+        }
+
         const rankings = await getRankingsForGame(game, game.week, game.season);
         const bracket = await getBracketForGame(game, game.season);
         res.json(explainGame(cfg.model, teamId, game, rankings, cfg, bracket));

--- a/routes/scoringConfig.js
+++ b/routes/scoringConfig.js
@@ -48,6 +48,7 @@ function configResponse(league, doc, season, overrides) {
     cfg.engagement = engagementForSeason(bySeason, season);
     cfg.engagementBySeason = bySeason;
     cfg.season = String(season);
+    cfg.frozenSeasons = Object.keys((doc && doc.configBySeason) || {});
     return cfg;
 }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -306,10 +306,11 @@ router.get('/league/:leagueCodeReq/roster', async (req, res) => {
 //Getting All By League & Current Year
 router.get('/league/:leagueCodeReq', async (req, res) => {
     var leagueCode = req.params.leagueCodeReq;
+    const year = req.query.season || process.env.YEAR;
     try {
-        console.log("finding all users in league", leagueCode);
-        const users = await User.find({"seasons.season": {"$eq": process.env.YEAR}, "league": leagueCode},
-                    {"firstName": 1, "lastName": 1, "email": 1, "league": 1, "lastUpdated": 1, "color": 1, "avatarUrl": 1, "profilePrompted": 1, "seasons": {"$elemMatch": {"season": {"$eq": process.env.YEAR}}}});
+        console.log("finding all users in league", leagueCode, "season", year);
+        const users = await User.find({"seasons.season": {"$eq": year}, "league": leagueCode},
+                    {"firstName": 1, "lastName": 1, "email": 1, "league": 1, "lastUpdated": 1, "color": 1, "avatarUrl": 1, "profilePrompted": 1, "seasons": {"$elemMatch": {"season": {"$eq": year}}}});
         res.json(users);
     } catch (err) {
         res.status(500).json({message: err.message});


### PR DESCRIPTION
## Summary
- **Season picker pills** on the My Team hero let managers browse any drafted season — roster, games, schedule, trajectory, draft grade all render for the selected year
- **Per-season scoring config snapshots** (`configBySeason` on `ScoringConfig`) freeze each season's point rules so the "Why these points?" breakdown uses the correct historical config instead of current rules
- **Auto-freeze on first scoring run** of a new season (`freezePriorSeasonConfig` in `modules/scoring.js`) — no manual step needed going forward
- **Routes accept `?season=`** (`/users/league/:league`, `/games/.../team/:id`, `/scoring-config/:league/explain`) to serve past-season data
- **Mismatch messaging** for past seasons now reads "Scored under 2025 rules" instead of the alarming "scoring rules changed" warning
- 2025 configs already snapshotted on both dev and prod via one-time migration script

## Test plan
- [ ] Load My Team for a user with multiple seasons — season pills appear and switch correctly
- [ ] Past-season view hides Captain, Recap, and Edit Profile (interactive features)
- [ ] Click "+N" on a past-season game — breakdown loads with no mismatch warning
- [ ] Verify trajectory rank and hero stats reflect the selected season's data
- [ ] Current season still works identically (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)