### PR TITLE
Add weekly betting parlays feature

### DIFF
--- a/models/bettingGroup.js
+++ b/models/bettingGroup.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+
+const bettingGroupSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        default: 'Betting Group'
+    },
+    members: [{
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User'
+    }],
+    season: {
+        type: Number,
+        required: true
+    },
+    active: {
+        type: Boolean,
+        default: true
+    },
+    createdAt: {
+        type: Date,
+        default: Date.now
+    },
+    updatedAt: {
+        type: Date,
+        default: Date.now
+    }
+});
+
+bettingGroupSchema.index({ season: 1, active: 1 });
+
+module.exports = mongoose.model('BettingGroup', bettingGroupSchema);

--- a/models/parlay.js
+++ b/models/parlay.js
@@ -1,0 +1,78 @@
+const mongoose = require('mongoose');
+
+const legSchema = new mongoose.Schema({
+    contributor: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User'
+    },
+    gameId: {
+        type: Number
+    },
+    betType: {
+        type: String,
+        enum: ['spread', 'moneyline', 'over_under', 'custom']
+    },
+    selection: {
+        type: String
+    },
+    line: {
+        type: Number
+    },
+    odds: {
+        type: Number
+    },
+    result: {
+        type: String,
+        enum: ['pending', 'win', 'loss', 'push'],
+        default: 'pending'
+    },
+    resolvedAt: {
+        type: Date
+    }
+});
+
+const parlaySchema = new mongoose.Schema({
+    group: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'BettingGroup',
+        required: true
+    },
+    season: {
+        type: Number,
+        required: true
+    },
+    seasonType: {
+        type: String,
+        required: true,
+        default: 'regular'
+    },
+    week: {
+        type: Number,
+        required: true
+    },
+    wager: {
+        type: Number
+    },
+    status: {
+        type: String,
+        enum: ['pending', 'won', 'lost', 'push'],
+        default: 'pending'
+    },
+    payout: {
+        type: Number
+    },
+    legs: [legSchema],
+    createdAt: {
+        type: Date,
+        default: Date.now
+    },
+    updatedAt: {
+        type: Date,
+        default: Date.now
+    }
+});
+
+parlaySchema.index({ group: 1, season: 1, week: 1 }, { unique: true });
+parlaySchema.index({ status: 1 });
+
+module.exports = mongoose.model('Parlay', parlaySchema);

--- a/modules/betting.js
+++ b/modules/betting.js
@@ -5,7 +5,7 @@ module.exports = {
     // logged and swallowed so it can't fail the whole scoring job.
     updateAllBettingLines: async function() {
         try {
-            const response = await internalFetch(`${process.env.URL}/betting/new/${process.env.YEAR}`, {
+            const response = await internalFetch(`${process.env.URL}/betting-lines/new/${process.env.YEAR}`, {
                 method: 'POST',
                 headers: {
                 'Accept': 'application/json',

--- a/modules/parlay-calc.js
+++ b/modules/parlay-calc.js
@@ -1,0 +1,37 @@
+function americanToDecimal(odds) {
+    if (odds >= 100) return 1 + (odds / 100);
+    if (odds <= -100) return 1 + (100 / Math.abs(odds));
+    return 1;
+}
+
+function parlayDecimalOdds(legs) {
+    return legs.reduce((acc, leg) => {
+        if (leg.result === 'push') return acc;
+        return acc * americanToDecimal(leg.odds);
+    }, 1);
+}
+
+function parlayPayout(wager, legs) {
+    if (!wager || !legs || !legs.length) return 0;
+    return Math.round(wager * parlayDecimalOdds(legs) * 100) / 100;
+}
+
+function decimalToAmerican(decimal) {
+    if (decimal >= 2) return Math.round((decimal - 1) * 100);
+    if (decimal > 1) return Math.round(-100 / (decimal - 1));
+    return 0;
+}
+
+function combinedAmericanOdds(legs) {
+    const activLegs = legs.filter(l => l.result !== 'push');
+    if (!activLegs.length) return 0;
+    return decimalToAmerican(parlayDecimalOdds(activLegs));
+}
+
+module.exports = {
+    americanToDecimal,
+    parlayDecimalOdds,
+    parlayPayout,
+    decimalToAmerican,
+    combinedAmericanOdds
+};

--- a/modules/parlay-resolve.js
+++ b/modules/parlay-resolve.js
@@ -1,0 +1,100 @@
+const Parlay = require('../models/parlay');
+const Game = require('../models/game');
+const { parlayPayout } = require('./parlay-calc');
+
+function resolveLeg(leg, game) {
+    if (leg.result !== 'pending') return leg.result;
+    if (!game || !game.completed) return 'pending';
+    if (game.homePoints == null || game.awayPoints == null) return 'pending';
+
+    const home = game.homePoints;
+    const away = game.awayPoints;
+    const total = home + away;
+    const sel = (leg.selection || '').toLowerCase();
+
+    switch (leg.betType) {
+        case 'spread': {
+            const margin = home - away;
+            const isHomePick = !sel.includes(game.awayTeam.toLowerCase());
+            const covered = isHomePick
+                ? margin + leg.line
+                : (away - home) + (-leg.line);
+            if (covered > 0) return 'win';
+            if (covered === 0) return 'push';
+            return 'loss';
+        }
+        case 'moneyline': {
+            if (home === away) return 'push';
+            const homeWon = home > away;
+            const pickedHome = !sel.includes(game.awayTeam.toLowerCase());
+            return (homeWon === pickedHome) ? 'win' : 'loss';
+        }
+        case 'over_under': {
+            const isOver = sel.includes('over');
+            if (total === leg.line) return 'push';
+            const wentOver = total > leg.line;
+            return (wentOver === isOver) ? 'win' : 'loss';
+        }
+        default:
+            return 'pending';
+    }
+}
+
+function deriveParlayStatus(legs) {
+    if (legs.some(l => l.result === 'loss')) return 'lost';
+    const nonPush = legs.filter(l => l.result !== 'push');
+    if (nonPush.some(l => l.result === 'pending')) return 'pending';
+    if (!nonPush.length) return 'push';
+    if (nonPush.every(l => l.result === 'win')) return 'won';
+    return 'pending';
+}
+
+async function resolveParlays() {
+    const pending = await Parlay.find({ status: 'pending' });
+    let resolved = 0;
+
+    for (const parlay of pending) {
+        if (!parlay.legs || !parlay.legs.length) continue;
+
+        const pendingLegs = parlay.legs.filter(l => l.result === 'pending' && l.gameId);
+        if (!pendingLegs.length) continue;
+
+        const gameIds = pendingLegs.map(l => l.gameId);
+        const games = await Game.find({ id: { $in: gameIds } }).lean();
+        const gameMap = new Map(games.map(g => [g.id, g]));
+
+        let changed = false;
+        for (const leg of parlay.legs) {
+            if (leg.result !== 'pending' || !leg.gameId) continue;
+            const game = gameMap.get(leg.gameId);
+            const result = resolveLeg(leg, game);
+            if (result !== 'pending') {
+                leg.result = result;
+                leg.resolvedAt = new Date();
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            const newStatus = deriveParlayStatus(parlay.legs);
+            parlay.status = newStatus;
+
+            if (newStatus === 'won' && parlay.wager) {
+                parlay.payout = parlayPayout(parlay.wager, parlay.legs);
+            } else if (newStatus === 'lost') {
+                parlay.payout = 0;
+            } else if (newStatus === 'push') {
+                parlay.payout = parlay.wager || 0;
+            }
+
+            parlay.updatedAt = new Date();
+            await parlay.save();
+            resolved++;
+        }
+    }
+
+    if (resolved) console.log(`Resolved ${resolved} parlay(s)`);
+    return resolved;
+}
+
+module.exports = { resolveParlays, resolveLeg, deriveParlayStatus };

--- a/modules/require-betting-group.js
+++ b/modules/require-betting-group.js
@@ -1,0 +1,24 @@
+const BettingGroup = require('../models/bettingGroup');
+
+module.exports = async function requireBettingGroupMember(req, res, next) {
+    try {
+        const group = await BettingGroup.findOne({ active: true });
+        if (!group) return res.status(403).json({ message: 'No active betting group' });
+
+        const userId = req.effUser
+            && req.effUser.user_metadata
+            && req.effUser.user_metadata.metadata
+            && req.effUser.user_metadata.metadata.userId;
+
+        if (!userId) return res.status(403).json({ message: 'Forbidden' });
+
+        const isMember = group.members.some(m => m.toString() === userId);
+        if (!isMember) return res.status(403).json({ message: 'Forbidden' });
+
+        req.bettingGroup = group;
+        req.bettingUserId = userId;
+        next();
+    } catch (err) {
+        return res.status(500).json({ message: 'Error checking betting group membership' });
+    }
+};

--- a/modules/score-update.js
+++ b/modules/score-update.js
@@ -370,6 +370,13 @@ async function doFullUpdate({ withBetting = false } = {}) {
         if (withBetting) await bettingModule.updateAllBettingLines();
     }
 
+    try {
+        const { resolveParlays } = require('./parlay-resolve');
+        await resolveParlays();
+    } catch (err) {
+        console.log('Parlay resolution failed (non-fatal):', err.message);
+    }
+
     return { week, seasonType, teams: teamCount, gamesNew, gamesUpdated, remainingCalls };
 }
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -1482,7 +1482,7 @@ if (bettingLinesForm) {
 
         const season = document.querySelector('[betting-season]').value;
 
-        const response = await fetch(`/betting/new/${season}`, {
+        const response = await fetch(`/betting-lines/new/${season}`, {
             method: 'POST',
             headers: {
             'Accept': 'application/json',
@@ -2409,3 +2409,100 @@ document.querySelectorAll('[scoring-config-shape] input[name="rule-shape"]').for
         loadScoringConfig(r.value);
     });
 });
+
+// ── Betting Group Management ──────────────────────────────────────────────
+var bettingGroupState = { id: null, members: [], allUsers: [] };
+
+function displayBettingGroupContainer() {
+    toggleSub('betting-group-container');
+    loadBettingGroup();
+}
+
+async function loadBettingGroup() {
+    try {
+        var res = await fetch('/betting-groups');
+        var group = await res.json();
+
+        var leagueCode = window.CC_LEAGUE && CC_LEAGUE.code;
+        if (!leagueCode) leagueCode = getDraftLeagueCode();
+        var usersRes = await fetch('/users/league/' + encodeURIComponent(leagueCode) + '/all');
+        var users = await usersRes.json();
+        bettingGroupState.allUsers = users.map(function (u) { return { _id: u._id, firstName: u.firstName, league: leagueCode }; });
+
+        if (group && group._id) {
+            bettingGroupState.id = group._id;
+            bettingGroupState.members = (group.members || []).map(function (m) { return m.toString(); });
+        } else {
+            bettingGroupState.id = null;
+            bettingGroupState.members = [];
+        }
+        renderBettingGroup();
+    } catch (err) {
+        console.error('Failed to load betting group:', err);
+    }
+}
+
+function renderBettingGroup() {
+    var container = document.getElementById('betting-group-members');
+    if (!container) return;
+
+    var html = '';
+    bettingGroupState.members.forEach(function (id) {
+        var u = bettingGroupState.allUsers.find(function (u) { return u._id === id; });
+        var name = u ? u.firstName : id;
+        html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 10px;background:var(--cc-surface-2,#171B31);border-radius:6px;margin-bottom:6px;">'
+            + '<span style="font-weight:500;font-size:14px;">' + name + '</span>'
+            + '<span onclick="removeBettingGroupMember(\'' + id + '\')" style="font-size:12px;color:var(--cc-muted-2,#8A90A8);cursor:pointer;padding:2px 6px;">✕</span>'
+            + '</div>';
+    });
+    container.innerHTML = html || '<p style="color:var(--cc-muted,#A4A9C2);font-size:13px;">No members yet.</p>';
+
+    var select = document.getElementById('betting-group-add-user');
+    if (!select) return;
+    select.innerHTML = '<option value="">Add a member...</option>';
+    bettingGroupState.allUsers.forEach(function (u) {
+        if (bettingGroupState.members.indexOf(u._id) === -1) {
+            select.innerHTML += '<option value="' + u._id + '">' + u.firstName + '</option>';
+        }
+    });
+}
+
+function addBettingGroupMember() {
+    var select = document.getElementById('betting-group-add-user');
+    if (!select || !select.value) return;
+    bettingGroupState.members.push(select.value);
+    renderBettingGroup();
+}
+
+function removeBettingGroupMember(id) {
+    bettingGroupState.members = bettingGroupState.members.filter(function (m) { return m !== id; });
+    renderBettingGroup();
+}
+
+async function saveBettingGroup() {
+    try {
+        var url, method;
+        if (bettingGroupState.id) {
+            url = '/betting-groups/' + bettingGroupState.id;
+            method = 'PATCH';
+        } else {
+            url = '/betting-groups';
+            method = 'POST';
+        }
+        var res = await fetch(url, {
+            method: method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ members: bettingGroupState.members })
+        });
+        var data = await res.json();
+        if (res.ok) {
+            bettingGroupState.id = data._id;
+            if (window.ccToast) ccToast.success('Betting group saved');
+        } else {
+            if (window.ccToast) ccToast.error(data.message || 'Failed to save');
+        }
+    } catch (err) {
+        console.error('Failed to save betting group:', err);
+        if (window.ccToast) ccToast.error('Failed to save betting group');
+    }
+}

--- a/public/betting.css
+++ b/public/betting.css
@@ -1,0 +1,592 @@
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 24px 12px;
+    gap: 4px;
+}
+.header-title {
+    font-size: 22px;
+    font-weight: 600;
+    text-align: center;
+}
+.header-league {
+    display: block;
+    font-size: 11px;
+    color: var(--cc-muted);
+    font-weight: 400;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.week-nav {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 6px;
+}
+.week-nav-btn {
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border);
+    color: var(--cc-muted);
+    border-radius: var(--cc-r-sm);
+    width: 30px;
+    height: 30px;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+.week-nav-btn:hover {
+    background: var(--cc-surface-3);
+    color: var(--cc-text);
+}
+.week-label {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--cc-muted-bright);
+    min-width: 60px;
+    text-align: center;
+}
+
+/* Parlay Card */
+.parlay-card {
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-md);
+    padding: 16px;
+    margin: 0 24px 16px;
+}
+.parlay-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--cc-border);
+}
+.parlay-week {
+    font-size: 14px;
+    font-weight: 500;
+}
+.parlay-status {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: var(--cc-r-pill);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.status-won { background: rgba(34,195,122,0.15); color: var(--cc-success); }
+.status-pending { background: rgba(108,155,255,0.15); color: var(--cc-info); }
+.status-lost { background: rgba(181,66,63,0.15); color: var(--cc-danger-text); }
+.status-push { background: rgba(224,179,65,0.15); color: var(--cc-amber); }
+
+/* Legs */
+.legs {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.leg {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    background: var(--cc-surface-2);
+    border-radius: var(--cc-r-sm);
+    font-size: 13px;
+}
+.leg-contributor {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+.leg-avatar {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 600;
+    flex-shrink: 0;
+    color: #fff;
+}
+.leg-avatar-img {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+.leg-name {
+    color: var(--cc-muted-bright);
+    font-weight: 500;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.leg-detail { flex: 1; min-width: 0; }
+.leg-pick { font-weight: 500; }
+.leg-game { color: var(--cc-muted-2); font-size: 11px; }
+.leg-odds { color: var(--cc-muted); font-size: 12px; font-family: monospace; white-space: nowrap; }
+.leg-result {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+.result-win { background: rgba(34,195,122,0.2); color: var(--cc-success); }
+.result-loss { background: rgba(181,66,63,0.2); color: var(--cc-danger-text); }
+.result-push { background: rgba(224,179,65,0.2); color: var(--cc-amber); }
+.result-pending { background: rgba(108,155,255,0.15); color: var(--cc-info); }
+.leg-actions { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+
+/* Empty leg (awaiting pick) */
+.leg-empty {
+    border: 1px dashed var(--cc-border);
+    background: transparent;
+}
+.leg-empty .leg-pick { color: var(--cc-muted-2); font-weight: 400; font-style: italic; }
+
+/* ── Pick-your-game CTA (replaces old dropdown form) ── */
+.leg-pick-cta {
+    border: 1px solid var(--cc-interactive);
+    background: var(--cc-surface-2);
+    border-radius: var(--cc-r-sm);
+    padding: 14px 12px;
+}
+.leg-pick-cta-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+.leg-pick-cta-title { font-size: 14px; font-weight: 500; }
+.leg-pick-cta-sub { font-size: 11px; color: var(--cc-muted-2); }
+
+.btn-pick-game {
+    width: 100%;
+    padding: 10px 14px;
+    background: var(--cc-surface-3);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-muted);
+    font-size: 13px;
+    font-family: 'Poppins', sans-serif;
+    text-align: left;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.btn-pick-game:hover { border-color: var(--cc-interactive); color: var(--cc-text); }
+.btn-pick-game i { font-size: 11px; }
+
+/* ── Game Picker Panel ── */
+.game-picker-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 900;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    overflow: hidden;
+}
+.game-picker {
+    background: var(--cc-bg);
+    border-radius: var(--cc-r-lg) var(--cc-r-lg) 0 0;
+    width: 100%;
+    max-width: 500px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+.game-picker-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px 10px;
+    border-bottom: 1px solid var(--cc-border);
+}
+.game-picker-head input {
+    flex: 1;
+    padding: 8px 12px;
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-text);
+    font-size: 14px;
+    font-family: 'Poppins', sans-serif;
+}
+.game-picker-head input:focus { border-color: var(--cc-interactive); outline: none; }
+.game-picker-close {
+    background: none;
+    border: none;
+    color: var(--cc-muted);
+    font-size: 18px;
+    cursor: pointer;
+    padding: 4px 8px;
+}
+.game-picker-list {
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 8px 0;
+    flex: 1;
+    min-height: 200px;
+}
+.game-picker-item {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    padding: 10px 12px;
+    cursor: pointer;
+    font-size: 13px;
+    border-bottom: 1px solid var(--cc-surface-2);
+    gap: 6px;
+}
+.game-picker-item:hover { background: var(--cc-surface); }
+.game-picker-teams {
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    min-width: 0;
+    overflow: hidden;
+}
+.game-picker-teams > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    flex-shrink: 1;
+}
+.game-picker-logo {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+    flex-shrink: 0;
+}
+.game-picker-rank {
+    font-size: 10px;
+    color: var(--cc-amber, #E0B341);
+    font-weight: 600;
+    flex-shrink: 0;
+}
+.game-picker-at {
+    color: var(--cc-muted-2);
+    font-size: 11px;
+    flex-shrink: 0;
+}
+.game-picker-time { font-size: 11px; color: var(--cc-muted-2); white-space: nowrap; text-align: right; }
+.game-picker-empty {
+    text-align: center;
+    padding: 24px;
+    color: var(--cc-muted);
+    font-size: 13px;
+}
+
+/* ── Bet Type Cards (DraftKings-style) ── */
+.bet-board {
+    margin-top: 10px;
+}
+.bet-board-game {
+    font-size: 12px;
+    color: var(--cc-muted);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+.bet-board-game button {
+    background: none;
+    border: none;
+    color: var(--cc-muted-2);
+    font-size: 11px;
+    cursor: pointer;
+    text-decoration: underline;
+}
+.bet-row {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+.bet-row-label {
+    min-width: 40px;
+    font-size: 10px;
+    color: var(--cc-muted-2);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+}
+.bet-btn {
+    flex: 1;
+    padding: 10px 8px;
+    background: var(--cc-surface-3);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-text);
+    font-size: 12px;
+    font-family: 'Poppins', sans-serif;
+    cursor: pointer;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    transition: border-color 0.15s, background 0.15s;
+}
+.bet-btn:hover { border-color: var(--cc-interactive); }
+.bet-btn.selected {
+    border-color: var(--cc-interactive);
+    background: rgba(108,155,255,0.12);
+}
+.bet-btn-label { font-weight: 500; font-size: 12px; }
+.bet-btn-odds { font-size: 11px; color: var(--cc-muted); font-family: monospace; }
+.bet-btn.selected .bet-btn-odds { color: var(--cc-info); }
+.bet-btn-na {
+    flex: 1;
+    padding: 10px 8px;
+    background: var(--cc-surface-2);
+    border: 1px solid transparent;
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-muted-2);
+    font-size: 11px;
+    text-align: center;
+}
+
+/* Custom bet row */
+.bet-custom-input {
+    flex: 1;
+    padding: 8px 10px;
+    background: var(--cc-bg);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-text);
+    font-size: 12px;
+    font-family: 'Poppins', sans-serif;
+    min-width: 0;
+}
+.bet-custom-input:focus { border-color: var(--cc-interactive); outline: none; }
+.bet-btn-custom { flex: 0 0 auto; min-width: 48px; }
+
+/* Custom odds override */
+.bet-custom-odds {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 8px;
+    font-size: 11px;
+    color: var(--cc-muted-2);
+}
+.bet-custom-odds input {
+    width: 70px;
+    padding: 5px 8px;
+    background: var(--cc-bg);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-text);
+    font-size: 12px;
+    font-family: monospace;
+    text-align: center;
+}
+.bet-custom-odds input:focus { border-color: var(--cc-interactive); outline: none; }
+
+.bet-confirm {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+    gap: 8px;
+}
+.btn-submit-leg {
+    background: var(--cc-interactive);
+    border: none;
+    border-radius: var(--cc-r-sm);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 8px 20px;
+    font-family: 'Poppins', sans-serif;
+    cursor: pointer;
+}
+.btn-submit-leg:disabled { opacity: 0.4; cursor: default; }
+.dk-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 10px;
+    color: var(--cc-info);
+}
+
+/* Payout bar */
+.payout-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--cc-border);
+}
+.payout-item { text-align: center; flex: 1; }
+.payout-label {
+    font-size: 10px;
+    color: var(--cc-muted-2);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.payout-value {
+    font-size: 16px;
+    font-weight: 600;
+    margin-top: 2px;
+}
+.payout-won { color: var(--cc-success); }
+.payout-lost { color: var(--cc-danger-text); }
+
+/* Create parlay CTA */
+.create-parlay-cta {
+    text-align: center;
+    padding: 32px 24px;
+    margin: 0 24px;
+    background: var(--cc-surface);
+    border: 1px dashed var(--cc-border);
+    border-radius: var(--cc-r-md);
+}
+.create-parlay-cta p {
+    color: var(--cc-muted);
+    font-size: 13px;
+    margin-bottom: 10px;
+}
+.btn-create-parlay {
+    background: var(--cc-interactive);
+    border: none;
+    border-radius: var(--cc-r-sm);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 8px 20px;
+    font-family: 'Poppins', sans-serif;
+    cursor: pointer;
+}
+
+/* Wager section (admin-editable) */
+.wager-section {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 12px 24px 0;
+}
+.wager-section label {
+    font-size: 11px;
+    color: var(--cc-muted-2);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.wager-input {
+    width: 80px;
+    padding: 6px 8px;
+    background: var(--cc-bg);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-text);
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    font-family: 'Poppins', sans-serif;
+}
+
+/* Season summary */
+.section-divider {
+    height: 1px;
+    background: var(--cc-border);
+    margin: 20px 24px;
+}
+.summary-title {
+    font-size: 14px;
+    font-weight: 500;
+    padding: 0 24px;
+    margin-bottom: 10px;
+    text-align: center;
+}
+.season-summary {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    padding: 0 24px;
+    margin-bottom: 16px;
+}
+.stat-card {
+    background: var(--cc-surface);
+    border-radius: var(--cc-r-sm);
+    padding: 10px 12px;
+    text-align: center;
+}
+.stat-label {
+    font-size: 10px;
+    color: var(--cc-muted-2);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.stat-value {
+    font-size: 18px;
+    font-weight: 600;
+    margin-top: 2px;
+}
+.stat-positive { color: var(--cc-success); }
+.stat-negative { color: var(--cc-danger-text); }
+
+/* History table */
+.history-section {
+    padding: 0 24px;
+    overflow-x: auto;
+}
+.history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.history-table th {
+    text-align: left;
+    padding: 8px 10px;
+    color: var(--cc-muted-2);
+    font-weight: 500;
+    border-bottom: 1px solid var(--cc-border);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.history-table td {
+    padding: 10px;
+    color: var(--cc-muted-bright);
+    border-bottom: 1px solid var(--cc-surface-2);
+    white-space: nowrap;
+}
+.history-table tr:nth-child(even) td { background: var(--cc-surface-2); }
+.text-right { text-align: right; }
+
+@media (max-width: 600px) {
+    .header { padding: 16px 16px 10px; }
+    .parlay-card { margin: 0 16px 12px; }
+    .leg { flex-wrap: wrap; gap: 6px; padding: 8px 10px; }
+    .leg-contributor { min-width: 80px; }
+    .season-summary { grid-template-columns: repeat(2, 1fr); padding: 0 16px; }
+    .history-section { padding: 0 16px; }
+    .section-divider { margin: 16px; }
+    .summary-title { padding: 0 16px; }
+    .create-parlay-cta { margin: 0 16px; }
+    .wager-section { margin: 12px 16px 0; }
+    .bet-row-label { min-width: 32px; font-size: 9px; }
+    .game-picker { max-height: 90vh; border-radius: var(--cc-r-md) var(--cc-r-md) 0 0; }
+}

--- a/public/betting.js
+++ b/public/betting.js
@@ -1,0 +1,572 @@
+var currentWeek = 1;
+var currentSeason = window.APP_YEAR;
+var parlays = [];
+var games = [];
+var memberNames = {};
+var memberAvatars = {};
+var memberFranchises = {};
+var myUserId = '';
+
+var MEMBER_COLORS = ['#ed5858', '#6C9BFF', '#22C37A', '#E0B341', '#8E8CF0', '#D27171'];
+
+function getMyUserId() {
+    if (!window.userState) return '';
+    var meta = userState.user_metadata && userState.user_metadata.metadata;
+    return (meta && meta.userId) || '';
+}
+
+function initials(name) {
+    if (!name) return '?';
+    var parts = name.trim().split(/\s+/);
+    return parts.map(function (p) { return p[0]; }).join('').toUpperCase().slice(0, 2);
+}
+
+function avatarHtml(contributorId, color, init) {
+    var url = memberAvatars[contributorId];
+    if (url) return '<img class="leg-avatar-img" src="' + url + '" alt="">';
+    return '<div class="leg-avatar" style="background:' + color + ';">' + init + '</div>';
+}
+
+function displayName(contributorId) {
+    var name = memberNames[contributorId] || 'Member';
+    return '<span class="leg-name">' + name + '</span>';
+}
+
+function americanToDecimal(odds) {
+    if (odds >= 100) return 1 + (odds / 100);
+    if (odds <= -100) return 1 + (100 / Math.abs(odds));
+    return 1;
+}
+
+function formatOdds(odds) {
+    if (odds == null) return '';
+    return odds >= 0 ? '+' + odds : String(odds);
+}
+
+function combinedOdds(legs) {
+    var active = legs.filter(function (l) { return l.odds && l.result !== 'push'; });
+    if (!active.length) return '—';
+    var dec = active.reduce(function (acc, l) { return acc * americanToDecimal(l.odds); }, 1);
+    if (dec >= 2) return '+' + Math.round((dec - 1) * 100);
+    if (dec > 1) return String(Math.round(-100 / (dec - 1)));
+    return '+100';
+}
+
+function calcPayout(wager, legs) {
+    if (!wager) return 0;
+    var active = legs.filter(function (l) { return l.odds && l.result !== 'push'; });
+    var dec = active.reduce(function (acc, l) { return acc * americanToDecimal(l.odds); }, 1);
+    return Math.round(wager * dec * 100) / 100;
+}
+
+function formatGameTime(dateStr) {
+    if (!dateStr) return '';
+    var d = new Date(dateStr);
+    var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    var h = d.getHours();
+    var m = d.getMinutes();
+    var p = h >= 12 ? 'p' : 'a';
+    h = h % 12 || 12;
+    return days[d.getDay()] + ' ' + h + (m ? ':' + String(m).padStart(2, '0') : '') + p;
+}
+
+async function loadMemberNames() {
+    try {
+        var r = await fetch('/betting-groups');
+        if (!r.ok) return;
+        var group = await r.json();
+        if (group && group.memberDetails) {
+            group.memberDetails.forEach(function (u) {
+                memberNames[u._id] = u.firstName || 'Unknown';
+                if (u.avatarUrl) memberAvatars[u._id] = u.avatarUrl;
+                if (u.franchiseName) memberFranchises[u._id] = u.franchiseName;
+            });
+        }
+    } catch (e) { /* skip */ }
+}
+
+async function loadParlays() {
+    try {
+        var res = await fetch('/betting/list?season=' + currentSeason);
+        if (!res.ok) return;
+        parlays = await res.json();
+    } catch (e) {
+        parlays = [];
+    }
+}
+
+async function loadGames() {
+    try {
+        var res = await fetch('/betting/games/' + currentSeason + '/' + currentWeek);
+        if (!res.ok) return;
+        games = await res.json();
+    } catch (e) {
+        games = [];
+    }
+}
+
+async function loadSeasonSummary() {
+    var el = document.getElementById('season-summary');
+    var yearEl = document.getElementById('summary-year');
+    if (yearEl) yearEl.textContent = currentSeason;
+    if (!el) return;
+
+    try {
+        var res = await fetch('/betting/season-summary/' + currentSeason);
+        if (!res.ok) return;
+        var data = await res.json();
+        var r = data.record;
+        var netClass = data.net >= 0 ? 'stat-positive' : 'stat-negative';
+        var netSign = data.net >= 0 ? '+' : '';
+        el.innerHTML =
+            '<div class="stat-card"><div class="stat-label">Record</div><div class="stat-value">'
+            + r.wins + '-' + r.losses + (r.pushes ? '-' + r.pushes : '') + '</div></div>'
+            + '<div class="stat-card"><div class="stat-label">Wagered</div><div class="stat-value">$' + data.totalWagered + '</div></div>'
+            + '<div class="stat-card"><div class="stat-label">Won</div><div class="stat-value">$' + data.totalReturned + '</div></div>'
+            + '<div class="stat-card"><div class="stat-label">Net</div><div class="stat-value ' + netClass + '">' + netSign + '$' + Math.abs(data.net) + '</div></div>';
+    } catch (e) { /* skip */ }
+}
+
+function renderHistory() {
+    var body = document.getElementById('history-body');
+    if (!body) return;
+    if (!parlays.length) { body.innerHTML = '<tr><td colspan="5" style="text-align:center;color:var(--cc-muted);padding:20px;">No parlays yet this season.</td></tr>'; return; }
+
+    var sorted = parlays.slice().sort(function (a, b) { return a.week - b.week; });
+    body.innerHTML = sorted.map(function (p) {
+        var filled = p.legs.filter(function (l) { return l.gameId; }).length;
+        var total = p.legs.length;
+        var statusColor = p.status === 'won' ? 'var(--cc-success)' : (p.status === 'lost' ? 'var(--cc-danger-text)' : 'var(--cc-info)');
+        var statusLabel = p.status === 'won' ? 'Won' : (p.status === 'lost' ? 'Lost' : (p.status === 'push' ? 'Push' : 'Pend'));
+        var payoutColor = p.status === 'won' ? 'var(--cc-success)' : (p.status === 'lost' ? 'var(--cc-danger-text)' : 'var(--cc-muted)');
+        var payoutText = p.payout != null ? '$' + p.payout : '—';
+
+        return '<tr>'
+            + '<td>Wk ' + p.week + '</td>'
+            + '<td style="color:var(--cc-muted-2);">' + filled + '/' + total + '</td>'
+            + '<td>$' + (p.wager || 0) + '</td>'
+            + '<td><span style="font-weight:600;color:' + statusColor + ';">' + statusLabel + '</span></td>'
+            + '<td class="text-right" style="color:' + payoutColor + ';">' + payoutText + '</td>'
+            + '</tr>';
+    }).join('');
+}
+
+function renderCurrentParlay() {
+    var container = document.getElementById('betting-content');
+    if (!container) return;
+
+    var parlay = parlays.find(function (p) { return p.week === currentWeek; });
+
+    if (!parlay) {
+        container.innerHTML =
+            '<div class="create-parlay-cta">'
+            + '<p>No parlay for Week ' + currentWeek + ' yet.</p>'
+            + '<button class="btn-create-parlay" onclick="createParlay()">Create Week ' + currentWeek + ' Parlay</button>'
+            + '</div>';
+        return;
+    }
+
+    var statusClass = 'status-' + parlay.status;
+    var statusLabel = parlay.status === 'won' ? 'Won' : (parlay.status === 'lost' ? 'Lost' : (parlay.status === 'push' ? 'Push' : 'Pending'));
+
+    var legsHtml = parlay.legs.map(function (leg, i) {
+        var name = memberNames[leg.contributor] || 'Member';
+        var color = MEMBER_COLORS[i % MEMBER_COLORS.length];
+        var init = initials(name);
+
+        if (!leg.gameId) {
+            var isMine = leg.contributor === myUserId;
+            if (isMine) {
+                return renderLegPickCTA(leg, parlay._id, i, name, color, init);
+            }
+            if (window.IS_ADMIN) {
+                return renderLegPickCTA(leg, parlay._id, i, name, color, init);
+            }
+            return '<div class="leg leg-empty">'
+                + '<div class="leg-contributor">' + avatarHtml(leg.contributor, color, init) + displayName(leg.contributor) + '</div>'
+                + '<div class="leg-detail"><div class="leg-pick">Awaiting pick...</div></div>'
+                + '</div>';
+        }
+
+        var game = games.find(function (g) { return g.id === leg.gameId; });
+        var matchup = game ? (game.awayTeam + ' @ ' + game.homeTeam) : 'Game #' + leg.gameId;
+
+        var resultHtml = '';
+        if (leg.result === 'win') resultHtml = '<div class="leg-result result-win"><i class="fa-solid fa-check"></i></div>';
+        else if (leg.result === 'loss') resultHtml = '<div class="leg-result result-loss"><i class="fa-solid fa-xmark"></i></div>';
+        else if (leg.result === 'push') resultHtml = '<div class="leg-result result-push"><i class="fa-solid fa-minus"></i></div>';
+        else resultHtml = '<div class="leg-result result-pending"><i class="fa-solid fa-clock"></i></div>';
+
+        var editBtn = '';
+        if (parlay.status === 'pending' && (leg.contributor === myUserId || window.IS_ADMIN)) {
+            editBtn = '<button type="button" onclick="editLeg(\'' + parlay._id + '\',\'' + leg.contributor + '\')" style="background:none;border:none;color:var(--cc-interactive);font-size:12px;cursor:pointer;padding:2px 4px;" title="Edit"><i class="fa-solid fa-pen-to-square"></i></button>';
+        }
+
+        return '<div class="leg">'
+            + '<div class="leg-contributor">' + avatarHtml(leg.contributor, color, init) + displayName(leg.contributor) + '</div>'
+            + '<div class="leg-detail"><div class="leg-pick">' + (leg.selection || '—') + '</div><div class="leg-game">' + matchup + '</div></div>'
+            + '<div class="leg-odds">' + formatOdds(leg.odds) + '</div>'
+            + '<div class="leg-actions">' + resultHtml + editBtn + '</div>'
+            + '</div>';
+    }).join('');
+
+    var filledLegs = parlay.legs.filter(function (l) { return l.odds; });
+    var combined = filledLegs.length ? combinedOdds(filledLegs) : '—';
+    var potential = parlay.wager && filledLegs.length ? '$' + calcPayout(parlay.wager, filledLegs) : '—';
+    var payoutDisplay = parlay.payout != null ? '$' + parlay.payout : potential;
+    var payoutClass = parlay.status === 'won' ? 'payout-won' : (parlay.status === 'lost' ? 'payout-lost' : '');
+
+    var wagerHtml = '';
+    if (window.IS_ADMIN && parlay.status === 'pending') {
+        wagerHtml = '<div class="wager-section">'
+            + '<label>Wager $</label>'
+            + '<input type="number" class="wager-input" value="' + (parlay.wager || '') + '" onchange="updateWager(\'' + parlay._id + '\', this.value)">'
+            + '</div>';
+    }
+
+    container.innerHTML =
+        '<div class="parlay-card">'
+        + '<div class="parlay-header"><div class="parlay-week">Week ' + currentWeek + ' Parlay</div>'
+        + '<span class="parlay-status ' + statusClass + '">' + statusLabel + '</span></div>'
+        + '<div class="legs">' + legsHtml + '</div>'
+        + '<div class="payout-bar">'
+        + '<div class="payout-item"><div class="payout-label">Wager</div><div class="payout-value">$' + (parlay.wager || 0) + '</div></div>'
+        + '<div class="payout-item"><div class="payout-label">Combined Odds</div><div class="payout-value" style="font-size:13px;color:var(--cc-muted);">' + combined + '</div></div>'
+        + '<div class="payout-item"><div class="payout-label">Payout</div><div class="payout-value ' + payoutClass + '">' + payoutDisplay + '</div></div>'
+        + '</div>'
+        + '</div>'
+        + wagerHtml;
+}
+
+/* ── New leg entry: CTA button → game picker → bet board ── */
+
+function renderLegPickCTA(leg, parlayId, index, name, color, init) {
+    return '<div class="leg-pick-cta" id="leg-cta-' + index + '">'
+        + '<div class="leg-pick-cta-header">'
+        + avatarHtml(leg.contributor, color, init)
+        + '<div><div class="leg-pick-cta-title">' + name + '</div><div class="leg-pick-cta-sub">Pick a game and bet</div></div>'
+        + '</div>'
+        + '<button type="button" class="btn-pick-game" onclick="openGamePicker(\'' + parlayId + '\',\'' + leg.contributor + '\',' + index + ')">'
+        + '<span>Choose a game...</span><i class="fa-solid fa-chevron-right"></i>'
+        + '</button>'
+        + '<div id="bet-board-' + index + '"></div>'
+        + '</div>';
+}
+
+var activePick = null; // { parlayId, contributor, index, gameId, game }
+
+function openGamePicker(parlayId, contributor, index) {
+    activePick = { parlayId: parlayId, contributor: contributor, index: index };
+
+    var sortedGames = games.slice().sort(function (a, b) {
+        return (a.startDate || '').localeCompare(b.startDate || '');
+    });
+
+    var html = '<div class="game-picker-backdrop" id="game-picker-backdrop" onclick="closeGamePicker(event)">'
+        + '<div class="game-picker" onclick="event.stopPropagation()">'
+        + '<div class="game-picker-head">'
+        + '<input type="text" id="game-search" placeholder="Search teams..." oninput="filterGames(this.value)" autocomplete="off">'
+        + '<button type="button" class="game-picker-close" onclick="closeGamePicker()">✕</button>'
+        + '</div>'
+        + '<div class="game-picker-list" id="game-picker-list">'
+        + renderGameList(sortedGames)
+        + '</div>'
+        + '</div></div>';
+
+    document.body.insertAdjacentHTML('beforeend', html);
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
+    var searchInput = document.getElementById('game-search');
+    if (searchInput) searchInput.focus();
+}
+
+function teamLogo(logos) {
+    var src = typeof ccLogo === 'function' ? ccLogo(logos) : (logos && logos[0] || '');
+    if (!src) return '';
+    return '<img class="game-picker-logo" src="' + src + '" alt="" loading="lazy">';
+}
+
+function rankLabel(rank) {
+    return rank ? '<span class="game-picker-rank">#' + rank + '</span>' : '';
+}
+
+function renderGameList(gamesToShow) {
+    if (!gamesToShow.length) return '<div class="game-picker-empty">No games found.</div>';
+    return gamesToShow.map(function (g) {
+        return '<div class="game-picker-item" onclick="selectGame(' + g.id + ')">'
+            + '<div class="game-picker-teams">'
+            + teamLogo(g.awayLogos) + rankLabel(g.awayRank) + '<span>' + g.awayTeam + '</span>'
+            + '<span class="game-picker-at">@</span>'
+            + teamLogo(g.homeLogos) + rankLabel(g.homeRank) + '<span>' + g.homeTeam + '</span>'
+            + '</div>'
+            + '<span class="game-picker-time">' + formatGameTime(g.startDate) + '</span>'
+            + '</div>';
+    }).join('');
+}
+
+function filterGames(query) {
+    var list = document.getElementById('game-picker-list');
+    if (!list) return;
+    var q = query.toLowerCase();
+    var filtered = games.filter(function (g) {
+        return g.homeTeam.toLowerCase().includes(q) || g.awayTeam.toLowerCase().includes(q);
+    }).sort(function (a, b) {
+        return (a.startDate || '').localeCompare(b.startDate || '');
+    });
+    list.innerHTML = renderGameList(filtered);
+}
+
+function closeGamePicker(e) {
+    if (e && e.target !== document.getElementById('game-picker-backdrop')) return;
+    var backdrop = document.getElementById('game-picker-backdrop');
+    if (backdrop) backdrop.remove();
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
+}
+
+function selectGame(gameId) {
+    var backdrop = document.getElementById('game-picker-backdrop');
+    if (backdrop) backdrop.remove();
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
+    if (!activePick) return;
+
+    var game = games.find(function (g) { return g.id === gameId; });
+    if (!game) return;
+
+    activePick.gameId = gameId;
+    activePick.game = game;
+
+    var btn = document.querySelector('#leg-cta-' + activePick.index + ' .btn-pick-game');
+    if (btn) btn.innerHTML = '<span>' + game.awayTeam + ' @ ' + game.homeTeam + '</span><i class="fa-solid fa-chevron-down"></i>';
+
+    renderBetBoard(activePick.index, game);
+}
+
+function renderBetBoard(index, game) {
+    var board = document.getElementById('bet-board-' + index);
+    if (!board) return;
+
+    var dk = game.dk;
+    var html = '<div class="bet-board">';
+
+    html += '<div class="bet-board-game">'
+        + '<span>' + game.awayTeam + ' @ ' + game.homeTeam + '</span>'
+        + (dk ? ' <span class="dk-badge"><i class="fa-solid fa-bolt"></i> DraftKings</span>' : '')
+        + '<button type="button" onclick="openGamePicker(\'' + activePick.parlayId + '\',\'' + activePick.contributor + '\',' + index + ')">change</button>'
+        + '</div>';
+
+    // Spread row
+    html += '<div class="bet-row"><div class="bet-row-label">Spread</div>';
+    if (dk && dk.spread != null) {
+        var homeSpread = dk.spread;
+        var awaySpread = -homeSpread;
+        var homeFmt = (homeSpread >= 0 ? '+' : '') + homeSpread;
+        var awayFmt = (awaySpread >= 0 ? '+' : '') + awaySpread;
+        html += betButton(index, 'spread', game.homeTeam + ' ' + homeFmt, homeSpread, -110, game.homeTeam + ' ' + homeFmt);
+        html += betButton(index, 'spread', game.awayTeam + ' ' + awayFmt, awaySpread, -110, game.awayTeam + ' ' + awayFmt);
+    } else {
+        html += '<div class="bet-btn-na">N/A</div><div class="bet-btn-na">N/A</div>';
+    }
+    html += '</div>';
+
+    // Moneyline row
+    html += '<div class="bet-row"><div class="bet-row-label">ML</div>';
+    if (dk && (dk.homeMoneyline != null || dk.awayMoneyline != null)) {
+        html += betButton(index, 'moneyline', game.homeTeam + ' ML', null, dk.homeMoneyline, game.homeTeam + ' ML');
+        html += betButton(index, 'moneyline', game.awayTeam + ' ML', null, dk.awayMoneyline, game.awayTeam + ' ML');
+    } else {
+        html += '<div class="bet-btn-na">N/A</div><div class="bet-btn-na">N/A</div>';
+    }
+    html += '</div>';
+
+    // Over/Under row
+    html += '<div class="bet-row"><div class="bet-row-label">O/U</div>';
+    if (dk && dk.overUnder != null) {
+        var ou = dk.overUnder;
+        html += betButton(index, 'over_under', 'Over ' + ou, ou, -110, 'Over ' + ou);
+        html += betButton(index, 'over_under', 'Under ' + ou, ou, -110, 'Under ' + ou);
+    } else {
+        html += '<div class="bet-btn-na">N/A</div><div class="bet-btn-na">N/A</div>';
+    }
+    html += '</div>';
+
+    // Custom bet row
+    html += '<div class="bet-row bet-row-custom"><div class="bet-row-label">Custom</div>'
+        + '<input type="text" class="bet-custom-input" id="custom-desc-' + index + '" placeholder="e.g. Saquon Over 2.5 TDs">'
+        + '<button type="button" class="bet-btn bet-btn-custom" onclick="pickCustomBet(' + index + ', this)"><span class="bet-btn-label">Use</span></button>'
+        + '</div>';
+
+    // Custom odds + submit
+    html += '<div class="bet-custom-odds">Odds: <input type="number" id="custom-odds-' + index + '" value="" placeholder="auto"></div>';
+    html += '<div class="bet-confirm"><button class="btn-submit-leg" id="btn-submit-' + index + '" onclick="submitLegNew(' + index + ')" disabled>Submit Leg</button></div>';
+
+    html += '</div>';
+    board.innerHTML = html;
+}
+
+var selectedBet = null; // { index, betType, selection, line, odds }
+
+function betButton(index, betType, label, line, odds, selection) {
+    var safeSelection = selection.replace(/'/g, "\\'");
+    return '<button type="button" class="bet-btn" '
+        + 'onclick="pickBet(' + index + ',\'' + betType + '\',\'' + safeSelection + '\',' + (line != null ? line : 'null') + ',' + (odds != null ? odds : 'null') + ', this)">'
+        + '<span class="bet-btn-label">' + label + '</span>'
+        + '<span class="bet-btn-odds">' + formatOdds(odds) + '</span>'
+        + '</button>';
+}
+
+function pickBet(index, betType, selection, line, odds, btn) {
+    selectedBet = { index: index, betType: betType, selection: selection, line: line, odds: odds };
+
+    // Toggle selected state
+    var board = document.getElementById('bet-board-' + index);
+    if (board) {
+        board.querySelectorAll('.bet-btn').forEach(function (b) { b.classList.remove('selected'); });
+    }
+    btn.classList.add('selected');
+
+    // Clear custom description when picking a standard bet
+    var customDesc = document.getElementById('custom-desc-' + index);
+    if (customDesc) customDesc.value = '';
+
+    // Fill custom odds field and enable submit
+    var oddsInput = document.getElementById('custom-odds-' + index);
+    if (oddsInput) oddsInput.value = odds || '';
+
+    var submitBtn = document.getElementById('btn-submit-' + index);
+    if (submitBtn) submitBtn.disabled = false;
+}
+
+function pickCustomBet(index, btn) {
+    var descInput = document.getElementById('custom-desc-' + index);
+    var desc = descInput ? descInput.value.trim() : '';
+    if (!desc) { descInput.focus(); return; }
+
+    selectedBet = { index: index, betType: 'custom', selection: desc, line: null, odds: null };
+
+    var board = document.getElementById('bet-board-' + index);
+    if (board) {
+        board.querySelectorAll('.bet-btn').forEach(function (b) { b.classList.remove('selected'); });
+    }
+    btn.classList.add('selected');
+
+    var oddsInput = document.getElementById('custom-odds-' + index);
+    if (oddsInput) { oddsInput.value = ''; oddsInput.focus(); }
+
+    var submitBtn = document.getElementById('btn-submit-' + index);
+    if (submitBtn) submitBtn.disabled = false;
+}
+
+async function submitLegNew(index) {
+    if (!activePick || !selectedBet) return;
+
+    var oddsInput = document.getElementById('custom-odds-' + index);
+    var finalOdds = oddsInput && oddsInput.value ? Number(oddsInput.value) : selectedBet.odds;
+
+    if (!finalOdds) { alert('Enter the odds'); return; }
+
+    try {
+        var res = await fetch('/betting/' + activePick.parlayId + '/legs', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                contributor: activePick.contributor,
+                gameId: activePick.gameId,
+                betType: selectedBet.betType,
+                selection: selectedBet.selection,
+                line: selectedBet.line,
+                odds: finalOdds
+            })
+        });
+        if (res.ok) {
+            if (window.ccToast) ccToast.success('Leg submitted');
+            activePick = null;
+            selectedBet = null;
+            await refresh();
+        } else {
+            var data = await res.json();
+            if (window.ccToast) ccToast.error(data.message || 'Failed to submit');
+        }
+    } catch (e) {
+        if (window.ccToast) ccToast.error('Failed to submit leg');
+    }
+}
+
+var editingLeg = null;
+
+function editLeg(parlayId, contributor) {
+    editingLeg = { parlayId: parlayId, contributor: contributor };
+    var parlay = parlays.find(function (p) { return p._id === parlayId; });
+    if (!parlay) return;
+    var leg = parlay.legs.find(function (l) { return l.contributor === contributor; });
+    if (!leg) return;
+    leg.gameId = null;
+    renderCurrentParlay();
+}
+
+async function createParlay() {
+    try {
+        var prevWager = null;
+        var prev = parlays.filter(function (p) { return p.week < currentWeek && p.wager; })
+            .sort(function (a, b) { return b.week - a.week; });
+        if (prev.length) prevWager = prev[0].wager;
+
+        var res = await fetch('/betting', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ season: currentSeason, week: currentWeek, wager: prevWager })
+        });
+        if (res.ok) {
+            if (window.ccToast) ccToast.success('Parlay created for Week ' + currentWeek);
+            await refresh();
+        } else {
+            var data = await res.json();
+            if (window.ccToast) ccToast.error(data.message || 'Failed to create');
+        }
+    } catch (e) {
+        if (window.ccToast) ccToast.error('Failed to create parlay');
+    }
+}
+
+async function updateWager(parlayId, value) {
+    try {
+        var res = await fetch('/betting/' + parlayId, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ wager: Number(value) })
+        });
+        if (res.ok) {
+            if (window.ccToast) ccToast.success('Wager updated');
+            await refresh();
+        }
+    } catch (e) { /* skip */ }
+}
+
+async function refresh() {
+    await Promise.all([loadParlays(), loadGames(), loadMemberNames()]);
+    renderCurrentParlay();
+    renderHistory();
+    loadSeasonSummary();
+}
+
+document.getElementById('week-prev').addEventListener('click', function () {
+    if (currentWeek > 1) { currentWeek--; updateWeekDisplay(); refresh(); }
+});
+document.getElementById('week-next').addEventListener('click', function () {
+    currentWeek++;
+    updateWeekDisplay();
+    refresh();
+});
+
+function updateWeekDisplay() {
+    document.getElementById('week-label').textContent = 'Week ' + currentWeek;
+}
+
+async function init() {
+    myUserId = getMyUserId();
+    currentSeason = window.APP_YEAR || new Date().getFullYear();
+    await refresh();
+}
+
+init();

--- a/public/styles.css
+++ b/public/styles.css
@@ -127,6 +127,16 @@ body {
     margin: 0;
     flex-direction: column;
 }
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    opacity: 0.035;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+body > * { position: relative; z-index: 1; }
 
 .navbar {
     display: flex;

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -448,11 +448,20 @@
     background: var(--cc-surface);
     border: 1px solid var(--cc-border);
     border-radius: 10px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.12);
     padding: 1em;
     overflow: hidden;
     box-sizing: border-box;
 }
+.game-card.gc-live {
+    border-color: rgba(34,195,122,0.35);
+    animation: gc-pulse 3s ease-in-out infinite;
+}
+@keyframes gc-pulse {
+    0%, 100% { box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.12); }
+    50% { box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.12), 0 0 16px 2px rgba(34,195,122,0.12); }
+}
+@media (prefers-reduced-motion: reduce) { .game-card.gc-live { animation: none; } }
 .game-card .game-table {
     width: 100%;
     margin: 0;
@@ -615,9 +624,10 @@
 /* ---------- My Team bento (#230 redesign, feat/my-team-redesign) ---------- */
 .uh-bento { width: 92%; max-width: 1000px; margin: 1.5em auto; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 @media (max-width: 640px) { .uh-bento { grid-template-columns: 1fr; } }
-.uh-tile { background: var(--cc-surface); border: 1px solid var(--cc-border); border-radius: 14px; padding: 16px; text-align: left; color: inherit; font: inherit; min-width: 0; }
-button.uh-tile { display: flex; flex-direction: column; cursor: pointer; transition: border-color 0.15s ease, transform 0.12s ease; }
-button.uh-tile:hover { border-color: var(--cc-border-2); }
+.uh-tile { background: var(--cc-surface); border: 1px solid var(--cc-border); border-radius: 14px; padding: 16px; text-align: left; color: inherit; font: inherit; min-width: 0; box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.12); }
+button.uh-tile { display: flex; flex-direction: column; cursor: pointer; transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease; }
+button.uh-tile:hover { border-color: var(--cc-border-2); transform: translateY(-2px); box-shadow: 0 2px 4px rgba(0,0,0,0.25), 0 8px 24px rgba(0,0,0,0.18); }
+button.uh-tile:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 2px 6px rgba(0,0,0,0.12); }
 button.uh-tile:active { transform: scale(0.992); }
 button.uh-tile:focus-visible { outline: 2px solid var(--cc-info); outline-offset: 2px; }
 .uh-tile.span2 { grid-column: 1 / -1; }
@@ -655,7 +665,7 @@ button.uh-tile:focus-visible { outline: 2px solid var(--cc-info); outline-offset
 
 .uh-scrim { position: fixed; inset: 0; background: rgba(4,6,14,0.6); opacity: 0; pointer-events: none; transition: opacity 0.25s ease; z-index: 1200; }
 .uh-scrim.open { opacity: 1; pointer-events: auto; }
-.uh-drawer { position: fixed; z-index: 1201; background: var(--cc-surface); border: 1px solid var(--cc-border); display: flex; flex-direction: column; top: 0; right: 0; height: 100vh; width: min(440px, 92vw); border-radius: 18px 0 0 18px; transform: translateX(102%); transition: transform 0.3s cubic-bezier(0.2,0.8,0.2,1); overscroll-behavior: contain; }
+.uh-drawer { position: fixed; z-index: 1201; background: var(--cc-surface); border: 1px solid var(--cc-border); box-shadow: -8px 0 32px rgba(0,0,0,0.5), -2px 0 8px rgba(0,0,0,0.3); display: flex; flex-direction: column; top: 0; right: 0; height: 100vh; width: min(440px, 92vw); border-radius: 18px 0 0 18px; transform: translateX(102%); transition: transform 0.3s cubic-bezier(0.2,0.8,0.2,1); overscroll-behavior: contain; }
 .uh-drawer.open { transform: translateX(0); }
 @media (max-width: 640px) { .uh-drawer { top: auto; left: 0; right: 0; bottom: 0; width: auto; height: auto; max-height: 86vh; border-radius: 20px 20px 0 0; transform: translateY(102%); } .uh-drawer.open { transform: translateY(0); } }
 .uh-drawer-grab { display: none; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -185,6 +185,7 @@ async function renderBento(data, yearOverride) {
             ${own && !isPastSeason ? `<button class="uh-edit" edit-profile-btn type="button" aria-label="Edit profile" hidden>${pencil}</button>` : ''}
         </div>`
         + tile('matchup', isPastSeason ? 'H2H results' : 'This week · matchup', isPastSeason ? (activeYear + ' matchups') : (uhPoss(own, true) + ' current H2H matchup'), 2, isPastSeason ? 'Results ›' : 'Lineups ›')
+        + (window.IS_BETTING_MEMBER && !isPastSeason ? `<a href="/betting" class="uh-tile" id="uh-tile-betting" style="text-decoration:none;"><span class="uh-tlabel">Betting<span class="uh-chev">›</span></span><span class="uh-glance" id="uh-glance-betting">Weekly parlays</span></a>` : '')
         + tile('roster', 'Roster · top performers', uhPoss(own, true) + ' 10 teams', 2, 'All 10 teams ›')
         + (isPastSeason ? '' : tile('captain', 'Captain', 'Double a team each week', 1))
         + (isPastSeason ? '' : tile('recap', own ? 'Your week' : 'Their week', 'Latest recap', 1))
@@ -222,6 +223,7 @@ async function renderBento(data, yearOverride) {
     if (!isPastSeason) {
         hydrateCaptain(data, activeYear);
         hydrateRecap(data, activeYear);
+        hydrateBetting(data, activeYear);
     }
     hydrateDraft(data, activeYear);
     hydrateRoster(data, activeYear);
@@ -1125,8 +1127,50 @@ async function hydrateRecap(user, activeYear) {
     }
 }
 
-// Draft grade → Draft grade tile. Glance shows the color-coded letter; drawer
-// renders this manager's full draft-grade card (reused from draftGrades.js).
+async function hydrateBetting(user, activeYear) {
+    const tile = document.getElementById('uh-tile-betting');
+    if (!tile || !window.IS_BETTING_MEMBER) return;
+    if (!uhOwns(user)) { tile.hidden = true; return; }
+    try {
+        const res = await fetch('/betting/list?season=' + activeYear, { headers: { Accept: 'application/json' } });
+        if (!res.ok) return;
+        const parlays = await res.json();
+        if (!parlays || !parlays.length) return;
+        const uid = String(currentUserId());
+        const pending = parlays.filter(p => p.status === 'pending').sort((a, b) => a.week - b.week);
+        const filled = pending.find(p => (p.legs || []).some(l => String(l.contributor) === uid && l.selection));
+        const unfilled = pending.find(p => (p.legs || []).some(l => String(l.contributor) === uid && !l.selection));
+        const target = filled || unfilled || pending[0];
+        if (!target) return;
+        const myLeg = (target.legs || []).find(l => String(l.contributor) === uid);
+        const g = document.getElementById('uh-glance-betting');
+        if (g) {
+            if (myLeg && myLeg.selection) {
+                let logoHtml = '';
+                if (myLeg.gameId) {
+                    try {
+                        const gr = await fetch('/betting/games/' + activeYear + '/' + target.week, { headers: { Accept: 'application/json' } });
+                        if (gr.ok) {
+                            const games = await gr.json();
+                            const game = games.find(gm => gm.id === myLeg.gameId);
+                            if (game) {
+                                const sel = (myLeg.selection || '').toLowerCase();
+                                const isHome = sel.includes(game.homeTeam.toLowerCase());
+                                const logos = isHome ? game.homeLogos : game.awayLogos;
+                                const src = typeof ccLogo === 'function' ? ccLogo(logos) : (logos && logos[0] || '');
+                                if (src) logoHtml = '<img src="' + src + '" alt="" style="height:18px;width:18px;vertical-align:middle;margin-right:4px;">';
+                            }
+                        }
+                    } catch (_) {}
+                }
+                g.innerHTML = 'Wk ' + target.week + ' · ' + logoHtml + escapeHtml(myLeg.selection);
+            } else {
+                g.textContent = 'Wk ' + target.week + ' · Pick your leg';
+            }
+        }
+    } catch (e) { /* non-fatal */ }
+}
+
 async function hydrateDraft(user, activeYear) {
     const tile = document.getElementById('uh-tile-draft');
     const hide = () => { if (tile) tile.hidden = true; };
@@ -1743,7 +1787,7 @@ async function getAllBettingLines (seasonYear) {
     // year, so betting lines are fetched for the season actually being viewed.
     if (seasonYear == null) seasonYear = new Date().getFullYear();
 
-    var bettingPromise = await fetch(`/betting/${seasonYear}`, {
+    var bettingPromise = await fetch(`/betting-lines/${seasonYear}`, {
         method: 'GET',
         headers: {
         'Accept': 'application/json',
@@ -1912,7 +1956,8 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
         homeScore = (game.startTimeTbd ? 'TBD' : kickoffTime(d)) + '</td>';
     }
 
-    return '<div class="game-card"><table class="game-table"><tbody><tr></tr>'
+    const isLive = !game.completed && game.startDate && new Date(game.startDate) < new Date();
+    return '<div class="game-card' + (isLive ? ' gc-live' : '') + '"><table class="game-table"><tbody><tr></tr>'
         + '<tr><td class="gc-team">' + awayCol + '</td><td class="gc-divider"></td><td class="gc-score">' + awayScore + '</tr>'
         + '<tr><td class="gc-team">' + homeCol + '</td><td class="gc-divider"></td><td class="gc-score">' + homeScore + '</tr>'
         + (game.outlet ? '<tr><td class="game-broadcast">' + (window.ccIcon ? window.ccIcon('broadcast', { size: 15 }) : '') + ' ' + game.outlet + '</td></tr>' : '')

--- a/routes/betting-groups.js
+++ b/routes/betting-groups.js
@@ -1,0 +1,97 @@
+const express = require('express');
+const router = express.Router();
+const BettingGroup = require('../models/bettingGroup');
+const Parlay = require('../models/parlay');
+const User = require('../models/user');
+
+router.get('/', async (req, res) => {
+    try {
+        const group = await BettingGroup.findOne({ active: true }).lean();
+        if (!group) return res.json(null);
+
+        const season = Number(process.env.YEAR);
+        const members = await User.find(
+            { _id: { $in: group.members } },
+            { firstName: 1, league: 1, seasons: 1, avatarUrl: 1 }
+        ).lean();
+
+        const memberDetails = members.map(m => {
+            const s = (m.seasons || []).find(s => s.season === season);
+            return {
+                _id: m._id,
+                firstName: m.firstName,
+                league: m.league,
+                avatarUrl: m.avatarUrl,
+                franchiseName: s ? s.franchiseName : null
+            };
+        });
+
+        res.json({ ...group, memberDetails });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.post('/', async (req, res) => {
+    try {
+        const { name, members } = req.body;
+        if (!members || !members.length) {
+            return res.status(400).json({ message: 'Members are required' });
+        }
+
+        await BettingGroup.updateMany({ active: true }, { active: false });
+
+        const group = new BettingGroup({
+            name: name || 'Betting Group',
+            members,
+            season: Number(process.env.YEAR),
+            active: true
+        });
+        await group.save();
+        res.status(201).json(group);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.patch('/:id', async (req, res) => {
+    try {
+        const updates = {};
+        if (req.body.name != null) updates.name = req.body.name;
+        if (req.body.members != null) updates.members = req.body.members;
+        updates.updatedAt = new Date();
+
+        const group = await BettingGroup.findByIdAndUpdate(
+            req.params.id,
+            { $set: updates },
+            { new: true }
+        );
+        if (!group) return res.status(404).json({ message: 'Group not found' });
+
+        if (req.body.members) {
+            const newMembers = req.body.members.map(m => m.toString());
+            const pendingParlays = await Parlay.find({ group: group._id, status: 'pending' });
+            for (const parlay of pendingParlays) {
+                const existingIds = parlay.legs.map(l => l.contributor.toString());
+                for (const mid of newMembers) {
+                    if (!existingIds.includes(mid)) {
+                        parlay.legs.push({ contributor: mid });
+                    }
+                }
+                parlay.legs = parlay.legs.filter(l => {
+                    const cid = l.contributor.toString();
+                    if (newMembers.includes(cid)) return true;
+                    return !!l.selection;
+                });
+                parlay.updatedAt = new Date();
+                await parlay.save();
+            }
+        }
+
+        res.json(group);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+module.exports = router;

--- a/routes/betting-lines.js
+++ b/routes/betting-lines.js
@@ -1,0 +1,87 @@
+const express = require('express');
+const router = express.Router();
+const Betting = require('../models/bettingLine');
+
+//Getting All
+router.get('/', async (req, res) => {
+    try {
+        const bettingLines = await Betting.find();
+        res.json(bettingLines);
+    } catch (err) {
+        res.status(500).json({message: err.message});
+    }
+});
+
+// Getting All By Season
+router.get('/:year', async (req, res) => {
+    try {
+        const bettingLines = await Betting.find({season: req.params.year});
+
+        if (JSON.stringify(bettingLines) === '[]') {
+            res.status(400).json({message: `No betting lines found for year ${req.body.year}`});
+        } else {
+            res.status(200).json(bettingLines);
+        }
+
+    } catch (err) {
+        res.status(500).json({message: err.message});
+    }
+});
+
+//Getting All By Year & Saving to Database
+router.post('/new/:year', async (req, res) => {
+    try {
+        const response = await fetch(`https://api.collegefootballdata.com/lines?year=${req.body.season}`, {
+            method: 'GET',
+            headers: {
+            'Accept': 'application/json',
+            'Authorization': process.env.CFBD_API_KEY
+            }
+        });
+
+        const allBettingLines = await response.json();
+        if (!Array.isArray(allBettingLines)) {
+            return res.status(400).json({ message: 'CFBD lines response was not a list' });
+        }
+
+        // Upsert every line in one bulk write, keyed on the CFBD line id (unique
+        // per game). The old code did a findOne + findOneAndUpdate PER line —
+        // ~1,600 sequential round-trips for a full season, which blew past
+        // Heroku's 30s request limit (H12) and killed the nightly scoring job.
+        const ops = allBettingLines
+            .filter(bl => bl && bl.id != null)
+            .map(bl => ({
+                updateOne: {
+                    filter: { id: bl.id },
+                    update: { $set: {
+                        id: bl.id,
+                        season: bl.season,
+                        seasonType: bl.seasonType,
+                        week: bl.week,
+                        startDate: bl.startDate,
+                        homeTeam: bl.homeTeam,
+                        homeConference: bl.homeConference,
+                        homeClassification: bl.homeClassification,
+                        homeScore: bl.homeScore,
+                        awayTeam: bl.awayTeam,
+                        awayConference: bl.awayConference,
+                        awayClassification: bl.awayClassification,
+                        awayScore: bl.awayScore,
+                        lines: bl.lines
+                    } },
+                    upsert: true
+                }
+            }));
+
+        const result = ops.length
+            ? await Betting.bulkWrite(ops, { ordered: false })
+            : { upsertedCount: 0, modifiedCount: 0 };
+        const created = result.upsertedCount || 0;
+        console.log(`Betting lines for ${req.body.season}: ${ops.length} total, ${created} new, ${result.modifiedCount || 0} updated`);
+        return res.status(201).json({ total: ops.length, created, updated: result.modifiedCount || 0 });
+    } catch (err) {
+        res.status(400).json({message: err.message});
+    }
+});
+
+module.exports = router;

--- a/routes/betting.js
+++ b/routes/betting.js
@@ -1,86 +1,244 @@
 const express = require('express');
 const router = express.Router();
-const Betting = require('../models/bettingLine');
+const Parlay = require('../models/parlay');
+const Game = require('../models/game');
+const Team = require('../models/team');
+const BettingLine = require('../models/bettingLine');
+const Ranking = require('../models/ranking');
+const requireBettingGroupMember = require('../modules/require-betting-group');
+const { effectiveRoles } = require('../modules/dev-role');
+const { parlayPayout, combinedAmericanOdds } = require('../modules/parlay-calc');
 
-//Getting All
-router.get('/', async (req, res) => {
+router.use(requireBettingGroupMember);
+
+function isAdmin(req) {
+    return effectiveRoles(req).includes('Admin');
+}
+
+router.get('/list', async (req, res) => {
     try {
-        const bettingLines = await Betting.find();
-        res.json(bettingLines);
+        const season = req.query.season || process.env.YEAR;
+        const parlays = await Parlay.find({
+            group: req.bettingGroup._id,
+            season: Number(season)
+        }).sort({ week: -1 }).lean();
+        res.json(parlays);
     } catch (err) {
-        res.status(500).json({message: err.message});
+        res.status(500).json({ message: err.message });
     }
 });
 
-// Getting All By Season
-router.get('/:year', async (req, res) => {
+router.get('/season-summary/:season', async (req, res) => {
     try {
-        const bettingLines = await Betting.find({season: req.params.year});
+        const parlays = await Parlay.find({
+            group: req.bettingGroup._id,
+            season: Number(req.params.season)
+        }).lean();
 
-        if (JSON.stringify(bettingLines) === '[]') {
-            res.status(400).json({message: `No betting lines found for year ${req.body.year}`});
-        } else {
-            res.status(200).json(bettingLines);
+        const record = { wins: 0, losses: 0, pushes: 0, pending: 0 };
+        let totalWagered = 0;
+        let totalReturned = 0;
+
+        for (const p of parlays) {
+            totalWagered += p.wager || 0;
+            totalReturned += p.payout || 0;
+            if (p.status === 'won') record.wins++;
+            else if (p.status === 'lost') record.losses++;
+            else if (p.status === 'push') record.pushes++;
+            else record.pending++;
         }
 
+        res.json({
+            record,
+            totalParlays: parlays.length,
+            totalWagered,
+            totalReturned,
+            net: totalReturned - totalWagered
+        });
     } catch (err) {
-        res.status(500).json({message: err.message});
+        res.status(500).json({ message: err.message });
     }
 });
 
-//Getting All By Year & Saving to Database
-router.post('/new/:year', async (req, res) => {
+router.get('/games/:season/:week', async (req, res) => {
     try {
-        const response = await fetch(`https://api.collegefootballdata.com/lines?year=${req.body.season}`, {
-            method: 'GET',
-            headers: {
-            'Accept': 'application/json',
-            'Authorization': process.env.CFBD_API_KEY
+        const season = Number(req.params.season);
+        const week = Number(req.params.week);
+        const seasonType = req.query.seasonType || 'regular';
+
+        const teamIds = new Set();
+        const [games, lines, ranking] = await Promise.all([
+            Game.find({ season, week, seasonType }).sort({ startDate: 1 }).lean(),
+            BettingLine.find({ season, week, seasonType }).lean(),
+            Ranking.findOne({ season, week, seasonType }).lean()
+        ]);
+
+        const rankMap = new Map();
+        if (ranking && ranking.polls) {
+            const ap = ranking.polls.find(p => p.poll === 'AP Top 25');
+            if (ap && ap.ranks) {
+                ap.ranks.forEach(r => rankMap.set(r.school, r.rank));
             }
+        }
+
+        games.forEach(g => { teamIds.add(g.homeId); teamIds.add(g.awayId); });
+        const teams = await Team.find({ id: { $in: [...teamIds] } }, 'id logos').lean();
+        const logoMap = new Map(teams.map(t => [t.id, t.logos]));
+        const lineMap = new Map(lines.map(l => [l.id, l]));
+
+        const merged = games.map(game => {
+            const bl = lineMap.get(game.id);
+            let dk = null;
+            if (bl && bl.lines) {
+                dk = bl.lines.find(l => l.provider && l.provider.toLowerCase().includes('draftkings'));
+            }
+            return {
+                id: game.id,
+                homeTeam: game.homeTeam,
+                awayTeam: game.awayTeam,
+                homeId: game.homeId,
+                awayId: game.awayId,
+                homeLogos: logoMap.get(game.homeId) || [],
+                awayLogos: logoMap.get(game.awayId) || [],
+                homeRank: rankMap.get(game.homeTeam) || null,
+                awayRank: rankMap.get(game.awayTeam) || null,
+                startDate: game.startDate,
+                completed: game.completed,
+                homePoints: game.homePoints,
+                awayPoints: game.awayPoints,
+                dk: dk ? {
+                    spread: dk.spread,
+                    formattedSpread: dk.formattedSpread,
+                    overUnder: dk.overUnder,
+                    homeMoneyline: dk.homeMoneyline,
+                    awayMoneyline: dk.awayMoneyline
+                } : null
+            };
         });
 
-        const allBettingLines = await response.json();
-        if (!Array.isArray(allBettingLines)) {
-            return res.status(400).json({ message: 'CFBD lines response was not a list' });
+        res.json(merged);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.get('/:id', async (req, res) => {
+    try {
+        const parlay = await Parlay.findById(req.params.id).lean();
+        if (!parlay) return res.status(404).json({ message: 'Parlay not found' });
+        res.json(parlay);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.post('/', async (req, res) => {
+    try {
+        const { season, seasonType, week, wager } = req.body;
+        const s = Number(season || process.env.YEAR);
+        const w = Number(week);
+        const st = seasonType || 'regular';
+
+        if (!w) return res.status(400).json({ message: 'Week is required' });
+
+        const existing = await Parlay.findOne({
+            group: req.bettingGroup._id, season: s, week: w
+        });
+        if (existing) return res.status(409).json({ message: 'Parlay already exists for this week' });
+
+        const legs = req.bettingGroup.members.map(memberId => ({
+            contributor: memberId
+        }));
+
+        const parlay = new Parlay({
+            group: req.bettingGroup._id,
+            season: s,
+            seasonType: st,
+            week: w,
+            wager: wager || null,
+            legs
+        });
+        await parlay.save();
+        res.status(201).json(parlay);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.patch('/:id/legs', async (req, res) => {
+    try {
+        const parlay = await Parlay.findById(req.params.id);
+        if (!parlay) return res.status(404).json({ message: 'Parlay not found' });
+        if (parlay.status !== 'pending') {
+            return res.status(400).json({ message: 'Parlay is already resolved' });
         }
 
-        // Upsert every line in one bulk write, keyed on the CFBD line id (unique
-        // per game). The old code did a findOne + findOneAndUpdate PER line —
-        // ~1,600 sequential round-trips for a full season, which blew past
-        // Heroku's 30s request limit (H12) and killed the nightly scoring job.
-        const ops = allBettingLines
-            .filter(bl => bl && bl.id != null)
-            .map(bl => ({
-                updateOne: {
-                    filter: { id: bl.id },
-                    update: { $set: {
-                        id: bl.id,
-                        season: bl.season,
-                        seasonType: bl.seasonType,
-                        week: bl.week,
-                        startDate: bl.startDate,
-                        homeTeam: bl.homeTeam,
-                        homeConference: bl.homeConference,
-                        homeClassification: bl.homeClassification,
-                        homeScore: bl.homeScore,
-                        awayTeam: bl.awayTeam,
-                        awayConference: bl.awayConference,
-                        awayClassification: bl.awayClassification,
-                        awayScore: bl.awayScore,
-                        lines: bl.lines
-                    } },
-                    upsert: true
-                }
-            }));
+        const { contributor, gameId, betType, selection, line, odds } = req.body;
+        if (!contributor) return res.status(400).json({ message: 'Contributor is required' });
 
-        const result = ops.length
-            ? await Betting.bulkWrite(ops, { ordered: false })
-            : { upsertedCount: 0, modifiedCount: 0 };
-        const created = result.upsertedCount || 0;
-        console.log(`Betting lines for ${req.body.season}: ${ops.length} total, ${created} new, ${result.modifiedCount || 0} updated`);
-        return res.status(201).json({ total: ops.length, created, updated: result.modifiedCount || 0 });
+        const isSelf = req.bettingUserId === contributor;
+        if (!isSelf && !isAdmin(req)) {
+            return res.status(403).json({ message: 'You can only edit your own leg' });
+        }
+
+        const leg = parlay.legs.find(l => l.contributor && l.contributor.toString() === contributor);
+        if (!leg) return res.status(404).json({ message: 'No leg found for this contributor' });
+
+        if (gameId != null) {
+            const game = await Game.findOne({ id: gameId }).lean();
+            if (game && game.startDate && new Date(game.startDate) < new Date() && !isAdmin(req)) {
+                return res.status(400).json({ message: 'Game has already started' });
+            }
+            leg.gameId = gameId;
+        }
+        if (betType != null) leg.betType = betType;
+        if (selection != null) leg.selection = selection;
+        if (line !== undefined) leg.line = line;
+        if (odds != null) leg.odds = odds;
+        leg.result = 'pending';
+        leg.resolvedAt = null;
+
+        parlay.updatedAt = new Date();
+        await parlay.save();
+        res.json(parlay);
     } catch (err) {
-        res.status(400).json({message: err.message});
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.patch('/:id', async (req, res) => {
+    try {
+        if (!isAdmin(req)) {
+            return res.status(403).json({ message: 'Admin only' });
+        }
+
+        const parlay = await Parlay.findById(req.params.id);
+        if (!parlay) return res.status(404).json({ message: 'Parlay not found' });
+
+        if (req.body.wager != null) parlay.wager = req.body.wager;
+        if (req.body.seasonType != null) parlay.seasonType = req.body.seasonType;
+        parlay.updatedAt = new Date();
+        await parlay.save();
+        res.json(parlay);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.delete('/:id', async (req, res) => {
+    try {
+        if (!isAdmin(req)) {
+            return res.status(403).json({ message: 'Admin only' });
+        }
+        const parlay = await Parlay.findById(req.params.id);
+        if (!parlay) return res.status(404).json({ message: 'Parlay not found' });
+        if (parlay.status !== 'pending') {
+            return res.status(400).json({ message: 'Cannot delete a resolved parlay' });
+        }
+        await Parlay.findByIdAndDelete(req.params.id);
+        res.json({ message: 'Deleted' });
+    } catch (err) {
+        res.status(500).json({ message: err.message });
     }
 });
 

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const ScoringConfig = require('./models/scoringConfig');
 const User = require('./models/user');
 const League = require('./models/league');
 const { resolveConfig, fieldsForModel, LEAGUES, engagementForSeason, overridesFromDoc } = require('./modules/scoring-defaults');
+const BettingGroup = require('./models/bettingGroup');
 const draftToken = require('./modules/draft-token');
 const registerDraftSockets = require('./modules/draft-socket');
 const { cloudinaryConfig } = require('./modules/profile-update');
@@ -163,6 +164,24 @@ app.use(async (req, res, next) => {
             }
         }
     } catch (e) { /* non-fatal: navbar falls back to the generic icon */ }
+    next();
+});
+
+// Betting group membership flag for the navbar and My Team links. HTML GETs
+// only so API calls and static assets skip the query.
+app.use(async (req, res, next) => {
+    res.locals.isBettingGroupMember = false;
+    try {
+        if (req.method === 'GET'
+            && (req.headers.accept || '').includes('text/html')
+            && req.oidc && req.oidc.isAuthenticated()) {
+            const innerMeta = (req.oidc.user.user_metadata && req.oidc.user.user_metadata.metadata) || {};
+            if (innerMeta.userId) {
+                const group = await BettingGroup.findOne({ active: true, members: innerMeta.userId }).lean();
+                res.locals.isBettingGroupMember = !!group;
+            }
+        }
+    } catch (e) { /* non-fatal */ }
     next();
 });
 
@@ -525,6 +544,15 @@ app.get('/draft-board', (req, res) => {
     });
 });
 
+app.get('/betting', async (req, res) => {
+    if (!req.oidc.isAuthenticated()) return res.redirect('/login');
+    const user = buildUserContext(req.effUser);
+    if (!res.locals.isBettingGroupMember) return res.redirect('/');
+    const userState = safeJson(req.effUser);
+    const isAdmin = devRole.effectiveRoles(req).includes('Admin');
+    res.render('betting', { user, userState, year: process.env.YEAR, isAdmin });
+});
+
 app.get('/admin', (req, res) => {
     if (req.oidc.isAuthenticated()) {
         const user = buildUserContext(req.effUser);
@@ -604,7 +632,7 @@ app.use('/teams', (req, res, next) => {
     if (req.method === 'GET' || (req.method === 'POST' && req.path === '/teamLogos')) return next();
     return requireAdmin(req, res, next);
 });
-app.use(['/scores', '/records', '/games', '/betting', '/rankings', '/playoffs', '/recruiting', '/job-runs', '/audit-log'], (req, res, next) => {
+app.use(['/scores', '/records', '/games', '/betting-lines', '/rankings', '/playoffs', '/recruiting', '/job-runs', '/audit-log', '/betting-groups'], (req, res, next) => {
     if (req.method === 'GET') return next();
     return requireAdmin(req, res, next);
 });
@@ -640,8 +668,14 @@ app.use('/recruiting', requireAuthOrToken, recruitingRouter);
 const recordRouter = require('./routes/records');
 app.use('/records', requireAuthOrToken, recordRouter);
 
+const bettingLinesRouter = require('./routes/betting-lines');
+app.use('/betting-lines', requireAuthOrToken, bettingLinesRouter);
+
 const bettingRouter = require('./routes/betting');
 app.use('/betting', requireAuthOrToken, bettingRouter);
+
+const bettingGroupsRouter = require('./routes/betting-groups');
+app.use('/betting-groups', requireAuthOrToken, bettingGroupsRouter);
 
 const draftRouter = require('./routes/draft');
 app.use('/draft', requireAuthOrToken, draftRouter);

--- a/tests/ScoreUpdate.spec.js
+++ b/tests/ScoreUpdate.spec.js
@@ -32,6 +32,7 @@ jest.mock('../modules/retrieve-games.js', () => ({
 jest.mock('../modules/team-scoring.js', () => ({ updateAllTeamScores: jest.fn(async () => {}) }));
 jest.mock('../modules/records.js', () => ({ updateAllTeamRecords: jest.fn(async () => {}) }));
 jest.mock('../modules/betting.js', () => ({ updateAllBettingLines: jest.fn(async () => {}) }));
+jest.mock('../modules/parlay-resolve', () => ({ resolveParlays: jest.fn(async () => {}) }));
 jest.mock('../modules/scoring.js', () => {
     const calls = [];
     return {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -293,6 +293,29 @@
         </div>
     </section>
 
+    <section class="admin-group">
+        <div class="group-head"><h2>Betting</h2><span class="group-count">1</span></div>
+        <div class="admin-functions">
+            <div class="function-container">
+                <div class="button-container">
+                    <button onclick="displayBettingGroupContainer()">
+                        <i class="fa-solid fa-users" style="padding-right: 5px;"></i>
+                        Manage Betting Group
+                    </button>
+                </div>
+                <div class="sub-container" betting-group-container style="display: none">
+                    <p class="function-description">Control who can see the Betting page. Add or remove members below.</p>
+                    <div id="betting-group-members"></div>
+                    <div style="display: flex; gap: 8px; margin-top: 12px; align-items: center;">
+                        <select id="betting-group-add-user" style="flex:1; width: auto; margin: 0; padding: 8px;"><option value="">Add a member...</option></select>
+                        <button type="button" onclick="addBettingGroupMember()" style="width: auto; min-width: 60px; margin: 0; padding: 8px 16px;">Add</button>
+                    </div>
+                    <button type="button" onclick="saveBettingGroup()" style="margin-top: 12px;">Save Betting Group</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <% } %>
 
     <section class="admin-group">

--- a/views/betting.ejs
+++ b/views/betting.ejs
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="styles.css" rel="stylesheet">
+    <link href="betting.css" rel="stylesheet">
+    <link href="loading.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Graduate&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+    <script src="logo.js"></script>
+    <script src="betting.js" defer></script>
+    <title data-league-title="Betting">Betting · Campus Clash</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png" />
+</head>
+
+<body>
+    <%- include('partials/navbar') %>
+    <% if (userState) { %>
+        <script>
+            var userState = <%- userState %>;
+            var APP_YEAR = '<%= year %>';
+            var IS_ADMIN = <%= isAdmin %>;
+        </script>
+    <% } %>
+
+    <div class="header">
+        <div class="header-title">
+            <span class="header-league" league-label hidden></span>
+            Betting
+        </div>
+        <div class="week-nav">
+            <button type="button" class="week-nav-btn" id="week-prev" aria-label="Previous week">
+                <i class="fa-solid fa-chevron-left"></i>
+            </button>
+            <span class="week-label" id="week-label">Week 1</span>
+            <button type="button" class="week-nav-btn" id="week-next" aria-label="Next week">
+                <i class="fa-solid fa-chevron-right"></i>
+            </button>
+        </div>
+    </div>
+
+    <div id="betting-content">
+        <div class="loading-container">
+            <div class="loading-spinner"></div>
+        </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <div class="summary-title">Season <span id="summary-year"></span></div>
+    <div class="season-summary" id="season-summary"></div>
+
+    <div class="history-section">
+        <table class="history-table" id="history-table">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Legs</th>
+                    <th>Wager</th>
+                    <th>Result</th>
+                    <th class="text-right">Pay</th>
+                </tr>
+            </thead>
+            <tbody id="history-body"></tbody>
+        </table>
+    </div>
+</body>
+</html>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -99,6 +99,9 @@
             <li><a href="./hall-of-fame">Hall of Fame</a></li>
             <li><a href="./rules">Scoring</a></li>
             <li><a href="./draft-room">Draft Room</a></li>
+            <% if (typeof isBettingGroupMember !== 'undefined' && isBettingGroupMember) { %>
+            <li><a href="./betting">Betting</a></li>
+            <% } %>
             <!-- A <button>, not a link: it opens a dialog rather than navigating.
                  Icon-only on desktop with the label revealed in the stacked mobile
                  menu — the same .nav-label treatment "My Team" uses, which is what

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -37,6 +37,7 @@
         // My Team tile keys off the season the league is actually playing — not
         // the wall-clock year or "latest season with data".
         window.APP_YEAR = "<%= year %>";
+        window.IS_BETTING_MEMBER = <%= typeof isBettingGroupMember !== 'undefined' && isBettingGroupMember %>;
     </script>
 
     <!-- My Team bento (#230 redesign, feat/my-team-redesign). Tiles rendered by


### PR DESCRIPTION
## Summary
- **Betting page** (`/betting`): each group member picks one leg per week to build a shared parlay — tracks wagers, combined odds, payouts, and season record
- **Self-service leg entry**: members pick their own leg from a game picker with DraftKings lines and AP Top 25 rankings; admin can edit any leg
- **Custom bet type**: supports spread, moneyline, over/under, and custom prop bets
- **Auto-resolution**: legs resolve automatically when games complete via the scoring pipeline (`parlay-resolve` hooked into `score-update`)
- **Admin group management**: same-league member picker with pending-parlay sync (adding/removing members updates all open parlays)
- **My Team tile**: 2nd position under Matchup, shows team logo + current week leg selection
- **Nav link**: conditional "Betting" link visible only to group members
- **Mobile-safe layouts**: CSS grid game picker, compact history table with leg counts, avatar + first name on leg cards

## Models
- `BettingGroup` — members array, season-scoped, active flag
- `Parlay` — group, season, week, wager, status, payout, legs subdocument (contributor, gameId, betType, selection, line, odds, result)

## Test plan
- [x] Create betting group in admin → only members see nav link and My Team tile
- [x] Submit own leg as non-admin member → saves and renders on parlay card
- [x] Edit another member's leg as admin → saves correctly
- [x] Add/remove member in admin → pending parlays sync automatically
- [x] Custom bet type → renders and stays pending (no auto-resolution)
- [x] Wager auto-fills from previous week
- [x] Rankings display in game picker
- [x] Mobile layout verified at 390px viewport
- [ ] Auto-resolution with completed games (untested in live play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)