### PR TITLE
Fix iOS Safari auto-zoom on game picker search

### DIFF
--- a/public/betting.css
+++ b/public/betting.css
@@ -228,7 +228,7 @@
     border: 1px solid var(--cc-border);
     border-radius: var(--cc-r-sm);
     color: var(--cc-text);
-    font-size: 14px;
+    font-size: 16px;
     font-family: 'Poppins', sans-serif;
 }
 .game-picker-head input:focus { border-color: var(--cc-interactive); outline: none; }


### PR DESCRIPTION
## Summary
- Bumps `.game-picker-head input` font-size from 14px to 16px
- iOS Safari auto-zooms into any input field with font-size below 16px, causing the game picker to appear zoomed in on mobile

## Test plan
- [ ] Open betting page on iOS Safari, tap "Choose a game...", verify search input no longer triggers auto-zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)