### PR TITLE
Add parlay resolve animation with money explosion

### DIFF
--- a/public/betting.css
+++ b/public/betting.css
@@ -527,6 +527,8 @@
     gap: 8px;
     padding: 0 24px;
     margin-bottom: 16px;
+    width: 100%;
+    box-sizing: border-box;
 }
 .stat-card {
     background: var(--cc-surface);
@@ -551,6 +553,8 @@
 /* History table */
 .history-section {
     padding: 0 24px;
+    width: 100%;
+    box-sizing: border-box;
     overflow-x: auto;
 }
 .history-table {
@@ -576,6 +580,70 @@
 }
 .history-table tr:nth-child(even) td { background: var(--cc-surface-2); }
 .text-right { text-align: right; }
+
+/* ── Resolve animation ── */
+.slot-spinner {
+    display: none; width: 22px; height: 22px; border-radius: 50%;
+    background: var(--cc-surface-2); color: var(--cc-muted-2, var(--cc-muted));
+    align-items: center; justify-content: center; font-size: 11px;
+    overflow: hidden;
+}
+.leg--unrevealed .slot-reveal { display: none; }
+.leg--unrevealed .slot-spinner { display: flex; }
+.slot--spinning .slot-spinner {
+    animation: slotSpin 0.12s linear infinite;
+    filter: blur(1.5px);
+}
+.slot--revealed .slot-reveal {
+    display: flex; animation: slotRevealPop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.slot--revealed .slot-spinner { display: none; }
+.parlay-status--unrevealed { visibility: hidden; }
+.parlay-status--revealed { visibility: visible; animation: revealPulse 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.payout-bar--unrevealed .payout-value { visibility: hidden; }
+.payout-bar--revealed .payout-value { visibility: visible; animation: revealFadeUp 0.4s ease-out; }
+.payout-bar--revealed .payout-won { animation: revealPulse 0.5s cubic-bezier(0.34, 1.56, 0.64, 1); font-size: 18px; }
+
+@keyframes slotSpin {
+    0%   { transform: translateY(100%);  }
+    100% { transform: translateY(-100%); }
+}
+@keyframes slotRevealPop {
+    0%   { transform: scale(0.3); opacity: 0; }
+    60%  { transform: scale(1.2); opacity: 1; }
+    100% { transform: scale(1);   opacity: 1; }
+}
+@keyframes revealFadeUp {
+    0%   { transform: translateY(8px); opacity: 0; }
+    100% { transform: translateY(0);   opacity: 1; }
+}
+@keyframes revealPulse {
+    0%   { transform: scale(0.8); opacity: 0; }
+    50%  { transform: scale(1.05); }
+    100% { transform: scale(1);   opacity: 1; }
+}
+
+.money-particle {
+    position: fixed; z-index: 9999; pointer-events: none;
+    font-size: 30px; line-height: 1;
+    translate: -50% -50%;
+    scale: 0.5;
+    rotate: 0deg;
+    opacity: 1;
+    transition: translate 1.5s cubic-bezier(0.15, 0.8, 0.3, 1),
+                scale 1.5s cubic-bezier(0.15, 0.8, 0.3, 1),
+                rotate 1.5s ease-out,
+                opacity 1.2s ease-out 0.4s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .slot--spinning .slot-spinner,
+    .slot--revealed .slot-reveal,
+    .parlay-status--revealed,
+    .payout-bar--revealed .payout-value,
+    .payout-bar--revealed .payout-won,
+    .money-particle { animation: none; }
+}
 
 @media (max-width: 600px) {
     .header { padding: 16px 16px 10px; }

--- a/public/betting.css
+++ b/public/betting.css
@@ -552,7 +552,7 @@
 
 /* History table */
 .history-section {
-    padding: 0 24px;
+    padding: 0 24px 3rem;
     width: 100%;
     box-sizing: border-box;
     overflow-x: auto;
@@ -651,7 +651,7 @@
     .leg { flex-wrap: wrap; gap: 6px; padding: 8px 10px; }
     .leg-contributor { min-width: 80px; }
     .season-summary { grid-template-columns: repeat(2, 1fr); padding: 0 16px; }
-    .history-section { padding: 0 16px; }
+    .history-section { padding: 0 16px 3rem; }
     .section-divider { margin: 16px; }
     .summary-title { padding: 0 16px; }
     .create-parlay-cta { margin: 0 16px; }

--- a/public/betting.js
+++ b/public/betting.js
@@ -9,6 +9,18 @@ var myUserId = '';
 
 var MEMBER_COLORS = ['#ed5858', '#6C9BFF', '#22C37A', '#E0B341', '#8E8CF0', '#D27171'];
 
+var SEEN_KEY = 'parlay-seen-resolved';
+var SEEN_TTL = 30 * 24 * 60 * 60 * 1000;
+function getSeenMap() {
+    try { var m = JSON.parse(localStorage.getItem(SEEN_KEY) || '{}'); } catch (e) { var m = {}; }
+    var now = Date.now(), changed = false;
+    Object.keys(m).forEach(function (k) { if (now - m[k] > SEEN_TTL) { delete m[k]; changed = true; } });
+    if (changed) localStorage.setItem(SEEN_KEY, JSON.stringify(m));
+    return m;
+}
+function hasSeenResolve(id) { return !!getSeenMap()[id]; }
+function markResolveAsSeen(id) { var m = getSeenMap(); m[id] = Date.now(); localStorage.setItem(SEEN_KEY, JSON.stringify(m)); }
+
 function getMyUserId() {
     if (!window.userState) return '';
     var meta = userState.user_metadata && userState.user_metadata.metadata;
@@ -166,6 +178,10 @@ function renderCurrentParlay() {
         return;
     }
 
+    var shouldAnimate = parlay.status !== 'pending'
+        && !hasSeenResolve(parlay._id)
+        && !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     var statusClass = 'status-' + parlay.status;
     var statusLabel = parlay.status === 'won' ? 'Won' : (parlay.status === 'lost' ? 'Lost' : (parlay.status === 'push' ? 'Push' : 'Pending'));
 
@@ -197,6 +213,13 @@ function renderCurrentParlay() {
         else if (leg.result === 'push') resultHtml = '<div class="leg-result result-push"><i class="fa-solid fa-minus"></i></div>';
         else resultHtml = '<div class="leg-result result-pending"><i class="fa-solid fa-clock"></i></div>';
 
+        if (shouldAnimate && leg.result && leg.result !== 'pending') {
+            resultHtml = '<div class="leg-result-slot leg--unrevealed">'
+                + '<div class="slot-spinner"><i class="fa-solid fa-question"></i></div>'
+                + '<div class="slot-reveal">' + resultHtml + '</div>'
+                + '</div>';
+        }
+
         var editBtn = '';
         if (parlay.status === 'pending' && (leg.contributor === myUserId || window.IS_ADMIN)) {
             editBtn = '<button type="button" onclick="editLeg(\'' + parlay._id + '\',\'' + leg.contributor + '\')" style="background:none;border:none;color:var(--cc-interactive);font-size:12px;cursor:pointer;padding:2px 4px;" title="Edit"><i class="fa-solid fa-pen-to-square"></i></button>';
@@ -216,6 +239,9 @@ function renderCurrentParlay() {
     var payoutDisplay = parlay.payout != null ? '$' + parlay.payout : potential;
     var payoutClass = parlay.status === 'won' ? 'payout-won' : (parlay.status === 'lost' ? 'payout-lost' : '');
 
+    var statusAnimClass = shouldAnimate ? ' parlay-status--unrevealed' : '';
+    var payoutAnimClass = shouldAnimate ? ' payout-bar--unrevealed' : '';
+
     var wagerHtml = '';
     if (window.IS_ADMIN && parlay.status === 'pending') {
         wagerHtml = '<div class="wager-section">'
@@ -227,15 +253,86 @@ function renderCurrentParlay() {
     container.innerHTML =
         '<div class="parlay-card">'
         + '<div class="parlay-header"><div class="parlay-week">Week ' + currentWeek + ' Parlay</div>'
-        + '<span class="parlay-status ' + statusClass + '">' + statusLabel + '</span></div>'
+        + '<span class="parlay-status ' + statusClass + statusAnimClass + '">' + statusLabel + '</span></div>'
         + '<div class="legs">' + legsHtml + '</div>'
-        + '<div class="payout-bar">'
+        + '<div class="payout-bar' + payoutAnimClass + '">'
         + '<div class="payout-item"><div class="payout-label">Wager</div><div class="payout-value">$' + (parlay.wager || 0) + '</div></div>'
         + '<div class="payout-item"><div class="payout-label">Combined Odds</div><div class="payout-value" style="font-size:13px;color:var(--cc-muted);">' + combined + '</div></div>'
         + '<div class="payout-item"><div class="payout-label">Payout</div><div class="payout-value ' + payoutClass + '">' + payoutDisplay + '</div></div>'
         + '</div>'
         + '</div>'
         + wagerHtml;
+
+    if (shouldAnimate) {
+        requestAnimationFrame(function () { playResolveAnimation(parlay); });
+    }
+}
+
+function delay(ms) { return new Promise(function (resolve) { setTimeout(resolve, ms); }); }
+
+async function playResolveAnimation(parlay) {
+    var legs = document.querySelectorAll('.leg-result-slot');
+    var statusBadge = document.querySelector('.parlay-status--unrevealed');
+    var payoutBar = document.querySelector('.payout-bar--unrevealed');
+
+    await delay(600);
+
+    for (var i = 0; i < legs.length; i++) {
+        var el = legs[i];
+        el.classList.add('slot--spinning');
+        await delay(800);
+        el.classList.remove('slot--spinning');
+        el.classList.remove('leg--unrevealed');
+        el.classList.add('slot--revealed');
+        await delay(400);
+    }
+
+    await delay(500);
+    if (statusBadge) {
+        statusBadge.classList.remove('parlay-status--unrevealed');
+        statusBadge.classList.add('parlay-status--revealed');
+    }
+    if (payoutBar) {
+        payoutBar.classList.remove('payout-bar--unrevealed');
+        payoutBar.classList.add('payout-bar--revealed');
+        if (parlay.status === 'won') {
+            var payoutEl = payoutBar.querySelector('.payout-won') || payoutBar.querySelector('.payout-value:last-child');
+            if (payoutEl) moneyExplosion(payoutEl);
+        }
+    }
+
+    markResolveAsSeen(parlay._id);
+}
+
+function moneyExplosion(anchor) {
+    var rect = anchor.getBoundingClientRect();
+    var cx = rect.left + rect.width / 2;
+    var cy = rect.top + rect.height / 2;
+    var symbols = ['💰', '💸', '💵', '🤑'];
+    var count = 32;
+    for (var i = 0; i < count; i++) {
+        var el = document.createElement('div');
+        el.className = 'money-particle';
+        el.textContent = symbols[i % symbols.length];
+        el.style.left = cx + 'px';
+        el.style.top = cy + 'px';
+        document.body.appendChild(el);
+        var angle = (i / count) * 2 * Math.PI;
+        var dist = 120 + Math.random() * 90;
+        var dx = Math.cos(angle) * dist;
+        var dy = Math.sin(angle) * dist;
+        (function (e, x, y) {
+            requestAnimationFrame(function () {
+                requestAnimationFrame(function () {
+                    e.style.translate = 'calc(' + x + 'px - 50%) calc(' + y + 'px - 50%)';
+                    e.style.scale = '0.4';
+                    e.style.rotate = (x > 0 ? 540 : -540) + 'deg';
+                    e.style.opacity = '0';
+                });
+            });
+            setTimeout(function () { e.remove(); }, 2000);
+        })(el, dx, dy);
+    }
 }
 
 /* ── New leg entry: CTA button → game picker → bet board ── */

--- a/views/betting.ejs
+++ b/views/betting.ejs
@@ -55,7 +55,7 @@
 
     <div class="section-divider"></div>
 
-    <div class="summary-title">Season <span id="summary-year"></span></div>
+    <div class="summary-title"><span id="summary-year"></span> Results</div>
     <div class="season-summary" id="season-summary"></div>
 
     <div class="history-section">


### PR DESCRIPTION
## Summary
- Slot-machine style leg-by-leg reveal animation when a parlay resolves (spin → pop-in result icon per leg → status badge → payout bar)
- 32-particle emoji explosion (💰💸💵🤑) spiraling out from the payout number on winning parlays
- localStorage tracking so the animation plays once per parlay per browser (30-day TTL auto-prune)
- Respects `prefers-reduced-motion`
- Renamed "Season 2026" to "2026 Results" in the stats section
- Fixed season stats cards not filling full page width on mobile (`align-items: center` on body was shrink-wrapping them)
- Added bottom padding to history table for mobile scroll comfort

## Test plan
- [ ] Navigate to a week with a resolved parlay — animation should play once
- [ ] Refresh — animation should NOT replay (localStorage gated)
- [ ] Won parlay: money emoji explosion fires after payout reveals
- [ ] Lost parlay: no explosion, just the reveal + LOST badge
- [ ] Mobile viewport: stat cards fill width, history rows have bottom padding
- [ ] `prefers-reduced-motion`: all animations disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)