### PR TITLE
Make team names and logos clickable across the app

### DIFF
--- a/public/standings-insights.js
+++ b/public/standings-insights.js
@@ -209,7 +209,7 @@ function teamTotals(users) {
                     if (Number(st.teamId) === Number(team.id) || st.team === team.school) total += (st.score || 0);
                 });
             });
-            totals.push({ team: team.mascot, school: team.school, owner: initialName(u), logo: ccLogo(team.logos), score: total });
+            totals.push({ team: team.mascot, school: team.school, id: team.id, owner: initialName(u), logo: ccLogo(team.logos), score: total });
         });
     });
     return totals.sort((a, b) => b.score - a.score);
@@ -278,7 +278,7 @@ export function buildHighlights(users) {
     // Best team (season) + best single team-game
     const totals = teamTotals(users);
     if (totals.length && totals[0].score > 0) {
-        cards.push({ icon: 'medal', title: 'Best Team', tag: 'season', name: `<img src="${totals[0].logo}" class="hl-logo">${escapeHtml(totals[0].team)}`, value: `+${totals[0].score}`, tone: 'good' });
+        cards.push({ icon: 'medal', title: 'Best Team', tag: 'season', name: `<a href="/team?team=${totals[0].id}" style="color:inherit;text-decoration:none"><img src="${totals[0].logo}" class="hl-logo">${escapeHtml(totals[0].team)}</a>`, value: `+${totals[0].score}`, tone: 'good' });
     }
     // Top single game: the highest one-game team score. Since the postseason
     // bonuses make the max a frequent multi-way tie, show all tied teams.
@@ -286,8 +286,8 @@ export function buildHighlights(users) {
     let topGames = [];
     withWeeks.forEach(u => weekly(u).forEach(wk => (wk.scoreByTeam || []).forEach(st => {
         const sc = st.score || 0;
-        if (sc > topScore) { topScore = sc; topGames = [{ team: st.team, owner: initialName(u) }]; }
-        else if (sc === topScore && sc > 0) { topGames.push({ team: st.team, owner: initialName(u) }); }
+        if (sc > topScore) { topScore = sc; topGames = [{ team: st.team, teamId: st.teamId, owner: initialName(u) }]; }
+        else if (sc === topScore && sc > 0) { topGames.push({ team: st.team, teamId: st.teamId, owner: initialName(u) }); }
     })));
     if (topScore > 0 && topGames.length) {
         const teamNames = [...new Set(topGames.map(g => g.team))];
@@ -306,7 +306,7 @@ export function buildHighlights(users) {
             }
             cards.push({ icon: 'bolt', title: 'Top Single Game', tag: `${teamNames.length}-way tie`, name, value: `+${topScore}`, tone: 'good' });
         } else {
-            cards.push({ icon: 'bolt', title: 'Top Single Game', tag: 'one game', name: `${escapeHtml(topGames[0].team)} <span class="hl-sub">(${escapeHtml(topGames[0].owner)})</span>`, value: `+${topScore}`, tone: 'good' });
+            cards.push({ icon: 'bolt', title: 'Top Single Game', tag: 'one game', name: `<a href="/team?team=${topGames[0].teamId}" style="color:inherit;text-decoration:none">${escapeHtml(topGames[0].team)}</a> <span class="hl-sub">(${escapeHtml(topGames[0].owner)})</span>`, value: `+${topScore}`, tone: 'good' });
         }
     }
 

--- a/public/standings.js
+++ b/public/standings.js
@@ -411,7 +411,7 @@ function renderProjPanel(managers) {
         <div class="pp-row">
             <span class="pp-rank">${i + 1}</span>
             ${projAvatarHtml(m)}
-            <span class="pp-id"><span class="pp-name">${escapeHtml(m.franchise || m.name)}</span>${m.franchise ? `<span class="pp-sub">${escapeHtml(m.name)}</span>` : ''}</span>
+            <a href="/userHome?user=${m.userId}" class="pp-id" style="color:inherit;text-decoration:none"><span class="pp-name">${escapeHtml(m.franchise || m.name)}</span>${m.franchise ? `<span class="pp-sub">${escapeHtml(m.name)}</span>` : ''}</a>
             <span class="pp-points"><span class="pp-cur">${m.banked}</span><i class="fa-solid fa-arrow-right pp-arrow"></i><span class="pp-proj">${m.projectedFinal}</span></span>
             <span class="pp-title"><span class="pp-bar"><i style="width:${Math.min(100, m.titleOdds)}%"></i></span><b>${m.titleOdds}%</b></span>
         </div>`).join('');
@@ -1111,12 +1111,12 @@ async function displaySchedule(data) {
 
                     teamTable += '<tr><td style="width: 250px;">';
         
-                    teamTable += awayImg + awayRank + awayTeam;
+                    teamTable += awayTeam.replace('>', '>' + awayImg + awayRank);
                     teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 70px;">' + topData;
                     teamTable += '</tr>';
-        
+
                     teamTable += '<tr><td style="width: 250px;">';
-                    teamTable += homeImg + homeRank + homeTeam;
+                    teamTable += homeTeam.replace('>', '>' + homeImg + homeRank);
                     teamTable += '</td><td align="center" style="width: 20px; border-left: 1px solid #A4A9C2;"></td><td style="width: 100px;">' + bottomData;
                     teamTable += '</tr>';
                     teamTable += `<tr><td><strong>${homeUser}</strong></td></tr>`;

--- a/public/team.css
+++ b/public/team.css
@@ -42,6 +42,7 @@
     }
 
     .team-conf {
+    margin-top: 0.5rem;
     font-size: 0.9rem;
     color: var(--cc-muted);
     }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -205,7 +205,7 @@ async function renderBento(data, yearOverride) {
     } catch (e) { /* rank optional */ }
     sh += statTile(String(season.cumulativeScore || 0), 'Total points');
     const bt = bestTeam(season);
-    if (bt && bt.total > 0) sh += statTile(`<img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}`, `Best: ${bt.team.school}`);
+    if (bt && bt.total > 0) sh += statTile(`<a href="/team?team=${bt.team.id}" style="color:inherit;text-decoration:none"><img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}</a>`, `Best: ${escapeHtml(bt.team.school)}`);
     statsEl.innerHTML = sh;
 
     if (own && !isPastSeason) setupEditModal(data, season, true);
@@ -350,7 +350,7 @@ function preRecapHtml(prior, own, name) {
     weeklyColumns(prior).forEach(c => { if (!c.entry) return; cum += c.entry.score || 0; series.push(cum); });
     const spark = series.length >= 2 ? `<div class="uh-pre-spark">${uhSpark(series, 240, 40, '#5BD08D')}</div>` : '';
     const bestStat = (bt && bt.total > 0)
-        ? `<div class="uh-pre-stat"><span class="uh-pre-stat-v"><img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}</span><span class="uh-pre-stat-k">Best: ${escapeHtml(bt.team.school)}</span></div>`
+        ? `<div class="uh-pre-stat"><span class="uh-pre-stat-v"><a href="/team?team=${bt.team.id}" style="color:inherit;text-decoration:none"><img src="${ccLogo(bt.team.logos)}" alt="">${bt.total}</a></span><span class="uh-pre-stat-k">Best: ${escapeHtml(bt.team.school)}</span></div>`
         : '';
     return `<div class="uh-tile uh-pre-recap">
         <span class="uh-tlabel">${uhPoss(own, true)} ${escapeHtml(prior.season)} season</span>
@@ -380,7 +380,7 @@ function preHistoryHtml(data, activeYear, own) {
         const chips = ordered.map((t, i) => {
             const isBest = bestId != null && Number(t.id) === Number(bestId);
             const pts = isBest ? ` <span class="uh-hist-pts num">${best.total}</span>` : '';
-            return `<span class="uh-hist-chip${isBest ? ' r1' : ''}${i >= 4 ? ' uh-hist-extra' : ''}">${isBest ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}${pts}</span>`;
+            return `<a href="/team?team=${t.id}" class="uh-hist-chip${isBest ? ' r1' : ''}${i >= 4 ? ' uh-hist-extra' : ''}" style="color:inherit;text-decoration:none">${isBest ? '<span class="uh-hist-star">★</span>' : ''}${escapeHtml(t.school)}${pts}</a>`;
         }).join('');
         const moreN = ordered.length - 4;
         const more = moreN > 0 ? `<button type="button" class="uh-hist-more" data-more="+${moreN} more">+${moreN} more</button>` : '';
@@ -529,7 +529,7 @@ function hydrateRoster(user, activeYear) {
     const g = document.getElementById('uh-glance-roster');
     if (g) {
         g.innerHTML = top && top.pts > 0
-            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => `<span class="uh-rg-row"><img src="${ccLogo(c.t.logos)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></span>`).join('')}</span>`
+            ? `<span class="uh-rg">${cards.slice(0, 4).map((c, i) => `<a href="/team?team=${c.t.id}" class="uh-rg-row" style="color:inherit;text-decoration:none"><img src="${ccLogo(c.t.logos)}" alt=""><span class="uh-rg-nm">${escapeHtml(c.t.school)}${i === 0 ? ' <span class="uh-rg-star">★</span>' : ''}</span><span class="uh-rg-pts num">${c.pts}</span></a>`).join('')}</span>`
             : (uhOwns(user) ? 'Your 10 teams' : 'Their 10 teams');
     }
 
@@ -632,7 +632,7 @@ async function hydrateGames(user, activeYear) {
                 getGame(seasonType, week, t).then(gs => ({ t, plays: !!(gs && gs.length) })).catch(() => ({ t, plays: false }))));
             const playing = per.filter(x => x.plays).map(x => x.t);
             if (playing.length) {
-                const logos = playing.map(t => `<img src="${ccLogo(t.logos)}" alt="">`).join('');
+                const logos = playing.map(t => `<a href="/team?team=${t.id}" style="color:inherit;text-decoration:none"><img src="${ccLogo(t.logos)}" alt=""></a>`).join('');
                 g.innerHTML = `<span class="uh-games-logos">${logos}</span><span class="uh-glance-sub uh-games-wk">${playing.length} of ${uhPoss(uhOwns(user))} teams · ${escapeHtml(label)}</span>`;
             } else {
                 g.innerHTML = `<span class="uh-glance-sub">No games for ${uhPoss(uhOwns(user))} teams · ${escapeHtml(label)}</span>`;
@@ -983,7 +983,7 @@ async function hydrateCaptain(user, activeYear) {
         if (!g) return;
         const t = state.teamId != null ? teamById[state.teamId] : null;
         const lead = t
-            ? `<span class="uh-cap-glance"><img src="${ccLogo(t.logos)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></span>`
+            ? `<a href="/team?team=${t.id}" class="uh-cap-glance" style="color:inherit;text-decoration:none"><img src="${ccLogo(t.logos)}" alt=""> ${escapeHtml(t.school)} <span class="uh-cap-2x">2×</span></a>`
             : `<span class="captain-unset">${state.locked ? 'No pick · Wk ' + state.week : 'Set for Wk ' + state.week}</span>`;
         let sub;
         if (state.locked) sub = 'Locked for this week';
@@ -1089,7 +1089,7 @@ async function hydrateCaptain(user, activeYear) {
         html += statTile(`+${earned}`, 'Bonus earned');
         if (left > 0) html += statTile(`${left}`, 'Left on table');
         if (t && bestWeek) html += statTile(
-            `<img src="${ccLogo(t.logos)}" alt=""> +${bestWeek.bonus}`,
+            `<a href="/team?team=${t.id}" style="color:inherit;text-decoration:none"><img src="${ccLogo(t.logos)}" alt=""> +${bestWeek.bonus}</a>`,
             `Best pick · Wk ${bestWeek.week}`);
         html += '</div></div>';
         return html;
@@ -1158,12 +1158,15 @@ async function hydrateBetting(user, activeYear) {
                                 const isHome = sel.includes(game.homeTeam.toLowerCase());
                                 const logos = isHome ? game.homeLogos : game.awayLogos;
                                 const src = typeof ccLogo === 'function' ? ccLogo(logos) : (logos && logos[0] || '');
-                                if (src) logoHtml = '<img src="' + src + '" alt="" style="height:18px;width:18px;vertical-align:middle;margin-right:4px;">';
+                                if (src) {
+                                    var teamId = isHome ? game.homeId : game.awayId;
+                                    logoHtml = '<a href="/team?team=' + teamId + '" style="color:inherit;text-decoration:none"><img src="' + src + '" alt="" style="height:18px;width:18px;vertical-align:middle;margin-right:4px;">' + escapeHtml(myLeg.selection) + '</a>';
+                                }
                             }
                         }
                     } catch (_) {}
                 }
-                g.innerHTML = 'Wk ' + target.week + ' · ' + logoHtml + escapeHtml(myLeg.selection);
+                g.innerHTML = 'Wk ' + target.week + ' · ' + (logoHtml || escapeHtml(myLeg.selection));
             } else {
                 g.textContent = 'Wk ' + target.week + ' · Pick your leg';
             }
@@ -1924,11 +1927,11 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
 
     const awayRostered = rosteredIds.has(game.awayId);
     const homeRostered = rosteredIds.has(game.homeId);
-    const nameHtml = (id, name, rostered) =>
-        `<a href="/team?team=${id}">${rostered ? '<strong>' + name + '</strong>' : name}</a>`;
+    const nameHtml = (id, name, rostered, logo) =>
+        `<a href="/team?team=${id}">${logo}${rostered ? '<strong>' + name + '</strong>' : name}</a>`;
 
-    const awayCol = logoHtmlFromMap(logoMap, game.awayId) + rankHtml(rankOf(game.awayTeam)) + nameHtml(game.awayId, game.awayTeam, awayRostered) + lineHtml(awayLine);
-    const homeCol = logoHtmlFromMap(logoMap, game.homeId) + rankHtml(rankOf(game.homeTeam)) + nameHtml(game.homeId, game.homeTeam, homeRostered) + lineHtml(homeLine);
+    const awayCol = nameHtml(game.awayId, game.awayTeam, awayRostered, logoHtmlFromMap(logoMap, game.awayId) + rankHtml(rankOf(game.awayTeam))) + lineHtml(awayLine);
+    const homeCol = nameHtml(game.homeId, game.homeTeam, homeRostered, logoHtmlFromMap(logoMap, game.homeId) + rankHtml(rankOf(game.homeTeam))) + lineHtml(homeLine);
 
     // A rostered team's points for this game -> a green badge cell, or '' at 0.
     const badgeCell = (id, rostered) => {

--- a/tests/StandingsInsights.spec.js
+++ b/tests/StandingsInsights.spec.js
@@ -560,7 +560,7 @@ describe('buildHighlights', () => {
                 { score: 15, scoreByTeam: [{ teamId: 1, team: 'Indiana', score: 15 }] }
             ], { teams })
         ]));
-        expect(cards['Best Team'].name).toBe('<img src="ind.png" class="hl-logo">Hoosiers');
+        expect(cards['Best Team'].name).toBe('<a href="/team?team=1" style="color:inherit;text-decoration:none"><img src="ind.png" class="hl-logo">Hoosiers</a>');
         expect(cards['Best Team'].value).toBe('+35');
     });
 
@@ -606,7 +606,7 @@ describe('buildHighlights', () => {
             user('b', 'Bob', 'Brown', [{ score: 10, scoreByTeam: [{ teamId: 2, team: 'Purdue', score: 10 }] }])
         ]));
         expect(cards['Top Single Game']).toMatchObject({ tag: 'one game', value: '+30' });
-        expect(cards['Top Single Game'].name).toBe('Indiana <span class="hl-sub">(Alice A.)</span>');
+        expect(cards['Top Single Game'].name).toBe('<a href="/team?team=1" style="color:inherit;text-decoration:none">Indiana</a> <span class="hl-sub">(Alice A.)</span>');
     });
 
     it('still reads as one game when the same team ties its own high', () => {


### PR DESCRIPTION
## Summary
- Wrap non-clickable team names/logos in `<a>` tags across userHome (hero stats, preseason recap, history chips, roster/games/captain/betting glances, game cards), standings (game card logos, projected finish franchise names), and standings insights (Best Team, Top Single Game)
- All links use `color:inherit; text-decoration:none` so displays are unchanged — just clickable
- Adds `margin-top: 0.5rem` to `.team-conf` on team page for spacing

## Test plan
- [x] All 1298 tests pass (2 test assertions updated for new `<a>` wrappers in standings-insights)
- [ ] Verify team name/logo links navigate to `/team?team={id}` on userHome, standings, and standings insights pages
- [ ] Verify projected finish franchise names link to `/userHome?user={id}`
- [ ] Confirm no visual changes — links should be invisible (same color, no underline)
- [ ] Check mobile layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)