### PR TITLE
Update game card date format to DAY M/D

### DIFF
--- a/public/team.js
+++ b/public/team.js
@@ -1119,22 +1119,15 @@ async function getRecruitingRankings(team, seasonYear) {
 // Helper: Format the date to readable format
 function formatDate(isTbd, dateStr) {
   const date = new Date(dateStr);
+  const day = ['SUN','MON','TUE','WED','THU','FRI','SAT'][date.getDay()];
+  const datePart = (date.getMonth() + 1) + '/' + date.getDate();
 
   if (isTbd) {
-    var formatDate = date.toLocaleString(undefined, {
-        month: 'numeric',
-        day: 'numeric',         // "30"
-    });
-
-    return formatDate + " TBD";
+    return day + ' ' + datePart + ' TBD';
   } else {
-    return date.toLocaleString(undefined, {
-        month: 'numeric',
-        day: 'numeric',         // "30"
-        hour: 'numeric',        // "1"
-        minute: '2-digit',      // "00"
-        hour12: true            // AM/PM
-    });
+    var h = date.getHours(), m = date.getMinutes().toString().padStart(2, '0');
+    var time = h === 0 ? '12:' + m + 'AM' : h < 12 ? h + ':' + m + 'AM' : h === 12 ? '12:' + m + 'PM' : (h - 12) + ':' + m + 'PM';
+    return day + ' ' + datePart + ', ' + time;
   }
 }
 

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -477,6 +477,8 @@
    (the winner row trails a caret + points badge, which would otherwise push
    its number out of line under right-alignment). */
 .game-card .gc-score { text-align: left; white-space: nowrap; padding-left: 0.9em; width: 1%; }
+.game-card .gc-date { font-size: 0.75rem; color: var(--cc-muted); font-weight: 500; }
+.game-card .gc-time { font-size: 0.8rem; color: #A4A9C2; font-weight: 500; }
 .game-card .score-added { white-space: nowrap; padding-left: 0.5em; }
 
 /* The "+N" badge is a button: tap to reveal the scoring breakdown. Looks like

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -1955,8 +1955,9 @@ function buildGameCard(game, rosteredIds, logoMap, rankingsInfo, allBettingLines
         homeScore = (game.homePoints ?? 0) + (homeWon ? caret : '') + '</td>' + badgeCell(game.homeId, homeRostered);
     } else {
         const d = new Date(game.startDate);
-        awayScore = d.toString().substring(4, 10) + '</td>';
-        homeScore = (game.startTimeTbd ? 'TBD' : kickoffTime(d)) + '</td>';
+        const dayAbbr = ['SUN','MON','TUE','WED','THU','FRI','SAT'][d.getDay()];
+        awayScore = '<span class="gc-date">' + dayAbbr + ' ' + (d.getMonth() + 1) + '/' + d.getDate() + '</span></td>';
+        homeScore = '<span class="gc-time">' + (game.startTimeTbd ? 'TBD' : kickoffTime(d)) + '</span></td>';
     }
 
     const isLive = !game.completed && game.startDate && new Date(game.startDate) < new Date();


### PR DESCRIPTION
## Summary
- Scheduled game dates now display as `FRI 9/4` instead of `Sep 04` — matches how people actually think about game day
- Date/time text is styled smaller (0.75–0.8rem) and muted so it reads as metadata, not a headline competing with team names
- Updated both `buildGameCard` in userHome.js and `formatDate` in team.js for consistency

## Test plan
- [ ] Check My Team schedule cards show `DAY M/D` format with subdued styling
- [ ] Check Team page schedule list and "next game" card show `DAY M/D` format
- [ ] Verify completed game scores are unaffected (still full size, white text)
- [ ] Check mobile rendering on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)