### PR TITLE
Apply DAY M/D date format to rivalry game cards

### DIFF
--- a/public/standings.js
+++ b/public/standings.js
@@ -1086,24 +1086,12 @@ async function displaySchedule(data) {
                     } else {
         
                         var centralDate = new Date(game.startDate);
-                        var militaryTime = centralDate.toString().substring(16,21);
-                        var time = militaryTime.split(':');
-                        var hours = parseInt(time[0]);
-                        var minutes = time[1];
-                        var standardTime = '';
-        
-                        if (hours < 12) {
-                            standardTime = hours.toString() + ":" + minutes +  "AM";
-                        }
-                        else if (hours == 12) {
-                            standardTime = hours.toString() + ":" + minutes + "PM";
-                        }
-                        else {
-                            standardTime =( hours - 12).toString() + ":" + minutes + "PM";
-                        }
-        
-                        topData = centralDate.toString().substring(4,10);
-                        bottomData = standardTime;
+                        var dayAbbr = ['SUN','MON','TUE','WED','THU','FRI','SAT'][centralDate.getDay()];
+                        var h = centralDate.getHours(), min = centralDate.getMinutes().toString().padStart(2, '0');
+                        var standardTime = h === 0 ? '12:' + min + 'AM' : h < 12 ? h + ':' + min + 'AM' : h === 12 ? '12:' + min + 'PM' : (h - 12) + ':' + min + 'PM';
+
+                        topData = '<span class="gc-date">' + dayAbbr + ' ' + (centralDate.getMonth() + 1) + '/' + centralDate.getDate() + '</span>';
+                        bottomData = '<span class="gc-time">' + standardTime + '</span>';
                     }
         
                     var teamTable = '<td><table class="schedule-table game-table"><tbody><tr firstRow></tr>';

--- a/public/styles.css
+++ b/public/styles.css
@@ -893,3 +893,7 @@ footer {
     .dev-spoof { justify-content: center; padding: 0.5rem 0; }
     .dev-spoof-menu { right: auto; left: 50%; transform: translateX(-50%); }
 }
+
+/* Scheduled game date/time — muted metadata styling */
+.gc-date { font-size: 0.75rem; color: var(--cc-muted); font-weight: 500; }
+.gc-time { font-size: 0.8rem; color: #A4A9C2; font-weight: 500; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -477,8 +477,6 @@
    (the winner row trails a caret + points badge, which would otherwise push
    its number out of line under right-alignment). */
 .game-card .gc-score { text-align: left; white-space: nowrap; padding-left: 0.9em; width: 1%; }
-.game-card .gc-date { font-size: 0.75rem; color: var(--cc-muted); font-weight: 500; }
-.game-card .gc-time { font-size: 0.8rem; color: #A4A9C2; font-weight: 500; }
 .game-card .score-added { white-space: nowrap; padding-left: 0.5em; }
 
 /* The "+N" badge is a button: tap to reveal the scoring breakdown. Looks like


### PR DESCRIPTION
## Summary
- Rivalry Games cards on standings now show `SAT 9/4` instead of `Sep 04`, matching the My Team schedule format from #344
- Date/time text uses the same muted `.gc-date`/`.gc-time` styling so it reads as metadata
- Moved shared `.gc-date`/`.gc-time` styles from `userHome.css` to `styles.css` so they apply on every page

## Test plan
- [ ] Check Rivalry Games section on standings shows `DAY M/D` format with subdued styling
- [ ] Verify completed rivalry game scores are unaffected
- [ ] Confirm My Team schedule cards still render correctly (styles moved, not removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)