### PR TITLE
Add page-load stagger animation to bento tiles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -894,6 +894,30 @@ footer {
     .dev-spoof-menu { right: auto; left: 50%; transform: translateX(-50%); }
 }
 
+/* Page-load stagger — children fade-slide in one by one. */
+@keyframes cc-stagger-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+.cc-stagger > * {
+    opacity: 0;
+    animation: cc-stagger-in 0.4s ease-out forwards;
+}
+.cc-stagger > :nth-child(1)  { animation-delay: 0s; }
+.cc-stagger > :nth-child(2)  { animation-delay: 0.06s; }
+.cc-stagger > :nth-child(3)  { animation-delay: 0.12s; }
+.cc-stagger > :nth-child(4)  { animation-delay: 0.15s; }
+.cc-stagger > :nth-child(5)  { animation-delay: 0.18s; }
+.cc-stagger > :nth-child(6)  { animation-delay: 0.21s; }
+.cc-stagger > :nth-child(7)  { animation-delay: 0.24s; }
+.cc-stagger > :nth-child(8)  { animation-delay: 0.27s; }
+.cc-stagger > :nth-child(9)  { animation-delay: 0.30s; }
+.cc-stagger > :nth-child(10) { animation-delay: 0.33s; }
+.cc-stagger > :nth-child(n+11) { animation-delay: 0.36s; }
+@media (prefers-reduced-motion: reduce) {
+    .cc-stagger > * { animation: none; opacity: 1; }
+}
+
 /* Scheduled game date/time — muted metadata styling */
 .gc-date { font-size: 0.75rem; color: var(--cc-muted); font-weight: 500; }
 .gc-time { font-size: 0.8rem; color: #A4A9C2; font-weight: 500; }

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -210,6 +210,7 @@ async function renderBento(data, yearOverride) {
 
     if (own && !isPastSeason) setupEditModal(data, season, true);
 
+    bento.classList.add('cc-stagger');
     bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
     setupDrawer();
 
@@ -291,6 +292,7 @@ function renderPreseason(bento, data, activeYear, ctx) {
         + preHistoryHtml(data, activeYear, own);
 
     renderAvatar(document.getElementById('uh-hero-av'), data);
+    bento.classList.add('cc-stagger');
     // Name is editable only once the manager has an active-season entry to write
     // it onto; before that only the photo can be set.
     if (own) setupEditModal(data, activeEntry || {}, !!activeEntry);


### PR DESCRIPTION
## Summary
- Adds a shared `.cc-stagger` CSS utility in `styles.css` — children fade-slide in with cascading delays
- Applied to the My Team bento grid so tiles appear one by one on page load
- Works on both the in-season and preseason bento layouts
- Respects `prefers-reduced-motion`

## Test plan
- [ ] Visit My Team — tiles should cascade in from top to bottom over ~0.4s
- [ ] Switch season pills (2026/2025/etc.) — re-render should stagger again
- [ ] Enable reduced motion in OS settings — tiles should appear instantly with no animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)