### PR TITLE
Add pull-to-refresh on mobile

### DIFF
--- a/public/pull-to-refresh.js
+++ b/public/pull-to-refresh.js
@@ -1,0 +1,52 @@
+// Pull-to-refresh for mobile — attach to any page by including this script.
+// Shows a small spinner indicator when the user pulls down from the top,
+// then reloads. Only activates on touch devices when scrolled to the top.
+(function () {
+    if (!('ontouchstart' in window)) return;
+
+    var startY = 0;
+    var pulling = false;
+    var indicator = null;
+    var THRESHOLD = 80;
+
+    function createIndicator() {
+        var el = document.createElement('div');
+        el.className = 'ptr-indicator';
+        el.innerHTML = '<span class="ptr-spinner"></span>';
+        document.body.appendChild(el);
+        return el;
+    }
+
+    document.addEventListener('touchstart', function (e) {
+        if (window.scrollY > 5) return;
+        startY = e.touches[0].clientY;
+        pulling = true;
+    }, { passive: true });
+
+    document.addEventListener('touchmove', function (e) {
+        if (!pulling) return;
+        var dy = e.touches[0].clientY - startY;
+        if (dy < 0) { pulling = false; return; }
+        if (dy > 10 && !indicator) indicator = createIndicator();
+        if (indicator) {
+            var progress = Math.min(dy / THRESHOLD, 1);
+            indicator.style.transform = 'translateX(-50%) translateY(' + Math.min(dy * 0.4, 60) + 'px)';
+            indicator.style.opacity = progress;
+            indicator.classList.toggle('ptr-ready', progress >= 1);
+        }
+    }, { passive: true });
+
+    document.addEventListener('touchend', function () {
+        if (!pulling) return;
+        pulling = false;
+        if (indicator && indicator.classList.contains('ptr-ready')) {
+            indicator.classList.add('ptr-loading');
+            indicator.style.transform = 'translateX(-50%) translateY(48px)';
+            window.location.reload();
+        } else if (indicator) {
+            indicator.style.transform = 'translateX(-50%) translateY(0)';
+            indicator.style.opacity = '0';
+            setTimeout(function () { if (indicator) { indicator.remove(); indicator = null; } }, 200);
+        }
+    }, { passive: true });
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -918,6 +918,36 @@ footer {
     .cc-stagger > * { animation: none; opacity: 1; }
 }
 
+/* Pull-to-refresh indicator */
+.ptr-indicator {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%) translateY(0);
+    z-index: 9999;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--cc-surface);
+    border: 1px solid var(--cc-border);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+}
+.ptr-spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--cc-border-2);
+    border-top-color: var(--cc-accent);
+    border-radius: 50%;
+}
+.ptr-ready .ptr-spinner { border-top-color: var(--cc-accent); }
+.ptr-loading .ptr-spinner { animation: ptr-spin 0.6s linear infinite; }
+@keyframes ptr-spin { to { transform: rotate(360deg); } }
+
 /* Scheduled game date/time — muted metadata styling */
 .gc-date { font-size: 0.75rem; color: var(--cc-muted); font-weight: 500; }
 .gc-time { font-size: 0.8rem; color: #A4A9C2; font-weight: 500; }

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -10,6 +10,7 @@
     <link href="loading.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">    
     <script src="confetti.js"></script>
+    <script src="pull-to-refresh.js"></script>
     <script src="standings.js" type="module"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -16,6 +16,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
     <script defer src="draftGrades.js"></script>
     <script src="win-reveal.js"></script>
+    <script src="pull-to-refresh.js"></script>
     <script defer src="userHome.js"></script>
     <title data-league-title="My Team">My Team · Campus Clash</title>
     <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />


### PR DESCRIPTION
## Summary
- Adds pull-to-refresh gesture on mobile for Standings and My Team pages
- Shows a small spinner indicator when pulling down from the top, reloads on release past threshold
- Touch-only — no-op on desktop (checks for `ontouchstart`)
- Shared `pull-to-refresh.js` script + `.ptr-indicator` CSS in `styles.css`

## Test plan
- [ ] On mobile (or Chrome DevTools mobile emulation with touch): pull down from top of Standings — spinner appears, page reloads
- [ ] Same on My Team page
- [ ] Pull down but not past threshold — spinner fades away, no reload
- [ ] On desktop — no effect from scrolling up
- [ ] Scrolled partway down the page — pulling doesn't trigger (only activates at scroll top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)