### PR TITLE
Swap favicon to team logo on team pages

### DIFF
--- a/public/team.js
+++ b/public/team.js
@@ -91,6 +91,19 @@ async function loadTeamPage() {
     // Theme the page from the team's own colours before anything renders.
     applyTeamTheme(teamData);
 
+    // Swap the favicon to the team's logo so the browser tab shows their mark.
+    var teamLogoUrl = typeof ccLogo === 'function' ? ccLogo(teamData.logos) : (teamData.logos && teamData.logos[0] || '');
+    if (teamLogoUrl) {
+        var svgIcon = document.querySelector('link[rel="icon"][type="image/svg+xml"]');
+        var pngIcons = document.querySelectorAll('link[rel="icon"][type="image/png"]');
+        if (svgIcon) svgIcon.remove();
+        pngIcons.forEach(function (el) { el.remove(); });
+        var link = document.createElement('link');
+        link.rel = 'icon';
+        link.href = teamLogoUrl;
+        document.head.appendChild(link);
+    }
+
     // Honour an explicit ?season=YYYY (from the season selector); otherwise show
     // the latest season with games played.
     const seasonParam = urlParams.get('season');


### PR DESCRIPTION
## Summary
- On team pages, the browser tab favicon swaps to the team's own logo
- Removes the default SVG/PNG favicon links and replaces with a single link to the team logo via `ccLogo`
- Runs right after `applyTeamTheme` so the tab updates early

## Test plan
- [ ] Visit a team page (e.g. /team?team=251 for Texas) — browser tab should show team logo instead of the football
- [ ] Navigate back to Standings or My Team — default favicon returns (full page load)
- [ ] Visit a team with no logo — default favicon should remain (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)