### PR TITLE
Add tactile button press and haptic feedback

### DIFF
--- a/public/haptic.js
+++ b/public/haptic.js
@@ -1,0 +1,26 @@
+// Haptic feedback on key mobile interactions.
+// Uses the Vibration API (Android) — iOS doesn't support it from the web,
+// but the tactile CSS press still provides visual feedback there.
+(function () {
+    if (!navigator.vibrate) return;
+
+    var LIGHT = 8;
+    var MEDIUM = 15;
+
+    document.addEventListener('click', function (e) {
+        var el = e.target.closest(
+            '.btn-primary, .btn-secondary, .btn-ghost, ' +
+            '.dropdown-toggle, .uh-season-pill, .uh-tile, ' +
+            '.welcome-actions button, .modal-actions button, ' +
+            '.standings-row, .h2h-card, .uh-edit'
+        );
+        if (!el) return;
+
+        // Stronger pulse for primary actions
+        if (el.matches('.btn-primary, .modal-actions .btn-primary')) {
+            navigator.vibrate(MEDIUM);
+        } else {
+            navigator.vibrate(LIGHT);
+        }
+    }, { passive: true });
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -948,6 +948,35 @@ footer {
 .ptr-loading .ptr-spinner { animation: ptr-spin 0.6s linear infinite; }
 @keyframes ptr-spin { to { transform: rotate(360deg); } }
 
+/* Tactile press — all interactive buttons get a subtle scale-down on tap/click. */
+.btn-primary,
+.btn-secondary,
+.btn-ghost,
+.dropdown-toggle,
+.uh-season-pill,
+.welcome-actions button,
+.modal-actions button {
+    transition: transform 0.1s ease, background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.btn-primary:active,
+.btn-secondary:active,
+.btn-ghost:active,
+.dropdown-toggle:active,
+.uh-season-pill:active,
+.welcome-actions button:active,
+.modal-actions button:active {
+    transform: scale(0.96);
+}
+@media (prefers-reduced-motion: reduce) {
+    .btn-primary:active,
+    .btn-secondary:active,
+    .btn-ghost:active,
+    .dropdown-toggle:active,
+    .uh-season-pill:active,
+    .welcome-actions button:active,
+    .modal-actions button:active { transform: none; }
+}
+
 /* Scheduled game date/time — muted metadata styling */
 .gc-date { font-size: 0.75rem; color: var(--cc-muted); font-weight: 500; }
 .gc-time { font-size: 0.8rem; color: #A4A9C2; font-weight: 500; }

--- a/public/userHome.css
+++ b/public/userHome.css
@@ -648,7 +648,7 @@ button.uh-tile:focus-visible { outline: 2px solid var(--cc-info); outline-offset
 .uh-hero-stats .stat-value img { height: 1.1rem; width: auto; }
 .uh-hero-stats .stat-label { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--cc-muted-2); margin-top: 2px; }
 .uh-season-picker { display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }
-.uh-season-pill { all: unset; cursor: pointer; font-size: 0.72rem; font-weight: 700; padding: 3px 10px; border-radius: 99px; border: 1px solid var(--cc-border); color: var(--cc-muted-2); transition: background 0.15s, color 0.15s, border-color 0.15s; }
+.uh-season-pill { all: unset; cursor: pointer; font-size: 0.72rem; font-weight: 700; padding: 3px 10px; border-radius: 99px; border: 1px solid var(--cc-border); color: var(--cc-muted-2); transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.1s ease; }
 .uh-season-pill:hover { color: var(--cc-text); border-color: var(--cc-muted); }
 .uh-season-pill.active { background: var(--cc-text); color: var(--cc-bg); border-color: var(--cc-text); }
 /* Preseason / undrafted-window empty state (active season not yet drafted). */

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="styles.css">
+    <script src="haptic.js"></script>
     <link rel="stylesheet" href="admin.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/views/betting.ejs
+++ b/views/betting.ejs
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="betting.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">

--- a/views/draftBoard.ejs
+++ b/views/draftBoard.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="draftBoard.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/views/draftRoom.ejs
+++ b/views/draftRoom.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="draftRoom.css" rel="stylesheet">
     <link href="draftGrades.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="history.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/views/scoringRules.ejs
+++ b/views/scoringRules.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="styles.css">
+    <script src="haptic.js"></script>
     <link rel="stylesheet" href="scoringRules.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"/>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/views/standings.ejs
+++ b/views/standings.ejs
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="standings.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">    

--- a/views/team.ejs
+++ b/views/team.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="team.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
+    <script src="haptic.js"></script>
     <link href="userHome.css" rel="stylesheet">
     <link href="draftGrades.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- CSS `scale(0.96)` on `:active` for all button types (primary, secondary, ghost, dropdowns, season pills, modal actions) with `prefers-reduced-motion` respect
- New `haptic.js` — Vibration API (Android) gives light (8ms) and medium (15ms) pulses on interactive element taps; no-ops gracefully on iOS
- Fix season pill transition override caused by `all: unset` in userHome.css
- Script added to all 9 view templates

## Test plan
- [ ] Tap buttons on mobile — verify subtle scale-down on press
- [ ] Test on Android — confirm vibration feedback on button/tile taps
- [ ] Test on iOS — confirm no errors (vibration silently skips)
- [ ] Verify `prefers-reduced-motion` disables the scale animation
- [ ] Check season pills still animate correctly on My Team page

🤖 Generated with [Claude Code](https://claude.com/claude-code)