### PR TITLE
Add count-up animations to scores and point totals

### DIFF
--- a/public/count-up.js
+++ b/public/count-up.js
@@ -1,0 +1,34 @@
+// Animate numeric values from 0 to their target on first appearance.
+// Call ccCountUp(containerEl) after inserting DOM with numeric elements.
+(function () {
+    var DURATION = 800;
+    var SELECTOR = '.stat-value, .uh-traj-num, .uh-mug-sc, .uh-rg-pts, .uh-mug-pct, .uh-sched-pct, .uh-pre-stat-v, .uh-hist-pts';
+    var reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    window.ccCountUp = function (root) {
+        if (!root || reduced) return;
+        var els = root.querySelectorAll(SELECTOR);
+        for (var i = 0; i < els.length; i++) animate(els[i]);
+    };
+
+    function animate(el) {
+        if (el.children.length > 0) return;
+        var text = el.textContent.trim();
+        var m = text.match(/^([+\-−]?)(\d+(?:\.\d+)?)(\s*%?)$/);
+        if (!m) return;
+        var prefix = m[1];
+        var target = parseFloat(m[2]);
+        var suffix = m[3];
+        if (target === 0) return;
+        var isInt = target % 1 === 0;
+        var start = performance.now();
+
+        requestAnimationFrame(function tick(now) {
+            var t = Math.min((now - start) / DURATION, 1);
+            var ease = 1 - Math.pow(1 - t, 3);
+            var cur = ease * target;
+            el.textContent = prefix + (isInt ? Math.round(cur) : cur.toFixed(1)) + suffix;
+            if (t < 1) requestAnimationFrame(tick);
+        });
+    }
+})();

--- a/public/userHome.js
+++ b/public/userHome.js
@@ -211,6 +211,7 @@ async function renderBento(data, yearOverride) {
     if (own && !isPastSeason) setupEditModal(data, season, true);
 
     bento.classList.add('cc-stagger');
+    if (typeof ccCountUp === 'function') ccCountUp(bento);
     bento.querySelectorAll('[data-tile]').forEach(t => t.addEventListener('click', () => openDrawer(t.getAttribute('data-tile'))));
     setupDrawer();
 
@@ -293,6 +294,7 @@ function renderPreseason(bento, data, activeYear, ctx) {
 
     renderAvatar(document.getElementById('uh-hero-av'), data);
     bento.classList.add('cc-stagger');
+    if (typeof ccCountUp === 'function') ccCountUp(bento);
     // Name is editable only once the manager has an active-season entry to write
     // it onto; before that only the photo can be set.
     if (own) setupEditModal(data, activeEntry || {}, !!activeEntry);
@@ -603,6 +605,7 @@ function hydrateTrajectory(user, activeYear) {
             }
         } catch (e) { /* stats degrade to points-only */ }
         statsEl.innerHTML = html;
+        if (typeof ccCountUp === 'function') ccCountUp(statsEl);
     };
 }
 

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -82,23 +82,6 @@
         }
         .error-btn:hover { filter: brightness(1.1); }
         .error-btn:focus-visible { outline: 2px solid var(--cc-info); outline-offset: 2px; }
-
-        /* Football Easter egg — tumbles down from above and settles with a bounce */
-        .error-football {
-            width: 64px;
-            height: 64px;
-            margin: 0 auto 0.75rem;
-            animation: fb-tumble 1.2s cubic-bezier(0.22, 1, 0.36, 1) both;
-        }
-        @keyframes fb-tumble {
-            0%   { opacity: 0; transform: translateY(-80px) rotate(-200deg) scale(0.6); }
-            60%  { opacity: 1; transform: translateY(8px) rotate(15deg) scale(1.05); }
-            80%  { transform: translateY(-4px) rotate(-5deg) scale(0.98); }
-            100% { opacity: 1; transform: translateY(0) rotate(0deg) scale(1); }
-        }
-        @media (prefers-reduced-motion: reduce) {
-            .error-football { animation: none; }
-        }
     </style>
 </head>
 
@@ -110,24 +93,6 @@
                 <div class="brand-clash">Clash</div>
             </div>
         </a>
-        <svg class="error-football" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <ellipse cx="32" cy="32" rx="28" ry="18" fill="#8B4513" stroke="#5C2D06" stroke-width="1.5"/>
-            <ellipse cx="32" cy="32" rx="28" ry="18" fill="url(#fb-shade)"/>
-            <!-- Laces -->
-            <line x1="24" y1="32" x2="40" y2="32" stroke="white" stroke-width="2" stroke-linecap="round"/>
-            <line x1="27" y1="28" x2="27" y2="36" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-            <line x1="32" y1="27" x2="32" y2="37" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-            <line x1="37" y1="28" x2="37" y2="36" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-            <!-- Seam lines -->
-            <path d="M6 26 Q 32 18 58 26" stroke="#5C2D06" stroke-width="0.8" fill="none" opacity="0.5"/>
-            <path d="M6 38 Q 32 46 58 38" stroke="#5C2D06" stroke-width="0.8" fill="none" opacity="0.5"/>
-            <defs>
-                <radialGradient id="fb-shade" cx="0.4" cy="0.35" r="0.6">
-                    <stop offset="0%" stop-color="white" stop-opacity="0.15"/>
-                    <stop offset="100%" stop-color="black" stop-opacity="0.2"/>
-                </radialGradient>
-            </defs>
-        </svg>
         <p class="error-status"><%= status %></p>
         <h1 class="error-heading"><%= heading %></h1>
         <p class="error-message"><%= message %></p>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -82,6 +82,23 @@
         }
         .error-btn:hover { filter: brightness(1.1); }
         .error-btn:focus-visible { outline: 2px solid var(--cc-info); outline-offset: 2px; }
+
+        /* Football Easter egg — tumbles down from above and settles with a bounce */
+        .error-football {
+            width: 64px;
+            height: 64px;
+            margin: 0 auto 0.75rem;
+            animation: fb-tumble 1.2s cubic-bezier(0.22, 1, 0.36, 1) both;
+        }
+        @keyframes fb-tumble {
+            0%   { opacity: 0; transform: translateY(-80px) rotate(-200deg) scale(0.6); }
+            60%  { opacity: 1; transform: translateY(8px) rotate(15deg) scale(1.05); }
+            80%  { transform: translateY(-4px) rotate(-5deg) scale(0.98); }
+            100% { opacity: 1; transform: translateY(0) rotate(0deg) scale(1); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .error-football { animation: none; }
+        }
     </style>
 </head>
 
@@ -93,6 +110,24 @@
                 <div class="brand-clash">Clash</div>
             </div>
         </a>
+        <svg class="error-football" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <ellipse cx="32" cy="32" rx="28" ry="18" fill="#8B4513" stroke="#5C2D06" stroke-width="1.5"/>
+            <ellipse cx="32" cy="32" rx="28" ry="18" fill="url(#fb-shade)"/>
+            <!-- Laces -->
+            <line x1="24" y1="32" x2="40" y2="32" stroke="white" stroke-width="2" stroke-linecap="round"/>
+            <line x1="27" y1="28" x2="27" y2="36" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+            <line x1="32" y1="27" x2="32" y2="37" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+            <line x1="37" y1="28" x2="37" y2="36" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+            <!-- Seam lines -->
+            <path d="M6 26 Q 32 18 58 26" stroke="#5C2D06" stroke-width="0.8" fill="none" opacity="0.5"/>
+            <path d="M6 38 Q 32 46 58 38" stroke="#5C2D06" stroke-width="0.8" fill="none" opacity="0.5"/>
+            <defs>
+                <radialGradient id="fb-shade" cx="0.4" cy="0.35" r="0.6">
+                    <stop offset="0%" stop-color="white" stop-opacity="0.15"/>
+                    <stop offset="100%" stop-color="black" stop-opacity="0.2"/>
+                </radialGradient>
+            </defs>
+        </svg>
         <p class="error-status"><%= status %></p>
         <h1 class="error-heading"><%= heading %></h1>
         <p class="error-message"><%= message %></p>

--- a/views/userHome.ejs
+++ b/views/userHome.ejs
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
     <script src="haptic.js"></script>
+    <script src="count-up.js"></script>
     <link href="userHome.css" rel="stylesheet">
     <link href="draftGrades.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- **Count-up animations**: Numeric values (total points, matchup scores, roster team pts, trajectory stats, win probabilities) animate from 0 to their target on page load using `requestAnimationFrame` with ease-out cubic easing. Respects `prefers-reduced-motion`. New `count-up.js` utility with `ccCountUp(container)` called after both `renderBento()` and `renderPreseason()`.
- **Football Easter egg**: SVG football with a tumble-bounce entrance animation on the 404/error page, placed between the Campus Clash brand logo and the status code.

## Test plan
- [ ] Load My Team page — verify total points, matchup scores, and roster points count up from 0
- [ ] Switch seasons via pills — verify count-up replays
- [ ] Open trajectory drawer — verify drawer stats count up
- [ ] Enable `prefers-reduced-motion` — verify numbers appear instantly (no animation)
- [ ] Visit a 404 page — verify football tumbles down with bounce
- [ ] Check for console errors on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)