### PR TITLE
Update custom bet placeholder to CFB reference

### DIFF
--- a/public/betting.js
+++ b/public/betting.js
@@ -492,7 +492,7 @@ function renderBetBoard(index, game) {
 
     // Custom bet row
     html += '<div class="bet-row bet-row-custom"><div class="bet-row-label">Custom</div>'
-        + '<input type="text" class="bet-custom-input" id="custom-desc-' + index + '" placeholder="e.g. Saquon Over 2.5 TDs">'
+        + '<input type="text" class="bet-custom-input" id="custom-desc-' + index + '" placeholder="e.g. Arkansas Over 3.5 turnovers">'
         + '<button type="button" class="bet-btn bet-btn-custom" onclick="pickCustomBet(' + index + ', this)"><span class="bet-btn-label">Use</span></button>'
         + '</div>';
 


### PR DESCRIPTION
## Summary
- Replaced the NFL player placeholder ("Saquon Over 2.5 TDs") with a college football example ("Arkansas Over 3.5 turnovers") so it stays relevant across seasons

## Test plan
- [ ] Open the betting page, expand a game's parlay card, and verify the custom bet input shows the new placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)