### PR TITLE
Add DK boost/payout fields and admin leg resolution

### DIFF
--- a/models/parlay.js
+++ b/models/parlay.js
@@ -53,6 +53,18 @@ const parlaySchema = new mongoose.Schema({
     wager: {
         type: Number
     },
+    parlayOdds: {
+        type: Number
+    },
+    boostPct: {
+        type: Number
+    },
+    boostedOdds: {
+        type: Number
+    },
+    totalPayout: {
+        type: Number
+    },
     status: {
         type: String,
         enum: ['pending', 'won', 'lost', 'push'],

--- a/modules/parlay-resolve.js
+++ b/modules/parlay-resolve.js
@@ -80,7 +80,7 @@ async function resolveParlays() {
             parlay.status = newStatus;
 
             if (newStatus === 'won' && parlay.wager) {
-                parlay.payout = parlayPayout(parlay.wager, parlay.legs);
+                parlay.payout = parlay.totalPayout || parlayPayout(parlay.wager, parlay.legs);
             } else if (newStatus === 'lost') {
                 parlay.payout = 0;
             } else if (newStatus === 'push') {

--- a/public/betting.css
+++ b/public/betting.css
@@ -508,6 +508,64 @@
     font-family: 'Poppins', sans-serif;
 }
 
+/* Boost section (admin-editable) */
+.boost-section {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 24px 0;
+    flex-wrap: wrap;
+}
+.boost-section label {
+    font-size: 11px;
+    color: var(--cc-muted-2);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.boost-input {
+    width: 72px;
+    padding: 6px 8px;
+    background: var(--cc-bg);
+    border: 1px solid var(--cc-border);
+    border-radius: var(--cc-r-sm);
+    color: var(--cc-text);
+    font-size: 13px;
+    font-weight: 600;
+    text-align: center;
+    font-family: 'Poppins', sans-serif;
+}
+.boost-badge {
+    display: inline-block;
+    background: var(--cc-interactive);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: var(--cc-r-sm);
+    margin-left: 4px;
+}
+
+/* Resolve buttons (admin) */
+.leg-resolve {
+    display: flex;
+    gap: 4px;
+    margin-left: 4px;
+}
+.btn-resolve {
+    border: none;
+    border-radius: var(--cc-r-sm);
+    font-size: 10px;
+    font-weight: 600;
+    padding: 3px 6px;
+    cursor: pointer;
+    font-family: 'Poppins', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+.btn-resolve-win { background: var(--cc-success); color: #fff; }
+.btn-resolve-loss { background: var(--cc-danger-text); color: #fff; }
+.btn-resolve-push { background: var(--cc-muted-2); color: #fff; }
+
 /* Season summary */
 .section-divider {
     height: 1px;

--- a/public/betting.js
+++ b/public/betting.js
@@ -225,19 +225,37 @@ function renderCurrentParlay() {
             editBtn = '<button type="button" onclick="editLeg(\'' + parlay._id + '\',\'' + leg.contributor + '\')" style="background:none;border:none;color:var(--cc-interactive);font-size:12px;cursor:pointer;padding:2px 4px;" title="Edit"><i class="fa-solid fa-pen-to-square"></i></button>';
         }
 
+        var resolveHtml = '';
+        if (window.IS_ADMIN && leg.gameId) {
+            resolveHtml = '<div class="leg-resolve">'
+                + '<button type="button" class="btn-resolve btn-resolve-win" onclick="resolveLeg(\'' + parlay._id + '\',\'' + leg.contributor + '\',\'win\')">W</button>'
+                + '<button type="button" class="btn-resolve btn-resolve-loss" onclick="resolveLeg(\'' + parlay._id + '\',\'' + leg.contributor + '\',\'loss\')">L</button>'
+                + '<button type="button" class="btn-resolve btn-resolve-push" onclick="resolveLeg(\'' + parlay._id + '\',\'' + leg.contributor + '\',\'push\')">P</button>'
+                + '</div>';
+        }
+
         return '<div class="leg">'
             + '<div class="leg-contributor">' + avatarHtml(leg.contributor, color, init) + displayName(leg.contributor) + '</div>'
             + '<div class="leg-detail"><div class="leg-pick">' + (leg.selection || '—') + '</div><div class="leg-game">' + matchup + '</div></div>'
             + '<div class="leg-odds">' + formatOdds(leg.odds) + '</div>'
-            + '<div class="leg-actions">' + resultHtml + editBtn + '</div>'
+            + '<div class="leg-actions">' + resultHtml + editBtn + resolveHtml + '</div>'
             + '</div>';
     }).join('');
 
     var filledLegs = parlay.legs.filter(function (l) { return l.odds; });
     var combined = filledLegs.length ? combinedOdds(filledLegs) : '—';
     var potential = parlay.wager && filledLegs.length ? '$' + calcPayout(parlay.wager, filledLegs) : '—';
-    var payoutDisplay = parlay.payout != null ? '$' + parlay.payout : potential;
+    var payoutDisplay = parlay.payout != null ? '$' + parlay.payout : (parlay.totalPayout ? '$' + parlay.totalPayout : potential);
     var payoutClass = parlay.status === 'won' ? 'payout-won' : (parlay.status === 'lost' ? 'payout-lost' : '');
+
+    var oddsDisplay = combined;
+    var boostBadge = '';
+    if (parlay.boostedOdds) {
+        oddsDisplay = formatOdds(parlay.boostedOdds);
+        boostBadge = '<span class="boost-badge">+' + (parlay.boostPct || '?') + '%</span>';
+    } else if (parlay.parlayOdds) {
+        oddsDisplay = formatOdds(parlay.parlayOdds);
+    }
 
     var statusAnimClass = shouldAnimate ? ' parlay-status--unrevealed' : '';
     var payoutAnimClass = shouldAnimate ? ' payout-bar--unrevealed' : '';
@@ -247,6 +265,16 @@ function renderCurrentParlay() {
         wagerHtml = '<div class="wager-section">'
             + '<label>Wager $</label>'
             + '<input type="number" class="wager-input" value="' + (parlay.wager || '') + '" onchange="updateWager(\'' + parlay._id + '\', this.value)">'
+            + '</div>'
+            + '<div class="boost-section">'
+            + '<label>Odds</label>'
+            + '<input type="number" class="boost-input" value="' + (parlay.parlayOdds || '') + '" placeholder="+342" onchange="updateBoost(\'' + parlay._id + '\', \'parlayOdds\', this.value)">'
+            + '<label>Boost %</label>'
+            + '<input type="number" class="boost-input" value="' + (parlay.boostPct || '') + '" placeholder="50" onchange="updateBoost(\'' + parlay._id + '\', \'boostPct\', this.value)">'
+            + '<label>Boosted</label>'
+            + '<input type="number" class="boost-input" value="' + (parlay.boostedOdds || '') + '" placeholder="+514" onchange="updateBoost(\'' + parlay._id + '\', \'boostedOdds\', this.value)">'
+            + '<label>Payout $</label>'
+            + '<input type="number" class="boost-input" value="' + (parlay.totalPayout || '') + '" placeholder="105.66" onchange="updateBoost(\'' + parlay._id + '\', \'totalPayout\', this.value)" step="0.01">'
             + '</div>';
     }
 
@@ -257,7 +285,7 @@ function renderCurrentParlay() {
         + '<div class="legs">' + legsHtml + '</div>'
         + '<div class="payout-bar' + payoutAnimClass + '">'
         + '<div class="payout-item"><div class="payout-label">Wager</div><div class="payout-value">$' + (parlay.wager || 0) + '</div></div>'
-        + '<div class="payout-item"><div class="payout-label">Combined Odds</div><div class="payout-value" style="font-size:13px;color:var(--cc-muted);">' + combined + '</div></div>'
+        + '<div class="payout-item"><div class="payout-label">Combined Odds' + boostBadge + '</div><div class="payout-value" style="font-size:13px;color:var(--cc-muted);">' + oddsDisplay + '</div></div>'
         + '<div class="payout-item"><div class="payout-label">Payout</div><div class="payout-value ' + payoutClass + '">' + payoutDisplay + '</div></div>'
         + '</div>'
         + '</div>'
@@ -640,6 +668,47 @@ async function updateWager(parlayId, value) {
             await refresh();
         }
     } catch (e) { /* skip */ }
+}
+
+async function updateBoost(parlayId, field, value) {
+    try {
+        var body = {};
+        body[field] = Number(value);
+        var res = await fetch('/betting/' + parlayId, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        if (res.ok) {
+            if (window.ccToast) ccToast.success(field + ' updated');
+            await refresh();
+        }
+    } catch (e) { /* skip */ }
+}
+
+async function resolveLeg(parlayId, contributor, result) {
+    try {
+        var res = await fetch('/betting/' + parlayId + '/legs/' + contributor + '/resolve', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ result: result })
+        });
+        if (res.ok) {
+            if (window.ccToast) ccToast.success('Leg marked as ' + result);
+            var data = await res.json();
+            if (data.status !== 'pending') {
+                var m = getSeenMap();
+                delete m[parlayId];
+                localStorage.setItem(SEEN_KEY, JSON.stringify(m));
+            }
+            await refresh();
+        } else {
+            var data = await res.json();
+            if (window.ccToast) ccToast.error(data.message || 'Failed to resolve');
+        }
+    } catch (e) {
+        if (window.ccToast) ccToast.error('Failed to resolve leg');
+    }
 }
 
 async function refresh() {

--- a/routes/betting.js
+++ b/routes/betting.js
@@ -8,6 +8,7 @@ const Ranking = require('../models/ranking');
 const requireBettingGroupMember = require('../modules/require-betting-group');
 const { effectiveRoles } = require('../modules/dev-role');
 const { parlayPayout, combinedAmericanOdds } = require('../modules/parlay-calc');
+const { deriveParlayStatus } = require('../modules/parlay-resolve');
 
 router.use(requireBettingGroupMember);
 
@@ -236,6 +237,47 @@ router.patch('/:id', async (req, res) => {
 
         if (req.body.wager != null) parlay.wager = req.body.wager;
         if (req.body.seasonType != null) parlay.seasonType = req.body.seasonType;
+        if (req.body.parlayOdds != null) parlay.parlayOdds = req.body.parlayOdds;
+        if (req.body.boostPct != null) parlay.boostPct = req.body.boostPct;
+        if (req.body.boostedOdds != null) parlay.boostedOdds = req.body.boostedOdds;
+        if (req.body.totalPayout != null) parlay.totalPayout = req.body.totalPayout;
+        parlay.updatedAt = new Date();
+        await parlay.save();
+        res.json(parlay);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+router.patch('/:id/legs/:contributor/resolve', async (req, res) => {
+    try {
+        if (!isAdmin(req)) {
+            return res.status(403).json({ message: 'Admin only' });
+        }
+
+        const { result } = req.body;
+        if (!['win', 'loss', 'push'].includes(result)) {
+            return res.status(400).json({ message: 'Result must be win, loss, or push' });
+        }
+
+        const parlay = await Parlay.findById(req.params.id);
+        if (!parlay) return res.status(404).json({ message: 'Parlay not found' });
+
+        const leg = parlay.legs.find(l => l.contributor && l.contributor.toString() === req.params.contributor);
+        if (!leg) return res.status(404).json({ message: 'Leg not found' });
+
+        leg.result = result;
+        leg.resolvedAt = new Date();
+
+        parlay.status = deriveParlayStatus(parlay.legs);
+        if (parlay.status === 'won' && parlay.wager) {
+            parlay.payout = parlay.totalPayout || parlayPayout(parlay.wager, parlay.legs);
+        } else if (parlay.status === 'lost') {
+            parlay.payout = 0;
+        } else if (parlay.status === 'push') {
+            parlay.payout = parlay.wager || 0;
+        }
+
         parlay.updatedAt = new Date();
         await parlay.save();
         res.json(parlay);


### PR DESCRIPTION
## Summary
- Add parlay-level DraftKings fields (combined odds, boost %, boosted odds, total payout) to model, admin UI, and payout bar display
- Add admin-only manual leg resolution (W/L/P buttons) with re-resolve support and automatic parlay status/payout derivation
- Auto-resolve uses DK `totalPayout` when available; slot machine animation replays on status change

## Test plan
- [ ] Create a parlay and fill in boost fields — verify they persist and display in the payout bar with boost badge
- [ ] Use W/L/P buttons to resolve individual legs — verify parlay status updates correctly
- [ ] Re-resolve a leg (e.g. push → win) — verify status and payout recalculate
- [ ] Verify slot machine animation plays when final leg resolves the parlay
- [ ] Confirm non-admin users don't see resolve buttons or boost inputs
- [ ] Run `npx jest tests/ScoreUpdate.spec.js` — all 44 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)