### PR TITLE
Show DK payout and odds in payout bar when entered

### DIFF
--- a/public/betting.css
+++ b/public/betting.css
@@ -534,6 +534,11 @@
     text-align: center;
     font-family: 'Poppins', sans-serif;
 }
+.boost-input::placeholder {
+    color: var(--cc-muted-2);
+    opacity: 0.4;
+    font-weight: 400;
+}
 .boost-badge {
     display: inline-block;
     background: var(--cc-interactive);

--- a/public/betting.css
+++ b/public/betting.css
@@ -542,7 +542,16 @@
     font-weight: 600;
     padding: 2px 6px;
     border-radius: var(--cc-r-sm);
-    margin-left: 4px;
+}
+.payout-odds { font-size: 13px; }
+.odds-original {
+    color: var(--cc-muted-2);
+    text-decoration: line-through;
+    font-size: 12px;
+}
+.odds-boosted {
+    color: var(--cc-success);
+    font-weight: 700;
 }
 
 /* Resolve buttons (admin) */

--- a/public/betting.js
+++ b/public/betting.js
@@ -278,13 +278,13 @@ function renderCurrentParlay() {
             + '</div>'
             + '<div class="boost-section">'
             + '<label>Odds</label>'
-            + '<input type="number" class="boost-input" value="' + (parlay.parlayOdds || '') + '" placeholder="+342" onchange="updateBoost(\'' + parlay._id + '\', \'parlayOdds\', this.value)">'
+            + '<input type="number" class="boost-input" value="' + (parlay.parlayOdds || '') + '" placeholder="—" onchange="updateBoost(\'' + parlay._id + '\', \'parlayOdds\', this.value)">'
             + '<label>Boost %</label>'
-            + '<input type="number" class="boost-input" value="' + (parlay.boostPct || '') + '" placeholder="50" onchange="updateBoost(\'' + parlay._id + '\', \'boostPct\', this.value)">'
+            + '<input type="number" class="boost-input" value="' + (parlay.boostPct || '') + '" placeholder="—" onchange="updateBoost(\'' + parlay._id + '\', \'boostPct\', this.value)">'
             + '<label>Boosted</label>'
-            + '<input type="number" class="boost-input" value="' + (parlay.boostedOdds || '') + '" placeholder="+514" onchange="updateBoost(\'' + parlay._id + '\', \'boostedOdds\', this.value)">'
+            + '<input type="number" class="boost-input" value="' + (parlay.boostedOdds || '') + '" placeholder="—" onchange="updateBoost(\'' + parlay._id + '\', \'boostedOdds\', this.value)">'
             + '<label>Payout $</label>'
-            + '<input type="number" class="boost-input" value="' + (parlay.totalPayout || '') + '" placeholder="105.66" onchange="updateBoost(\'' + parlay._id + '\', \'totalPayout\', this.value)" step="0.01">'
+            + '<input type="number" class="boost-input" value="' + (parlay.totalPayout || '') + '" placeholder="—" onchange="updateBoost(\'' + parlay._id + '\', \'totalPayout\', this.value)" step="0.01">'
             + '</div>';
     }
 

--- a/public/betting.js
+++ b/public/betting.js
@@ -668,21 +668,10 @@ async function createParlay() {
 
 async function updateWager(parlayId, value) {
     try {
-        var parlay = parlays.find(function (p) { return p._id === parlayId; });
-        var body = { wager: Number(value) };
-
-        if (parlay) {
-            parlay.wager = Number(value);
-            var computed = computeBoostFields(parlay);
-            if (computed && computed.totalPayout != null) {
-                body.totalPayout = computed.totalPayout;
-            }
-        }
-
         var res = await fetch('/betting/' + parlayId, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body)
+            body: JSON.stringify({ wager: Number(value) })
         });
         if (res.ok) {
             if (window.ccToast) ccToast.success('Wager updated');
@@ -697,23 +686,11 @@ function decimalToAmerican(dec) {
     return 0;
 }
 
-function computeBoostFields(parlay) {
-    if (!parlay.parlayOdds) return null;
-
+function computeBoostedOdds(parlay) {
+    if (!parlay.parlayOdds || !parlay.boostPct) return null;
     var dec = americanToDecimal(parlay.parlayOdds);
-    var boostPct = parlay.boostPct || 0;
-    var boostedDec = boostPct ? 1 + (dec - 1) * (1 + boostPct / 100) : null;
-    var boostedOdds = boostedDec ? decimalToAmerican(boostedDec) : null;
-    var totalPayout = null;
-    if (parlay.wager) {
-        if (boostedDec) {
-            totalPayout = Math.round(((parlay.wager / 2) * boostedDec + (parlay.wager / 2) * dec) * 100) / 100;
-        } else {
-            totalPayout = Math.round(parlay.wager * dec * 100) / 100;
-        }
-    }
-
-    return { boostedOdds: boostedOdds, totalPayout: totalPayout };
+    var boostedDec = 1 + (dec - 1) * (1 + parlay.boostPct / 100);
+    return decimalToAmerican(boostedDec);
 }
 
 async function updateBoost(parlayId, field, value) {
@@ -725,11 +702,8 @@ async function updateBoost(parlayId, field, value) {
         var body = {};
         body[field] = Number(value);
 
-        var computed = computeBoostFields(parlay);
-        if (computed) {
-            if (computed.boostedOdds != null) body.boostedOdds = computed.boostedOdds;
-            if (computed.totalPayout != null) body.totalPayout = computed.totalPayout;
-        }
+        var boosted = computeBoostedOdds(parlay);
+        if (boosted != null) body.boostedOdds = boosted;
 
         var res = await fetch('/betting/' + parlayId, {
             method: 'PATCH',

--- a/public/betting.js
+++ b/public/betting.js
@@ -243,12 +243,10 @@ function renderCurrentParlay() {
     }).join('');
 
     var filledLegs = parlay.legs.filter(function (l) { return l.odds; });
-    var combined = filledLegs.length ? combinedOdds(filledLegs) : '—';
-    var potential = parlay.wager && filledLegs.length ? '$' + calcPayout(parlay.wager, filledLegs) : '—';
-    var payoutDisplay = parlay.payout != null ? '$' + parlay.payout : (parlay.totalPayout ? '$' + parlay.totalPayout : potential);
-    var payoutClass = parlay.status === 'won' ? 'payout-won' : (parlay.status === 'lost' ? 'payout-lost' : '');
+    var calcOdds = filledLegs.length ? combinedOdds(filledLegs) : '—';
+    var calcPay = parlay.wager && filledLegs.length ? '$' + calcPayout(parlay.wager, filledLegs) : '—';
 
-    var oddsDisplay = combined;
+    var oddsDisplay = calcOdds;
     var boostBadge = '';
     if (parlay.boostedOdds) {
         oddsDisplay = formatOdds(parlay.boostedOdds);
@@ -256,6 +254,16 @@ function renderCurrentParlay() {
     } else if (parlay.parlayOdds) {
         oddsDisplay = formatOdds(parlay.parlayOdds);
     }
+
+    var payoutDisplay;
+    if (parlay.payout != null) {
+        payoutDisplay = '$' + parlay.payout;
+    } else if (parlay.totalPayout) {
+        payoutDisplay = '$' + parlay.totalPayout;
+    } else {
+        payoutDisplay = calcPay;
+    }
+    var payoutClass = parlay.status === 'won' ? 'payout-won' : (parlay.status === 'lost' ? 'payout-lost' : '');
 
     var statusAnimClass = shouldAnimate ? ' parlay-status--unrevealed' : '';
     var payoutAnimClass = shouldAnimate ? ' payout-bar--unrevealed' : '';

--- a/public/betting.js
+++ b/public/betting.js
@@ -621,6 +621,17 @@ async function submitLegNew(index) {
             activePick = null;
             selectedBet = null;
             await refresh();
+            var parlay = parlays.find(function (p) { return p.week === currentWeek; });
+            if (parlay) {
+                var computed = computeBoostFields(parlay);
+                if (computed) {
+                    var body = { parlayOdds: computed.parlayOdds };
+                    if (computed.boostedOdds != null) body.boostedOdds = computed.boostedOdds;
+                    if (computed.totalPayout != null) body.totalPayout = computed.totalPayout;
+                    await fetch('/betting/' + parlay._id, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+                    await refresh();
+                }
+            }
         } else {
             var data = await res.json();
             if (window.ccToast) ccToast.error(data.message || 'Failed to submit');
@@ -668,10 +679,21 @@ async function createParlay() {
 
 async function updateWager(parlayId, value) {
     try {
+        var parlay = parlays.find(function (p) { return p._id === parlayId; });
+        var body = { wager: Number(value) };
+
+        if (parlay) {
+            parlay.wager = Number(value);
+            var computed = computeBoostFields(parlay);
+            if (computed && computed.totalPayout != null) {
+                body.totalPayout = computed.totalPayout;
+            }
+        }
+
         var res = await fetch('/betting/' + parlayId, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ wager: Number(value) })
+            body: JSON.stringify(body)
         });
         if (res.ok) {
             if (window.ccToast) ccToast.success('Wager updated');
@@ -680,17 +702,51 @@ async function updateWager(parlayId, value) {
     } catch (e) { /* skip */ }
 }
 
+function decimalToAmerican(dec) {
+    if (dec >= 2) return Math.round((dec - 1) * 100);
+    if (dec > 1) return Math.round(-100 / (dec - 1));
+    return 0;
+}
+
+function computeBoostFields(parlay) {
+    var legs = parlay.legs || [];
+    var active = legs.filter(function (l) { return l.odds && l.result !== 'push'; });
+    if (!active.length) return null;
+
+    var dec = active.reduce(function (acc, l) { return acc * americanToDecimal(l.odds); }, 1);
+    var parlayOdds = decimalToAmerican(dec);
+    var boostPct = parlay.boostPct || 0;
+    var boostedDec = 1 + (dec - 1) * (1 + boostPct / 100);
+    var boostedOdds = boostPct ? decimalToAmerican(boostedDec) : null;
+    var payoutDec = boostPct ? boostedDec : dec;
+    var totalPayout = parlay.wager ? Math.round(parlay.wager * payoutDec * 100) / 100 : null;
+
+    return { parlayOdds: parlayOdds, boostedOdds: boostedOdds, totalPayout: totalPayout };
+}
+
 async function updateBoost(parlayId, field, value) {
     try {
-        var body = {};
-        body[field] = Number(value);
+        var parlay = parlays.find(function (p) { return p._id === parlayId; });
+        if (!parlay) return;
+
+        parlay[field] = Number(value);
+        var computed = computeBoostFields(parlay);
+        if (!computed) return;
+
+        var body = {
+            parlayOdds: computed.parlayOdds,
+            boostPct: parlay.boostPct || 0
+        };
+        if (computed.boostedOdds != null) body.boostedOdds = computed.boostedOdds;
+        if (computed.totalPayout != null) body.totalPayout = computed.totalPayout;
+
         var res = await fetch('/betting/' + parlayId, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)
         });
         if (res.ok) {
-            if (window.ccToast) ccToast.success(field + ' updated');
+            if (window.ccToast) ccToast.success('Boost updated');
             await refresh();
         }
     } catch (e) { /* skip */ }

--- a/public/betting.js
+++ b/public/betting.js
@@ -246,13 +246,15 @@ function renderCurrentParlay() {
     var calcOdds = filledLegs.length ? combinedOdds(filledLegs) : '—';
     var calcPay = parlay.wager && filledLegs.length ? '$' + calcPayout(parlay.wager, filledLegs) : '—';
 
-    var oddsDisplay = calcOdds;
-    var boostBadge = '';
-    if (parlay.boostedOdds) {
-        oddsDisplay = formatOdds(parlay.boostedOdds);
-        boostBadge = '<span class="boost-badge">+' + (parlay.boostPct || '?') + '%</span>';
+    var oddsHtml = '';
+    if (parlay.boostedOdds && parlay.parlayOdds) {
+        oddsHtml = '<span class="odds-original">' + formatOdds(parlay.parlayOdds) + '</span>'
+            + ' <span class="boost-badge">+' + (parlay.boostPct || '?') + '%</span> '
+            + '<span class="odds-boosted">' + formatOdds(parlay.boostedOdds) + '</span>';
     } else if (parlay.parlayOdds) {
-        oddsDisplay = formatOdds(parlay.parlayOdds);
+        oddsHtml = formatOdds(parlay.parlayOdds);
+    } else {
+        oddsHtml = calcOdds;
     }
 
     var payoutDisplay;
@@ -293,7 +295,7 @@ function renderCurrentParlay() {
         + '<div class="legs">' + legsHtml + '</div>'
         + '<div class="payout-bar' + payoutAnimClass + '">'
         + '<div class="payout-item"><div class="payout-label">Wager</div><div class="payout-value">$' + (parlay.wager || 0) + '</div></div>'
-        + '<div class="payout-item"><div class="payout-label">Combined Odds' + boostBadge + '</div><div class="payout-value" style="font-size:13px;color:var(--cc-muted);">' + oddsDisplay + '</div></div>'
+        + '<div class="payout-item"><div class="payout-label">Odds</div><div class="payout-value payout-odds">' + oddsHtml + '</div></div>'
         + '<div class="payout-item"><div class="payout-label">Payout</div><div class="payout-value ' + payoutClass + '">' + payoutDisplay + '</div></div>'
         + '</div>'
         + '</div>'

--- a/public/betting.js
+++ b/public/betting.js
@@ -621,17 +621,6 @@ async function submitLegNew(index) {
             activePick = null;
             selectedBet = null;
             await refresh();
-            var parlay = parlays.find(function (p) { return p.week === currentWeek; });
-            if (parlay) {
-                var computed = computeBoostFields(parlay);
-                if (computed) {
-                    var body = { parlayOdds: computed.parlayOdds };
-                    if (computed.boostedOdds != null) body.boostedOdds = computed.boostedOdds;
-                    if (computed.totalPayout != null) body.totalPayout = computed.totalPayout;
-                    await fetch('/betting/' + parlay._id, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-                    await refresh();
-                }
-            }
         } else {
             var data = await res.json();
             if (window.ccToast) ccToast.error(data.message || 'Failed to submit');
@@ -709,19 +698,22 @@ function decimalToAmerican(dec) {
 }
 
 function computeBoostFields(parlay) {
-    var legs = parlay.legs || [];
-    var active = legs.filter(function (l) { return l.odds && l.result !== 'push'; });
-    if (!active.length) return null;
+    if (!parlay.parlayOdds) return null;
 
-    var dec = active.reduce(function (acc, l) { return acc * americanToDecimal(l.odds); }, 1);
-    var parlayOdds = decimalToAmerican(dec);
+    var dec = americanToDecimal(parlay.parlayOdds);
     var boostPct = parlay.boostPct || 0;
-    var boostedDec = 1 + (dec - 1) * (1 + boostPct / 100);
-    var boostedOdds = boostPct ? decimalToAmerican(boostedDec) : null;
-    var payoutDec = boostPct ? boostedDec : dec;
-    var totalPayout = parlay.wager ? Math.round(parlay.wager * payoutDec * 100) / 100 : null;
+    var boostedDec = boostPct ? 1 + (dec - 1) * (1 + boostPct / 100) : null;
+    var boostedOdds = boostedDec ? decimalToAmerican(boostedDec) : null;
+    var totalPayout = null;
+    if (parlay.wager) {
+        if (boostedDec) {
+            totalPayout = Math.round(((parlay.wager / 2) * boostedDec + (parlay.wager / 2) * dec) * 100) / 100;
+        } else {
+            totalPayout = Math.round(parlay.wager * dec * 100) / 100;
+        }
+    }
 
-    return { parlayOdds: parlayOdds, boostedOdds: boostedOdds, totalPayout: totalPayout };
+    return { boostedOdds: boostedOdds, totalPayout: totalPayout };
 }
 
 async function updateBoost(parlayId, field, value) {
@@ -730,15 +722,14 @@ async function updateBoost(parlayId, field, value) {
         if (!parlay) return;
 
         parlay[field] = Number(value);
-        var computed = computeBoostFields(parlay);
-        if (!computed) return;
+        var body = {};
+        body[field] = Number(value);
 
-        var body = {
-            parlayOdds: computed.parlayOdds,
-            boostPct: parlay.boostPct || 0
-        };
-        if (computed.boostedOdds != null) body.boostedOdds = computed.boostedOdds;
-        if (computed.totalPayout != null) body.totalPayout = computed.totalPayout;
+        var computed = computeBoostFields(parlay);
+        if (computed) {
+            if (computed.boostedOdds != null) body.boostedOdds = computed.boostedOdds;
+            if (computed.totalPayout != null) body.totalPayout = computed.totalPayout;
+        }
 
         var res = await fetch('/betting/' + parlayId, {
             method: 'PATCH',


### PR DESCRIPTION
## Summary
- Payout bar now prefers DK values (`totalPayout`, `boostedOdds`, `parlayOdds`) over calculated per-leg values
- Eliminates the two competing payout/odds numbers — one source of truth in the card
- History rows already use the resolved `payout` field which prefers DK values, so no change needed there

## Test plan
- [ ] Enter DK boost fields (odds, boost %, boosted odds, payout) — verify the payout bar updates to show those values
- [ ] Leave DK fields empty — verify payout bar falls back to calculated values from per-leg odds
- [ ] Resolve a parlay with DK totalPayout set — verify history row shows the DK payout

🤖 Generated with [Claude Code](https://claude.com/claude-code)