### PR TITLE
Add pull-to-refresh to betting page

### DIFF
--- a/views/betting.ejs
+++ b/views/betting.ejs
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="styles.css" rel="stylesheet">
     <script src="haptic.js"></script>
+    <script src="pull-to-refresh.js"></script>
     <link href="betting.css" rel="stylesheet">
     <link href="loading.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">


### PR DESCRIPTION
## Summary
- `pull-to-refresh.js` was only included on standings and userHome — betting was missing it

## Test plan
- [ ] On mobile (or device emulation), pull down from the top of the betting page — should show spinner and reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)